### PR TITLE
Rename "Audacity" to "Tenacity" in Translatable Strings 

### DIFF
--- a/libraries/lib-strings/FutureStrings.h
+++ b/libraries/lib-strings/FutureStrings.h
@@ -1,11 +1,11 @@
 /**********************************************************************
- 
+
  Audacity: A Digital Audio Editor
- 
+
  @file FutureStrings.h
- 
+
  Paul Licameli
- 
+
  **********************************************************************/
 
 #if 0
@@ -95,25 +95,3 @@ Some example strings are also given first, to document the syntax.
 
 // //////////////////////////////////////////////// End examples
 #endif
-
-// Update version dialog
-XC("Update Audacity", "update dialog"),
-XC("&Skip", "update dialog"),
-XC("&Install update", "update dialog"),
-XC("Changelog", "update dialog"),
-XC("Read more on GitHub", "update dialog"),
-XC("Error checking for update", "update dialog"),
-XC("Unable to connect to Audacity update server.", "update dialog"),
-XC("Update data was corrupted.", "update dialog"),
-XC("Error downloading update.", "update dialog"),
-XC("Can't open the Audacity download link.", "update dialog"),
-// i18n-hint Substitution of version number for %s.
-XC("Audacity %s is available!", "update dialog"),
-
-// For after 3.0.3
-
-// See three occurrences of this XC in comments elsewhere;
-// to be uncommented, replacing an XO; and the i18n-hint comment to be moved
-// to one of them (one is enough)
-// i18n-hint: modifier as in "Recording preferences", not progressive verb
-XC("Recording", "preference"),

--- a/locale/af.po
+++ b/locale/af.po
@@ -7,53 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-27 11:11+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
-"Language-Team: Afrikaans <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/af/>\n"
+"Language-Team: Afrikaans <https://hosted.weblate.org/projects/tenacity/tenacity/af/>\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Sluit Tenacity af"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Kanaal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Fout met oopmaak van lêer"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Fout met oopmaak van lêer"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s-redigeerbalk"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Opneem"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -64,9 +27,31 @@ msgstr "Onbepaalbaar"
 msgid "%s bytes"
 msgstr "grepe"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Besig om te versterk"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -77,12 +62,68 @@ msgid "2nd Experimental Command"
 msgstr "Kies opdrag"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Nyquist-effek word toegepas..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Plak"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Plak"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Plak"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Plak"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Kies"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -105,15 +146,37 @@ msgid "Show &Output"
 msgstr "Wys afvoer"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "Funksieknop"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Stop"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Nyquist-opdraglyn..."
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Afvoermeter"
 
@@ -121,13 +184,38 @@ msgstr "Afvoermeter"
 msgid "Load Nyquist script"
 msgstr "Nyquist-opdraglyn..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Waarskuwing"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Nyquist-opdraglyn..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -138,20 +226,47 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "deur Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Nyquist-effek word toegepas..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "No matches found"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist-effek word toegepas..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Nuwe"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Nyquist-opdraglyn..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
 msgstr "&Open..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Open script"
+msgstr "Nyquist-opdraglyn..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
 msgid "Save"
@@ -177,7 +292,8 @@ msgstr "Kopieer"
 msgid "Copy to clipboard"
 msgstr "Knip na knipbord"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Knip"
 
@@ -185,7 +301,8 @@ msgstr "Knip"
 msgid "Cut to clipboard"
 msgstr "Knip na knipbord"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Plak"
 
@@ -210,7 +327,8 @@ msgstr "Kies"
 msgid "Select all text"
 msgstr "Kies"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Ontdoen"
 
@@ -218,16 +336,70 @@ msgstr "Ontdoen"
 msgid "Undo last change"
 msgstr "Formaatverandering"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&Herdoen"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Formaatverandering"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Match"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Geen etikette om uit te voer nie"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Vorige gereedskap"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Skuif baan op"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Volgende gereedskapstuk"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Begin"
 
@@ -235,35 +407,143 @@ msgstr "Begin"
 msgid "Start script"
 msgstr "Nyquist-opdraglyn..."
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Stop"
+msgstr "Stop"
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Stop script"
 msgstr "Nyquist-opdraglyn..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Regso"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Geaktiveer"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Gedeaktiveer"
 
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Opdrag:"
+msgid "The Build"
+msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "Version:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr " venster"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "&Keuses..."
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "&Keuses..."
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Sample rate conversion"
 msgstr "Monsterfrekwensie:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "Fout met invoer"
+
+#: src/AboutDialog.cpp
+msgid "Ogg Vorbis Import and Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "FLAC import and export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "Uitvoer"
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export"
+msgstr "LOF-fout"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "Inprop %i tot %i"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -290,6 +570,18 @@ msgstr "Omhulling"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Omhulling"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Omhulling"
 
@@ -297,6 +589,54 @@ msgstr "Omhulling"
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer and support"
+msgstr "Omhulling"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Omhulling"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Omhulling"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Omhulling"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Omhulling"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
 msgstr "Omhulling"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
@@ -311,9 +651,33 @@ msgstr "Nyquist-afvoer: "
 msgid "%s, web developer"
 msgstr "Omhulling"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Erkenning"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -331,6 +695,11 @@ msgstr "Ander bydraers:"
 msgid "Tenacity Special thanks:"
 msgstr "Spesiale dank aan:"
 
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "Gidse"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
@@ -344,14 +713,23 @@ msgid "%s Team Members"
 msgstr "Ander emeritusspanlede"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Ander bydraers:"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Afrikaanse vertaling deur Friedel Wolff <friedel BY translate.org.za>"
@@ -370,6 +748,26 @@ msgstr "Spesiale dank aan:"
 msgid "%s website: "
 msgstr "Eerste gebruik van Tenacity "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Ander bydraers:"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Klik en sleep om die relatiewe grootte van stereo bane te verstel."
@@ -380,9 +778,15 @@ msgstr "Klik en sleep om die relatiewe grootte van stereo bane te verstel."
 msgid "Record/Play head"
 msgstr "Opneem"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Inprop 1 tot %i"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klik en sleep om die monsters te wysig."
@@ -390,12 +794,57 @@ msgstr "Klik en sleep om die monsters te wysig."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klik en sleep om die grootte van die baan te wysig."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Skuif baan op"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Skuif baan af"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Skuif baan op"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr " (gedeaktiveer)"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr " (gedeaktiveer)"
 
 #: src/AdornedRulerPanel.cpp
@@ -403,14 +852,42 @@ msgid "Timeline Options"
 msgstr "Inprop 1 tot %i"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "Maak seleksie stil"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "Opneem"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Fout"
 
@@ -420,8 +897,36 @@ msgid "Failed to remove %s"
 msgstr "Kon nie '%s' skrap nie"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Tenacity-voorkeure"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -433,7 +938,18 @@ msgstr "Audacity loop reeds"
 msgid "&New"
 msgstr "&Nuwe"
 
+#. i18n-hint: (verb)
+#: src/AudacityApp.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Open..."
+msgstr "&Open..."
+
 #: src/AudacityApp.cpp
+#, fuzzy
+msgid "Open &Recent..."
+msgstr "&Open..."
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Aangaande Audacity..."
@@ -447,29 +963,33 @@ msgid "&File"
 msgstr "&Lêer"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity kon nie 'n plek vind om tydelike lêers te stoor nie.\n"
 "Spesifiseer die verlangde gids by die voorkeure."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity kon nie 'n plek vind om tydelike lêers te stoor nie.\n"
 "Spesifiseer die verlangde gids by die voorkeure."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Tenacity gaan nou afsluit. Laat loop Tenacity weer om die nuwe tydelike gids te gebruik."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -478,36 +998,91 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audcity kon nie die gids vir tydelike lêers sluit nie.\n"
 "Miskien gebruik 'n ander kopie van Tenacity dié gids.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Wil u nogtans Tenacity laat loop?"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Fout met oopmaak van lêer"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Die stelsel rapporteer dat Tenacity reeds loop.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Gebruik die 'Nuut'- of 'Open'-opdragte in die Tenacity wat reeds loop\n"
 "om projekte gelyktydig oop te maak.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity loop reeds"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Tenacity-projeklêers"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -527,7 +1102,8 @@ msgstr "-test (laat loop selfdiagnose)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "-version (wys die Tenacity-weergawe)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -537,9 +1113,10 @@ msgid "audio or project file name"
 msgstr "Kan nie projeklêer open nie"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -552,29 +1129,73 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tenacity-projeklêers"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "Stel omvang..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Opgeneemde oudio"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Hulp"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Sluit Tenacity af"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacity-redigeerbalk"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "&Stoor..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Sluit"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "%s gestoor"
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -603,13 +1224,61 @@ msgid "Error Initializing Audio"
 msgstr "Fout met inisialisering van oudio"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"U sal nie oudio kan speel of opneem nie.\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "Fout met inisialisering van oudio"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity-redigeerbalk"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "Toevoertoestel\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Toevoertoestel\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Device info unavailable for: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -642,8 +1311,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Opneem\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Opneem\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Opneem\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Opneem\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -657,37 +1336,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Toevoertoestel\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Toevoertoestel\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Terugspeel\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Kon nie genre-lêer open nie.\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Opneem\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
 msgstr "Terugspeel\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Opneem\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Monsterfrekwensie:\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Opneem\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Terugspeel\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Terugspeel\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -695,8 +1377,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Toevoertoestel\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Toevoertoestel\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Terugspeel\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Terugspeel\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -704,8 +1396,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Outomatiese herstel na omval"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -717,12 +1410,14 @@ msgid "Recoverable &projects"
 msgstr "Herwinbare projekte"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Kies"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Naam"
 
@@ -735,8 +1430,19 @@ msgid "&Recover Selected"
 msgstr "Kies"
 
 #: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "Geen ketting gekies nie"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -751,8 +1457,26 @@ msgid "&Edit Parameters"
 msgstr "&Wysig parameters"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Use Preset"
+msgstr "Effek-opstelling"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Parameters"
+msgstr "&Parameters"
+
+#: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "&Kies opdrag"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -781,6 +1505,22 @@ msgstr "&Effek"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Wysig parameters"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Wysig parameters"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -827,11 +1567,30 @@ msgstr "Toetsmodus"
 msgid "Apply %s"
 msgstr "Pas '%s' toe"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Kies"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Etikette..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Pas ketting toe"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -848,6 +1607,11 @@ msgstr "Pas toe op &Lêers..."
 #: src/BatchProcessDialog.cpp
 msgid "&Files..."
 msgstr "&Lêer"
+
+#. i18n-hint: The Expand button makes the dialog bigger, with more in it
+#: src/BatchProcessDialog.cpp
+msgid "&Expand"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "No macro selected"
@@ -882,13 +1646,43 @@ msgstr "&Kanselleer"
 msgid "Remo&ve"
 msgstr "&Verwyder"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "Naam..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "Voer &in..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "&Voer uit..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Wysig genres"
 
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "&Opdrag"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#, fuzzy
+msgid "Parameters"
+msgstr "&Parameters"
 
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp
 msgid "&Insert"
@@ -910,9 +1704,15 @@ msgstr "Skuif &op"
 msgid "Move &Down"
 msgstr "Skuif &af"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Stoor..."
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -958,11 +1758,38 @@ msgid "Benchmark"
 msgstr "Laat loop &normtoets..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Aantal herhalings: "
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Sluit"
 
@@ -977,9 +1804,51 @@ msgid "Export Benchmark Data as:"
 msgstr "Voer spektrale data uit as:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Preparing...\n"
+msgstr "Lengte"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 #, c-format
 msgid "Performing %d edits...\n"
 msgstr "Herhaling word toegepas\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -987,13 +1856,90 @@ msgid "Paste: %lld\n"
 msgstr "Plak\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Opgeneemde oudio\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Eindtyd en -datum"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
 
 #: src/BuildInfo.h
 #, fuzzy
@@ -1009,9 +1955,58 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "U moet eers een baan kies."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Geen ketting gekies nie"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr "U moet eers een baan kies."
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr "U moet eers een baan kies."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1028,9 +2023,26 @@ msgid "Checkpointing project"
 msgstr "Pas toe op huidige &projek"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "Pas toe op huidige &projek"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Kon nie skryf na lêer nie:\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr "Tenacity benodig die lêer %s op MP3's te skep."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1048,6 +2060,10 @@ msgid ""
 "%s"
 msgstr "Kon nie '%s' skrap nie"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "Afhanklikhede word verwyder"
@@ -1055,6 +2071,25 @@ msgstr "Afhanklikhede word verwyder"
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "Oudiodata word in projek in gekopieer..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "Wanneer 'n projek van ander lêers afhanklik is:"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1069,8 +2104,26 @@ msgid "Disk Space"
 msgstr "Skyfspasie"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "Maak seleksie stil"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "Kanselleer stoor"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Etiket"
+
+#: src/Dependencies.cpp
+msgid "Do Not Copy"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1082,19 +2135,58 @@ msgstr "Wanneer 'n projek van ander lêers afhanklik is:"
 msgid "Ask me"
 msgstr "Vra my"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "Kies 'n MIDI-lêer"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Knip na knipbord"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Missing"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
 msgstr "Indien u voortgaan, word ie projek nie gestoor nie. Is dit wat u wil hê?"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "Afhanklikheidstoets"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Geen"
 
@@ -1102,7 +2194,7 @@ msgstr "Geen"
 msgid "Rectangle"
 msgstr "Reghoek"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Driehoek"
 
@@ -1114,24 +2206,163 @@ msgstr "Gevormd"
 msgid "Rectangular"
 msgstr "Reghoekig"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Ligging van %s:"
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "To find '%s', click here -->"
+msgstr "Om %s op te spoor, klik hier -->"
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Blaai..."
 
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr "Vir 'n gratis kopie van Lame, klik hier -->"
+
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
+msgstr ""
+
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "Waar is %s?"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "Moenie dié waarskuwing weer wys nie"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Kon nie lêer \"%s\" open nie."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity is gebaseer op kode van die volgende projekte:"
 
 #: src/FileException.cpp
 #, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr "Tenacity benodig die lêer %s op MP3's te skep."
@@ -1147,10 +2378,29 @@ msgid "Error (file may not have been written): %s"
 msgstr "Fout (lêer is dalk nie geskryf nie): %s"
 
 #: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr "Oudiodata word in projek in gekopieer..."
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
 msgstr "Oudiodata word in projek in gekopieer..."
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Alle lêers (*)|*"
 
@@ -1161,6 +2411,14 @@ msgid "AUP3 project files"
 msgstr "Projekdatalêers word gestoor"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "Benoem lêers:"
 
@@ -1168,12 +2426,24 @@ msgstr "Benoem lêers:"
 msgid "XML files"
 msgstr "MP3-lêers"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "MP3-lêers"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -1223,9 +2493,34 @@ msgstr "Lineêre frekwensie"
 msgid "Log frequency"
 msgstr "Log-frekwensie"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Zoem"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1240,6 +2535,14 @@ msgstr "Horisontale stereo"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Merker links"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Algorithm:"
@@ -1258,6 +2561,10 @@ msgid "&Function:"
 msgstr "Aksie"
 
 #: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Replot..."
 msgstr "Herhaling..."
 
@@ -1274,6 +2581,37 @@ msgstr "Te veel oudio is gekies.  Slegs die eersste %.1f sekondes sal geanalisee
 msgid "Not enough data selected."
 msgstr "Nie genoeg data gekies nie."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "spektrum.txt"
@@ -1282,7 +2620,8 @@ msgstr "spektrum.txt"
 msgid "Export Spectral Data As:"
 msgstr "Voer spektrale data uit as:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Kon nie skryf na lêer nie:"
@@ -1298,6 +2637,16 @@ msgstr "Vertraging (sekondes)\tFrekwensie (Hz)\tVolume"
 #: src/FreqWindow.cpp
 msgid "Plot Spectrum..."
 msgstr "Teken spektrum"
+
+#: src/HelpText.cpp
+msgid "Welcome!"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "Speel"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
@@ -1319,6 +2668,95 @@ msgstr "Opneem"
 msgid "Recording - Setting the Recording Level"
 msgstr "Opneem"
 
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Voer lêer uit"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Tenacity-projek word oopgemaak"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
 #: src/HistoryWindow.cpp
 msgid "History"
 msgstr "&Ontdoengeheue..."
@@ -1336,6 +2774,10 @@ msgid "Used Space"
 msgstr "Skyfspasie"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Ontdoenvlakke beskikbaar"
 
@@ -1349,6 +2791,10 @@ msgid "&Discard"
 msgstr "&Verwerp"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Verwerp"
 
@@ -1356,15 +2802,39 @@ msgstr "&Verwerp"
 msgid "&Compact"
 msgstr "&Opdrag"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Ontdoengeheue..."
 
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
 #: src/InconsistencyException.h
 msgid "Internal Error"
 msgstr "(eksterne program)"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "Etiket gewysig"
 
 #. i18n-hint: (noun).  A track contains waves, audio etc.
 #: src/LabelDialog.cpp
@@ -1372,7 +2842,9 @@ msgid "Track"
 msgstr "Baan"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiket"
 
@@ -1429,19 +2901,47 @@ msgstr "Nuwe etiketbaan"
 msgid "Enter track name"
 msgstr "Gee baannaam"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "Etiketbaan"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Eerste gebruik van Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Kies die taal wat Tenacity moet gebruik:"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Bevestig"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "Kon nie skryf na lêer nie:"
 
 #: src/Legacy.cpp
 #, c-format
@@ -1453,8 +2953,19 @@ msgstr ""
 "Die ou lêer is gestoor as '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Tenacity-projek word oopgemaak"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Spesiale dank aan:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Blaai..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1474,34 +2985,101 @@ msgstr "Her&doen %s"
 msgid "&Redo"
 msgstr "&Herdoen"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "Gedeaktiveer"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
 msgstr "Meng"
 
+#: src/Mix.cpp src/menus/TrackMenus.cpp
+msgid "Mix and Render"
+msgstr ""
+
+#: src/Mix.cpp
+msgid "Mixing and rendering tracks"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr ""
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Versterking"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balans"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Stil"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
+
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Versterkbalk geksuif"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Versterkbalk geksuif"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Balansbalk geskuif"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "Mengbalk"
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1511,13 +3089,73 @@ msgid ""
 "Error: %s"
 msgstr "Kon nie toetslêer open/skep nie"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Geaktiveer"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Geen"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity-redigeerbalk"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1527,18 +3165,126 @@ msgstr "Notebaan"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GG"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Oorskryf bestaande lêers"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -1560,9 +3306,29 @@ msgstr[1] "Onbepaalbaar\n"
 msgid "Enable new plug-ins"
 msgstr "Onbepaalbaar"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Nyquist-opdraglyn..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Onbepaalbaar"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "Geaktiveer"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -1589,6 +3355,25 @@ msgstr "Geaktiveer"
 msgid "E&nabled"
 msgstr "Geaktiveer"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Geaktiveer"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Kies"
@@ -1597,7 +3382,8 @@ msgstr "Kies"
 msgid "C&lear All"
 msgstr "&Maak skoon"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Geaktiveer"
 
@@ -1636,6 +3422,19 @@ msgstr "Daar was 'n probleem om te druk."
 msgid "Print"
 msgstr "Druk"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+#, c-format
+msgid "Actual Rate: %d"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp src/effects/Effect.cpp
 msgid ""
 "Error opening sound device.\n"
@@ -1646,6 +3445,21 @@ msgstr "Fout met oopmaak van klanktoestel. Gaan asseblief die opstelling vir afv
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Om die spektrum te teken moet alle bane die selfde monstertempo hê."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Opgeneemde oudio"
@@ -1654,19 +3468,187 @@ msgstr "Opgeneemde oudio"
 msgid "Record"
 msgstr "Neem op"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "Stoor projek onmiddelik sonder veranderings"
 
 #: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Kan nie projeklêer open nie"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
 msgid "Close project immediately with no further changes"
 msgstr "Sluit projek onmiddelik af sonder verdere veranderings"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Vordering"
+
+#: src/ProjectFSCK.cpp
+msgid "Cleaning up unused directories in project data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Pas projek"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1705,11 +3687,96 @@ msgid ""
 msgstr "Kon nie toetslêer open/skep nie"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Kon nie '%s' skrap nie"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Kon nie toetslêer open/skep nie"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Kon nie genre-lêer stoor nie."
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1718,12 +3785,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Kon nie genre-lêer stoor nie."
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Kon nie '%s' na '%s' hernoem nie"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Kon nie '%s' skrap nie"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1734,9 +3827,9 @@ msgid "Error Writing to File"
 msgstr "Kon nie skryf na lêer nie:"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr "Tenacity benodig die lêer %s op MP3's te skep."
@@ -1745,13 +3838,40 @@ msgstr "Tenacity benodig die lêer %s op MP3's te skep."
 msgid "Compacting project"
 msgstr "Nuwe projek gemaak"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity-redigeerbalk"
+
+#. i18n-hint: E.g this is recovered audio that had been lost.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "(Recovered)"
+msgstr "Herwin"
+
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Kan nie projeklêer open nie"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -1766,14 +3886,62 @@ msgid "Unable to parse project information."
 msgstr "Kon nie toetslêer open/skep nie"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Stoor projek"
 
-#: src/ProjectFileManager.cpp
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "\"%s\"-effek word toegepas"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "&Stoor projek"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
+msgstr ""
+"Sommige projekte is nie korrek gestoor toe Tenacity laas gebruik is nie.\n"
+"Die volgende projekte kan gelukkig outomaties herwin word:"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
 msgstr ""
 "Sommige projekte is nie korrek gestoor toe Tenacity laas gebruik is nie.\n"
 "Die volgende projekte kan gelukkig outomaties herwin word:"
@@ -1782,9 +3950,41 @@ msgstr ""
 msgid "Project Recovered"
 msgstr "Projek is herwin"
 
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "&Stoor projek"
+
 #: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "Skyfspasie"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -1792,9 +3992,34 @@ msgid "Saved %s"
 msgstr "%s gestoor"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Stoor projek &as..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -1802,9 +4027,21 @@ msgid "Overwrite Project Warning"
 msgstr "Oorskryf bestaande lêers"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Stoor projek &as..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -1827,6 +4064,23 @@ msgstr "Kies een of meer oudiolêers..."
 msgid "%s is already open in another window."
 msgstr "%s is reeds oop in 'n ander venster."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Fout met oopmaak van lêer"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Fout met oopmaak van lêer"
@@ -1834,6 +4088,24 @@ msgstr "Fout met oopmaak van lêer"
 #: src/ProjectFileManager.cpp
 msgid "Error opening file"
 msgstr "Fout met oopmaak van lêer"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"File may be invalid or corrupted: \n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Fout met oopmaak van lêer"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -1862,12 +4134,33 @@ msgid "Error Importing"
 msgstr "Fout met invoer"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Stoor projek"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Kan nie projeklêer open nie"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Opdrag"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -1878,8 +4171,8 @@ msgid "Automatic database backup failed."
 msgstr "Outomatiese herstel na omval"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Welkom by Tenacity weergawe %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -1893,9 +4186,23 @@ msgid "Save project before closing?"
 msgstr "Stoor wysigings voor afsluiting?"
 
 #: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "Disk space remaining for recording: %s"
 msgstr "Hardeskyfplek is oor om %d minute op te neem."
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -1911,6 +4218,25 @@ msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
+#. i18n-hint: This is an experimental feature where the main panel in
+#. Audacity is put on a notebook tab, and this is the name on that tab.
+#. Other tabs in that notebook may have instruments, patch panels etc.
+#: src/ProjectWindow.cpp
+msgid "Main Mix"
+msgstr ""
+
 #: src/ProjectWindow.cpp
 msgid "Horizontal Scrollbar"
 msgstr "Horisontale stereo"
@@ -1919,6 +4245,26 @@ msgstr "Horisontale stereo"
 msgid "Vertical Scrollbar"
 msgstr "Vertikale stereo"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "Kwaliteit:"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Kwaliteit"
@@ -1926,6 +4272,10 @@ msgstr "Kwaliteit"
 #: src/Resample.cpp
 msgid "High Quality"
 msgstr "Kwaliteit"
+
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
 
 #. i18n-hint: Audio data bit depth (precision): 16-bit integers
 #: src/SampleFormat.cpp
@@ -1942,9 +4292,85 @@ msgstr "24-bis-PCM"
 msgid "32-bit float"
 msgstr "32-bis-dryfpunt"
 
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "Kies 'n ligging vir die uitvoer van lêers"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "Stoor wysigings?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Kies..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "Grootte"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "Grootte"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+msgid "White Bkgnd"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr " venster"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr " venster"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "Pas toe op huidige &projek"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "Funksieknop"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -1958,7 +4384,13 @@ msgstr "Alle lêers (*)|*"
 msgid "All Preferences"
 msgstr "Voorkeure..."
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Merker"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Plaas seleksiepunt"
 
@@ -1966,31 +4398,164 @@ msgstr "Plaas seleksiepunt"
 msgid "Timer"
 msgstr "Eindtyd"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Funksieknop"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "Effek-opstelling"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mengbank"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#. i18n-hint: Noun (the meter is used for playback or record level monitoring)
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter"
+msgstr "Meter"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Play Meter"
+msgstr "Terugspeel"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Record Meter"
+msgstr "Opneem"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&Redigeer"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Toestel:"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play-at-Speed"
+msgstr "Speel"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Scrub"
+msgstr ""
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
 msgstr "Baanpaneel"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Bane"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "&Bane"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "Nuwe baan"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "Speel een sekonde"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "&Bane"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "&Bane"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "Bane"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "Kies 'n ligging vir die uitvoer van lêers"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "-help (hierdie boodskap)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
+
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
+msgstr "&Voorskou"
+
+#: src/ShuttleGui.cpp
+#, fuzzy
+msgid "Dry Previe&w"
 msgstr "&Voorskou"
 
 #: src/ShuttleGui.cpp
@@ -2001,8 +4566,31 @@ msgstr "&Keuses..."
 msgid "Debu&g"
 msgstr "&Ontfout"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "[Inskiet aan]"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+msgid "Sound Activated Record"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "Versterking (dB):"
+
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "&Welkom by Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -2033,9 +4621,27 @@ msgstr "Baannommer"
 msgid "Year"
 msgstr "Jaar"
 
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genre"
+msgstr "Wysig genres"
+
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Opmerkings"
+
+#: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "Vlak:"
 
 #: src/Tags.cpp
 msgid "&Add"
@@ -2046,12 +4652,32 @@ msgid "&Remove"
 msgstr "&Verwyder"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Genres"
+msgstr "Wysig genres"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&Redigeer"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "Zoem uit"
+
+#: src/Tags.cpp
 msgid "Template"
 msgstr "Sjabloon"
 
 #: src/Tags.cpp
 msgid "&Load..."
 msgstr "&Laai..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "&Verstekwaardes"
 
 #: src/Tags.cpp
 msgid "Don't show this when exporting audio"
@@ -2066,6 +4692,11 @@ msgid "Unable to save genre file."
 msgstr "Kon nie genre-lêer stoor nie."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Reset Genres"
+msgstr "Wysig genres"
+
+#: src/Tags.cpp
 msgid "Are you sure you want to reset the genre list to defaults?"
 msgstr "Wil u definitief die genre-lys na verstekwaardes terugstel?"
 
@@ -2074,17 +4705,162 @@ msgid "Unable to open genre file."
 msgstr "Kon nie genre-lêer open nie."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Load Metadata As:"
+msgstr "Stoor metadata as:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Fout met oopmaak van lêer"
+
+#: src/Tags.cpp
 msgid "Save Metadata As:"
 msgstr "Stoor metadata as:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Fout met oopmaak van lêer"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "Geaktiveer"
 
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
+"  %s."
+msgstr "Kon nie skryf na lêer nie:"
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
+"  %s\n"
+"for writing."
+msgstr "Kon nie teikenlêer vir skryf open nie."
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write images to file:\n"
+"  %s."
+msgstr "Kon nie skryf na lêer nie:"
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not create directory:\n"
+"  %s"
+msgstr "Kon nie skryf na lêer nie:\n"
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not save file:\n"
+"  %s"
+msgstr "Kon nie lêer \"%s\" open nie."
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "regs"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Baannaam"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2093,12 +4869,85 @@ msgstr "regs"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Duur"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "&Tydbaan"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record"
+msgstr "Opneem"
+
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
+msgstr "Opneem"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "\"%s\"-effek word toegepas"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "Opgeneemde oudio"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Outomatiese herstel na omval"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Save"
+msgstr "Outomatiese herstel na omval"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Outomatiese herstel na omval"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "Outomatiese herstel na omval"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
 msgstr "Opneem"
 
 #: src/TimerRecordDialog.cpp
@@ -2108,6 +4957,12 @@ msgstr "Pas toe op huidige &projek"
 #: src/TimerRecordDialog.cpp
 msgid "Recording start:"
 msgstr "Opneem"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "Duur"
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
@@ -2120,6 +4975,16 @@ msgstr "Outomatiese herstel na omval"
 #: src/TimerRecordDialog.cpp
 msgid "Automatic Export enabled:"
 msgstr "Outomatiese herstel na omval"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Action after Timer Recording:"
+msgstr "Opneem"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
+msgstr "Opneem"
 
 #: src/TimerRecordDialog.cpp
 msgid "Timer Recording stopped."
@@ -2142,28 +5007,86 @@ msgstr "Opneem"
 msgid ""
 "%s\n"
 "\n"
+"Error saving recording."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
 "Recording exported: %s"
 msgstr "Opneem"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Fout met invoer"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Opneem"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint a format string for days, hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 days 024 h 060 m 060 s"
+msgstr ""
 
 #. i18n-hint: This string is used to configure the controls for times when the recording is
 #. * started and stopped. As such it is important that only the alphabetic parts of the string
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Begintyd en -datum"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "Begintyd"
 
 #: src/TimerRecordDialog.cpp
 msgid "End Date and Time"
 msgstr "Eindtyd en -datum"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date"
+msgstr "Eindtyd en -datum"
+
+#: src/TimerRecordDialog.cpp
 msgid "Automatic Save"
+msgstr "Outomatiese herstel na omval"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
 msgstr "Outomatiese herstel na omval"
 
 #: src/TimerRecordDialog.cpp
@@ -2179,10 +5102,16 @@ msgid "Automatic Export"
 msgstr "Outomatiese herstel na omval"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable Automatic &Export?"
+msgstr "Outomatiese herstel na omval"
+
+#: src/TimerRecordDialog.cpp
 msgid "Export Project As:"
 msgstr "Voer etikette uit as:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Keuses..."
 
@@ -2191,8 +5120,25 @@ msgid "After Recording completes:"
 msgstr "Opneem"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Sluit Tenacity af"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -2202,11 +5148,23 @@ msgstr "Opgeneemde oudio"
 msgid "Scheduled to stop at:"
 msgstr "Seleksie na begin"
 
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr ""
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Opneem"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -2215,6 +5173,26 @@ msgstr "Opneem"
 #: src/TimerRecordDialog.cpp
 msgid "Recording Exported:"
 msgstr "Opneem"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
+msgstr "Opneem"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Baan"
 
 #. i18n-hint: The %d is replaced by the number of the track.
 #. i18n-hint: compose a name identifying an unnamed track by number
@@ -2240,6 +5218,29 @@ msgstr "Solo"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Kies"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Mute On"
+msgstr "Stil"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Solo On"
+msgstr "Solo"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "Merker"
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
@@ -2309,25 +5310,129 @@ msgstr "Skuif baan op"
 msgid "Move Track Down"
 msgstr "Skuif baan af"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
+#. i18n-hint: Voice key is an experimental/incomplete feature that
+#. is used to navigate in vocal recordings, to move forwards and
+#. backwards by words.  So 'key' is being used in the sense of an index.
+#. This error message means that you've selected too short
+#. a region of audio to be able to use this feature.
+#: src/VoiceKey.cpp
+msgid "Selection is too small to use voice key."
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Results\n"
+msgstr ""
+
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Complete"
+msgstr ""
+
 #: src/WaveClip.cpp
 msgid "Resampling failed."
 msgstr "Herbemonster gedeaktiveer."
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to paste the selection"
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to expand the cut line"
+msgstr ""
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Pas tans toe..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Kies opdrag"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "&Opdrag"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Herhaal %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -2337,6 +5442,15 @@ msgstr "Opgeneemde oudio"
 msgid "Threshold:"
 msgstr "Drempel: "
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "Nuwe oudiobaan gemaak"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Vertraging (sekondes):"
@@ -2344,6 +5458,10 @@ msgstr "Vertraging (sekondes):"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Dempingsfaktor:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -2365,9 +5483,43 @@ msgstr "Baan"
 msgid "Track 1"
 msgstr "Baan"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr " venster"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Get Info"
+msgstr "Skuif baan af"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Commands"
@@ -2381,21 +5533,64 @@ msgstr "Alle lêers (*)|*"
 msgid "Preferences"
 msgstr "Voorkeure..."
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Volgende gereedskapstuk"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Omhulling"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etikette"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Meter"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formaat:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "Skuif baan af"
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "Meter"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
 
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
@@ -2404,6 +5599,18 @@ msgstr "Opmerkings"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Opdrag:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 # Opdrag of s.nw.?
 #: src/commands/ImportExportCommands.cpp
@@ -2423,6 +5630,11 @@ msgid "Number of Channels:"
 msgstr "Aantal herhalings: "
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Veelvuldige uitvoer"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Veelvuldige uitvoer"
 
@@ -2430,9 +5642,26 @@ msgstr "Veelvuldige uitvoer"
 msgid "Builtin Commands"
 msgstr "Kies opdrag"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tenacity %s se ondersteuningspan"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Eindtyd en -datum"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -2474,17 +5703,50 @@ msgstr "&Stoor projek"
 msgid "Saves a copy of current project."
 msgstr "&Stoor projek"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Voorkeure..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Naam"
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "Voorkeure..."
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "Vlak:"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "&Druk..."
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Window"
@@ -2499,8 +5761,23 @@ msgid "Window Plus"
 msgstr " venster"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "Funksieknop"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "&Effek"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Alle lêers (*)|*"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -2539,9 +5816,40 @@ msgid "All Tracks Plus"
 msgstr "Baanpaneel"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
+#. i18n-hint:  This really means the color, not as in "white noise"
+#: src/commands/ScreenshotCommand.cpp
+msgctxt "color"
+msgid "White"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Kon nie skryf na lêer nie:"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Druk..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -2563,6 +5871,11 @@ msgstr "Afhanklikhede van die projek"
 msgid "Selection Start"
 msgstr "na begin van seleksie"
 
+#: src/commands/SelectCommand.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Selection"
+msgstr "Merker"
+
 #: src/commands/SelectCommand.cpp
 msgid "Selection End"
 msgstr "na einde van seleksie"
@@ -2580,6 +5893,14 @@ msgid "Select Frequencies"
 msgstr "Frekwensie (Hz)"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&Bane"
 
@@ -2592,6 +5913,12 @@ msgstr "Kies"
 msgid "Add"
 msgstr "Voeg &by"
 
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&Verwyder"
+
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
 msgstr "&Bane"
@@ -2600,8 +5927,17 @@ msgstr "&Bane"
 msgid "Track Count:"
 msgstr "Etiketbaan-skriftipe"
 
+#: src/commands/SelectCommand.cpp
+msgid "Mode:"
+msgstr ""
+
 #: src/commands/SelectCommand.h
 msgid "Selects a time range."
+msgstr "Kies 'n MIDI-lêer"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
 msgstr "Kies 'n MIDI-lêer"
 
 #: src/commands/SelectCommand.h
@@ -2616,9 +5952,37 @@ msgstr "Stilte"
 msgid "Set Clip"
 msgstr "Volgende gereedskapstuk"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Begin"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -2637,9 +6001,14 @@ msgid "Edited Envelope"
 msgstr "Omhulling"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Omhulling"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -2649,6 +6018,10 @@ msgstr "&Skrap"
 msgid "Label Index"
 msgstr "Etiket gewysig"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Kies"
@@ -2656,6 +6029,10 @@ msgstr "Kies"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Etiket gewysig"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -2670,9 +6047,26 @@ msgstr "Stel tempo"
 msgid "Resize:"
 msgstr "Grootte"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "regs"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Stoor projek"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -2687,6 +6081,10 @@ msgid "Set Track Status"
 msgstr "Baannaam"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "Pouseer"
 
@@ -2699,16 +6097,40 @@ msgid "Gain:"
 msgstr "Versterking"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&Bane"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineêr"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Zoem uit"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Eindtyd"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Display:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -2730,16 +6152,36 @@ msgstr "Effek-opstelling"
 msgid "Spectral Select"
 msgstr "Plaas seleksiepunt"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Nuwe baan"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Nuwe oudiobaan gemaak"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Versterk"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "Versterking (dB):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "Versterking (dB):"
 
 #: src/effects/Amplify.cpp
@@ -2751,16 +6193,85 @@ msgid "Allo&w clipping"
 msgstr "Laat aftopping toe"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Etiketbaan-skriftipe"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#. i18n-hint: Name of time display format that shows time in seconds
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "seconds"
+msgstr "millisekondes"
+
+#: src/effects/AutoDuck.cpp
+msgid "Ma&ximum pause:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Drempel: "
+
+#: src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "Preview not available"
+msgstr "&Ontdoenvlakke beskikbaar"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
 
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Verklein seleksie links"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Drempel: "
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -2771,12 +6282,31 @@ msgid "Ba&ss (dB):"
 msgstr "Versterker (dB):"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "Basversterking"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "Vlak:"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Etiket gewysig"
+
+#: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
 msgstr "Vlak:"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Vlak:"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -2787,13 +6317,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Wysig toonhoogte (tempo onveranderd)"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Kwaliteit"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Wysig toonhoogte (tempo onveranderd)"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "Toonhoogte (EAC)"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -2827,13 +6379,40 @@ msgstr "Halftone (halwe stappies):"
 msgid "Frequency"
 msgstr "Frekwensie (Hz)"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "na"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Persentasie verandering:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "Persentasie verandering:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -2845,7 +6424,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n.v.t."
 
@@ -2865,11 +6446,42 @@ msgstr "Wysig spoed (verander tempo en toonhoogte)"
 msgid "&Speed Multiplier:"
 msgstr "Veelvuldige uitvoer"
 
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
 msgctxt "change speed"
 msgid "&to"
 msgstr "na"
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "Selection Length"
+msgstr "na einde van seleksie"
 
 #: src/effects/ChangeSpeed.cpp
 msgid "C&urrent Length:"
@@ -2878,6 +6490,12 @@ msgstr "Effek-opstelling"
 #: src/effects/ChangeSpeed.cpp
 msgid "Current length of selection."
 msgstr "Knip seleksie uit"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
@@ -2898,8 +6516,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "Wysig tempo (toonhoogte onveranderd)"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "Kwaliteit"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "Wysig tempo (toonhoogte onveranderd)"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -2910,6 +6553,12 @@ msgstr "na"
 #: src/effects/ChangeTempo.cpp
 msgid "Length (seconds)"
 msgstr "Lengte (sekondes)"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "from"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -2927,15 +6576,100 @@ msgid "Click Removal"
 msgstr "Klikverwydering"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Naam mag nie leeg wees nie"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "Kies drempel (laer is meer sensitief):"
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "Drempel: "
 
 #: src/effects/ClickRemoval.cpp
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "Maks piekwydte (hoër is meer sensitief):"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Kompressor..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "Saamdruktyd: %.1f sek"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+msgid "&Noise Floor:"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "Links klik"
+
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "Duur"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "Duur"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -2946,16 +6680,48 @@ msgid "&Attack Time:"
 msgstr "Saamdruktyd: "
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Saamdruktyd: "
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Saamdruktyd: %.1f sek"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "Saamdruktyd: %.1f sek"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "Drempel: %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -2968,25 +6734,271 @@ msgid "Release Time %.1f secs"
 msgstr "Saamdruktyd: %.1f sek"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Nuwe oudiobaan gemaak"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Nuwe oudiobaan gemaak"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Nuwe oudiobaan gemaak"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Einde"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "Vlak:"
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "Maak seleksie stil"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "Eindtyd en -datum"
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "Maak seleksie stil"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "Zoem uit"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "Voorkeure..."
 
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&Hulp"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Onbepaalbaar"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr "Pas toe op huidige &projek"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Voer etikette uit as:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "'%s' hernoem na '%s'"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "Herhaal"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "&Verstekwaardes"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Skriftipe..."
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -2997,12 +7009,124 @@ msgid "Soft Clipping"
 msgstr "Wys aftopping"
 
 #: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Dinamiese omvangkompressor"
 
 #: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "Vlak:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "Duur"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Wys aftopping"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -3025,8 +7149,16 @@ msgid "Distortion"
 msgstr "Duur"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Vinnige \"sinc\"-interpolasie"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -3041,8 +7173,26 @@ msgid "Clipping level"
 msgstr "Phaser word toegepas... "
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Pas ketting toe"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Drempel: "
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "Duur"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -3052,6 +7202,71 @@ msgstr "Afvoertoestel"
 msgid "Repeat processing"
 msgstr "Herhaal %s"
 
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "Wys aftopping"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Terugspeel"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Terugspeel"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Frekwensie (Hz)"
@@ -3060,13 +7275,46 @@ msgstr "Frekwensie (Hz)"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitude (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Duur"
 
 #: src/effects/DtmfGen.cpp
 msgid "&Tone/silence ratio:"
 msgstr "Toongenerator"
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Tone duration:"
+msgstr "Opgeneemde oudio"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Silence duration:"
+msgstr "Toongenerator"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -3075,6 +7323,11 @@ msgstr "Eggo"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -3085,6 +7338,10 @@ msgid "D&ecay factor:"
 msgstr "Dempingsfaktor:"
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "Eerste lêernaam:"
 
@@ -3092,7 +7349,8 @@ msgstr "Eerste lêernaam:"
 msgid "Export Effect Parameters"
 msgstr "&Wysig parameters"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Kon nie lêer \"%s\" open nie."
@@ -3116,6 +7374,31 @@ msgstr "&Wysig parameters"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Kon nie toetslêer open/skep nie\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Preparing preview"
+msgstr "Opneem"
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Previewing"
+msgstr "&Voorskou"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
+
 #: src/effects/EffectManager.cpp
 #, c-format
 msgid "Applied effect: %s"
@@ -3130,9 +7413,19 @@ msgstr "\"%s\"-effek toegepas"
 msgid "Select Preset"
 msgstr "Kies"
 
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "&Preset:"
+msgstr "Eerste lêernaam:"
+
 #: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
 msgid "User Presets"
 msgstr "Effek-opstelling"
+
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "&Verstekwaardes"
 
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
@@ -3141,6 +7434,35 @@ msgstr "Effek-opstelling"
 #: src/effects/EffectManager.cpp
 msgid "Factory Defaults"
 msgstr "&Verstekwaardes"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "Seleksie tot einde"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
@@ -3151,16 +7473,87 @@ msgid "&Apply"
 msgstr "Pas '%s' toe"
 
 #: src/effects/EffectUI.cpp
+msgid "Latency: 0"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Belyn"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Skuif &op"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect up in the rack"
+msgstr "na einde van seleksie"
 
 #: src/effects/EffectUI.cpp
 msgid "Move Down"
 msgstr "Skuif &af"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect down in the rack"
+msgstr "na einde van seleksie"
+
+#: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Remove effect from the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Gee die nam vir die nuwe ketting"
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Latency: %4d"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Kies opdrag"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "Ontdoengeheue"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Terugspeel"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3177,6 +7570,16 @@ msgid "&Preview effect"
 msgstr "&Voorskou"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Spring na begin"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Spring na begin"
+
+#: src/effects/EffectUI.cpp
 msgid "Skip forward"
 msgstr "Spring na begin"
 
@@ -3191,6 +7594,11 @@ msgstr "Geaktiveer"
 #: src/effects/EffectUI.cpp
 msgid "Save Preset..."
 msgstr "Stoor projek &as..."
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "Kies"
 
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
@@ -3209,14 +7617,43 @@ msgid "Options..."
 msgstr "Keuses..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Meter"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Naam"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Fout: "
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Fout: "
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Description: %s"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "Wil u definitief '%s' uitvee?"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "Stoor projek &as..."
 
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
@@ -3243,6 +7680,20 @@ msgstr "Terugspeel"
 msgid "Play"
 msgstr "Speel"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Doof uit"
+
+#: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Equalization"
 msgstr "Gelykstelling"
@@ -3250,6 +7701,22 @@ msgstr "Gelykstelling"
 #: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
 msgid "Filter Curve EQ"
 msgstr "Kies"
+
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
@@ -3260,8 +7727,35 @@ msgid "Bass Cut"
 msgstr "Basversterking"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "Etiket gewysig"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Etiket gewysig"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -3272,20 +7766,228 @@ msgid "Track sample rate is too low for this effect."
 msgstr "Bane is te lank om seleksie te herhaal."
 
 #: src/effects/Equalization.cpp
+msgid "Effect Unavailable"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "Meter"
+
+#: src/effects/Equalization.cpp
+msgid "Draw Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Tekenpen"
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Interpolation type"
 msgstr "Vinnige \"sinc\"-interpolasie"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Lineêre frekwensie"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Lineêre frekwensie"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "Pas tans toe..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Pas tans toe..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Kies"
 
 #: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Kies"
 
 #: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Spieëlgolf"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Processing: "
+msgstr "Notebaan"
+
+#: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "&Verstekwaardes"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "Laat loop &normtoets..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "\"%s\"-effek word toegepas"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "\"%s\"-effek word toegepas"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Ontdoengeheue"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Onbepaalbaar"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Merker links"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Eerste lêernaam:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Skrap"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Kies..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "&Verstekwaardes"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3293,9 +7995,23 @@ msgid "Rename '%s' to..."
 msgstr "'%s' hernoem na '%s'"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "Naam..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "'%s' hernoem na '%s'"
+
+#: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Her&noem"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3303,9 +8019,28 @@ msgid "Overwrite existing curve '%s'?"
 msgstr "Oorskryf bestaande lêers"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "Skuif &af"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Kan nie oudio na %s uitvoer nie"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Skrap"
+
+#: src/effects/Equalization.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Deletion"
+msgstr "Bevestig"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3313,8 +8048,50 @@ msgid "Delete %d items?"
 msgstr "DeleteKey"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Choose an EQ curve file"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Voer &etikette uit..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Kan nie oudio na %s uitvoer nie"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Opneem"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "Geen etikette om uit te voer nie"
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -3328,13 +8105,75 @@ msgstr "Uitdoof"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Klik en sleep om oudio te selekteer"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Klik en sleep om oudio te selekteer"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "Wys aftopping"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Wys aftopping"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "Drempel: %d dB"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "Drempel: %d dB"
+
+#: src/effects/Generator.cpp
+msgid "There is not enough room available to generate the audio"
+msgstr ""
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Spieëlgolf"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Nyquist-effek word toegepas..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normaliseer"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -3345,9 +8184,72 @@ msgstr "Normaliseer\n"
 msgid "Analyzing: %s"
 msgstr "A&naliseer"
 
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "Notebaan"
+
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normaliseer"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
+
+#. i18n-hint: not a color, but "white noise" having a uniform spectrum
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "White"
+msgstr ""
+
+#. i18n-hint: not a color, but "pink noise" having a spectrum with more power
+#. in low frequencies
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Pink"
+msgstr ""
+
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "Noise"
+msgstr "Toongenerator"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "&Noise type:"
+msgstr "Toongenerator"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Median"
@@ -3358,20 +8260,95 @@ msgid "Second greatest"
 msgstr "millisekondes"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "256 - standaard"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "256 - standaard"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Ruisverwydering"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Alle bane moet dieselfde monstertempo hê"
 
 #: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
 msgstr "Seleksie na begin"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Noise reduction (dB):"
+msgstr "Vlak:"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
+msgstr "Ruisverwydering"
+
+#: src/effects/NoiseReduction.cpp
+msgid "&Sensitivity:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Sensitivity"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Attac&k time (secs):"
@@ -3389,13 +8366,33 @@ msgstr "Vertraging (sekondes):"
 msgid "Release time"
 msgstr "%d keer herhaal"
 
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Frequency smoothing (bands):"
+msgstr "Frekwensie (Hz):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Frekwensieanalise"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "Vlak:"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old Sensitivity"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 1"
 msgstr "Stap 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Selekteer 'n paar sekondes met slegs ruis\n"
@@ -3419,6 +8416,27 @@ msgstr ""
 "kies hoeveel ruis uitgefilter moet word, en \n"
 "klik 'Verwyder ruis'.\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "Toongenerator"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "&Verwyder bane"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Grootte"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "Gevorderde mengkeuses"
@@ -3430,6 +8448,11 @@ msgstr " venster"
 #: src/effects/NoiseReduction.cpp
 msgid "Window si&ze:"
 msgstr " venster"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
 
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
@@ -3443,17 +8466,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - standaard"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "256 - standaard"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Ruisverwydering"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -3464,13 +8533,89 @@ msgstr ""
 "kies hoeveel ruis uitgefilter moet word, en \n"
 "klik 'Verwyder ruis'.\n"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise re&duction (dB):"
+msgstr "Vlak:"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "&Sensitivity (dB):"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Fr&equency smoothing (Hz):"
+msgstr "Frekwensie (Hz):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "Saamdruktyd: %.1f sek"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Saamdruktyd: "
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&Verwyder"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Normaliseer"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Ruis word verwyder\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Ruis word verwyder\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Ruis word verwyder\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -3480,9 +8625,23 @@ msgstr "Nuwe piekamplitude (dB):"
 msgid "Peak amplitude dB"
 msgstr "Nuwe piekamplitude (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Dempingsfaktor:"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Dempingsfaktor:"
@@ -3491,25 +8650,94 @@ msgstr "Dempingsfaktor:"
 msgid "&Time Resolution (seconds):"
 msgstr "Vertraging (sekondes):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Stappe:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Stappe:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "LFO-frekwensie (Hz):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "LFO-frekwensie (Hz):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "LFO-beginfase (grade):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "LFO-beginfase (grade):"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Bereik:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "Terugvoer (%):"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "&Output gain (dB):"
@@ -3523,9 +8751,33 @@ msgstr "Afvoerkanale: %2d"
 msgid "Repair"
 msgstr "Herstel"
 
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Herhaal"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -3549,6 +8801,65 @@ msgstr "Nuwe seleksielengte: "
 msgid "New selection length: %s"
 msgstr "Nuwe seleksielengte: "
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Vocal I"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "Groot greepvolorde (Big-endian, ongewoon)"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Agteruit"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "&Room Size (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Vertraging (sekondes):"
+
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
 msgstr "Terugvoer (%):"
@@ -3556,6 +8867,33 @@ msgstr "Terugvoer (%):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "Bereik (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Bereik (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Afvoerkanale: %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Afvoerkanale: %2d"
+
+#: src/effects/Reverb.cpp
+msgid "Stereo Wid&th (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -3570,13 +8908,116 @@ msgstr "Agteruit"
 msgid "Reverses the selected audio"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "&Laai lêer op..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "Om die spektrum te teken moet alle bane die selfde monstertempo hê."
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Meter"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Belyn einde met seleksie-einde"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Duur"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Duur"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size:"
+msgstr " venster"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size"
+msgstr " venster"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -3592,6 +9033,15 @@ msgstr "Drempel: "
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "Sorteer volgens tyd"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "Sorteer volgens tyd"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -3630,15 +9080,28 @@ msgstr "&Verstekwaardes"
 msgid "Restore Defaults"
 msgstr "&Verstekwaardes"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Stilte"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "&Stereo na mono"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -3656,6 +9119,43 @@ msgstr "&Stereo na mono"
 msgid "Sliding Stretch"
 msgstr "Dempingsfaktor:"
 
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "Vinnige \"sinc\"-interpolasie"
+
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
 msgstr "Sinus"
@@ -3669,8 +9169,24 @@ msgid "Sawtooth"
 msgstr "Saagtand"
 
 #: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr "Toon..."
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
 
 #: src/effects/ToneGen.cpp
 msgid "&Waveform:"
@@ -3681,18 +9197,91 @@ msgid "&Frequency (Hz):"
 msgstr "Frekwensie (Hz):"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Frekwensie (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "Frekwensie (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "na begin van seleksie"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Amplitude (0-1)"
+
+#: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "Vinnige \"sinc\"-interpolasie"
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Detected Silence"
+msgstr "Stilte word gegenereer"
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Stilte"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Stilte word gegenereer"
 
 #: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Kompressor..."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "&Effek"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Kon nie die MP3-enkoderingbiblioteek open nie!"
 
@@ -3700,33 +9289,129 @@ msgstr "Kon nie die MP3-enkoderingbiblioteek open nie!"
 msgid "VST Effect Options"
 msgstr "Effek-opstelling"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Lengte"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Sleutelkombinasie"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "Sleutelkombinasie"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Stoor spraak as:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Voer lêer uit"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Voer lêer uit"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Tenacity-projeklêers"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "\"%s\"-effek word toegepas"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Stoor spraak as:"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Kies 'n MIDI-lêer"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "\"%s\"-effek word toegepas"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Kon nie toetslêer open/skep nie"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Effek-opstelling"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -3737,8 +9422,29 @@ msgid "Reso&nance:"
 msgstr "Resonansie:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Resonansie:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Wahwah-frekwensieverplasing (%):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Wahwah-frekwensieverplasing (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Effek-opstelling"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Effek-opstelling"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -3753,16 +9459,47 @@ msgid "Audio Unit Effect Options"
 msgstr "Effek-opstelling"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Koppelvlak"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Verklein seleksie links"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr " venster"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Genereer"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Voer lêer uit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "Eerste lêernaam:"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
@@ -3834,19 +9571,74 @@ msgid "Failed to retrieve preset content"
 msgstr "Kon nie '%s' skrap nie"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Monsterfrekwensie:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Kon nie '%s' skrap nie"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Kon nie '%s' skrap nie"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Kon nie '%s' skrap nie"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Oudiolêer"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "&Effek"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "&Effek"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Effek-opstelling"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -3854,6 +9646,7 @@ msgstr "Effek-opstelling"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "&Effek"
@@ -3862,13 +9655,59 @@ msgstr "&Effek"
 msgid "LV2 Effect Settings"
 msgstr "Effek-opstelling"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Genereer"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "&Effek"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Nyquist-effek word toegepas..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -3882,6 +9721,24 @@ msgstr "Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Nyquist-afvoer: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
 
 # moet eintlik verlede tyd wees...
 #: src/effects/nyquist/Nyquist.cpp
@@ -3897,8 +9754,37 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Jammer, kan nie effek toepas op stereo bane waar die individuele kanale van die baan nie ooreenstem nie."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Nyquist-afvoer: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "Opneem"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -3935,6 +9821,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Geen oudio van Nyquist ontvang nie.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Hierdie weergawe van Tenacity is nie met %s-ondersteuning gebou nie."
@@ -3943,10 +9833,37 @@ msgstr "Hierdie weergawe van Tenacity is nie met %s-ondersteuning gebou nie."
 msgid "Could not open file"
 msgstr "Kon nie lêer open nie:"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Kon nie lêer open nie:"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Kon nie toetslêer open/skep nie\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -3967,6 +9884,21 @@ msgid "Lisp scripts"
 msgstr "Nyquist-opdraglyn..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Kon nie lêer open nie:"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -3985,13 +9917,51 @@ msgstr "Kies 'n MIDI-lêer"
 msgid "Save file as"
 msgstr "Benoem lêers:"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "&Effek"
 
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
 msgstr "Jammer, Vamp-inproppe werk nie op stereo bane waar die individuele kanale van die baan nie ooreenstem nie."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "Inprop 1 tot %i"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogramme"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Effek-opstelling"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -4004,6 +9974,14 @@ msgstr "Wysig metadata"
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "Uitvoer"
+
+#: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -4077,6 +10055,11 @@ msgid "Output Channels: %2d"
 msgstr "Afvoerkanale: %2d"
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "Baanpaneel"
+
+#: src/export/Export.cpp
 #, c-format
 msgid ""
 "Unable to export.\n"
@@ -4086,6 +10069,26 @@ msgstr "Kon nie '%s' skrap nie"
 #: src/export/ExportCL.cpp
 msgid "Show output"
 msgstr "Wys afvoer"
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Kies opdrag"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -4116,9 +10119,128 @@ msgstr "Opdrag se afvoer"
 msgid "&OK"
 msgstr "&Regso"
 
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "LOF-fout"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -4126,12 +10248,42 @@ msgid "Exporting the audio as %s"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Monsterfrekwensie:"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample"
+msgstr "Monsterfrekwensie:"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
 msgid "Sample Rates"
 msgstr "Monsterfrekwensie:"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -4143,6 +10295,51 @@ msgstr "Bistempo:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Kwaliteit:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -4157,6 +10354,10 @@ msgid "Constrained"
 msgstr "Konstant"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Oudio..."
 
@@ -4165,8 +10366,44 @@ msgid "Low Delay"
 msgstr "Uitdoof"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Groot greepvolorde (Big-endian, ongewoon)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -4181,8 +10418,20 @@ msgid "Frame Duration:"
 msgstr "Duur"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Vbr Mode:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "Pas ketting toe"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
@@ -4193,21 +10442,431 @@ msgid "Current Codec:"
 msgstr "Pas toe op huidige &projek"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "\"%s\"-effek word toegepas"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Oorskryf bestaande lêers"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "Bevestig"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "Nuwe oudiobaan gemaak"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Gids %s bestaan nie.  Skep?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "'%s' hernoem na '%s'"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Main"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "LOF-fout"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Vlak:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Vlak:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Vlak:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "Eerste lêernaam:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Eerste lêernaam:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Voer etikette uit as:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Voer etikette uit as:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Pas toe op huidige &projek"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Inprop 1 tot %i"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Taal:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "Kwaliteit:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Monsterfrekwensie:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Alle lêers (*)|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "FLAC-lêers"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Kompressor..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Naam"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "MPEG container options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+# frekwensie? bistempo?
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Stel tempo"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "Baan se titel"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "'%s' hernoem na '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "Geen etikette om uit te voer nie"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "Kies lêer(s) vir bondelverwerking..."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Kon nie '%s' skrap nie"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Kon nie toetslêer open/skep nie"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -4238,6 +10897,18 @@ msgid "FLAC Files"
 msgstr "FLAC-lêers"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Kon nie lêer \"%s\" open nie."
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
 msgstr "Die seleksie word as FLAC uitgevoer"
 
@@ -4258,17 +10929,94 @@ msgid "Unable to open target file for writing"
 msgstr "Kon nie teikenlêer vir skryf open nie."
 
 #: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
+
+#: src/export/ExportMP2.cpp
 #, c-format
 msgid "Exporting the audio at %ld kbps"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standaard"
 
 #: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "Groot greepvolorde (Big-endian, ongewoon)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "Gedeaktiveer"
 
 #: src/export/ExportMP3.cpp
 msgid "Average"
@@ -4278,14 +11026,44 @@ msgstr "Gemiddeld"
 msgid "Constant"
 msgstr "Konstant"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "2 (stereo)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "Bistempo:"
+
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "Kwaliteit"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "Kanaal: %2d"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Verwyder baan"
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity benodig die lêer %s op MP3's te skep."
 
 #: src/export/ExportMP3.cpp
@@ -4313,6 +11091,43 @@ msgid "Where is %s?"
 msgstr "Waar is %s?"
 
 #: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Projekdatalêers word gestoor"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "MP2-lêers"
+
+#: src/export/ExportMP3.cpp
 msgid "Could not open MP3 encoding library!"
 msgstr "Kon nie die MP3-enkoderingbiblioteek open nie!"
 
@@ -4325,9 +11140,24 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "Biblioteek ongeldig of nie geondersteun vir MP3-enkodering nie!"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Voer lêer uit"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
 msgstr "Voer lêer uit"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
 #: src/export/ExportMP3.cpp
 #, c-format
@@ -4335,9 +11165,41 @@ msgid "Exporting the audio with VBR quality %s"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
@@ -4348,8 +11210,18 @@ msgid "Cannot Export Multiple"
 msgstr "Veelvuldige uitvoer"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Ligging vir uitvoer:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -4372,6 +11244,11 @@ msgid "First file name:"
 msgstr "Eerste lêernaam:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Eerste lêernaam:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "Benoem lêers:"
 
@@ -4380,7 +11257,22 @@ msgid "Using Label/Track Name"
 msgstr "volgens etiket-/baannaam"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "volgens etiket-/baannaam"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Lêernaamvoorvoegsel:"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "Lêernaamvoorvoegsel:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "Lêernaamvoorvoegsel:"
 
 #: src/export/ExportMultiple.cpp
@@ -4398,6 +11290,31 @@ msgstr "Kies 'n ligging vir die uitvoer van lêers"
 
 #: src/export/ExportMultiple.cpp
 #, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
 msgid ""
 "\"%s\" doesn't exist.\n"
 "\n"
@@ -4411,9 +11328,60 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "Kon nie toetslêer open/skep nie"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Save As..."
+msgstr "%s gestoor"
+
 #: src/export/ExportOGG.cpp
 msgid "Ogg Vorbis Files"
 msgstr "Ogg Vorbis-lêers"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Kon nie toetslêer open/skep nie"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -4427,6 +11395,14 @@ msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Kop:"
@@ -4436,8 +11412,33 @@ msgid "Encoding:"
 msgstr "Karakterstel:"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "WAV, AIFF en ander tipes sonder saampersing"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Fout met invoer"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -4448,26 +11449,203 @@ msgstr "Kan audio nie in dié formaat uitvoer nie."
 msgid "Exporting the selected audio as %s"
 msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
 
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "Monsterfrekwensie:"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Seleksie tot einde"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Hierdie weergawe van Tenacity is nie met %s-ondersteuning gebou nie."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
 msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "is 'n speellyslêer. \n"
 "Tenacity kan nie hierdie lêer oopmaak nie want dit bevat slegs skakels na ander lêers.\n"
 "U kan dit dalk in 'n teksredigeerder oopmaak en die werklike oudiolêers aflaai."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Projekdatalêers word gestoor"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -4484,13 +11662,123 @@ msgid "Import Project"
 msgstr "Voer etikette uit as:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Kon nie die projek se datagids, \"%s\" vind nie."
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "na begin van seleksie"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -4507,21 +11795,19 @@ msgstr "Kon nie toetslêer open/skep nie"
 msgid "Unable to read %lld samples from %s"
 msgstr "Kon nie toetslêer open/skep nie"
 
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC-lêers"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Kon nie toetslêer open/skep nie"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Kon nie '%s' na '%s' hernoem nie"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Kon nie toetslêer open/skep nie"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -4579,9 +11865,22 @@ msgstr "Kon nie lêer \"%s\" open nie."
 msgid "MP3 files"
 msgstr "MP3-lêers"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis-lêers"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -4608,12 +11907,120 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF en ander tipes sonder saampersing"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bis-PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-bis-PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-bis-PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bis-PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bis-PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -4624,12 +12031,49 @@ msgid "64 bit float"
 msgstr "32-bis-dryfpunt"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bis"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "16 bis"
 
 #: src/import/ImportPCM.cpp
 msgid "24 bit DWVW"
 msgstr "24 bis"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
@@ -4639,9 +12083,51 @@ msgstr "16-bis-PCM"
 msgid "8 bit DPCM"
 msgstr "16-bis-PCM"
 
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "'%s' is ingevoer"
+
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "QuickTime-lêers"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "Kon nie '%s' skrap nie"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Kon nie genre-lêer stoor nie."
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "Voer rou data in"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -4684,6 +12170,15 @@ msgstr "2 kanale (stereo)"
 msgid "%d Channels"
 msgstr "%d kanale"
 
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Kanaal"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
@@ -4707,6 +12202,10 @@ msgstr "Monsterfrekwensie:"
 msgid "&Import"
 msgstr "Voer &in"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -4727,6 +12226,7 @@ msgstr "regs"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -4750,6 +12250,7 @@ msgstr "Einde"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -4769,12 +12270,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Baan '%s' %s met %.02f sekondes verskuif"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Baan '%s' %s met %.02f sekondes verskuif"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Tydverskuiwing"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "na begin van seleksie"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -4791,6 +12315,26 @@ msgstr "Volgende gereedskapstuk"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Volgende gereedskapstuk"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "Vorige gereedskap"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "Pas toe op huidige &projek"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "Volgende gereedskapstuk"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "na begin van seleksie"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -4826,6 +12370,14 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "%.2f sekondes geskrap by t=%.2f"
 
 #: src/menus/EditMenus.cpp
+msgid "Pasting one type of track into another is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Copying stereo audio into a mono track is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
 msgid "Duplicated"
 msgstr "Gedupliseer"
 
@@ -4834,9 +12386,24 @@ msgid "Duplicate"
 msgstr "Duplikaat"
 
 #: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split-cut to the clipboard"
+msgstr "Knip na knipbord"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Cut"
+msgstr "Etiket gewysig"
+
+#: src/menus/EditMenus.cpp
 #, c-format
 msgid "Split-deleted %.2f seconds at t=%.2f"
 msgstr "%.2f sekondes geskrap by t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Delete"
+msgstr "Plaas seleksiepunt"
 
 #: src/menus/EditMenus.cpp
 #, c-format
@@ -4858,14 +12425,39 @@ msgstr "Gekose bane stilgemaak vir %.2f sekonde vanaf %.2f"
 msgid "Trim Audio"
 msgstr "Opgeneemde oudio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
+msgstr "Verdeel"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split to new track"
+msgstr "Verdeel stereo baan"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split New"
 msgstr "Verdeel"
 
 #: src/menus/EditMenus.cpp
 #, c-format
 msgid "Joined %.2f seconds at t=%.2f"
 msgstr "%.2f sekondes geskrap by t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Join"
+msgstr "&Voeg saam"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "%.2f sekondes geskrap by t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
@@ -4899,19 +12491,62 @@ msgstr "&Plak"
 msgid "Duplic&ate"
 msgstr "&Dupliseer"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "&Verwyder bane"
+
+#. i18n-hint: (verb) Do a special kind of cut
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Spl&it Cut"
+msgstr "Etiket gewysig"
+
+#. i18n-hint: (verb) Do a special kind of DELETE
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split D&elete"
+msgstr "Plaas seleksiepunt"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "Maak seleksie stil"
+
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
 msgid "Tri&m Audio"
 msgstr "&Uitknip"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/EditMenus.cpp
+msgid "Sp&lit"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Ne&w"
+msgstr "Verdeel"
 
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
 msgid "&Join"
 msgstr "&Voeg saam"
 
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "Stilte word gegenereer"
+
 #: src/menus/EditMenus.cpp
 msgid "&Metadata..."
 msgstr "Wysig metadata"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "&Voorkeure..."
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -4922,32 +12557,8 @@ msgid "Delete Key&2"
 msgstr "DeleteKey2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mengbalk"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Terugspeel"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Terugspeel"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Terugspeel"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Opneem"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Opneem"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Opneem"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -4968,6 +12579,17 @@ msgstr "Verander baan se naam na:"
 #: src/menus/ExtraMenus.cpp
 msgid "Change Recording Cha&nnels..."
 msgstr "Wysig toonhoogte"
+
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -4991,12 +12613,28 @@ msgid "Please select a Note Track."
 msgstr "Nuwe oudiobaan gemaak"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "&Voer uit..."
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "Kies 'n MIDI-lêer"
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "Alle lêers (*)|*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "&Voer uit..."
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -5012,6 +12650,11 @@ msgid "Select a MIDI file"
 msgstr "Kies 'n MIDI-lêer"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Alle lêers (*)|*"
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI files"
 msgstr "MP3-lêers"
 
@@ -5022,6 +12665,18 @@ msgstr "Alle lêers (*)|*"
 #: src/menus/FileMenus.cpp
 msgid "&Dangerous Reset..."
 msgstr "Stoor projek &as..."
+
+#. i18n-hint: This is the name of the menu item on Mac OS X only
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Open Recent"
+msgstr "Nuwe projek"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "Benoem lêers:"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -5080,6 +12735,11 @@ msgid "&Labels..."
 msgstr "&Etikette..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "&Voer uit..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Rou data..."
 
@@ -5096,6 +12756,10 @@ msgstr "&Druk..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "Afsluit"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -5128,6 +12792,10 @@ msgid "Nothing to do"
 msgstr "Niks om te ontdoen nie"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Skuif baan op"
 
@@ -5140,6 +12808,18 @@ msgid "Recording stops and starts"
 msgstr "Opneem"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "&Hulp"
 
@@ -5148,7 +12828,8 @@ msgid "&Getting Started"
 msgstr "na begin van seleksie"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "Tenacity-redigeerbalk"
 
 #: src/menus/HelpMenus.cpp
@@ -5156,20 +12837,76 @@ msgid "&Quick Help..."
 msgstr "&Hulp"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
 msgstr "-test (laat loop selfdiagnose)"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Aangaande Tenacity..."
+msgid "Au&dio Device Info..."
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etiket bygevoeg"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "Skuif baan op"
+
+#. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
+#. regions.
+#: src/menus/LabelMenus.cpp
+msgid "Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Cut Labeled Audio"
+msgstr "Verdeel by etikette"
+
+#. i18n-hint: (verb) Audacity has just deleted the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Deleted labeled audio regions"
+msgstr "Verdeel by etikette"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Delete Labeled Audio"
+msgstr "Verdeel by etikette"
+
+#. i18n-hint: (verb) Audacity has just split cut the labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Cut labeled audio regions to clipboard"
+msgstr "Verdeel by etikette"
 
 #. i18n-hint: (verb) Do a special kind of cut on the labels
 #: src/menus/LabelMenus.cpp
 msgid "Split Cut Labeled Audio"
+msgstr "Verdeel by etikette"
+
+#. i18n-hint: (verb) Audacity has just done a special kind of DELETE on
+#. the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Deleted labeled audio regions"
 msgstr "Verdeel by etikette"
 
 #. i18n-hint: (verb) Do a special kind of DELETE on labeled audio
@@ -5180,13 +12917,60 @@ msgstr "Verdeel by etikette"
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silenced labeled audio regions"
+msgstr "Maak seleksie stil"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
 msgid "Silence Labeled Audio"
 msgstr "Maak seleksie stil"
+
+#: src/menus/LabelMenus.cpp
+msgid "Copied labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Copy Labeled Audio"
+msgstr "Opgeneemde oudio"
+
+#. i18n-hint: (verb) past tense.  Audacity has just split the labeled
+#. audio (a point or a region)
+#: src/menus/LabelMenus.cpp
+msgid "Split labeled audio (points or regions)"
+msgstr ""
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
 msgid "Split Labeled Audio"
 msgstr "Verdeel by etikette"
+
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+msgid "Joined labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Join Labeled Audio"
+msgstr "Maak seleksie stil"
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+msgid "Detached labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detach Labeled Audio"
+msgstr "Maak seleksie stil"
 
 #: src/menus/LabelMenus.cpp
 msgid "&Labels"
@@ -5205,6 +12989,15 @@ msgid "Add Label at &Playback Position"
 msgstr "Voeg etiket by by speelpunt"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "Skuif baan op"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Opgeneemde oudio"
 
@@ -5221,9 +13014,30 @@ msgstr "Etiket gewysig"
 msgid "Label Delete"
 msgstr "Skrap"
 
+#. i18n-hint: (verb) A special way to cut out a piece of audio
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Split Cut"
+msgstr "Etiket gewysig"
+
 #: src/menus/LabelMenus.cpp
 msgid "Label Split Cut"
 msgstr "Etiket gewysig"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Sp&lit Delete"
+msgstr "Plaas seleksiepunt"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Delete"
+msgstr "Skrap"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "Maak seleksie stil"
 
 #: src/menus/LabelMenus.cpp
 msgid "Label Silence"
@@ -5238,6 +13052,12 @@ msgstr "Ko&pieer"
 msgid "Label Copy"
 msgstr "Etiket"
 
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Spli&t"
+msgstr "Verdeel"
+
 #: src/menus/LabelMenus.cpp
 msgid "Label Split"
 msgstr "Etiket gewysig"
@@ -5245,6 +13065,23 @@ msgstr "Etiket gewysig"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "Etiket gewysig"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "Skuif baan op"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -5267,6 +13104,16 @@ msgid "Move Focus to &Last Track"
 msgstr "Skuif baan op"
 
 #: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to P&revious and Select"
+msgstr "Skuif baan op"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to N&ext and Select"
+msgstr "Skuif baan op"
+
+#: src/menus/NavigationMenus.cpp
 msgid "&Toggle Focused Track"
 msgstr "Skuif baan op"
 
@@ -5275,8 +13122,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Skuif baan op"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "…"
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -5293,12 +13148,31 @@ msgid "&Generate"
 msgstr "&Genereer"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Generator"
+msgstr "Herhaal %s"
+
+#: src/menus/PluginMenus.cpp
 msgid "Effe&ct"
 msgstr "&Effek"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "Herhaal %s"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "A&naliseer"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "Herhaal %s"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -5336,6 +13210,10 @@ msgstr "Laat loop &normtoets..."
 msgid "Simulate Recording Errors"
 msgstr "Opneem"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -5356,6 +13234,16 @@ msgstr "Kies"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "Baannaam"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Stilte"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&Bane"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -5381,9 +13269,20 @@ msgstr "&Wysig etikette"
 msgid "Set Project..."
 msgstr "Stoor projek &as..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Alle lêers (*)|*"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "&Bane"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "Skuif baan af"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -5409,6 +13308,33 @@ msgstr "Kies..."
 msgid "Compare Audio..."
 msgstr "Kompressor..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "&Druk..."
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Plaas seleksiepunt"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Aksie"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Plaas seleksiepunt"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "Kies"
+
 #: src/menus/SelectMenus.cpp
 msgid "&None"
 msgstr "&Niks"
@@ -5422,16 +13348,54 @@ msgid "&Tracks"
 msgstr "&Bane"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "Bane"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Merker"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Left at Playback Position"
+msgstr "Voeg etiket by by speelpunt"
+
+#: src/menus/SelectMenus.cpp
 msgid "Set Selection Left at Play Position"
 msgstr "Plaas seleksiepunt"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Right at Playback Position"
+msgstr "Voeg etiket by by speelpunt"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Selection Right at Play Position"
 msgstr "Plaas seleksiepunt"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "Seleksie na begin"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "Seleksie na begin"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "Baannaam"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -5470,8 +13434,16 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Lineêre frekwensie"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Seleksie na begin"
+
+#: src/menus/SelectMenus.cpp
+msgid "Store Cursor Pos&ition"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -5609,9 +13581,64 @@ msgstr "Merker links"
 msgid "Cursor Long Ju&mp Right"
 msgstr "Merker regs"
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "Funksieknop"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
+
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
 msgstr "Herstel balke"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr "Oudiobane verwyder"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+msgid "Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr ""
 
 #. i18n-hint: One or more audio tracks have been panned
 #: src/menus/TrackMenus.cpp
@@ -5621,6 +13648,11 @@ msgstr "Oudiobane verwyder"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Track"
 msgstr "Baan"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Zero"
+msgstr "Begin"
 
 #: src/menus/TrackMenus.cpp
 msgid "Start to &Cursor/Selection Start"
@@ -5734,6 +13766,25 @@ msgid "Align Together"
 msgstr "Belyn bane saam"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "Belyn einde met seleksie-einde"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted gain"
+msgstr "Omhulling aangepas."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted Pan"
+msgstr "Omhulling aangepas."
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
 msgstr "Nuwe oudiobaan gemaak"
 
@@ -5750,16 +13801,60 @@ msgid "Created new label track"
 msgstr "Nuwe etiketbaan gemaak"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Nuwe tydbaan gemaak"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Monsterfrekwensie:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "The entered value is invalid"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Resampling track %d"
+msgstr "Herbemonster gedeaktiveer."
 
 #: src/menus/TrackMenus.cpp
 msgid "Resampled audio track(s)"
 msgstr "Oudiobane verwyder"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "Verwyder baan"
+
+#: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "Nuwe oudiobaan gemaak"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "Belyn einde met seleksie-einde"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -5778,6 +13873,15 @@ msgid "Sort by Name"
 msgstr "Sorteer volgens naam"
 
 #: src/menus/TrackMenus.cpp
+msgid "Can't delete track with active audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&Nuwe"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "Skuif baan"
 
@@ -5794,8 +13898,26 @@ msgid "&Time Track"
 msgstr "&Tydbaan"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Mengbalk"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "&Stereo na mono"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x and Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix and Render to Ne&w Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Resample..."
+msgstr "Naam..."
 
 #: src/menus/TrackMenus.cpp
 msgid "Remo&ve Tracks"
@@ -5804,6 +13926,11 @@ msgstr "&Verwyder bane"
 #: src/menus/TrackMenus.cpp
 msgid "M&ute/Unmute"
 msgstr "Skuif baan op"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "&Tydbaan"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
@@ -5816,6 +13943,10 @@ msgstr "&Bane"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Tydbaan"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -5844,12 +13975,22 @@ msgid "Pan Center"
 msgstr "Middel"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "Bane"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
 msgstr "Belyn einde met seleksie-einde"
 
 #: src/menus/TrackMenus.cpp
 msgid "Align &Together"
 msgstr "Belyn bane saam"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Move Selection with Tracks (on/off)"
+msgstr "na einde van seleksie"
 
 #: src/menus/TrackMenus.cpp
 msgid "Move Sele&ction and Tracks"
@@ -5866,6 +14007,10 @@ msgstr "Begintyd"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "Naam"
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -5937,7 +14082,9 @@ msgstr "Speel"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Opneem"
 
@@ -5946,8 +14093,32 @@ msgid "no label track"
 msgstr "Nuwe etiketbaan gemaak"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track at or below focused track"
+msgstr "Nuwe etiketbaan gemaak"
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Nuwe etiketbaan gemaak"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -5976,9 +14147,34 @@ msgstr "Effek-opstelling"
 msgid "Pl&aying"
 msgstr "Speel"
 
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "Speel"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Pouseer"
+
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "Opneem"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "Neem op"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -5989,8 +14185,71 @@ msgid "Record &New Track"
 msgstr "&Verwyder bane"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Opneem"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Opneem"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "Effek-opstelling"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Opneem"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "Effek-opstelling"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&ay"
+msgstr "Speel"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -6040,6 +14299,11 @@ msgstr "Speel"
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play-at-Speed"
 msgstr "Speel"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview-at-Speed"
+msgstr "&Voorskou"
 
 #: src/menus/TransportMenus.cpp
 msgid "Ad&just Playback Speed..."
@@ -6104,6 +14368,20 @@ msgid "&Fit to Width"
 msgstr "Pas &horisontaal"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "Pas &horisontaal"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Collapse All Tracks"
+msgstr "&Tydbaan"
+
+#: src/menus/ViewMenus.cpp
+msgid "E&xpand Collapsed Tracks"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "Sk&ip to"
 msgstr "Spring na einde"
 
@@ -6120,12 +14398,57 @@ msgid "Skip to Selection End"
 msgstr "na einde van seleksie"
 
 #: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
 msgstr "Wys aftopping"
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "&Effek"
 
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr " venster"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Opneem"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -6133,7 +14456,7 @@ msgstr "Voorkeure..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Sluit Audacity af"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -6141,9 +14464,26 @@ msgstr "Sluit Audacity af"
 msgid "&Check for Updates"
 msgstr "Gaan &afhanklikhede na..."
 
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+msgid "Batch"
+msgstr ""
+
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
 msgstr "Voorkeure..."
+
+#: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Behaviors"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "Toestel:"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
@@ -6155,7 +14495,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Koppelvlak"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "Using:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Terugspeel"
 
@@ -6171,7 +14521,12 @@ msgstr "Toestel:"
 msgid "Cha&nnels:"
 msgstr "Kanaal"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp
+msgid "Latency"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "millisekondes"
 
@@ -6184,6 +14539,15 @@ msgid "&Latency compensation:"
 msgstr "Sleutelkombinasie"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Oudiobane verwyder"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "1 (mono)"
 
@@ -6192,17 +14556,37 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Gidse"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Herwin projekte"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Gidse"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Blaai..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -6230,6 +14614,20 @@ msgid "&Macro output:"
 msgstr "Wys afvoer"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "Nuwe tydelike gids"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Aksie"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
 msgstr "Blaai..."
 
@@ -6242,8 +14640,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Kies 'n ligging vir die tydelike gids"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "&Kies opdrag"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -6261,8 +14668,14 @@ msgstr "Gids %s is nie skryfbaar nie"
 
 # Punt aan einde van sin?
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Verandering aan die tydelike gids word eers effektief wanneer Tenacity oor begin"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Nuwe tydelike gids"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -6272,11 +14685,36 @@ msgstr "Voorkeure..."
 msgid "Sorted by Effect Name"
 msgstr "Sorteer volgens naam"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Sorteer volgens naam"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Sorteer volgens naam"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&Effek"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -6286,17 +14724,141 @@ msgstr "&Effek"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "&Effek"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Effek-opstelling"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Inprop 1 tot %i"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Vinnige \"sinc\"-interpolasie"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+# Opdrag of s.nw.?
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Voer in"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Voorkeure..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Mime-types"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Voer etikette uit as:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Skuif &op"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Skuif &af"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "Skuif &op"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Skuif &af"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Die seleksie word as Ogg Vorbis uitgevoer"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Ligging vir uitvoer:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Kies"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "Wil u definitief '%s' uitvee?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Opgeneemde oudio"
 
 # Opdrag of s.nw.?
 #: src/prefs/ExtImportPrefs.h
@@ -6322,6 +14884,11 @@ msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (PCM-omvang van 8-bis-monsters)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (PCM-omvang van 16-bis-monsters)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
 msgstr "-96 dB (PCM-omvang van 16-bis-monsters)"
 
@@ -6341,6 +14908,102 @@ msgstr "-120 dB (omtrent tot waar 'n mens hoor)"
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (PCM-omvang van 24-bis-monsters)"
 
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Aksie"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "From Internet"
+msgstr "Hulp op die Internet"
+
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "Display"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Taal:"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "Ligging van %s:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Golfvorm (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "-help (hierdie boodskap)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Inprop 1 tot %i"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Wysigbalk"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "Voer etikette uit as:"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Voorkeure..."
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
 msgstr "&Stereo na mono"
@@ -6354,6 +15017,10 @@ msgid "S&tandard"
 msgstr "Standaard"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
 msgstr "millisekondes"
 
@@ -6362,12 +15029,29 @@ msgid "&Beats"
 msgstr "Herhaal"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "S&how Metadata Tags editor before export"
 msgstr "Wysig metadata"
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Voer etikette uit as:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -6379,12 +15063,70 @@ msgid "Preferences for KeyConfig"
 msgstr "Voorkeure..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Key Bindings"
+msgstr "Sleutelkombinasie"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "View by:"
 msgstr "&Aansig"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Naam"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Aansig"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Aansig"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Aansig"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Bindings"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Keuses..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -6399,7 +15141,15 @@ msgid "&Defaults"
 msgstr "&Verstekwaardes"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Kies 'n XML-lêer wat Tenacity-snelsleutels bevat..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -6408,8 +15158,21 @@ msgstr "Voer sleutelbord-kortpaaie uit as:"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d snelsleutels gelaai\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -6423,6 +15186,38 @@ msgstr "Voer sleutelbord-kortpaaie uit as:"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Voer sleutelbord-kortpaaie uit as:"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "Sleutelkombinasie"
@@ -6432,12 +15227,72 @@ msgid "Preferences for Library"
 msgstr "Voorkeure..."
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "MP3-biblioteekweergawe:"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "MP3-biblioteekweergawe:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "LOF-fout"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "&Stoor..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "MP3-lêers"
 
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "Voorkeure..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Koppelvlak"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -6445,18 +15300,78 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Koppelvlak"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Die minimum frekwensie moet 'n heelgetal wees"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "Voorkeure..."
 
+#: src/prefs/ModulePrefs.cpp
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
 # Punt aan einde van sin?
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Verandering aan die tydelike gids word eers effektief wanneer Tenacity oor begin"
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "Vra my"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -6498,13 +15413,26 @@ msgstr "Links sleep"
 msgid "Set Selection Range"
 msgstr "Stel seleksie-omvang"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-links-klik"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Extend Selection Range"
 msgstr "Vergroot seleksie-omvang"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Links klik"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "Seleksie tot einde"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
@@ -6523,6 +15451,11 @@ msgid "Zoom in on a Range"
 msgstr "Zoem in op gebied"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "same as right-drag"
+msgstr "Selfde as links sleep"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Right-Click"
 msgstr "Regs klik"
 
@@ -6539,12 +15472,55 @@ msgid "same as left-drag"
 msgstr "Selfde as links sleep"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Links sleep"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Zoom out on a Range"
 msgstr "Zoem in op gebied"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Links klik"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom default"
+msgstr "&Verstekwaardes"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip left/right or between tracks"
+msgstr "Skuif baan op"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Left-Drag"
+msgstr "Links sleep"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
 msgstr "Links sleep"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip up/down between tracks"
+msgstr "Skuif baan op"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Links sleep"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -6596,6 +15572,11 @@ msgid "Scroll tracks up or down"
 msgstr "Rol op of af"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Wheel-Rotate"
+msgstr "Muiswielietjie"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Scroll waveform"
 msgstr "Golfvorm"
 
@@ -6620,12 +15601,60 @@ msgid "Preferences for Playback"
 msgstr "Voorkeure..."
 
 #: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Effects Preview"
+msgstr "&Voorskou"
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "&Length:"
 msgstr "Lengte"
 
+#. i18n-hint: (noun) this is a preview of the cut
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Cut Preview"
+msgstr "&Voorskou"
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Tenacity-voorkeure"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -6636,8 +15665,18 @@ msgid "Preferences for Quality"
 msgstr "Voorkeure..."
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Ander..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "Monsterfrekwensie:"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Rate:"
@@ -6646,6 +15685,35 @@ msgstr "Verstek monsterfrekwensie:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Format:"
 msgstr "Verstek monsterformaat:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Monsterfrekwensie:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Con&verter:"
+msgstr "Monsterfrekwensie:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+msgid "High-quality Conversion"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Conver&ter:"
+msgstr "Monsterfrekwensie:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -6660,8 +15728,30 @@ msgid "Preferences for Recording"
 msgstr "Voorkeure..."
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Nuwe baan"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Opneem"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -6672,9 +15762,19 @@ msgstr "Vlak:"
 msgid "Name newly recorded tracks"
 msgstr "Nuwe stereo oudiobaan gemaak"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Baannaam"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Etiket gewysig"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -6684,11 +15784,67 @@ msgstr "Opgeneemde oudio"
 msgid "&Track Number"
 msgstr "Baannommer"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "System &Date"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Voorkeure..."
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Notebaan"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "256 - standaard"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "256 - standaard"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "Lineêr"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -6700,14 +15856,42 @@ msgstr "Lineêr"
 msgid "Frequencies"
 msgstr "Frekwensie (Hz)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Toonhoogte (EAC)"
 
 #: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Minimum frekwensie moet ten minste 0 Hz wees"
+
+#: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "Minimum frekwensie moet ten minste 0 Hz wees"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Minimum frekwensie moet ten minste 0 Hz wees"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "Minimum frekwensie moet ten minste 0 Hz wees"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -6726,6 +15910,10 @@ msgstr "Voorkeure..."
 msgid "&Use Preferences"
 msgstr "Voorkeure..."
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "Minimum frekwensie (Hz):"
@@ -6733,6 +15921,24 @@ msgstr "Minimum frekwensie (Hz):"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "Maksimum frekwensie (Hz):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Afvoerkanale: %2d"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Vlak:"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -6743,6 +15949,11 @@ msgid "A&lgorithm:"
 msgstr "Algoritme:"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &size:"
+msgstr " venster"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "8 - most wideband"
 msgstr "64 - wyeband"
 
@@ -6751,8 +15962,53 @@ msgid "1024 - default"
 msgstr "256 - standaard"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "32768 - most narrowband"
+msgstr "64 - wyeband"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr " venster"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Dempingsfaktor:"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Plaas seleksiepunt"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "Nuwe piekamplitude (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -6770,6 +16026,36 @@ msgstr "Die maksimum frekwensie moet 'n heelgetal wees"
 msgid "The minimum frequency must be an integer"
 msgstr "Die minimum frekwensie moet 'n heelgetal wees"
 
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Die maksimum frekwensie moet 'n heelgetal wees"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Die maksimum frekwensie moet 'n heelgetal wees"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Die maksimum frekwensie moet 'n heelgetal wees"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Die minimum frekwensie moet 'n heelgetal wees"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Die maksimum frekwensie moet 'n heelgetal wees"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Die maksimum frekwensie moet 'n heelgetal wees"
+
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
 #. such as those on button controls.  Audacity can load and save alternative
@@ -6781,6 +16067,72 @@ msgstr "Tema"
 #: src/prefs/ThemePrefs.cpp
 msgid "Preferences for Theme"
 msgstr "Voorkeure..."
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Info"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Save Files"
+msgstr "Benoem lêers:"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Load Files"
+msgstr "FLAC-lêers"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+msgid "Tracks Behaviors"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "Voorkeure..."
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "Monsterfrekwensie:"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -6801,8 +16153,33 @@ msgid "Enable &dragging selection edges"
 msgstr "Maak seleksie stil"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Gevorderde mengkeuses"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Knoppie"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -6816,6 +16193,14 @@ msgstr "Golfvorm"
 msgid "Spectrogram"
 msgstr "Spektrogramme"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "Pas &horisontaal"
@@ -6827,6 +16212,10 @@ msgstr "&Zoem in op seleksie"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "&Verstekwaardes"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -6849,6 +16238,16 @@ msgid "50ths of Seconds"
 msgstr "millisekondes"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "millisekondes"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "millisekondes"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "millisekondes"
 
@@ -6856,7 +16255,12 @@ msgstr "millisekondes"
 msgid "Samples"
 msgstr "Monsterfrekwensie:"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoem"
 
@@ -6865,12 +16269,42 @@ msgid "Preferences for Tracks"
 msgstr "Voorkeure..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Opneem"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "Verstek monsterfrekwensie:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Verstek monsterformaat:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "Monsterfrekwensie:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -6893,9 +16327,46 @@ msgstr "Eerste lêernaam:"
 msgid "Preset 2:"
 msgstr "Eerste lêernaam:"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "Waarskuwing"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "Voorkeure..."
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&Stoor projek"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&Stoor projek"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "&Stereo na mono"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "&Stereo na mono"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -6918,16 +16389,24 @@ msgid "Stopped"
 msgstr "Stop"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pouseer"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Spring na begin"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Spring na einde"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pouseer"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Seleksie na begin"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Seleksie tot einde"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -6941,20 +16420,24 @@ msgstr "Nuwe baan"
 msgid "Append Record"
 msgstr "Neem op"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Seleksie tot einde"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Seleksie na begin"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pouseer"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Wysigbalk"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -6965,6 +16448,11 @@ msgstr "Terugspeel"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Opneem"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "&Oudio..."
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -6987,8 +16475,17 @@ msgid "Select Playback Device"
 msgstr "Terugspeel"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Stilte"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Regterkanaal"
+
+#: src/toolbars/DeviceToolBar.cpp
+msgid "Device information is not available."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -7012,11 +16509,22 @@ msgstr "Knip alles buite seleksie weg"
 msgid "Silence audio selection"
 msgstr "Maak seleksie stil"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "&Bane"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zoem in"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zoem uit"
 
@@ -7028,10 +16536,20 @@ msgstr "Pas seleksie in venster"
 msgid "Fit project to width"
 msgstr "Pas projek in venster"
 
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "&Effek"
+
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
 msgid "&Edit Toolbar"
 msgstr "Wysigbalk"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "Opneem"
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Meter"
@@ -7040,6 +16558,22 @@ msgstr "Opneem"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "Terugspeel"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "Neem op"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Play"
+msgstr "Meter"
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Level"
@@ -7061,38 +16595,24 @@ msgstr "Meterbalk"
 msgid "&Playback Meter Toolbar"
 msgstr "Terugspeel"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Opneem"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Terugspeel"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Wysigbalk"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Opneem"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Terugspeel"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Terugspeel"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Mengbalk"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Nyquist-opdraglyn..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Nyquist-opdraglyn..."
@@ -7100,6 +16620,7 @@ msgstr "Nyquist-opdraglyn..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Nyquist-opdraglyn..."
@@ -7107,9 +16628,24 @@ msgstr "Nyquist-opdraglyn..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "na einde van seleksie"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "na einde van seleksie"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Wysigbalk"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -7124,6 +16660,10 @@ msgstr "na begin van seleksie"
 #: src/toolbars/SelectionBar.cpp
 msgid "Snap-To"
 msgstr "[Inskiet aan]"
+
+#: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
+msgid "Audio Position"
+msgstr ""
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
@@ -7141,14 +16681,38 @@ msgstr "na einde van seleksie"
 msgid "Length and Center of Selection"
 msgstr "Knip seleksie uit"
 
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Snap To"
+msgstr "[Inskiet aan]"
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Length"
 msgstr "Lengte"
 
 # Weet nie of dit ww. of s.nw. is nie.
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Middel"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -7175,6 +16739,10 @@ msgstr "Basfrekwensies word versterk..."
 msgid "Center Frequency"
 msgstr "Lineêre frekwensie"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -7193,13 +16761,18 @@ msgstr "Toestelbalk"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Tenacity-redigeerbalk"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Klik en sleep om die grootte van die baan te wysig."
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Funksieknop"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -7217,13 +16790,19 @@ msgstr "Verskuif tyd"
 msgid "Zoom Tool"
 msgstr "Vergrootglas"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Tekenpen"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Multi-Tool"
 msgstr "Kombinasiewerktuig"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "Merker"
 
 #. i18n-hint: Clicking this menu item shows a toolbar
 #. that has some tools in it
@@ -7263,17 +16842,42 @@ msgstr "Vorige gereedskap"
 msgid "&Next Tool"
 msgstr "Volgende gereedskapstuk"
 
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "Snelheid word aangepas"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Playback Speed"
+msgstr "Terugspeel"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "Speel"
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
 #: src/toolbars/TranscriptionToolBar.cpp
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "Terugspeel"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Etiket gewysig"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Etiket gewysig"
 
@@ -7293,6 +16897,12 @@ msgstr "Etiketbaan-skriftipe"
 #. i18n-hint: (noun) The name of the typeface
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Face name"
+msgstr "Her&noem"
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
 msgstr "Her&noem"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -7316,34 +16926,50 @@ msgid "Deleted Label"
 msgstr "DeleteKey"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Edited labels"
+msgstr "Etiket gewysig"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "New label"
 msgstr "Etiket bygevoeg"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Oktaaf hoër"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Oktaaf laer"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klik om vertikaal in te zoem,  Shift-klik om uit te zoem,  Sleep om 'n spesifieke  zoemstreek te maak."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Regs klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zoem uit"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-links-klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-links-klik"
 
@@ -7365,9 +16991,44 @@ msgstr "Notebaan"
 msgid "Stretch"
 msgstr "Dempingsfaktor:"
 
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "Wys aftopping"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Expand"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Removed Cut Line"
+msgstr "Verwyder baan"
+
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Click and drag to edit the samples"
 msgstr "Klik en sleep om die monsters te wysig."
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
@@ -7377,6 +17038,11 @@ msgstr "Monster geskuif"
 msgid "Sample Edit"
 msgstr "Monsterwysiging"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Zoem in op punt"
@@ -7384,6 +17050,16 @@ msgstr "Zoem in op punt"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Spektrogramme"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -7402,9 +17078,15 @@ msgstr "Tempo word aangepas"
 msgid "Processing...   0%%"
 msgstr "Notebaan"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   %i%%"
+msgstr "Notebaan"
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' gewysig na %s"
@@ -7417,6 +17099,54 @@ msgstr "Formaatverandering"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Stel tempo"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -7437,7 +17167,8 @@ msgstr "Tempoverandering"
 msgid "Set Rate"
 msgstr "Stel tempo"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Verskeie"
 
@@ -7456,6 +17187,11 @@ msgstr "Verdeel stereo baan"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "&Stereo na mono"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -7527,6 +17263,27 @@ msgstr "Links, "
 msgid "Right, %dHz"
 msgstr "Regs, "
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "regs"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "Klik en sleep om die relatiewe grootte van stereo bane te verstel."
@@ -7534,6 +17291,15 @@ msgstr "Klik en sleep om die relatiewe grootte van stereo bane te verstel."
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "Klik en sleep om 'n baan in tyd te skuif."
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Klik en sleep om 'n baan in tyd te skuif."
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -7543,6 +17309,10 @@ msgstr "Zoem in"
 msgid "Zoom x2"
 msgstr "Zoem"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "Golfvorm"
@@ -7550,6 +17320,11 @@ msgstr "Golfvorm"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Golfvorm"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -7582,12 +17357,38 @@ msgid "Set Range"
 msgstr "Stel omvang"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Display"
+msgstr "Volgende gereedskapstuk"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Vinnige \"sinc\"-interpolasie"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "Lineêr"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Vinnige \"sinc\"-interpolasie"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -7599,9 +17400,8 @@ msgstr "Vinnige \"sinc\"-interpolasie"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klik en sleep om 'n baan in tyd te skuif."
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -7652,6 +17452,20 @@ msgstr "Omhulling aangepas."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+msgid "&Scrub"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "na einde van seleksie"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Wysigbalk"
@@ -7667,6 +17481,16 @@ msgstr "Skuif baan op"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Skuif baan af"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Nyquist-opdraglyn..."
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Spring na begin"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -7719,9 +17543,19 @@ msgstr "Klik en sleep om oudio te selekteer"
 msgid "Click and drag to select audio"
 msgstr "Klik en sleep om oudio te selekteer"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Klik en sleep om 'n baan in tyd te skuif."
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Could not shift between tracks"
+msgstr "Kon nie skryf na lêer nie:\n"
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Moved clips to another track"
@@ -7736,6 +17570,10 @@ msgstr "Gekose bane stilgemaak vir %.2f sekonde vanaf %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Gekose bane stilgemaak vir %.2f sekonde vanaf %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -7762,6 +17600,12 @@ msgstr "&Opdrag"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Links klik"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Nuwe oudiobaan gemaak"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -7802,21 +17646,103 @@ msgstr "Links=Inzoem, Regs=Uitzoem, Middel=Normaal"
 msgid "(disabled)"
 msgstr " (gedeaktiveer)"
 
+#: src/widgets/AButton.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Press"
+msgstr "Eerste lêernaam:"
+
 #: src/widgets/AButton.cpp
 msgid "Button"
 msgstr "Knoppie"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" bestaan nie.\n"
+"\n"
+"Wil u dit skep?"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy
+msgid "Please choose an existing file."
+msgstr "Nuwe oudiobaan gemaak"
+
+#: src/widgets/FileDialog/mac/FileDialogPrivate.mm
+#, fuzzy
+msgid "File type:"
+msgstr "Uitdoof"
+
 #: src/widgets/FileHistory.cpp
 msgid "&Clear"
 msgstr "&Maak skoon"
+
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
 
 #: src/widgets/Grid.cpp
 msgid "Empty"
 msgstr "Leeg"
 
 #: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Spring na begin"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Hulp op die Internet"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Alle lêers (*)|*"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click to Start Monitoring"
+msgstr "Spring na begin"
+
+#: src/widgets/Meter.cpp
+msgid "Click for Monitoring"
+msgstr ""
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start"
@@ -7825,6 +17751,16 @@ msgstr "Spring na begin"
 #: src/widgets/Meter.cpp
 msgid "Click"
 msgstr "Links klik"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Stop Monitoring"
+msgstr "Nyquist-opdraglyn..."
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Start Monitoring"
+msgstr "Nyquist-opdraglyn..."
 
 #: src/widgets/Meter.cpp
 msgid "Recording Meter Options"
@@ -7840,8 +17776,27 @@ msgid "Refresh Rate"
 msgstr "Stel tempo"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Style"
 msgstr "Meter"
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
 
 #: src/widgets/Meter.cpp
 msgid "Meter Type"
@@ -7851,6 +17806,11 @@ msgstr "Meter"
 msgid "Orientation"
 msgstr "Duur"
 
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Outomatiese herstel na omval"
+
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
 msgstr "Horisontale stereo"
@@ -7859,11 +17819,241 @@ msgstr "Horisontale stereo"
 msgid "Vertical"
 msgstr "Pas &vertikaal"
 
+#: src/widgets/Meter.cpp
+msgid " Monitoring "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Nuwe oudiobaan gemaak"
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + hundredths"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>0100 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + milliseconds"
+msgstr "millisekondes"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>01000 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + samples"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+># samples"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "Monsterfrekwensie:"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + film frames (24 fps)"
+msgstr "filmrame 24 rame/sekonde"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr ""
+
 #. i18n-hint: Name of time display format that shows time in frames (lots of
 #. * frames) at 24 frames per second (commonly used for films)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "film frames (24 fps)"
 msgstr "filmrame 24 rame/sekonde"
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr "PAL-rame 25 rame/sek"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr ""
 
 #. i18n-hint: Name of time display format that shows time in frames at PAL
 #. * TV frame rate (used for European TV)
@@ -7871,11 +18061,159 @@ msgstr "filmrame 24 rame/sekonde"
 msgid "PAL frames (25 fps)"
 msgstr "PAL-rame 25 rame/sek"
 
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr "PAL-rame 25 rame/sek"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "CDDA frames (75 fps)"
+msgstr "PAL-rame 25 rame/sek"
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
 msgid "octaves"
 msgstr "Oktaaf laer"
+
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "Lengte (sekondes)"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Saamdruktyd: %.1f sek"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "Eindtyd"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Cancel"
+msgstr "&Kanselleer"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to cancel?"
@@ -7907,6 +18245,11 @@ msgstr "Bevestig"
 msgid "Unable to write files to directory: %s."
 msgstr "Kon nie toetslêer open/skep nie"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -7922,14 +18265,44 @@ msgstr "Herwin projekte"
 msgid "Don't show this warning again"
 msgstr "Moenie dié waarskuwing weer wys nie"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
 #: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Leeg"
 
 #: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Neem op"
+
+#: src/widgets/valnum.cpp
 #, fuzzy, c-format
 msgid "Not in range %d to %d"
 msgstr "Zoem in op gebied"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "LOF-fout"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -7947,12 +18320,26 @@ msgid "Value must not be greater than %s"
 msgstr "Naam mag nie leeg wees nie"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Nuwe projek gemaak"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
 msgstr "Gidse"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "Gidse"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "Fout: "
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
@@ -7967,16 +18354,49 @@ msgstr "Kon nie lêer open nie:"
 msgid "Spectral edit multi tool"
 msgstr "Plaas seleksiepunt"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Lengte"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Frekwensie (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Fout"
@@ -7991,8 +18411,34 @@ msgstr "Afvoerkanale: %2d"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Minimum frekwensie moet ten minste 0 Hz wees"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -8005,6 +18451,32 @@ msgstr "Uitdoof"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Pas tans toe..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -8027,8 +18499,16 @@ msgid "S-Curve Down"
 msgstr "Skuif &af"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Begin"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -8037,6 +18517,14 @@ msgstr "Versterking"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Begin"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -8049,6 +18537,14 @@ msgstr "Lineêr"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Lineêr"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -8087,6 +18583,24 @@ msgstr "Skuif &af"
 msgid "Error~%~%"
 msgstr "Fout"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Herhaal"
@@ -8094,6 +18608,10 @@ msgstr "Herhaal"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Stilte..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity-redigeerbalk"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -8107,6 +18625,23 @@ msgstr "Merker regs"
 msgid "Reconstructing clips..."
 msgstr "Pop- klikklanke word verwyder..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Drempel: %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Notebaan"
@@ -8114,6 +18649,21 @@ msgstr "Notebaan"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Notebaan"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -8147,6 +18697,19 @@ msgstr "Baannaam"
 msgid "Fade direction"
 msgstr "Indoof"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Uitdoof"
@@ -8164,6 +18727,19 @@ msgid "Regular"
 msgstr "Reghoekig"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Vlak:"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Vertraging (sekondes):"
 
@@ -8176,12 +18752,24 @@ msgid "Pitch/Tempo"
 msgstr "Toonhoogte (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
 msgstr "&Voorskou"
 
 #: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "Aantal herhalings: "
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -8196,18 +18784,40 @@ msgid "XML file"
 msgstr "MP3-lêers"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "Neem op"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Kon nie genre-lêer open nie."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Fout (lêer is dalk nie geskryf nie): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Fout (lêer is dalk nie geskryf nie): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -8238,18 +18848,67 @@ msgstr "Lengte (sekondes)"
 msgid "Length of label region (seconds)"
 msgstr "Lengte (sekondes)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Etiket gewysig"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "Sleutelkombinasie"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "Waarskuwing"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -8259,6 +18918,17 @@ msgstr "Etiket bygevoeg"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Voer etikette in"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -8272,13 +18942,46 @@ msgstr "Gelykstelling word toegepas"
 msgid "Dominic Mazzoni"
 msgstr "Ruisverwydering, deur Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekwensie (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Minimum frekwensie moet ten minste 0 Hz wees"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -8302,6 +19005,11 @@ msgid "Average level"
 msgstr "Gemiddeld"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "Terugspeel"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "Toongenerator"
 
@@ -8314,14 +19022,64 @@ msgid "Label type"
 msgstr "Etiket gewysig"
 
 #: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Point after sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Stilte..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Stilte..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Naam mag nie leeg wees nie"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -8349,8 +19107,25 @@ msgid "Hard Clip"
 msgstr "Wys aftopping"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Regterkanaal"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Vlak:"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -8373,11 +19148,24 @@ msgid "Select Function"
 msgstr "Frekwensie (Hz)"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Stereo Linking"
 msgstr "Stereo"
 
 #: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
+msgstr "Maak stereo baan"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
 msgstr "Maak stereo baan"
 
 #: plug-ins/noisegate.ny
@@ -8400,6 +19188,44 @@ msgstr "Saamdruktyd: "
 msgid "Decay (ms)"
 msgstr "Vertraging (sekondes):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Naam mag nie leeg wees nie"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Pas tans toe..."
@@ -8407,6 +19233,22 @@ msgstr "Pas tans toe..."
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "Pas tans toe..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -8429,7 +19271,8 @@ msgstr "MP3-lêers"
 msgid "HTML file"
 msgstr "MP3-lêers"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Benoem lêers:"
 
@@ -8446,9 +19289,24 @@ msgid "Disallow"
 msgstr "Gedeaktiveer"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Gedeaktiveer"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Kon nie '%s' skrap nie"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -8459,16 +19317,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Kies 'n MIDI-lêer"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Ligging vir uitvoer:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Kies 'n MIDI-lêer"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Toon word gegenereer"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Uitdoof"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -8483,8 +19383,40 @@ msgid "Generating Rhythm..."
 msgstr "Toon word gegenereer"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Aantal herhalings: "
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -8507,12 +19439,54 @@ msgid "Beat sound"
 msgstr "Herhaal"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Ruis word verwyder"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Links klik"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -8523,12 +19497,25 @@ msgid "Generating Risset Drum..."
 msgstr "Toon word gegenereer"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Vertraging (sekondes):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "Lineêre frekwensie"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Frekwensie (Hz)"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -8541,6 +19528,10 @@ msgstr "Monsterwysiging"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Pas tans toe..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -8559,6 +19550,10 @@ msgid "HTML files"
 msgstr "MP3-lêers"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Monsterwysiging"
 
@@ -8567,8 +19562,34 @@ msgid "Time Indexed"
 msgstr "Etiket gewysig"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Kon nie toetslêer open/skep nie"
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "&Alles"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -8583,6 +19604,11 @@ msgstr "-help (hierdie boodskap)"
 msgid "Errors Only"
 msgstr "Fout: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -8595,6 +19621,46 @@ msgstr "Regterkanaal"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "Monsterfrekwensie:"
 
@@ -8602,6 +19668,43 @@ msgstr "Monsterfrekwensie:"
 #, lisp-format
 msgid "~a seconds."
 msgstr "millisekondes"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -8620,6 +19723,10 @@ msgid "Value (dB)"
 msgstr "Vlak:"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Lineêr"
 
@@ -8636,6 +19743,14 @@ msgid "Right (dB)"
 msgstr "Regs, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Lineêr"
 
@@ -8647,17 +19762,87 @@ msgstr "2 kanale (stereo)"
 msgid "1 channel (mono)"
 msgstr "1 kanaal (mono)"
 
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Fout (lêer is dalk nie geskryf nie): %s"
+
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
 msgstr "Monsterfrekwensie:"
+
+#: plug-ins/sample-data-import.ny
+msgid "Reading and rendering samples..."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Select file"
 msgstr "Kies 'n MIDI-lêer"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Fout"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -8667,6 +19852,15 @@ msgstr "Kon nie genre-lêer open nie."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Plaas seleksiepunt"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -8684,9 +19878,21 @@ msgstr "Saagtand"
 msgid "Starting phase (degrees)"
 msgstr "LFO-beginfase (grade):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Pas tans toe..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -8731,6 +19937,98 @@ msgstr "A&naliseer"
 msgid "Strength"
 msgstr "Lengte"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Processing Vocoder..."
+msgstr "Notebaan"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Output choice"
 msgstr "Afvoertoestel"
@@ -8762,3 +20060,102 @@ msgstr "Frekwensie (Hz)"
 #: plug-ins/vocoder.ny
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Frekwensie (Hz)"
+
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Sluit Tenacity af"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Kanaal"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s-redigeerbalk"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Opneem"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Opdrag:"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Kon nie genre-lêer open nie.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Opneem\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Terugspeel\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Opneem\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Opneem\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Terugspeel\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Terugspeel\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Kon nie toetslêer open/skep nie"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Kon nie '%s' na '%s' hernoem nie"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Kon nie toetslêer open/skep nie"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Terugspeel"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Terugspeel"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Terugspeel"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Opneem"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Opneem"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Opneem"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Aangaande Tenacity..."
+
+#~ msgid "Recording Volume"
+#~ msgstr "Opneem"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Terugspeel"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Opneem"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Terugspeel"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Terugspeel"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klik en sleep om 'n baan in tyd te skuif."

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -10,54 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Arabic <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"ar/>\n"
+"Language-Team: Arabic <https://hosted.weblate.org/projects/tenacity/tenacity/ar/>\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
-"&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "اخرج من Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "القناة"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "خطأ في حل شفرة الملف"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "خطأ في تحميل ما وراء المعطيات"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "شريط أدوات %s Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "التسجيل"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -67,6 +29,24 @@ msgstr "غير قادر على تحديد"
 #, c-format
 msgid "%s bytes"
 msgstr "بايتات"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -193,7 +173,8 @@ msgid "Script"
 msgstr "نص"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "مخرجات"
 
@@ -209,7 +190,12 @@ msgstr "نصوص Nyquist (*.ny)|*.ny|نصوص Lisp (*.lsp)|*.lsp|جميع الم
 msgid "Script was not saved."
 msgstr "لم يحفظ النص."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "تحذير"
 
@@ -230,11 +216,17 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "مجلد أيقونات Tango (أيقونات شريط الأدوات)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 بواسطة Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 بواسطة Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "وحدة Tenacity خارجية توفر بيئة تطوير متكاملة لكتابة التأثيرات."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -257,7 +249,8 @@ msgstr "غير معنون"
 msgid "Nyquist Effect Workbench - "
 msgstr "نضد عمل تأثير Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "جديد"
 
@@ -297,7 +290,8 @@ msgstr "انسخ"
 msgid "Copy to clipboard"
 msgstr "انسخ إلى الحافظة"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "قص"
 
@@ -305,7 +299,8 @@ msgstr "قص"
 msgid "Cut to clipboard"
 msgstr "قص إلى الحافظة"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "الصق"
 
@@ -330,7 +325,8 @@ msgstr "اختر الجميع"
 msgid "Select all text"
 msgstr "اختر جميع النصوص"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "تراجع"
 
@@ -338,7 +334,8 @@ msgstr "تراجع"
 msgid "Undo last change"
 msgstr "تراجع عن التغيير الأخير"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "كرر"
 
@@ -395,7 +392,8 @@ msgid "Go to next S-expr"
 msgstr "اذهب إلى تعبير رمزي تال"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "بداية"
 
@@ -403,7 +401,8 @@ msgstr "بداية"
 msgid "Start script"
 msgstr "ابدأ النص"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "توقف"
 
@@ -418,7 +417,8 @@ msgid "About %s"
 msgstr "حول"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "حسنا"
 
@@ -426,11 +426,13 @@ msgstr "حسنا"
 msgid "Build Information"
 msgstr "معلومات الصيغة"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "ممَكن"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "غير ممَكن"
 
@@ -440,8 +442,9 @@ msgid "The Build"
 msgstr "صيغة تنقيح"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "معرف التسليم:"
+#, fuzzy
+msgid "Version:"
+msgstr "إصدار"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -451,22 +454,28 @@ msgstr "نوع الصيغة:"
 msgid "Compiler:"
 msgstr "المجمع:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "بادئة التثبيت:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "مجلد الأوضاع: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "مجلد الأوضاع: "
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "دعم صيغة الملف"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "مكتبة واجهة مستخدم رسومية متعددة-المنصات"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -480,7 +489,6 @@ msgstr "تحويل معدل العينة"
 msgid "MP3 Importing"
 msgstr "استوراد MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "استيراد و تصدير Ogg Vorbis"
@@ -489,7 +497,6 @@ msgstr "استيراد و تصدير Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "دعم علامة ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "استيراد و تصدير FLAC"
@@ -507,14 +514,6 @@ msgid "FFmpeg Import/Export"
 msgstr "استيراد/تصدير FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "استورد عبر GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "الميزات"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "دعم البرامج المساعدة"
 
@@ -529,6 +528,10 @@ msgstr "دعم تغيير الطبقة و درجة السرعة"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "دعم تغيير الطبقة و درجة السرعة المفرط"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "الميزات"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -647,6 +650,10 @@ msgstr "رسوميات"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (يتضمن %s، %s، %s، %s و %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -656,6 +663,10 @@ msgstr "Tenacity برنامج مجاني، مفتوح المصدر، متعدد-
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "تقدير"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -706,6 +717,7 @@ msgstr "الموقع و الرسوميات"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "الترجمة العربية من قبل حسام الحمصي."
@@ -723,6 +735,22 @@ msgstr "شكر خاص:"
 #, c-format
 msgid "%s website: "
 msgstr "موقع Tenacity الشبكي: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "المساهمون"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -745,6 +773,7 @@ msgstr "خط الزمن"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "انقر أو اسحب لتبدأ القصد"
@@ -752,6 +781,7 @@ msgstr "انقر أو اسحب لتبدأ القصد"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "انقر أو اسحب لتبدأ الفرك"
@@ -759,6 +789,7 @@ msgstr "انقر أو اسحب لتبدأ الفرك"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "انقر و حرك لتفرك . انقر و اسحب لتقصد."
@@ -766,6 +797,7 @@ msgstr "انقر و حرك لتفرك . انقر و اسحب لتقصد."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "حرك لتقصد"
@@ -773,6 +805,7 @@ msgstr "حرك لتقصد"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "حرك لتفرك"
@@ -827,7 +860,17 @@ msgid ""
 "end of project."
 msgstr "لا أستطيع قفل المنطقة بعد نهاية المشروع."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "خطأ"
 
@@ -851,7 +894,8 @@ msgstr ""
 "هذا سؤال مرة واحدة، بعد 'تثبيت' طلبت فيه أن يعاد تعيين التفضيلات."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "أعد تعيين تفضيلات Tenacity"
 
 #: src/AudacityApp.cpp
@@ -864,6 +908,10 @@ msgstr ""
 "لم يتمكن من العثور على %s.\n"
 "\n"
 "لقد تمت إزالته من قائمة الملفات الحديثة."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -888,7 +936,7 @@ msgstr "افتح..."
 msgid "Open &Recent..."
 msgstr "فتح ملف حديث..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "حول Audacity..."
@@ -902,9 +950,10 @@ msgid "&File"
 msgstr "ملف"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity لم يجد مكانا آمنا لتخزين الملفات المؤقتة.\n"
@@ -912,20 +961,23 @@ msgstr ""
 "من فضلك أدخل مجلدا مناسبا لهذه الملفات في حوار التفضيلات."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity لم يتمكن من إيجاد مكان لتخزين الملفات المؤقتة.\n"
 "من فضلك أدخل مجلدا مناسبا في حوار التفضيلات."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "سيتم الخروج من Tenacity الآن. من فضلك شغل Tenacity مرة أخرى لكي تستخدم المجلد المؤقت الجديد."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -934,15 +986,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "لم يستطع Tenacity من إقفال مجلد الملفات المؤقتة.\n"
 "يُحتمل أن نسخة أخرى من Tenacity تستخدم هذا المجلد.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "هل لا تزال تريد بدأ Tenacity؟"
 
 #: src/AudacityApp.cpp
@@ -950,24 +1004,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "خطأ في إقفال وجهة الملفات المؤقتة"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "كشف النظام أن هناك نسخة أخرى من Tenacity قيد الاستخدام.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "استخدم أوامر \"جديد\" أو \"فتح\" في Tenacity الذي قيد الاستخدام حاليا \n"
 "أكمل لفتح عدة مشاريع معا.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity يشتغل الآن"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "ملفات مشروع Tenacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -987,7 +1089,8 @@ msgstr "شغل التشخيصات الذاتية"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "اعرض إصدار Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -997,9 +1100,10 @@ msgid "audio or project file name"
 msgstr "اسم ملف صوتي أو مشروع"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1012,24 +1116,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "ملفات مشروع Tenacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "رسالة"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "تعديلات Tenacity المظلم"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "مساعدة"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "اخرج من Tenacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "سجل Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1041,7 +1169,8 @@ msgstr "حفظ..."
 msgid "Cl&ear"
 msgstr "مسح"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "إغلاق"
 
@@ -1092,7 +1221,8 @@ msgid "Error Initializing Midi"
 msgstr "خطأ في بدء MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "سجل Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1108,36 +1238,9 @@ msgstr ""
 msgid "Out of memory!"
 msgstr "نفذت الذاكرة!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "توقف تعديل مستوى الصوت المؤتمت. لم بكن ممكنا تحسينه أكثر. لا يزال أعلى مما ينبغي."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "أنقص تعديل مستوى الصوت المؤتمت الحجم إلى %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "توقف تعديل مستوى الصوت المؤتمت. لم بكن ممكنا تحسينه أكثر. لا يزال أخفض مما ينبغي."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "زاد تعديل مستوى الصوت المؤتمت الحجم إلى %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "توقف تعديل مستوى الصوت المؤتمت. تخطي العدد الإجمالي للتحليلات بدون إيجاد حجم مقبول. لا يزال أعلى مما ينبغي."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "توقف تعديل مستوى الصوت المؤتمت. تخطي العدد الإجمالي للتحليلات بدون إيجاد حجم مقبول. لا يزال أخفض مما ينبغي."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "توقف تعديل مستوى الصوت المؤتمت. يبدو %.2f حجما مقبولا."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1191,8 +1294,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "نهاية التسجيل:\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "نهاية التسجيل:\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "نهاية التسجيل:\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "نهاية التسجيل:\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -1206,37 +1319,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "جهاز التسجيل المختار: %d - %s\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "جهاز التسجيل المختار: %d - %s\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "جهاز التشغيل المختار: %d - %s\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "غير قادر على فتح ملف النوع.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "جهاز التشغيل المختار: %d - %s\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "مصادر التسجيل المتاحة:\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "معدَّلات العينة\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "حجوم التشغيل المتاحة:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "حجم التسجيل محاكى\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "حجم التسجيل محلي\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "حجم التشغيل: %s (محاكى)\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "حجم التشغيل: %s (محاكى)\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1244,8 +1360,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "جهاز تسجيل MIDI المختار: %d - %s\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "جهاز تسجيل MIDI المختار: %d - %s\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "جهاز تشغيل MIDI المختار: %d - %s\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "جهاز تشغيل MIDI المختار: %d - %s\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1253,8 +1379,9 @@ msgid "Automatic Crash Recovery"
 msgstr "استرجاع تلقائي بعد التحطم"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1266,12 +1393,14 @@ msgid "Recoverable &projects"
 msgstr "المشاريع القابلة للاسترجاع"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "اختيار"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "الاسم"
 
@@ -1282,6 +1411,10 @@ msgstr " مختار"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "لا شيء مختار"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1357,6 +1490,22 @@ msgstr "تأثير"
 msgid "Menu Command (With Parameters)"
 msgstr "حرر المتغيرات"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, fuzzy, c-format
+msgid "(%s)"
+msgstr "(%s)"
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "حرر المتغيرات"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
 #: src/BatchCommands.cpp
 #, c-format
 msgid "Your batch command of %s was not recognized."
@@ -1401,6 +1550,10 @@ msgstr "صيغة اختبارية"
 #, c-format
 msgid "Apply %s"
 msgstr "طبق %s"
+
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
@@ -1487,7 +1640,8 @@ msgstr "استرجاع المنطقة"
 msgid "I&mport..."
 msgstr "استورد..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "صدر..."
 
@@ -1528,7 +1682,8 @@ msgstr "حرك لأعلى"
 msgid "Move &Down"
 msgstr "حرك لأسفل"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "حفظ"
 
@@ -1611,7 +1766,8 @@ msgid "Run"
 msgstr "شغل"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "إغلاق"
 
@@ -1753,9 +1909,13 @@ msgid "Benchmark completed successfully.\n"
 msgstr "أنجزت الصُوَّة بنجاح.\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "يوم و ساعة النهاية"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "صيغة إطلاق"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1794,6 +1954,18 @@ msgstr "اختر الصوت ليستخدمه %s (مثلا، Ctrl + A لتختا�
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "لا صوت مختار"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1843,10 +2015,24 @@ msgstr "المشروع الحالي"
 msgid "Checkpointing %s"
 msgstr "استورد %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "لم أتمكن من الكتابة إلى الملف: %s\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"أخفق Tenacity في الكتابة إلى ملف.\n"
+"ربما %s غير قابل للكتابة أو القرص ممتلئ."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1863,6 +2049,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "أخفقت في تدوين %s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1960,6 +2150,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "انسخ الأسماء إلى الحافظة"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "الملفات المفقودة"
 
@@ -1968,10 +2163,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "إذا واصلت، لن يتم حفظ المشروع على القرص. هل هذا ما تريده؟"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1985,7 +2181,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "فحص التبعيات"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "لا شيء"
 
@@ -1993,7 +2192,7 @@ msgstr "لا شيء"
 msgid "Rectangle"
 msgstr "مستطيل"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "مثلث"
 
@@ -2035,14 +2234,30 @@ msgstr "بلاكمان-هاريس"
 msgid "Welch"
 msgstr "ولتش"
 
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "دعم FFmpeg غير مجمع"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2064,8 +2279,8 @@ msgid "Locate FFmpeg"
 msgstr "حدد موقع FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity يحتاج إلى الملف '%s' ليستورد و يصدر الصوت عبر FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2078,7 +2293,8 @@ msgstr "موقع '%s':"
 msgid "To find '%s', click here -->"
 msgstr "لتجد '%s'، انقر هنا -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "تصفح..."
 
@@ -2104,8 +2320,9 @@ msgid "FFmpeg not found"
 msgstr "لم يعثر على FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2135,24 +2352,24 @@ msgid "Only libavformat.so"
 msgstr "فقط libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "أخفق Tenacity في فتح ملف في %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "أخفق Tenacity في القراءة من ملف في %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "كتب Tenacity ملفا في %s بنجاح لكن أخفق في إعادة تسميته إلى %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2189,7 +2406,9 @@ msgstr "لا تنسخ أي صوت"
 msgid "As&k"
 msgstr "اسأل"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "جميع الملفات|*"
 
@@ -2259,6 +2478,14 @@ msgstr "ارتباط ذاتي بجذر المكعب"
 msgid "Enhanced Autocorrelation"
 msgstr "ارتباط ذاتي محسَّن"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "طيف"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2275,6 +2502,18 @@ msgstr "تردد خطي"
 msgid "Log frequency"
 msgstr "تردد لوغاريتمي"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "بل"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "مرر"
@@ -2286,7 +2525,9 @@ msgstr "زوم"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "هرتز"
 
@@ -2388,7 +2629,8 @@ msgstr "طيف.txt"
 msgid "Export Spectral Data As:"
 msgstr "صدر البيانات الطيفة كـ:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "لم أتمكن من الكتابة إلى الملف: %s"
@@ -2566,6 +2808,11 @@ msgstr "انبذ"
 msgid "&Compact"
 msgstr "أمر"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2573,19 +2820,19 @@ msgid "&History..."
 msgstr "التاريخ..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "خطأ داخلي في %s عند %s سطر %d.\n"
 "من فضلك أخبر فريق Tenacity عند /https://forum.audacityteam.org."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "خطأ داخلي عند %s سطر %d.\n"
 "من فضلك أخبر فريق Tenacity عند /https://forum.audacityteam.org."
@@ -2604,7 +2851,9 @@ msgid "Track"
 msgstr "مقطع"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "علامة"
 
@@ -2664,7 +2913,8 @@ msgstr "أدخل اسم المقطع"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "مقطع علامة"
 
@@ -2675,11 +2925,13 @@ msgstr "لم بمكن قراءة واحد أو أكثر من العلامات ا
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "أول تشغيل لTenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "اختر لغة ليستخدمها Tenacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2689,7 +2941,8 @@ msgstr "اختر لغة ليستخدمها Tenacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "اللغة التي اخترتها، %s (%s)، ليست نفس لغة النظام، %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "أكد"
 
@@ -2707,12 +2960,13 @@ msgstr ""
 "الملف القديم محفوظ كـ '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "فتح مشروع  Tenacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke Tenacity%s"
 
 #: src/LyricsWindow.cpp
@@ -2763,19 +3017,23 @@ msgid "Mixing and rendering tracks"
 msgstr "مزج و تقديم المقاطع"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "منصة مازج Tenacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "الزيادة"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "السرعة"
 
@@ -2784,17 +3042,23 @@ msgid "Musical Instrument"
 msgstr "آلة موسيقية"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "التوزيع"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "أصمت"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "أفرد"
 
@@ -2802,15 +3066,18 @@ msgstr "أفرد"
 msgid "Signal Level Meter"
 msgstr "مقياس مستوى الإشارة"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "حركت منزلق الزيادة"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "حركت منزلق السرعة"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "حركت منزلق التوزيع"
 
@@ -2841,9 +3108,9 @@ msgstr ""
 "لن تُحمَّل."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2876,16 +3143,19 @@ msgstr ""
 "\n"
 "فقط استخدم الوحدات من المصادر الموثوقة"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "نعم"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "لا"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "محمل وحدة Tenacity"
 
 #: src/ModuleManager.cpp
@@ -2920,6 +3190,11 @@ msgstr "دو♯"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "D♯"
 msgstr "ري♯"
 
@@ -2937,6 +3212,11 @@ msgstr "فا"
 #: src/PitchName.cpp
 msgid "F♯"
 msgstr "فا♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
@@ -3118,7 +3398,8 @@ msgstr "اختر الجميع"
 msgid "C&lear All"
 msgstr "امسح الجميع"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "مكن"
 
@@ -3192,6 +3473,21 @@ msgstr ""
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "لتطبق مرشحة، يجب أن يكون لجميع المقاطع المختارة نفس معدل العينة."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "صوت مسجل"
@@ -3210,10 +3506,11 @@ msgid "Dropouts"
 msgstr "الانقطاعات المؤقتة"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3253,11 +3550,11 @@ msgid "Inspecting project file data"
 msgstr "افتش بيانات ملف المشروع"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3299,11 +3596,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "تحذير - ملف(ات) ذو(ذات) اسم مستعار مفقود(ة)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "تحقق المشروع من مجلد \"%s\" \n"
@@ -3328,12 +3625,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "تحذير - ملف(ات) ملخص ذو(ذات) اسم مستعار مفقود(ة)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3389,7 +3686,8 @@ msgstr "تحذير - ملف(ات) كتلة يتيم(ة)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "تقدم"
 
@@ -3414,6 +3712,11 @@ msgstr "تحذير: مشاكل في الاسترجاع التلقائي"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<غير معنون>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "المشروع"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3452,11 +3755,96 @@ msgid ""
 msgstr "غير قادر على قراءة ملف المسبقات."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "أخفقت في تدوين %s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "حفظ مشروع Tenacity"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "غير قادر على بدأ تيار MP3"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "غير قادر على بدأ تيار MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "غير قادر على بدأ تيار MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "غير قادر على بدأ تيار MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "غير قادر على بدأ تيار MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "غير قادر على بدأ تيار MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "غير قادر على بدأ تيار MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "غير قادر على بدأ تيار MP3"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3470,12 +3858,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "ملف الكتلة اليتيم: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "غير قادر على على تعيين حالة المجرى إلى متوقف."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "أخفقت في إيجاد المشفر"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "أخفقت في تدوين %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3486,9 +3895,9 @@ msgid "Error Writing to File"
 msgstr "خطأ في كتابة الملف: \"%s\""
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3499,8 +3908,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "احفظ المشاريع"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -3510,10 +3928,10 @@ msgstr "(مسترجع)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "حفظ المشروع باستخدام Tenacity %s.\n"
 "أنت تستخدم Tenacity %s. قد تحتاج إلى أن تحدث إلى إصدار أحدث لتفتح هذا الملف."
@@ -3521,6 +3939,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "لا يمكنني فتح ملف المشروع"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3535,6 +3957,10 @@ msgid "Unable to parse project information."
 msgstr "غير قادر على قراءة ملف المسبقات."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "احفظ المشاريع"
 
@@ -3543,12 +3969,35 @@ msgid "Error Saving Project"
 msgstr "خطأ في حفظ المشروع"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "احفظ المشاريع الفارغة"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3556,8 +4005,24 @@ msgstr ""
 "لحسن الحظ، يمكن استرجاع المشاريع التالية تلقائيا:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"بعض المشاريع لم تُحفظ بشكل  عند آخر تشغيل لTenacity.\n"
+"لحسن الحظ، يمكن استرجاع المشاريع التالية تلقائيا:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "استرجع المشروع"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "مجلد الملفات المؤقتة"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3587,6 +4052,17 @@ msgstr "تحذير - مشروع فارغ"
 msgid "Insufficient Disk Space"
 msgstr "مساحة القرص"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3606,12 +4082,26 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sاحفظ المشروع \"%s\" كـ..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'احفظ المشروع' هي لمشروع Tenacity، ليست لملف صوت.\n"
 "لملف صوت قابل للفتح في تطبيقات أخرى، استخدم 'استورد'.\n"
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -3665,11 +4155,12 @@ msgid "Error Opening Project"
 msgstr "خطأ في فتح المشروع"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "أنت تحاول فتح ملف احتياطي منشأ تلقائيا.\n"
 "فعل هذا قد يؤدي إلى فقدان بيانات خطر.\n"
@@ -3702,6 +4193,12 @@ msgid "Error Opening File or Project"
 msgstr "خطأ في فتح الملف أو المشروع"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "استرجع المشروع"
 
@@ -3727,12 +4224,33 @@ msgid "Error Importing"
 msgstr "خطأ في الاستوراد"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "حدد المشروع"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "لا يمكنني فتح ملف المشروع"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "أمر"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3743,8 +4261,8 @@ msgid "Automatic database backup failed."
 msgstr "الحفظ التلقائي ممكن:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "أهلا و سهلا في Tenacity إصدار %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3810,6 +4328,12 @@ msgstr[5] "%d دقيقة"
 msgid "%s and %s."
 msgstr "%s و %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3824,6 +4348,21 @@ msgstr "شريط تمرير أفقي"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "شريط تمرير عمودي"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -3933,6 +4472,11 @@ msgid "All Effects"
 msgstr "جميع التأثيرات"
 
 #: src/Screenshot.cpp
+#, fuzzy
+msgid "All Scriptables"
+msgstr "نص"
+
+#: src/Screenshot.cpp
 msgid "All Preferences"
 msgstr "جميع التفضيلات"
 
@@ -3940,7 +4484,8 @@ msgstr "جميع التفضيلات"
 msgid "SelectionBar"
 msgstr "شريط الاختيار"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "الاختيار الطيفي"
 
@@ -3948,46 +4493,55 @@ msgstr "الاختيار الطيفي"
 msgid "Timer"
 msgstr "المؤقت"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "الأدوات"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "النقل"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "المازج"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "العداد"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "عداد التشغيل"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "عداد التسجيل"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "حرر"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "جهاز"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "شغل-في-سرعة"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "افرك"
 
@@ -4002,7 +4556,10 @@ msgstr "المسطرة"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "المقاطع"
 
@@ -4112,7 +4669,8 @@ msgid "Activation level (dB):"
 msgstr "مستوى التفعيل (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "أهلا و سهلا في Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4239,10 +4797,25 @@ msgstr "خطأ في حفظ ملف البطاقات"
 msgid "Unsuitable"
 msgstr "الوحدة غير ملائمة"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "مجلد الملفات المؤقتة"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "لم يتمكن Tenacity من كتابة الملف:\n"
@@ -4262,9 +4835,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4273,9 +4846,9 @@ msgstr ""
 "للكتابة."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "لم يتمكن Tenacity من كتابة الصور في الملف:\n"
@@ -4292,9 +4865,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4304,9 +4877,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4315,8 +4888,9 @@ msgstr ""
 "ربما تكون صيغة بي.أن.جي سيئة؟"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "لم يتمكن Tenacity من قراءة الموضوع الافتراضي.\n"
@@ -4354,9 +4928,9 @@ msgstr ""
 "كانت موجودة بالفعل. اكتب عليها؟"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "لم يتمكن Tenacity من حفظ الملف:\n"
@@ -4395,7 +4969,11 @@ msgstr "خاص"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "الأمد"
 
@@ -4406,7 +4984,8 @@ msgid "Time Track"
 msgstr "مقطع وقت"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "مسجِل مؤقِت Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4480,7 +5059,8 @@ msgstr "المشروع الحالي"
 msgid "Recording start:"
 msgstr "بداية التسجيل:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "الأمد:"
 
@@ -4501,7 +5081,8 @@ msgid "Action after Timer Recording:"
 msgstr "الفعل بعد تسجيل المؤقت:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "تقدم تسجيل مؤقت Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4597,6 +5178,7 @@ msgstr "099 يوم 024 سا 060 دق 060 ثا"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "تاريخ و وقت البداية"
@@ -4641,7 +5223,8 @@ msgstr "مكن التصدير التلقائي؟"
 msgid "Export Project As:"
 msgstr "صدر المشروع كـ:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "اختيارات"
 
@@ -4654,7 +5237,8 @@ msgid "Do nothing"
 msgstr "افعل لا شيء"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "اخرج من Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4678,7 +5262,8 @@ msgid "Scheduled to stop at:"
 msgstr "معين ليتوقف عند:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "تسجيل مؤقت Tenacity - أنتظر للبدء"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4704,7 +5289,8 @@ msgid "Recording Exported:"
 msgstr "التسجيل المصدر:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "تسجيل مؤقِت Tenacity - ينتظر"
 
 #: src/TrackInfo.cpp
@@ -4830,6 +5416,10 @@ msgstr "حرك المقطع لأعلى"
 msgid "Move Track Down"
 msgstr "حرك المقطع لأسفل"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4896,6 +5486,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "أطبق %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "فشل"
@@ -4914,13 +5514,15 @@ msgstr "%s ليس معاملا مقبولا لدى %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "قيمة غير صالحة للمعامل '%s': يجب أن تكون %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "أمر"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "كرر %s"
@@ -4990,6 +5592,11 @@ msgstr "مقطع 0"
 msgid "Track 1"
 msgstr "مقطع 1"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "اسم النافذة:"
@@ -5042,13 +5649,24 @@ msgstr "مقاطع ضمنية"
 msgid "Envelopes"
 msgstr "الأغلفة"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "علامات"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "صناديق"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5058,7 +5676,8 @@ msgstr "وجيز"
 msgid "Type:"
 msgstr "النوع:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "الصيغة:"
 
@@ -5086,9 +5705,17 @@ msgstr "تعليقات"
 msgid "Command:"
 msgstr "أمر:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "يقدم مساعدة لأمر."
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -5118,12 +5745,17 @@ msgstr "يصدر إلى ملف."
 msgid "Builtin Commands"
 msgstr "أمر مبني داخليا"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "فريق Tenacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "يوفر تأثيرات مصيغة-داخليا إلى Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5174,11 +5806,22 @@ msgstr "احفظ مشروعا."
 msgid "Saves a copy of current project."
 msgstr "احفظ مشروعا."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "استخدم التفضيلات"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "الاسم:"
 
@@ -5226,7 +5869,8 @@ msgstr "شاشة كاملة"
 msgid "Toolbars"
 msgstr "أشرطة الأدوات"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "التأثيرات"
 
@@ -5346,6 +5990,14 @@ msgid "Select Frequencies"
 msgstr "اختر ترددات"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "رتب المقاطع"
 
@@ -5358,7 +6010,8 @@ msgstr "عَينْ"
 msgid "Add"
 msgstr "أضف"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "أزل"
 
@@ -5443,7 +6096,8 @@ msgid "Edited Envelope"
 msgstr "حدد الغلاف"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "غلاف"
 
@@ -5543,7 +6197,10 @@ msgstr "التوزيع:"
 msgid "Set Track Visuals"
 msgstr "رتب المقاطع"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "خطي"
 
@@ -5568,12 +6225,33 @@ msgid "Scale:"
 msgstr "المقياس:"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "زوم"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom Top:"
+msgstr "أداة التزويم"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom Bottom:"
+msgstr "أداة التزويم"
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Use Spectral Prefs"
 msgstr "استخدم التفضيلات الطيفية"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "الاختيار الطيفي"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5629,12 +6307,18 @@ msgstr "لقد اخترت مقطعا لا يحتوي صوتا. تأثير الغ
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "الغمر التلقائي يحتاج إلى مقطع تحكم يجب وضعه تحت المقطاطع المختارة."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "كمية الغمر:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "ثواني"
 
@@ -5658,7 +6342,8 @@ msgstr "طول الخبو لأسفل الداخلي:"
 msgid "Inner &fade up length:"
 msgstr "طول الخبو لأعلى الداخلي:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "العتبة:"
 
@@ -5796,11 +6481,13 @@ msgstr "إلى (هرتز)"
 msgid "t&o"
 msgstr "إلى"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "التغير النسبي:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "التغير النسبي"
 
@@ -5822,7 +6509,9 @@ msgstr "8"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "غير قابل للتطبيق"
 
@@ -5850,6 +6539,7 @@ msgstr "العدد القياسي للدورات في الدقيقة للفين�
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "من دورة في الدقيقة"
@@ -5862,6 +6552,7 @@ msgstr "من"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "إلى دورة في الدقيقة"
@@ -6004,6 +6695,12 @@ msgstr "ضاغط"
 msgid "Compresses the dynamic range of audio"
 msgstr "اضغط المدى  للصوت"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6012,6 +6709,20 @@ msgstr "%.2f ثواني"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f ثواني"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f ملي الثانية"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f ثواني"
 
 #: src/effects/Compressor.cpp
@@ -6129,7 +6840,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "محلل التباين، لقياس اختلافات حجم جذر متوسط المربع بين اختيارين من الصوت."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "نهاية"
 
@@ -6189,6 +6901,18 @@ msgstr "اختلاف:"
 msgid "&Help"
 msgstr "مساعدة"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "صفر"
@@ -6196,6 +6920,13 @@ msgstr "صفر"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "غير محدد"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB متوسط جذر متوسط المربع"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6249,6 +6980,12 @@ msgstr "الفرق الحالي"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "مستوى المقدمة المُقاس"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6393,6 +7130,10 @@ msgstr "صندوق الزغب"
 #: src/effects/Distortion.cpp src/effects/Equalization.cpp
 msgid "Walkie-talkie"
 msgstr "المتكلم-الماشي"
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Light Crunch Overdrive"
@@ -6583,6 +7324,12 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "يولد نغمات ثنائية-النغمة متعددة-الترددات مثل تلك المنتجة بواسطة لوحة المفاتيح على الهواتف"
 
 #: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "تسلسل النغمات ثنائية-النغمة متعددة-الترددات:"
 
@@ -6590,7 +7337,9 @@ msgstr "تسلسل النغمات ثنائية-النغمة متعددة-الت�
 msgid "&Amplitude (0-1):"
 msgstr "السعة (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "الأمد:"
 
@@ -6635,7 +7384,8 @@ msgstr "صدى"
 msgid "Repeats the selected audio again and again"
 msgstr "كرر ملفات الصوت المختارة مجددا و مجددا"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "القيمة المطلوبة تتخطى سعة الذاكرة."
 
@@ -6659,7 +7409,8 @@ msgstr "مسبقة"
 msgid "Export Effect Parameters"
 msgstr "حرر المتغيرات"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "لم أتمكن من فتح ملف: \"%s\""
@@ -6696,6 +7447,15 @@ msgstr "أحضر العرض المسبق"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "أعرض"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7005,6 +7765,10 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "يعدل مستويات الصوت لترددات مفردة"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "AM Radio"
 msgstr "راديو AM"
 
@@ -7015,6 +7779,14 @@ msgstr "رفع الباس"
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "رفع الباس"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Telephone"
@@ -7053,17 +7825,35 @@ msgid "Effect Unavailable"
 msgstr "التأثير غير متوفر"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "أعلى dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "أدنى dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 #, c-format
 msgid "%d Hz"
 msgstr "%d هرتز"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
 
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
@@ -7396,7 +8186,8 @@ msgid "Builtin Effects"
 msgstr "التأثيرات المصيغة داخليا"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "يوفر تأثيرات مصيغة-داخليا إلى Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7410,6 +8201,10 @@ msgstr "الجهارة المحسوسة"
 #: src/effects/Loudness.cpp src/widgets/Meter.cpp
 msgid "RMS"
 msgstr "ج.م.م"
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Sets the loudness of one or more tracks"
@@ -7433,9 +8228,26 @@ msgstr "أعالج: %s"
 msgid "&Normalize"
 msgstr "طبع"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "طبع القنوات الثنائية على حدة"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -7605,8 +8417,9 @@ msgid "Step 1"
 msgstr "خطوة 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "اختر بضع ثوان من الضجيج فقط حتى يعرف Tenacity ماذا يرشح،\n"
@@ -7658,13 +8471,63 @@ msgstr "أنواع النافذة"
 msgid "Window si&ze:"
 msgstr "حجم النافذة:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (أساسي)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "الخطوات لكل نافذة:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7790,6 +8653,7 @@ msgstr "استخدم Paulstretch  فقط لتمديد-وقت متطرف أو ت�
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "معامل التمديد:"
@@ -8070,6 +8934,11 @@ msgstr "اعكس الصوت المختار"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "وقت SBSMS / تمديد الطبقة"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8079,6 +8948,14 @@ msgstr "Chebyshev نوع I"
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type II"
 msgstr "Chebyshev نوع II"
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "Classic Filters"
@@ -8103,6 +8980,14 @@ msgid "O&rder:"
 msgstr "الترتيب:"
 
 #: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
 msgstr "النوع الفرعي:"
 
@@ -8113,6 +8998,14 @@ msgstr "حد القطع (هرتز)"
 #: src/effects/ScienFilter.cpp
 msgid "C&utoff:"
 msgstr "حد القطع:"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
@@ -8201,6 +9094,11 @@ msgstr "استخدم الافتراضيات"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "أرجع الافتراضيات"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8360,6 +9258,10 @@ msgstr "اكتشف السكون"
 msgid "Tr&uncate to:"
 msgstr "قلم إلى:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "اضغط إلى:"
@@ -8373,7 +9275,8 @@ msgid "VST Effects"
 msgstr "تأثيرات VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "يضيف القدرة على استخدام تأثيرات VST في Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8385,7 +9288,8 @@ msgstr "أمسح Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "تسجيل %d من %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "لم أتمكن من فتح المكتبة"
 
@@ -8397,15 +9301,25 @@ msgstr "اختيارات تأثير VST"
 msgid "Buffer Size"
 msgstr "حجم الصوان"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "حجم الصوان (8 إلى 1048576 عينة):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "تعويض الكمون"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "مكن التعويض"
 
@@ -8439,7 +9353,8 @@ msgid "Standard VST program file"
 msgstr "ملف برنامج VST قياسي"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "ملفات مشروع Tenacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8466,7 +9381,8 @@ msgstr "خطأ في تحميل مسبقة VST"
 msgid "Unable to load presets file."
 msgstr "غير قادر على تحميل ملف المسبقات."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "أوضاع التأثير"
 
@@ -8482,6 +9398,13 @@ msgstr "غير قادر على قراءة ملف المسبقات."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "حُفظ ملف المعامل من %s. استأنف؟"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+#, fuzzy
+msgid "VST"
+msgstr "VST"
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -8517,7 +9440,8 @@ msgid "Audio Unit Effects"
 msgstr "تأثيرات Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "يوفر دعم تأثيرات Audio Unit لTenacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8533,8 +9457,16 @@ msgid "Audio Unit Effect Options"
 msgstr "اختيارات تأثير وحدة الصوت"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "واجهة المستخدم"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -8598,6 +9530,16 @@ msgstr ""
 "  إلى %s."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Export Audio Unit Preset As %s:"
+msgstr "استورد مسبقات Audio Unit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Standard Audio Unit preset file"
+msgstr "استورد مسبقات Audio Unit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid ""
 "Could not export \"%s\" preset\n"
@@ -8625,6 +9567,11 @@ msgid "Failed to retrieve preset content"
 msgstr "غير قادر على استرداد وصف المجرى"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "غير قادر على قراءة ملف المسبقات."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "تحويل معدل العينة"
 
@@ -8632,6 +9579,21 @@ msgstr "تحويل معدل العينة"
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "أخفقت في تدوين %s"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "غير قادر على استرداد وصف المجرى"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "غير قادر على استرداد وصف المجرى"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "غير قادر على قراءة ملف المسبقات."
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -8641,6 +9603,7 @@ msgstr "وحدة صوت"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "تأثير LADSPA"
@@ -8650,16 +9613,23 @@ msgid "Provides LADSPA Effects"
 msgstr "يوفر تأثيرات LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity لا يستخدم vst-bridge بعد الآن"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "اختيارات تأثير LADSPA"
 
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s: %s"
@@ -8667,6 +9637,14 @@ msgstr "%s: %s"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "مخرجات التأثير"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8676,6 +9654,10 @@ msgstr "أوضاع تأثير LV2"
 #, c-format
 msgid "&Buffer Size (8 to %d) samples:"
 msgstr "حجم الصوان (8 إلى 1048576 عينة):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -8699,12 +9681,20 @@ msgstr "%d منحنيات صدرت إلى %s\n"
 msgid "Generator"
 msgstr "مولد"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+#, fuzzy
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "تأثيرات LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "يوفر دعم تأثيرات LV2 لTenacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8712,7 +9702,8 @@ msgid "Nyquist Effects"
 msgstr "تأثيرات Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "يوفر دعم تأثيرات Nyquist لTenacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8727,6 +9718,12 @@ msgstr "عامل Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "رأس موصلة Ill-formed Nyquist"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -8773,6 +9770,16 @@ msgstr "مخرجات التنقيح: "
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "أنجزت المعالجة."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -8857,6 +9864,14 @@ msgstr "لم أتمكن من تحديد اللغة"
 msgid "\"%s\" is not a valid file path."
 msgstr "\"%s\" ليس طريق ملف صالحا."
 
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "أدخل أمر Nyquist: "
@@ -8912,7 +9927,8 @@ msgstr "اختر ملفا"
 msgid "Save file as"
 msgstr "احفظ الملف كـ"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "غير معنون"
 
@@ -8921,7 +9937,8 @@ msgid "Vamp Effects"
 msgstr "تأثيرات Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "يوفر دعم تأثيرات  Vamp لTenacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -8943,6 +9960,13 @@ msgstr "أوضاع البرنامج المساعد"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "برنامج"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+#, fuzzy
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9109,6 +10133,10 @@ msgstr ""
 "هل تريد أن تستأنف؟"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "\"%s\" لم يوجد."
@@ -9163,6 +10191,14 @@ msgid ""
 msgstr ""
 "لا يستطيع FFmpeg إيجاد مشفر الصوت 0x%x.\n"
 "على الأرجح أن يكون دعم هذا المشفر غير مُكون."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -9228,7 +10264,8 @@ msgstr "أصدر الصوت كـ %s"
 msgid "Invalid sample rate"
 msgstr "معدَّل عينة غير صالح"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "أعد أخذ العينات"
 
@@ -9258,6 +10295,14 @@ msgstr "يمكن إعادة أخذ العينة إلى أحد المعدَّلا
 msgid "Sample Rates"
 msgstr "معدَّلات العينة"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "معدل البت:"
@@ -9265,6 +10310,49 @@ msgstr "معدل البت:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "الجودة (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f ثواني"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -9279,6 +10367,10 @@ msgid "Constrained"
 msgstr "ثابت"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "صوت"
 
@@ -9287,8 +10379,44 @@ msgid "Low Delay"
 msgstr "تأخير"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "متوسط"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -9359,8 +10487,18 @@ msgid "Replace preset '%s'?"
 msgstr "استبدل المسبقة'%s'؟"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "التشفير التنبؤي"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "رئيسي"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LTP"
+msgstr "التشفير التنبؤي"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9468,6 +10606,10 @@ msgstr "اللغة:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "احتياطي البت"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9764,6 +10906,17 @@ msgstr "لايوجد علامات للتصدير."
 msgid "Select xml file to export presets into"
 msgstr "اختر ملف XML لتصدر المحددات مسبقا إليه"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "أخفقت في تخمين الصيغة"
@@ -9848,12 +11001,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "%s kbps (أفضل جودة)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "%s kbps (ملفات أصغر)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -9864,7 +11069,8 @@ msgstr "جنوني"
 msgid "Extreme"
 msgstr "متطرف"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "قياسي"
 
@@ -9915,8 +11121,8 @@ msgid "Locate LAME"
 msgstr "حدد موقع LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity يحتاج الملف %s لإنشاء MP3."
 
 #: src/export/ExportMP3.cpp
@@ -9944,10 +11150,10 @@ msgid "Where is %s?"
 msgstr "أين %s؟"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "أنت تربط إلى lame_enc.dll v%d.%d.. هذا الإصدار غير متوافق مع Tenacity %d.%d.%d.\n"
 "من فضلك نزل أحدث إصدار من 'LAME لـ Tenacity'."
@@ -9967,6 +11173,11 @@ msgstr "فقط libmp3lame.dylib"
 #: src/export/ExportMP3.cpp
 msgid "Only libmp3lame.so.0"
 msgstr "فقط libmp3lame.so.0"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "احفظ ملفات بيانات المشروع"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -10216,6 +11427,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "غير قادر على تعيين جودة التقديم لـ QuickTime"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "غير قادر على التصدير - مشكلة في الملف"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "غير قادر على التصدير - مشكلة في الملف"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "غير قادر على التصدير - مشكلة في الملف"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "غير قادر على التصدير - مشكلة في الملف"
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "غير قادر على التصدير - مشكلة في الملف"
 
@@ -10226,6 +11457,14 @@ msgstr "أصدر الصوت المختار كـ Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "أصدر الصوت كـ Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Header:"
@@ -10240,8 +11479,28 @@ msgid "Other uncompressed files"
 msgstr "ملفات غير مضغوطة اخرى"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "خطأ في الاستوراد"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -10267,11 +11526,11 @@ msgid "All supported files"
 msgstr "جميع الملفات|*|جميع الملفات المدعومة|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10280,11 +11539,11 @@ msgstr ""
 "تحريره بنقر ملف > استورد > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "هو ملف MIDI، ليس ملف صوت.\n"
@@ -10296,18 +11555,18 @@ msgid "Select stream(s) to import"
 msgstr "اختر المجرى/المجاري لتستورد"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "هذا الإصدار من Tenacity لم يجمع مع دعم %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو مقطع قرص مضغوط صوتي. \n"
 "Tenacity لا يستطيع فتح الأقراص المضغوطة الصوتية مباشرة. \n"
@@ -10316,10 +11575,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" هو ملف قائمة تشغيل. \n"
@@ -10328,10 +11587,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف Windows Media Audio. \n"
@@ -10340,10 +11599,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف Advanced Audio Coding. \n"
@@ -10352,12 +11611,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف صوت مشفر، عادة يكون مصدره موقع بيع على الإنترنت. \n"
@@ -10367,10 +11626,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف وسائط RealPlayer . \n"
@@ -10379,12 +11638,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" هو ملف علامات، ليس ملف صوت. \n"
 "Tenacity لا يستطيع فتح هذا النوع من الملفات.\n"
@@ -10393,10 +11652,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10409,10 +11668,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف Wavpack و ليس ملف صوت. \n"
@@ -10421,10 +11680,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف صوت Dolby Digital. \n"
@@ -10433,10 +11692,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف صوت Ogg Speex. \n"
@@ -10445,10 +11704,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" هو ملف فيديو.\n"
@@ -10462,14 +11721,20 @@ msgstr "الملف \"%s\" لم يوجد."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "لم يتعرف Tenacity على نوع الملف '%s'.\n"
 "جرب تثبيت FFmpeg. للملفات الغير مضغوطة، جرب أيضا ملف > صدر > بيانات خام."
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
 
 #: src/import/Import.cpp src/menus/ClipMenus.cpp
 #, c-format
@@ -10478,9 +11743,9 @@ msgstr "%s، %s"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10489,6 +11754,11 @@ msgstr ""
 "المصدرون المفترض دعمهم لهكذا ملفات هم:\n"
 "%s،\n"
 "لكن لم يفهم أي واحد منهم هذه الصيغة."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "احفظ ملفات بيانات المشروع"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10505,8 +11775,57 @@ msgid "Import Project"
 msgstr "استورد مسبقات"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "خطأ داخلي تم تقريره بواسطة عملية المحاذاة."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "معدَّل عينة غير صالح"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10514,16 +11833,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "لم أتمكن من إيجاد مجلد بيانات المشروع: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "بداية المشروع"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "معدَّل عينة غير صالح"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "معدَّل عينة غير صالح"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10553,40 +11930,6 @@ msgstr "الفهرس[%02x] المشفر[%s]، اللغة[%s]، معدل العي
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "ملفات FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "الملفات المتوافقة مع GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "غير قادر على إضاف حالل الشفرات إلى خط الأنابيب"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "مستورد GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "غير قادر على على تعيين حالة المجرى إلى متوقف."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "الفهرس[%02d]، النوع[%s]، القنوات[%d]، المعدل[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "الملف لا يحتوي أي مجاري صوت."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "غير قادر على استوراد ملف، أخفق تغيير الحالة."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "خطأ GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10644,6 +11987,14 @@ msgstr "لم أتمكن من فتح الملف %s."
 msgid "MP3 files"
 msgstr "ملفات MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "ملفات Ogg Vorbis"
@@ -10678,12 +12029,120 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "AIFF ،WAV و أنواع أخرى غير مضغوطة"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-بِت PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-بِت PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-بِت PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-بِت PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-بِت PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -10702,6 +12161,31 @@ msgid "A-Law"
 msgstr "قانون A"
 
 #: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 بت"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "16 بت"
 
@@ -10710,12 +12194,20 @@ msgid "24 bit DWVW"
 msgstr "24 بت"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-بِت PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-بِت PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -10826,6 +12318,10 @@ msgstr "معدَّل العينة:"
 msgid "&Import"
 msgstr "استورد"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -10846,6 +12342,7 @@ msgstr "%s يمين"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -10873,6 +12370,7 @@ msgstr "نهاية"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -10907,7 +12405,8 @@ msgstr "حركت المقاطع-الضمنية زمنيا إلى اليمين"
 msgid "Time shifted clips to the left"
 msgstr "حركت المقاطع-الضمنية زمنيا إلى اليسار"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "تحويل-الوقت"
 
@@ -11045,7 +12544,8 @@ msgstr "قلم المقاطع المختارة من %.2f ثواني إلى %.2f 
 msgid "Trim Audio"
 msgstr "قلم الصوت"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "افلق"
 
@@ -11166,32 +12666,8 @@ msgid "Delete Key&2"
 msgstr "مفتاح الحذف 2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "المازج"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "اضبط حجم التشغيل..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "زد حجم التشغيل"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "أنقص حجم التشغيل"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "اضبط حجم التسجيل..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "زد حجم التسجيل"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "أنقص حجم التسجيل"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -11283,6 +12759,11 @@ msgstr "استورد علامات"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "اختر ملف MIDI"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "جميع الملفات|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -11385,6 +12866,10 @@ msgid "E&xit"
 msgstr "اخرج"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "صدر كـ FLAC"
 
@@ -11451,8 +12936,9 @@ msgid "&Getting Started"
 msgstr "أتهيأ للبدأ"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "كتيب Tenacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "الكتيب..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -11478,11 +12964,8 @@ msgstr "معلومات جهاز MIDI..."
 msgid "Show &Log..."
 msgstr "أظهر السجل..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "حول Tenacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "العلامة المضافة"
 
@@ -11684,6 +13167,10 @@ msgid "Move Forward Through Active Windows"
 msgstr "تحرك إلى الأمام عير النوافذ النشطة"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "تحرك إلى الوراء من أشرطة الأدوات إلى المقاطع"
 
@@ -11835,6 +13322,16 @@ msgid "Set Track Status..."
 msgstr "حدد حالة المقطع..."
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "مدة الصمت:"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "رتب المقاطع"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "خذ التفضيل..."
 
@@ -11857,6 +13354,12 @@ msgstr "حرر العلامات..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "حدد المشروع..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "نص"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -12155,6 +13658,7 @@ msgstr "قفزة طويلة للمؤشر نحو اليمين"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "اقصد"
@@ -12366,18 +13870,21 @@ msgid "Created new label track"
 msgstr "أنشأت مقطع علامة جديد"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "يسمح هذا الإصدار من Tenacity بمقطع وقت واحد فقط لكل نافذة مشروع."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "أنشأت مقطع وقت جديد"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "معدل العينة الجديد (هرتز):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "القيمة المدخلة ليست صالحة"
 
@@ -12634,7 +14141,9 @@ msgstr "أشغل"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "التسجيل"
 
@@ -12741,6 +14250,11 @@ msgid "&Timer Record..."
 msgstr "تسجيل المؤقت..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "تسجيل مفعل بالصوت"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "شغل منطقة"
 
@@ -12779,10 +14293,6 @@ msgstr "... (جار/متوقف)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "تشغيل عبر البرنامج (جار/متوقف)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "تعديل مستوى الصوت المؤتمت (جار/متوقف)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -12998,7 +14508,7 @@ msgstr "تفضيلات للجودة"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "اخرج من Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13045,7 +14555,8 @@ msgstr "المضيف:"
 msgid "Using:"
 msgstr "باستخدام:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "التشغيل"
 
@@ -13065,7 +14576,8 @@ msgstr "القنوات:"
 msgid "Latency"
 msgstr "الكمون"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "أجزاء من ألف من الثانية"
 
@@ -13094,7 +14606,8 @@ msgid "2 (Stereo)"
 msgstr "2 (ثنائي)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "المجلدات"
 
@@ -13107,8 +14620,22 @@ msgid "Default directories"
 msgstr "المجلدات"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "تصفح..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -13186,7 +14713,8 @@ msgid "Directory %s is not writable"
 msgstr "لا يمكن كتابة المجلد %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "التغييرات إلى المجلد المؤقت لن تكون فعّالة إلا عند إعادة تشغيل Tenacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13219,6 +14747,7 @@ msgstr "مُجمَّعة حسب النوع"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "LADSPA"
@@ -13270,11 +14799,13 @@ msgid "Plugin Options"
 msgstr "اختيارات البرامج المساعدة"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "تحقق من وجود تأثيرات محدثة عندما يبدأ Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "أعد فحص التأثيرات في المرة القادمة عندما يبدأ Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13454,8 +14985,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "احتفظ بالعلامات إذا كان الاختيار يتلقف إلى علامة"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "ادمح موضوع النظام و Tenacity"
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13470,9 +15011,18 @@ msgstr "أظهر مسطرة الفرك"
 msgid "Language \"%s\" is unknown"
 msgstr "اللغة \"%s\" مجهولة"
 
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "الاستيراد / التصدير"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "تفضيلات للاستيراد الخارجي"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -13518,6 +15068,10 @@ msgstr "صدر العلامات كـ:"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "ملفات Allegro (.gro) المصدرة تحفظ الوقت كـ:"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13602,7 +15156,15 @@ msgid "&Defaults"
 msgstr "الافتراضيات"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "اختر ملف XML يحتوي اختصارات لوحة مفاتيح Tenacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13611,8 +15173,21 @@ msgstr "خطأ في استوراد اختصارات لوحة المفاتيح"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "حملت %d اختصارات للوحة المفاتيح\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -13633,6 +15208,15 @@ msgstr "لا يمكنك أن تخصص مفتاحا لهذا المدخل"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "يجب أن تختار ارتباطا قبل أن تخصص اختصارا"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -13703,8 +15287,9 @@ msgid "Dow&nload"
 msgstr "نزل"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity اكتشف تلقائيا مكتبات FFmpeg صالحة.\n"
@@ -13749,6 +15334,10 @@ msgstr "كمون مركب MIDI (ملي الثانية):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "يجب أن يكون كمون مركب MIDI عددا صحيحا"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -13759,8 +15348,9 @@ msgid "Preferences for Module"
 msgstr "تفضيلات للوحدة"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "هذه وحدات تجريبية. مَكنها فقط إذا قرأت كتيب Tenacity\n"
@@ -13768,12 +15358,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'اسأل' تعني أن Tenacity سيسأل إذا كنت تريد تحميل الوحدة عند كل بدء لTenacity."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'أخفق' تعني أن Tenacity يظن أن الوحدة مكسورة و لن يشغلها."
 
 #. i18n-hint preserve the leading spaces
@@ -13782,7 +15374,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "'جديد' تعني أنه لم يتم عمل اختيار حتى الآن."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "التغييرات إلى هذه الأوضاع  ستكون فعالة فقط عند بدء Tenacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -13800,6 +15393,10 @@ msgstr "لم يعثر على وحدات"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "وحدة"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -13841,7 +15438,10 @@ msgstr "يسار-سحب"
 msgid "Set Selection Range"
 msgstr "عين مجال الاختيار"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-يسار-نقرة"
 
@@ -13928,6 +15528,15 @@ msgstr "-يسار-سحب"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "حرك المقطع الضمني إلى أعلى/أسفل بين المقاطع"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-يسار-سحب"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14039,8 +15648,21 @@ msgstr "المدة القصيرة:"
 msgid "Lo&ng period:"
 msgstr "المدة الطويلة:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "تفضيلات Tenacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14054,6 +15676,11 @@ msgstr "التفضيلات: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "تفضيلات للجودة"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14114,6 +15741,10 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "شغل مقاطع أخرى أثناء التسجيل"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "تشغيل المدخلات عبر البرمجيات"
 
@@ -14169,41 +15800,32 @@ msgid "System T&ime"
 msgstr "وقت النظام"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "تعديل مستوى الصوت المؤتمت"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "مكن تعديل مستوى الصوت المؤتمت."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "القمة الهدف:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "داخل:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "وقت التحليل:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "أجزاء من ألف من الثانية (وقت التحليل)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "عدد التحليلات المتعاقبة:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 تعني لا نهائي"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "تسجيل مفعل بالصوت"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "مقطع نغمة"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14314,6 +15936,10 @@ msgid "&Range (dB):"
 msgstr "المدى (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
 msgstr "الخوارزمية"
 
@@ -14332,6 +15958,10 @@ msgstr "8 - أعرض موجة"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - أساسي"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -14431,13 +16061,14 @@ msgid "Info"
 msgstr "معلومة"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14531,6 +16162,10 @@ msgid "&Type to create a label"
 msgstr "اكتب لتنشأ علامة"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Enable scrolling left of &zero"
 msgstr "مكن التمرير يسار الصفر"
 
@@ -14599,6 +16234,16 @@ msgid "50ths of Seconds"
 msgstr "50 جزء من الثانية"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "10 أجزاء من الثانية"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "50 جزء من الثانية"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "أجزاء من ألف من الثانية"
 
@@ -14610,7 +16255,8 @@ msgstr "عينات"
 msgid "4 Pixels per Sample"
 msgstr "4 عنصورات (بكسل) لكل عينة"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "أقصى تزويم"
 
@@ -14627,12 +16273,20 @@ msgid "Sho&w track name as overlay"
 msgstr "أظهر اسم مقطع الصوت كغطاء"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "&Pinned Recording/Playback head"
 msgstr "مقدمة تسجيل/تشغيل مدبسة"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "A&uto-scroll if head unpinned"
 msgstr "مرر تلقائيا إذا كانت المقدمة غير مدبسة"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -14709,6 +16363,11 @@ msgid "Waveforms"
 msgstr "أشكال موجية"
 
 #: src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "Preferences for Waveforms"
+msgstr "تفضيلات للتحذيرات"
+
+#: src/prefs/WaveformPrefs.cpp
 msgid "Waveform dB &range:"
 msgstr "مدى dB للشكل الموجي:"
 
@@ -14720,16 +16379,24 @@ msgid "Stopped"
 msgstr "متوقف"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "توقف مؤقتا"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "تخطي إلى البداية"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "تخطى إلى النهاية"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "توقف مؤقتا"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "الاختيار إلى البداية"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "الاختيار إلى النهاية"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -14743,20 +16410,17 @@ msgstr "سجل مقطعا جديدا"
 msgid "Append Record"
 msgstr "ألحق التسجيل"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "الاختيار إلى النهاية"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "الاختيار إلى البداية"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "متوقف مؤقتا"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s: %s"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -14836,11 +16500,17 @@ msgstr "أصمت اختيار الصوت"
 msgid "Sync-Lock Tracks"
 msgstr "اقفل المقاطع تزامنيا"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "زوم داخلا"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "زوم خارجا"
 
@@ -14907,43 +16577,6 @@ msgstr "شريط أدوات مقياس التسجيل"
 msgid "&Playback Meter Toolbar"
 msgstr "شريط أدوات مقياس التشغيل"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "حجم التسجيل"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "حجم التشغيل"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "حجم التسجيل: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "حجم التسجيل (غير متوفر، استخدم مازج النظام.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "حجم التشغيل: %s (محاكى)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "حجم التشغيل: %s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "حجم التشغيل (غير متوفر، استخدم مازج النظام.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "شريط أدوات المازج"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "اقصد"
@@ -14959,6 +16592,7 @@ msgstr "الفرك"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "أوقف الفرك"
@@ -14966,6 +16600,7 @@ msgstr "أوقف الفرك"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "ابدأ الفرك"
@@ -14973,6 +16608,7 @@ msgstr "ابدأ الفرك"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "أوقف القصد"
@@ -14980,6 +16616,7 @@ msgstr "أوقف القصد"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "ابدأ القصد"
@@ -15034,7 +16671,9 @@ msgstr "احصر إلى"
 msgid "Length"
 msgstr "الطول"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "مركز"
 
@@ -15098,8 +16737,8 @@ msgstr "شريط أدوات الزمن"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "شريط أدوات %s Tenacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15126,7 +16765,8 @@ msgstr "أداة تحريك الوقت"
 msgid "Zoom Tool"
 msgstr "أداة التزويم"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "أداة الرسم"
 
@@ -15202,11 +16842,13 @@ msgstr "اسحب حدا واحد أو أكثر من حدود العلامة."
 msgid "Drag label boundary."
 msgstr "اسحب حد العلامة."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "علامةمعدَّلة"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "تحرير علامة"
 
@@ -15261,31 +16903,42 @@ msgstr "العلامات المحررة"
 msgid "New label"
 msgstr "علامة جديدة"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "جواب فوق"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "جواب أسفل"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "انقر لتزوم عموديا. Shift-نقرة لتزوم خارجا. اسحب لتعين منطقة تزويم."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "نقرة-يمنى للقائمة."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "زوم طبيعيا"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-يسار-نقرة"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "زوم داخلا\tنقرة-يسرى/سحب-أيسر"
 
@@ -15327,7 +16980,8 @@ msgstr "مزج"
 msgid "Expanded Cut Line"
 msgstr "وسعت خط القص"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "وسع"
 
@@ -15350,6 +17004,11 @@ msgstr "حركت العينة"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "تحرير العينة"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15395,7 +17054,8 @@ msgstr "أعالج: %s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "غيرت '%s' إلى %s"
@@ -15474,7 +17134,8 @@ msgstr "تغيير المعدل"
 msgid "Set Rate"
 msgstr "عين المعدل"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "متعدد"
 
@@ -15567,19 +17228,22 @@ msgid "Right, %dHz"
 msgstr "يمين، %dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% يسار"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% يمين"
@@ -15591,6 +17255,15 @@ msgstr "انقر و اسحب لتعدل، نقرة-ثنائية لـ"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "انقر و اسحب لتحريك المقطع في الوقت"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "انقر و اسحب لتحريك المقطع في الوقت"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -15689,9 +17362,8 @@ msgstr "استيفاء لوغارثمي"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "انقر و اسحب لتحريك المقطع في الوقت"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15742,6 +17414,7 @@ msgstr "الغلاف المعدل."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "افرك"
@@ -15753,6 +17426,7 @@ msgstr "القصد"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "مسطرة الفرك"
@@ -16212,6 +17886,7 @@ msgstr "0100 س 060 د 060  ث+># عينات"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "عينات"
@@ -16373,10 +18048,27 @@ msgstr "01000،01000 إطار|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000>0100 هرتز"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows frequency in kilohertz
 #: src/widgets/NumericTextCtrl.cpp
 msgid "kHz"
 msgstr "ألف هرتز"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000>01000 kHz|0.001"
+msgstr "0100000>0100 هرتز"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -16489,6 +18181,11 @@ msgstr "أكد الإغلاق"
 msgid "Unable to write files to directory: %s."
 msgstr "غير قادر على قراءة ملف المسبقات."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -16595,16 +18292,49 @@ msgstr "لم أتمكن من فتح الملف"
 msgid "Spectral edit multi tool"
 msgstr "الاختيار الطيفي"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "أرشح..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aمن فضلك اختر ترددات."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "خطأ.~%"
@@ -16619,8 +18349,34 @@ msgstr "الزيادة (dB)"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "~aيجب أن يكون التردد المركزي فوق 0 هرتز."
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -16634,9 +18390,22 @@ msgstr "خبو خارج استوديو"
 msgid "Applying Fade..."
 msgstr "أطبق الخبو..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "ستيف دالتون"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16692,6 +18461,10 @@ msgid "End (or start)"
 msgstr "النهاية (أو البداية)"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "None Selected"
 msgstr "لا شيء مختار"
 
@@ -16702,6 +18475,14 @@ msgstr "خطي"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "خطي"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -16750,6 +18531,14 @@ msgstr "لا يمكن أن تكون زيادة التردد سالبة"
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "لا يمكن أن تكون زيادة التردد سالبة"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "النقرات"
@@ -16757,6 +18546,10 @@ msgstr "النقرات"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "البحث عن القطع..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -16769,6 +18562,23 @@ msgstr "قص اليمين"
 #: plug-ins/clipfix.ny
 msgid "Reconstructing clips..."
 msgstr "حذف النقرة و الفرقعة..."
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "العتبة %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
 
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
@@ -16791,6 +18601,11 @@ msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
 msgstr ""
 "اختيار صوت غير صالح.\n"
 "من فضلك تأكد من أن الصوت مختار."
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -16824,6 +18639,19 @@ msgstr "منحنى خاص"
 msgid "Fade direction"
 msgstr "اتجاه الخبو"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "تأخير"
@@ -16839,6 +18667,19 @@ msgstr "نوع التأخير"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "اعتيادي"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "تقليل الضجيج (dB):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -16869,6 +18710,10 @@ msgid "Allow duration to change"
 msgstr "اسمح للأمد أن يتغير"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "كرر آخر تأثير"
 
@@ -16879,6 +18724,10 @@ msgstr "تسوية"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "ملفات MP3"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -16893,10 +18742,24 @@ msgstr "تأكيد الكتابة"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "غير قادر على فتح ملف النوع."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "خطأ. ~%~s لا يمكن كتابته.~%"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "خطأ. ~%~s لا يمكن كتابته.~%"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -16927,10 +18790,22 @@ msgstr "فاصل العلامة (ثواني)"
 msgid "Length of label region (seconds)"
 msgstr "طول منطقة العلامة (ثواني)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "نص العلامة"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "1 (Before Label)"
@@ -16972,6 +18847,11 @@ msgstr "تفاصيل"
 msgid "Warnings only"
 msgstr "التحذيرات فقط"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -16981,21 +18861,72 @@ msgstr "علامات المناطق"
 msgid "point labels"
 msgstr "علامات النقاط"
 
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
+#: plug-ins/highpass.ny
+#, fuzzy
+msgid "High-Pass Filter"
+msgstr "المراشح الكلاسيكية"
+
+#: plug-ins/highpass.ny
+#, fuzzy
+msgid "Performing High-Pass Filter..."
+msgstr "أؤدي %d تحريرات...\n"
+
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
 msgid "Dominic Mazzoni"
 msgstr "حذف الضجيج من طرف دومينيك مازوني"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "تردد (هرتز)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, fuzzy
+msgid "6 dB"
+msgstr "36 db"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "36 dB"
 msgstr "36 db"
 
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
+
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "يجب أن يكون التردد 0.1 هرتز على الأقل."
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -17043,14 +18974,53 @@ msgid "Point after sound"
 msgstr "ثنائي مشترك"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "ثنائي مشترك"
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "أجد السكون..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "أجد السكون..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "يجب أن يكون الاختيار أكير من %d عينة."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -17082,12 +19052,39 @@ msgid "Hard Clip"
 msgstr "قطع شديد"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "القناة اليمنى"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "حد إلى (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
 msgstr "زيادة التعويض"
+
+#: plug-ins/lowpass.ny
+#, fuzzy
+msgid "Low-Pass Filter"
+msgstr "المراشح الكلاسيكية"
+
+#: plug-ins/lowpass.ny
+#, fuzzy
+msgid "Performing Low-Pass Filter..."
+msgstr "أؤدي %d تحريرات...\n"
 
 #: plug-ins/noisegate.ny
 msgid "Noise Gate"
@@ -17096,6 +19093,10 @@ msgstr "نوع الضجيج:"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "اختيار"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -17133,6 +19134,54 @@ msgstr "وقت الهجوم/التضاؤل"
 msgid "Decay (ms)"
 msgstr "وقت الهجوم/التضاؤل"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "يجب أن يكون الاختيار أكير من %d عينة."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, fuzzy
+msgid "Notch Filter"
+msgstr "طول المرشحة"
+
+#: plug-ins/notch.ny
+#, fuzzy
+msgid "Applying Notch Filter..."
+msgstr "أطبق الخبو..."
+
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "ستيف دالتون و بيل واري"
@@ -17140,6 +19189,14 @@ msgstr "ستيف دالتون و بيل واري"
 #: plug-ins/notch.ny
 msgid "Q (higher value reduces width)"
 msgstr "Q (القيم الأعلى تنقص العرض)"
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -17162,7 +19219,8 @@ msgstr "ملفات MP3"
 msgid "HTML file"
 msgstr "ملفات MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "ملفات نص"
 
@@ -17179,9 +19237,24 @@ msgid "Disallow"
 msgstr "غير مسموح"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "غير مسموح"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "أخفقت في إزالة %s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -17192,8 +19265,35 @@ msgid "Files copied to plug-ins folder:"
 msgstr "اختر ملفا"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "نوع ملف غير مدعوم:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "اختر ملفا"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Generating pluck sound..."
+msgstr "البحث عن القطع..."
 
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
@@ -17204,8 +19304,20 @@ msgid "David R.Sky"
 msgstr "ديفيد آر.سكاي"
 
 #: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "نوع الخبو الخارج"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -17214,6 +19326,10 @@ msgstr "الأمد (60ث أقصى)"
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm Track"
 msgstr "حذف المقطع"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Generating Rhythm..."
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Tempo (bpm)"
@@ -17228,12 +19344,38 @@ msgid "Beats per bar"
 msgstr "دقات في الدقيقة"
 
 #: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "1 - 20 beats/measure"
+msgstr "30 - 300 دقة/دقيقة"
+
+#: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "كمية الأرجحة"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Number of bars"
+msgstr "عدد العلامات"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
 msgstr "حذف المقطع"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Used if 'Number of bars' = 0"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Start time offset"
@@ -17248,6 +19390,22 @@ msgid "Beat sound"
 msgstr "النقرات"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "حذف الضجيج"
 
@@ -17255,8 +19413,39 @@ msgstr "حذف الضجيج"
 msgid "Noise Click"
 msgstr "الحد الأدنى للضجيج"
 
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
+msgstr "توليد الضجيج"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Generating Risset Drum..."
 msgstr "توليد الضجيج"
 
 #: plug-ins/rissetdrum.ny
@@ -17290,6 +19479,10 @@ msgstr "غير قادر على التصدير"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "أحلل..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -17383,6 +19576,41 @@ msgstr "~aكتبت البيانات إلى:~%~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "~a  عينات."
 
@@ -17390,6 +19618,43 @@ msgstr "~a  عينات."
 #, lisp-format
 msgid "~a seconds."
 msgstr "~a ثواني."
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -17408,6 +19673,10 @@ msgid "Value (dB)"
 msgstr "القيمة (dB)"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "اليسار (خطي)"
 
@@ -17422,6 +19691,14 @@ msgstr "يسار (dB)"
 #: plug-ins/sample-data-export.ny
 msgid "Right (dB)"
 msgstr "يمين (dB)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "linear"
@@ -17482,6 +19759,10 @@ msgid "Select file"
 msgstr "اختر ملف"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "خطأ"
 
@@ -17491,12 +19772,45 @@ msgstr "اقرأ كـ صفر"
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
 msgid "Error.~%Unable to open file"
 msgstr "غير قادر على فتح ملف النوع."
 
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "الاختيار الطيفي"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -17519,8 +19833,16 @@ msgid "Wet level (percent)"
 msgstr "مستوى المبلل (في المئة)"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "أطبق..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -17562,9 +19884,96 @@ msgstr "حلل"
 msgid "Strength"
 msgstr "الشدة"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "أنجزت المعالجة."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -17577,6 +19986,11 @@ msgstr "كلتا القناتين"
 #: plug-ins/vocoder.ny
 msgid "Right Only"
 msgstr "يمين فقط"
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Number of vocoder bands"
+msgstr "عدد الصدى"
 
 #: plug-ins/vocoder.ny
 msgid "Amplitude of original audio (percent)"
@@ -17593,6 +20007,206 @@ msgstr "سعة إبر الرادار (في المئة)"
 #: plug-ins/vocoder.ny
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "تردد إبر الرادار (هرتز)"
+
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "اخرج من Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "القناة"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "خطأ في حل شفرة الملف"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "خطأ في تحميل ما وراء المعطيات"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "شريط أدوات %s Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "التسجيل"
+
+#~ msgid "Commit Id:"
+#~ msgstr "معرف التسليم:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "مكتبة واجهة مستخدم رسومية متعددة-المنصات"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "استورد عبر GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "توقف تعديل مستوى الصوت المؤتمت. لم بكن ممكنا تحسينه أكثر. لا يزال أعلى مما ينبغي."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "أنقص تعديل مستوى الصوت المؤتمت الحجم إلى %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "توقف تعديل مستوى الصوت المؤتمت. لم بكن ممكنا تحسينه أكثر. لا يزال أخفض مما ينبغي."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "زاد تعديل مستوى الصوت المؤتمت الحجم إلى %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "توقف تعديل مستوى الصوت المؤتمت. تخطي العدد الإجمالي للتحليلات بدون إيجاد حجم مقبول. لا يزال أعلى مما ينبغي."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "توقف تعديل مستوى الصوت المؤتمت. تخطي العدد الإجمالي للتحليلات بدون إيجاد حجم مقبول. لا يزال أخفض مما ينبغي."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "توقف تعديل مستوى الصوت المؤتمت. يبدو %.2f حجما مقبولا."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "غير قادر على فتح ملف النوع.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "مصادر التسجيل المتاحة:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "حجوم التشغيل المتاحة:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "حجم التسجيل محاكى\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "حجم التسجيل محلي\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "حجم التشغيل: %s (محاكى)\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "حجم التشغيل: %s (محاكى)\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "يوم و ساعة النهاية"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "الملفات المتوافقة مع GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "غير قادر على إضاف حالل الشفرات إلى خط الأنابيب"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "مستورد GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "غير قادر على على تعيين حالة المجرى إلى متوقف."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "الفهرس[%02d]، النوع[%s]، القنوات[%d]، المعدل[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "الملف لا يحتوي أي مجاري صوت."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "غير قادر على استوراد ملف، أخفق تغيير الحالة."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "خطأ GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "المازج"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "اضبط حجم التشغيل..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "زد حجم التشغيل"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "أنقص حجم التشغيل"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "اضبط حجم التسجيل..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "زد حجم التسجيل"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "أنقص حجم التسجيل"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "كتيب Tenacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "حول Tenacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "تعديل مستوى الصوت المؤتمت (جار/متوقف)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "تعديل مستوى الصوت المؤتمت"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "مكن تعديل مستوى الصوت المؤتمت."
+
+#~ msgid "Target Peak:"
+#~ msgstr "القمة الهدف:"
+
+#~ msgid "Within:"
+#~ msgstr "داخل:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "وقت التحليل:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "أجزاء من ألف من الثانية (وقت التحليل)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "عدد التحليلات المتعاقبة:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 تعني لا نهائي"
+
+#~ msgid "Recording Volume"
+#~ msgstr "حجم التسجيل"
+
+#~ msgid "Playback Volume"
+#~ msgstr "حجم التشغيل"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "حجم التسجيل: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "حجم التسجيل (غير متوفر، استخدم مازج النظام.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "حجم التشغيل: %s (محاكى)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "حجم التشغيل: %s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "حجم التشغيل (غير متوفر، استخدم مازج النظام.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "شريط أدوات المازج"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "انقر و اسحب لتحريك المقطع في الوقت"
 
 #~ msgid "Program build date:"
 #~ msgstr "تاريخ بناء البرنامج:"
@@ -17615,10 +20229,6 @@ msgstr "تردد إبر الرادار (هرتز)"
 #, fuzzy
 #~ msgid "Unknown error"
 #~ msgstr "مجهول"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "غير قادر على قراءة ملف المسبقات."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -18065,10 +20675,6 @@ msgstr "تردد إبر الرادار (هرتز)"
 #~ msgid "FFmpeg : ERROR - Failed to write audio frame to file."
 #~ msgstr "FFmpeg : خطأ - أخفقت في كتابة إطار الصوت إلى الملف."
 
-#, fuzzy
-#~ msgid "%d kpbs"
-#~ msgstr "%d kbps"
-
 #~ msgid ""
 #~ "\"%s\" is an Audacity Project file. \n"
 #~ "Use the 'File > Open' command to open Audacity Projects."
@@ -18216,10 +20822,6 @@ msgstr "تردد إبر الرادار (هرتز)"
 #, fuzzy
 #~ msgid "Sound Finder"
 #~ msgstr "مولد الصمت"
-
-#, fuzzy
-#~ msgid "Finding sound..."
-#~ msgstr "البحث عن القطع..."
 
 #, fuzzy
 #~ msgid "Gating audio..."
@@ -18970,9 +21572,6 @@ msgstr "تردد إبر الرادار (هرتز)"
 #~ msgid "Independent"
 #~ msgstr "مستقل"
 
-#~ msgid "Version"
-#~ msgstr "إصدار"
-
 #~ msgid "Moderate"
 #~ msgstr "متوسط"
 
@@ -19056,9 +21655,6 @@ msgstr "تردد إبر الرادار (هرتز)"
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "لاستعمال الرسم، اختر 'شكل الموجة' من القائمة المنسدلة للمسار."
-
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "%.2f dB متوسط جذر متوسط المربع"
 
 #~ msgid "You must select audio in the project window."
 #~ msgstr "يجب أن تختار صوتاً في نافذة المشروع."

--- a/locale/be.po
+++ b/locale/be.po
@@ -5,57 +5,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Belarusian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/be/>\n"
+"Language-Team: Belarusian <https://hosted.weblate.org/projects/tenacity/tenacity/be/>\n"
 "Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-Country: BELARUS\n"
 "X-Poedit-Language: Belarusian\n"
 "X-Poedit-SourceCharset: utf-8\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Выйсці з Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Канал"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Памылка пры чытанні файла"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Памылка пры чытанні файла"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Панэль %s Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Запіс"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -65,6 +27,24 @@ msgstr "Немагчыма вызначыць"
 #, c-format
 msgid "%s bytes"
 msgstr "байтаў"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -83,12 +63,68 @@ msgid "2nd Experimental Command"
 msgstr "Абярыце каманду"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Эфекты"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Уставіць"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Уставіць"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Уставіць"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Уставіць"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Вылучэнне"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -111,15 +147,37 @@ msgid "Show &Output"
 msgstr "Паказаць выснову"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "&Панэлі"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "&Стоп"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Зменная"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Індыкатар узроўня на выйсці"
 
@@ -127,13 +185,38 @@ msgstr "Індыкатар узроўня на выйсці"
 msgid "Load Nyquist script"
 msgstr "Запыт Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Папярэджанне"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Запыт Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -144,6 +227,10 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "Аўтар - Леланд Люшес"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Эфекты"
 
@@ -152,12 +239,26 @@ msgid "No matches found"
 msgstr "Прылады не выяўлены"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Эфекты"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Стварыць праект"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Нядаўнія файлы"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -191,7 +292,8 @@ msgstr "Скапіяваць"
 msgid "Copy to clipboard"
 msgstr "Выразаць у буфер"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Выразаць"
 
@@ -199,7 +301,8 @@ msgstr "Выразаць"
 msgid "Cut to clipboard"
 msgstr "Выразаць у буфер"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Уставіць"
 
@@ -224,7 +327,8 @@ msgstr "Вылучэнне"
 msgid "Select all text"
 msgstr "Вылучэнне"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Адмяніць"
 
@@ -232,9 +336,20 @@ msgstr "Адмяніць"
 msgid "Undo last change"
 msgstr "Змена фармату"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Вярнуць"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Змена фармату"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "&Знайсці ноты"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -245,23 +360,46 @@ msgid "Match"
 msgstr "Пакетная апрацоўка"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "Да:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Няма пазнак для экспарту."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Угару"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Папярэдняя прылада"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Перамясціць фокус на дарожку вышэй і вылучыць"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Наступная прылада"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Пачатак"
 
@@ -269,7 +407,8 @@ msgstr "Пачатак"
 msgid "Start script"
 msgstr "Запыт Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Спыніць"
 
@@ -277,15 +416,29 @@ msgstr "Спыніць"
 msgid "Stop script"
 msgstr "Запыт Nyquist..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Інфармацыя пра зборку"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Уключана"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Адключана"
 
@@ -295,8 +448,9 @@ msgid "The Build"
 msgstr "Зборка з адладкавымі паведамленнямі"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Каманда:"
+#, fuzzy
+msgid "Version:"
+msgstr "Выконваецца рэверс"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -306,13 +460,23 @@ msgstr "Тып зборкі:"
 msgid "Compiler:"
 msgstr "Кампрэсары"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Прэфікс усталёўкі:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Тэчка з наладамі: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Тэчка з наладамі: "
 
 #: src/AboutDialog.cpp
@@ -331,7 +495,6 @@ msgstr "Пераўтварэнне чашчыні сэмпліравання"
 msgid "MP3 Importing"
 msgstr "Імпарт MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Імпарт і экспарт Ogg Vorbis"
@@ -340,7 +503,6 @@ msgstr "Імпарт і экспарт Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Падтрымка тэгаў ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Імпарт і экспарт FLAC"
@@ -358,14 +520,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Бібліятэка для імпарту/экспарту з FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Імпарт сродкамі QuickTime"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Магчымасці"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Падтрымка пашырэнняў"
 
@@ -380,6 +534,10 @@ msgstr "Падтрымка змены тэмпу і вышыні тону"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Падтрымка змены тэмпу і вышыні тону"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Магчымасці"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -406,6 +564,18 @@ msgstr "Агінальная"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Агінальная"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Агінальная"
 
@@ -417,9 +587,51 @@ msgstr "Агінальная"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Агінальная"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Агінальная"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Агінальная"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "Графічны EQ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Агінальная"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Агінальная"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -440,8 +652,26 @@ msgid "%s, graphics"
 msgstr "Графічны EQ"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Пра аўтараў"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -476,14 +706,23 @@ msgid "%s Team Members"
 msgstr "Іншыя якія адышлі ад спраў распрацоўнікі"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Іншыя ўдзельнікі праекта"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Руская лакалізацыя - Аляксандр Прокудін"
@@ -502,6 +741,26 @@ msgstr "Адмысловыя падзякі:"
 msgid "%s website: "
 msgstr "Першы запуск Tenacity "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Іншыя ўдзельнікі праекта"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Пстрыкніце і перацягніце для рэгуляцыі адноснага памеру стереодорожек"
@@ -519,6 +778,7 @@ msgstr "Змена часавай шкалы"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Пстрыкніце і перацягніце для рэдагавання сэмплаў"
@@ -526,17 +786,66 @@ msgstr "Пстрыкніце і перацягніце для рэдагаван
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Пстрыкніце і перацягніце для змены вышыні дарожкі"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Перамясціць фокус на дарожку ніжэй і вылучыць"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Перамясціць дарожку ўніз"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Зачыніць актыўную дарожку"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr " (адключана)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr " (адключана)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "Параметры пашырэння"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -554,7 +863,23 @@ msgstr "Прайгравана&я вобласць"
 msgid "Pinned Play Head"
 msgstr "Канец запісу"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Памылка"
 
@@ -564,7 +889,19 @@ msgid "Failed to remove %s"
 msgstr "Немагчыма выдаліць '%s'"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Параметры Tenacity"
 
 #: src/AudacityApp.cpp
@@ -577,6 +914,14 @@ msgstr ""
 "Не атрымалася знайсці %s.\n"
 "\n"
 "Файл выдалены са спісу нядаўна якія адчыняліся."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -597,7 +942,7 @@ msgstr "&Адкрыць..."
 msgid "Open &Recent..."
 msgstr "&Нядаўнія файлы..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Пра праграму..."
@@ -611,29 +956,33 @@ msgid "&File"
 msgstr "&Файл"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Праграма не можа знайсці каталог для захоўвання часавых файлаў.\n"
 "Пакажыце падыходны каталог у дыялогу параметраў праграмы."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Праграма не можа знайсці каталог для захоўвання часавых файлаў.\n"
 "Пакажыце падыходны каталог у дыялогу параметраў праграмы."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Tenacity рыхтуецца да выйсця.  Паўторна загрузіце праграму для выкарыстання новага каталога для часавых файлаў."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -642,24 +991,33 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity не атрымалася заблакаваць каталог з часавымі файламі.\n"
 "Магчыма, гэты каталог выкарыстоўваецца іншай копіяй Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Вы па-ранейшаму жадаеце запусціць Tenacity?"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Памылка пры чытанні файла"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Сістэма выявіла іншую запушчаную копію Tenacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Выкарыстоўвайце каманды Стварыць ці \"Адкрыць у\n"
@@ -667,12 +1025,58 @@ msgstr ""
 "з некалькімі праектамі.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity ужо загружаны"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Праектныя файлы Tenacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -692,7 +1096,8 @@ msgstr "\t-test (запусціць самодіагностіку)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "-version (паказаць нумар версіі Tenacity)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -702,9 +1107,10 @@ msgid "audio or project file name"
 msgstr "Немагчыма адкрыць файл праекта"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -718,20 +1124,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Праектныя файлы Tenacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "Змяніць чашчыню дыск&ретізаціі дарожкі"
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Запіс гуку"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Даведка"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Выйсці з Tenacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Праекты Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -743,9 +1178,14 @@ msgstr "&Захаваць..."
 msgid "Cl&ear"
 msgstr "Пра&чысціць"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Зачыніць"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -794,7 +1234,8 @@ msgid "Error Initializing Midi"
 msgstr "Памылка пры ініцыялізацыі MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Праекты Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -805,23 +1246,21 @@ msgid ""
 msgstr "Памылка пры адкрыцці гукавой прылады. "
 
 #: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+msgid "Out of memory!"
+msgstr ""
 
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Канец запісу\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Канец запісу\n"
 
 #: src/AudioIOBase.cpp
@@ -864,8 +1303,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Канец запісу\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Канец запісу\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Канец запісу\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Канец запісу\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -879,37 +1328,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Канец запісу\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Канец запісу\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Хуткасць прайгравання\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Немагчыма адкрыць файл з жанрамі.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Хуткасць прайгравання\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Запіс\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Чашчыні сэмпліравання\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Прайграванне\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Канец запісу\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Канец запісу\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Прайграванне\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Прайграванне\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -917,8 +1369,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Канец запісу\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Канец запісу\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Хуткасць прайгравання\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Хуткасць прайгравання\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -926,8 +1388,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Аўтаматычнае аднаўленне пасля аварыі"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -939,12 +1402,14 @@ msgid "Recoverable &projects"
 msgstr "Аднаўляльныя праекты"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Вылучэнне"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Імя"
 
@@ -955,6 +1420,10 @@ msgstr "Вылучэнне"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Вылучэнне"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -990,6 +1459,11 @@ msgid "&Parameters"
 msgstr "&Параметры"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Адчапіць"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "&Абярыце каманду"
 
@@ -1006,6 +1480,11 @@ msgid "Import Macro"
 msgstr "Імпарт файла без загалоўка"
 
 #: src/BatchCommands.cpp
+#, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr ""
+
+#: src/BatchCommands.cpp
 msgid "Export Macro"
 msgstr "Экспарт MIDI"
 
@@ -1016,6 +1495,22 @@ msgstr "Эфекты"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Змяніць параметры"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Змяніць параметры"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1062,11 +1557,30 @@ msgstr "Тэставы рэжым"
 msgid "Apply %s"
 msgstr "Ужыць %s"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Выдаліць перадусталёўку"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "Па&пазнакі..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Ужыць ланцужок эфектаў"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1122,13 +1636,34 @@ msgstr "Пра&тменіть"
 msgid "Remo&ve"
 msgstr "Выдаліць"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "Змяніць чашчыню дыск&ретізаціі дарожкі"
+
 #: src/BatchProcessDialog.cpp
 msgid "Re&store"
 msgstr "Аднавіць пра&ласть"
 
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "&Імпартаваць"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "&Экспартаваць..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Змяніць пазнакі"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1158,9 +1693,15 @@ msgstr "Перамясціць &угару"
 msgid "Move &Down"
 msgstr "Перамясціць у&ніз"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Захаваць"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1206,11 +1747,38 @@ msgid "Benchmark"
 msgstr "&Запусціць тэст прадукцыйнасці..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Колькасць паўтораў: "
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Зачыніць"
 
@@ -1225,8 +1793,30 @@ msgid "Export Benchmark Data as:"
 msgstr "Экспартаваць вынікі спектральнага аналізу ў файл:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Рыхтуецца предпрослушіваніе\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1235,17 +1825,104 @@ msgstr "Ствараюцца паўторы\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Уставіць\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Запіс гуку\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Дата і час завяршэння"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Зборка для канчатковых карыстачоў"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1266,9 +1943,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Спачатку прыйдзецца вылучыць вобласць гуку."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Ланцужок не абрана"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1294,6 +1995,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Не атрымалася знайсці кодэк"
 
@@ -1311,10 +2017,24 @@ msgstr "Дастасаваць да бягучаму праекту"
 msgid "Checkpointing %s"
 msgstr "Імпартуецца %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Не атрымалася вырабіць запіс у файл: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Не атрымалася захаваць праект. Магчыма, у вас няма правоў\n"
+"на запіс у %s, або дыск перапоўнены."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1332,6 +2052,10 @@ msgid ""
 "%s"
 msgstr "Немагчыма выдаліць '%s'"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "Выдаляюцца залежнасці"
@@ -1339,6 +2063,25 @@ msgstr "Выдаляюцца залежнасці"
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "Гукавыя файлы капіююцца ў праект..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "Пры захаванні праекта,які змяшчае вонкавыя файлы"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1353,8 +2096,27 @@ msgid "Disk Space"
 msgstr "Дыскавая прастора"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "Вылучэнне"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "Адмяніць захаванне"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Пазнака"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Do Not Copy"
+msgstr "Не аднаўляць"
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1366,9 +2128,32 @@ msgstr "Кожны раз, калі праект утрымоўвае вонка
 msgid "Ask me"
 msgstr "Пытаць мяне"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "Абраць MIDI-файл..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Выразаць у буфер"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1379,10 +2164,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Калі працягнуць, ваш праект не будзе запісаны на дыск. Вы сапраўды гэтага жадаеце?"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "Праверка залежнасцяў"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Не"
 
@@ -1390,7 +2187,7 @@ msgstr "Не"
 msgid "Rectangle"
 msgstr "Прастакутнае"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Трохкутнае"
 
@@ -1398,14 +2195,67 @@ msgstr "Трохкутнае"
 msgid "Shaped"
 msgstr "Па абрысах"
 
+#: src/FFT.cpp
+#, fuzzy
+msgid "Rectangular"
+msgstr "Прастакутнае"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
 #. i18n-hint a proper name
 #: src/FFT.cpp
 msgid "Welch"
 msgstr "Сардэчна запрашаем!"
 
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Праграма сабрана без падтрымкі FFmpeg"
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -1420,11 +2270,22 @@ msgid "Locate FFmpeg"
 msgstr "Паказаць FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity неабходзен файл %s для імпарту і экспарту пры дапамозе FFmpeg."
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Размяшчэнне %s:"
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "To find '%s', click here -->"
+msgstr "Каб знайсці %s, пстрыкніце тут -->"
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Агляд..."
 
@@ -1437,9 +2298,26 @@ msgstr "Каб атрымаць копію FFmpeg, пстрыкніце тут ?
 msgid "Download"
 msgstr "Запампаваць"
 
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "Дзе знаходзіцца %s?"
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg not found"
 msgstr "Бібліятэка FFmpeg не знойдзена"
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "Do not show this warning again"
@@ -1449,24 +2327,38 @@ msgstr "Больш не паказваць гэта папярэджанне"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Не атрымалася знайсці сумяшчальныя бібліятэкі FFmpeg"
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Tenacity не атрымалася запісаць файл:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Tenacity не атрымалася запісаць файл:\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Tenacity не атрымалася запісаць файл:\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1503,7 +2395,9 @@ msgstr "&Не капіяваць гукавыя дадзеныя"
 msgid "As&k"
 msgstr "&Пытаць карыстача"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Усе файлы (*)|*"
 
@@ -1512,6 +2406,11 @@ msgstr "Усе файлы (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Захоўваюцца дадзеныя праекта"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Бібліятэкі"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1525,12 +2424,20 @@ msgstr "Найменне файлаў:"
 msgid "XML files"
 msgstr "MP3"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "MP3"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
 
 #: src/FileNames.cpp
 msgid "Specify New Filename:"
@@ -1561,6 +2468,14 @@ msgstr "Сярэднеквадратовая аўтакарэляцыя"
 msgid "Enhanced Autocorrelation"
 msgstr "Падвышаная аўтакарэляцыя"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Спектр"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1579,9 +2494,18 @@ msgstr "Лагарыфмічны маштаб"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "Дб"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
 
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
@@ -1590,7 +2514,9 @@ msgstr "Маштаб"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "Гц"
 
@@ -1607,6 +2533,10 @@ msgstr "Гарызантальная арыентацыя"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Курсор налева"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1658,11 +2588,43 @@ msgstr "Абрана недастаткова дадзеных"
 msgid "s"
 msgstr "з"
 
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Спектр"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Экспартаваць вынікі спектральнага аналізу ў файл:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Не атрымалася вырабіць запіс у файл: "
@@ -1725,12 +2687,37 @@ msgstr "Захоўваецца праект Tenacity"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
 msgid "Burn to CD"
 msgstr "Запіс CD"
 
 #: src/HelpText.cpp
 msgid "No Local Help"
 msgstr "Лакальная даведка адсутнічае"
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
 
 #: src/HelpText.cpp
 msgid "These are our support methods:"
@@ -1754,6 +2741,22 @@ msgstr " <a href=\"http://forum.audacityteam.org/\">Форум</a> (вы сам�
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
 msgstr " [[http://wiki.audacityteam.org/index.php|Вікі]] (самыя свежыя рады, хітрасці і ўрокі; даступныя толькі ў Інтэрнэце)"
 
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
 #: src/HistoryWindow.cpp
 msgid "History"
 msgstr "&Гісторыя змен у праекце..."
@@ -1771,6 +2774,10 @@ msgid "Used Space"
 msgstr "Дыскавая прастора"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Усяго ўзроўняў адмены:"
 
@@ -1784,6 +2791,10 @@ msgid "&Discard"
 msgstr "Ад&здавацца"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "Ад&здавацца"
 
@@ -1791,11 +2802,30 @@ msgstr "Ад&здавацца"
 msgid "&Compact"
 msgstr "&Каманда"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Гісторыя змен у праекце..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -1811,7 +2841,9 @@ msgid "Track"
 msgstr "Дарожка"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Пазнака"
 
@@ -1871,21 +2903,36 @@ msgstr "Увядзіце назву дарожкі"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Дарожка пазнак"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Першы запуск Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Абярыце мову інтэрфейсу для Tenacity:"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Пацверджанне"
 
@@ -1903,12 +2950,13 @@ msgstr ""
 "Стары файл захаваны пад імем '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Адкрываецца праект Tenacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Караоке ў Tenacity%s"
 
 #: src/LyricsWindow.cpp
@@ -1934,6 +2982,12 @@ msgid "&Redo"
 msgstr "&Паўтарыць"
 
 #: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
 msgid "Disallowed"
 msgstr "Не дазволена"
 
@@ -1951,32 +3005,49 @@ msgid "Mixing and rendering tracks"
 msgstr "Зводзяцца дарожкі"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Мікшар Tenacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Гучнасць"
+
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Velocity"
+msgstr "Сіла націску ноты"
 
 #: src/MixerBoard.cpp
 msgid "Musical Instrument"
 msgstr "Музычная прылада"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Панарама"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Ціха"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Сола"
 
@@ -1984,11 +3055,19 @@ msgstr "Сола"
 msgid "Signal Level Meter"
 msgstr "Індыкатар узроўня сігналу"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Рэгулятар гучнасці зрушаны"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Рэгулятар гучнасці зрушаны"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Рэгулятар панарамы зрушаны"
 
@@ -2004,13 +3083,73 @@ msgid ""
 "Error: %s"
 msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Уключана"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy, c-format
+msgid "Module \"%s\" found."
+msgstr "Бібліятэка FFmpeg не знойдзена"
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Не"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Мадуляцыя"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -2020,18 +3159,126 @@ msgstr "Дарожка для пазнак"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "Гбайт"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "Дб"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Перазапісаць існыя файлы"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2054,9 +3301,24 @@ msgstr[2] "Выбачыце, не атрымалася загрузіць паш
 msgid "Enable new plug-ins"
 msgstr "Выбачыце, не атрымалася загрузіць пашырэнне VAMP."
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Эфекты"
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Выбачыце, не атрымалася загрузіць пашырэнне VAMP."
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Паказаць усе кодэкі"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -2088,6 +3350,25 @@ msgstr "Уключана"
 msgid "E&nabled"
 msgstr "Уключана"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Уключана"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Вылучэнне"
@@ -2096,7 +3377,8 @@ msgstr "Вылучэнне"
 msgid "C&lear All"
 msgstr "Пра&чысціць"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Уключана"
 
@@ -2167,6 +3449,21 @@ msgstr ""
 "Для пабудовы спектраграмы ўсе абраныя дарожкі\n"
 "павінны мець аднолькавую чашчыню"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Запісаны гук"
@@ -2175,19 +3472,189 @@ msgstr "Запісаны гук"
 msgid "Record"
 msgstr "Запісаць"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "Неадкладна зачыніць праект, не ўносячы змен"
 
 #: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Немагчыма адкрыць файл праекта"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
 msgid "Close project immediately with no further changes"
 msgstr "Неадкладна зачыніць праект, не ўносячы далейшых змен"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Прагрэс"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "Выконваецца ачыстка каталогаў з кэшам"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning: Problems in Automatic Recovery"
+msgstr "Памылка працягласці"
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Праекты"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2226,11 +3693,96 @@ msgid ""
 msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Немагчыма выдаліць '%s'"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Захоўваецца праект Tenacity"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Немагчыма ініцыялізаваць MP3-струмень"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Немагчыма ініцыялізаваць MP3-струмень"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Немагчыма ініцыялізаваць MP3-струмень"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Немагчыма ініцыялізаваць MP3-струмень"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Немагчыма ініцыялізаваць MP3-струмень"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Немагчыма ініцыялізаваць MP3-струмень"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Немагчыма ініцыялізаваць MP3-струмень"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Немагчыма ініцыялізаваць MP3-струмень"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2239,12 +3791,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Немагчыма ініцыялізаваць MP3-струмень"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Назва пераназваць '%s' у '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Не атрымалася знайсці кодэк"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Немагчыма выдаліць '%s'"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2255,9 +3833,9 @@ msgid "Error Writing to File"
 msgstr "Памылка пры спробе захаваць файл: "
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2268,8 +3846,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "&Захаванні праектаў"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Праекты Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2277,9 +3864,21 @@ msgstr "Праекты Tenacity"
 msgid "(Recovered)"
 msgstr "(Адноўлена)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Немагчыма адкрыць файл праекта"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2294,6 +3893,10 @@ msgid "Unable to parse project information."
 msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Захаванні праектаў"
 
@@ -2302,14 +3905,48 @@ msgid "Error Saving Project"
 msgstr "Памылка пры захаванні праекта"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Захаванні &пустых праектаў"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
+msgstr ""
+"Некаторыя праекты не былі карэктна захаваны калі вы ў папярэдні раз \n"
+"працавалі з Tenacity. Да шчасця, некаторыя з іх можна аднавіць:"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
 msgstr ""
 "Некаторыя праекты не былі карэктна захаваны калі вы ў папярэдні раз \n"
 "працавалі з Tenacity. Да шчасця, некаторыя з іх можна аднавіць:"
@@ -2318,9 +3955,52 @@ msgstr ""
 msgid "Project Recovered"
 msgstr "Праект адноўлены"
 
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Каталог для часавых файлаў"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+"\n"
+"Калі захаваць, у праекце не будзе\n"
+"ніводнай дарожкі.\n"
+"\n"
+"Каб вярнуць дарожкі, націсніце\n"
+"кнопку Адмена, і паслядоўна\n"
+"выбірайце пункт меню Праўка > Адмяніць,\n"
+"пакуль усе дарожкі не будуць вернутыя,\n"
+"затым абярыце Файл > Захаваць праект."
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "Захаванні &пустых праектаў"
+
 #: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "Дыскавая прастора"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -2328,9 +4008,34 @@ msgid "Saved %s"
 msgstr "Захаваны %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Захаваць праект як..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2338,9 +4043,21 @@ msgid "Overwrite Project Warning"
 msgstr "Перазапісаць існыя файлы"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Захаваць сціснутую копію праекта..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -2363,6 +4080,23 @@ msgstr "Абярыце адзін ці некалькі гукавых файл�
 msgid "%s is already open in another window."
 msgstr "%s ужо адкрыты ў іншым акне."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Памылка пры захаванні праекта"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Памылка пры чытанні файла"
@@ -2379,6 +4113,17 @@ msgid ""
 msgstr ""
 "Файл можа быць непадтрымоўванага фармату ці сапсаваны: \n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Памылка пры чытанні файла"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -2406,12 +4151,33 @@ msgid "Error Importing"
 msgstr "Памылка пры імпарце"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Захаваць праект"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Немагчыма адкрыць файл праекта"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Каманда"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2422,8 +4188,8 @@ msgid "Automatic database backup failed."
 msgstr "Аўтаматычнае аднаўленне пасля аварыі"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Сардэчна запрашаем у Tenacity версіі %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2461,6 +4227,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "Час да канца запісу ў мін: %d"
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -2475,6 +4245,18 @@ msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2491,6 +4273,26 @@ msgstr "Гарызантальная арыентацыя"
 msgid "Vertical Scrollbar"
 msgstr "Вертыкальная арыентацыя"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(Найлепшая якасць)"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Якасць"
@@ -2502,6 +4304,28 @@ msgstr "Якасць"
 #: src/Resample.cpp
 msgid "Best Quality (Slowest)"
 msgstr "(Найлепшая якасць)"
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "32-bit float"
+msgstr "32-bit float"
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -2587,7 +4411,8 @@ msgstr "Параметры..."
 msgid "SelectionBar"
 msgstr "Панэль вылучэння"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Вылучэнне"
 
@@ -2595,40 +4420,59 @@ msgstr "Вылучэнне"
 msgid "Timer"
 msgstr "Час"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Прылады"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "&Кіраванне"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Мікшары"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Індыкатар"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Індыкатар воспр."
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Індыкатар зап."
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Рэдагаванне"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Прылада"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Прайграванне на хуткасці"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "&Панэлі"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -2641,7 +4485,10 @@ msgstr "Лінейка"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Дарожкі"
 
@@ -2693,6 +4540,26 @@ msgstr "Высокія дарожкі"
 msgid "Choose a location to save screenshot images"
 msgstr "Абярыце тэчку для захоўвання здымкаў экрана"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (гэта паведамленне)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
+
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
 msgstr "Пра&слухаць"
@@ -2709,6 +4576,19 @@ msgstr "П&араметры..."
 msgid "Debu&g"
 msgstr "Ад&ладка"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "Уключыць прыліпанне"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
 #: src/SoundActivatedRecord.cpp
 msgid "Sound Activated Record"
 msgstr "Актывацыя запісу па сігнале"
@@ -2718,7 +4598,8 @@ msgid "Activation level (dB):"
 msgstr "Узровень гучнасці для актывацыі (Дб):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Сардэчна запрашаем у Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -2830,26 +4711,62 @@ msgid "Load Metadata As:"
 msgstr "Загрузіць метададзеныя як:"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Праўка метададзеных"
+
+#: src/Tags.cpp
 msgid "Save Metadata As:"
 msgstr "Захаваць метададзеныя як:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Памылка пры чытанні файла"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "Уключана"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Каталог для часавых файлаў"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity не атрымалася запісаць файл:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2858,18 +4775,26 @@ msgstr ""
 "на запіс."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity не атрымалася запісаць малюнкі ў файл:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -2879,9 +4804,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -2890,8 +4815,9 @@ msgstr ""
 "Можа быць, няправільны фармат PNG?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity не змог прачытаць сваю зыходную тэму.\n"
@@ -2929,24 +4855,40 @@ msgstr ""
 "ужо прысутнічаюць."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity не атрымалася захаваць файл:\n"
 "  %s"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "Невялікая"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Кантраст..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Назва дарожкі"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2955,7 +4897,11 @@ msgstr "Кантраст..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Працягласць"
 
@@ -2966,12 +4912,20 @@ msgid "Time Track"
 msgstr "Дарожка часу"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Таймер запісу Tenacity"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
 msgstr "Запіс"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
@@ -2986,12 +4940,38 @@ msgid "Error in Duration"
 msgstr "Памылка працягласці"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Аўтаматычнае аднаўленне пасля аварыі"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Памылка працягласці"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Экспарце праз FFmpeg"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "Памылка працягласці"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "&Таймер запісу..."
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3001,7 +4981,8 @@ msgstr "Дастасаваць да бягучаму праекту"
 msgid "Recording start:"
 msgstr "Пачатак запісу"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Працягласць:"
 
@@ -3022,7 +5003,8 @@ msgid "Action after Timer Recording:"
 msgstr "Таймер запісу Tenacity"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Прагрэс запісу па таймеры"
 
 #: src/TimerRecordDialog.cpp
@@ -3057,6 +5039,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "Канец запісу"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Памылка пры захаванні праекта"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Запіс"
@@ -3076,6 +5082,7 @@ msgstr "0100 дзён 024 ч 060 м 060 з"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Дата і час пачатку"
@@ -3120,7 +5127,8 @@ msgstr "Немагчыма экспартаваць"
 msgid "Export Project As:"
 msgstr "Экспартаваць перадусталёўкі"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Параметры..."
 
@@ -3129,8 +5137,21 @@ msgid "After Recording completes:"
 msgstr "Індыкатар зап."
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Выйсці з Tenacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3144,11 +5165,24 @@ msgstr "Запіс гуку"
 msgid "Scheduled to stop at:"
 msgstr "Вылучыць да пачатку дарожкі"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr "Таймер запісу Tenacity"
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Канец запісу"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3159,12 +5193,23 @@ msgid "Recording Exported:"
 msgstr "Канец запісу"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Таймер запісу Tenacity"
 
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "Стэрэа, 999999 Гц"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Дарожка"
 
 #. i18n-hint: The %d is replaced by the number of the track.
 #. i18n-hint: compose a name identifying an unnamed track by number
@@ -3191,6 +5236,14 @@ msgstr "Сола"
 msgid " Selected"
 msgstr "Вылучэнне"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
 msgstr "Ціха"
@@ -3198,6 +5251,11 @@ msgstr "Ціха"
 #: src/TrackPanelAx.cpp
 msgid " Solo On"
 msgstr "Сола вкл."
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "Вылучэнне"
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
@@ -3264,6 +5322,10 @@ msgstr "Перамясціць дарожку ўгару"
 msgid "Move Track Down"
 msgstr "Перамясціць дарожку ўніз"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3278,6 +5340,17 @@ msgstr ""
 #: src/VoiceKey.cpp
 msgid "Calibration Results\n"
 msgstr "Вынікі каліброўкі\n"
+
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, fuzzy, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr "Змена напрвленія  -- сярэдняе значэнне: %1.4f  sd: (%1.4f)\n"
+
+#: src/VoiceKey.cpp
+#, fuzzy, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr "Змена напрвленія  -- сярэдняе значэнне: %1.4f  sd: (%1.4f)\n"
 
 #: src/VoiceKey.cpp
 #, c-format
@@ -3296,25 +5369,84 @@ msgstr "Змена чашчыні сэмпліравання адключана.
 msgid "There is not enough room available to paste the selection"
 msgstr "Недастаткова месцы для ўстаўкі вылучанага"
 
+#: src/WaveTrack.cpp
+#, fuzzy
+msgid "There is not enough room available to expand the cut line"
+msgstr "Недастаткова месцы для ўстаўкі вылучанага"
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Ужываецца..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Каманда"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Каманда"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Паўтарыць %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -3329,12 +5461,20 @@ msgid "Compares a range on two tracks."
 msgstr "Кампрэсія па піках"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Час затрымкі (з):"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Каэфіцыент згасання: "
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -3356,6 +5496,11 @@ msgstr "Дарожка"
 msgid "Track 1"
 msgstr "Дарожка"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "&Памер аконнай функцыі"
@@ -3367,6 +5512,22 @@ msgstr "Ад:"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Ад:"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -3392,13 +5553,42 @@ msgstr "Перагрузка"
 msgid "Envelopes"
 msgstr "Агінальная"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Пазнакі"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Фільтры"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Фармат:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -3408,6 +5598,10 @@ msgstr "Перамясціць дарожку ўніз"
 msgid "Types:"
 msgstr "Фільтры"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Каментары"
@@ -3415,6 +5609,18 @@ msgstr "Каментары"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Каманда:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -3433,6 +5639,11 @@ msgid "Number of Channels:"
 msgstr "Колькасць паўтораў: "
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Экспарт у некалькі файлаў"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Экспарт у некалькі файлаў"
 
@@ -3440,9 +5651,26 @@ msgstr "Экспарт у некалькі файлаў"
 msgid "Builtin Commands"
 msgstr "Абярыце каманду"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Каманда падтрымкі Tenacity %s"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Дата і час завяршэння"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -3484,11 +5712,22 @@ msgstr "&Захаваць праект"
 msgid "Saves a copy of current project."
 msgstr "&Захаваць праект"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Параметры..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Імя"
 
@@ -3499,6 +5738,18 @@ msgstr "Параметры..."
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Значэнне"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3524,7 +5775,8 @@ msgstr "Поўнаэкранны рэжым"
 msgid "Toolbars"
 msgstr "&Панэлі"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Эфекты"
 
@@ -3568,6 +5820,10 @@ msgstr "Высокія дарожкі"
 msgid "All Tracks Plus"
 msgstr "Высокія дарожкі"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -3575,13 +5831,30 @@ msgid "White"
 msgstr "Белы"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Задні план:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Памылка пры спробе захаваць файл: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Захоп здымкаў экрана..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -3628,6 +5901,10 @@ msgid "High:"
 msgstr "Фільтры верхніх чашчынь"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "Нізкія дарожкі"
 
@@ -3640,7 +5917,8 @@ msgstr "Усталяваць"
 msgid "Add"
 msgstr "&Дадаць"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Выдаліць"
 
@@ -3661,6 +5939,11 @@ msgid "Selects a time range."
 msgstr "Абраць MIDI-файл..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Абраць MIDI-файл..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Абярыце дзеянне"
 
@@ -3672,9 +5955,37 @@ msgstr "Запоўніць ті&шынай"
 msgid "Set Clip"
 msgstr "Наступная прылада"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Пачатак"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -3693,9 +6004,14 @@ msgid "Edited Envelope"
 msgstr "Агінальная"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Агінальная"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -3705,6 +6021,10 @@ msgstr "Падзяліць па пазнаках"
 msgid "Label Index"
 msgstr "Праўка пазнакі"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Вылучэнне"
@@ -3712,6 +6032,10 @@ msgstr "Вылучэнне"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Зменены пазнакі"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -3725,9 +6049,26 @@ msgstr "Чашчыня сэмпліравання"
 msgid "Resize:"
 msgstr "Паменшыць акно"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Невялікая"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Захаваць праект"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -3742,6 +6083,10 @@ msgid "Set Track Status"
 msgstr "да пачатку &дарожкі"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "Прыпыніць"
 
@@ -3754,10 +6099,17 @@ msgid "Gain:"
 msgstr "Гучнасць"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Нізкія дарожкі"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Лінейны"
 
@@ -3768,6 +6120,10 @@ msgstr "Скінуць"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "Час"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -3797,13 +6153,28 @@ msgstr "Апрацоўка спектру"
 msgid "Spectral Select"
 msgstr "Вылучэнне"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Новая дарожка"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Абярыце дзеянне"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Узмацненне сігналу"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -3825,6 +6196,17 @@ msgstr "Дазволіць перагрузку сігналу"
 msgid "Auto Duck"
 msgstr "Автопріглушеніе"
 
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -3832,12 +6214,18 @@ msgstr "Автопріглушеніе"
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Эфекту автопріглушенія патрэбна кантрольная дарожка, змешчаная ніжэй абранай."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Наколькі прыглушыць:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "секунд"
 
@@ -3861,7 +6249,8 @@ msgstr "Працягласць унутранага фейда ўніз:"
 msgid "Inner &fade up length:"
 msgstr "Працягласць унутранага фейда ўгару:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Парог:"
 
@@ -3870,8 +6259,17 @@ msgid "Preview not available"
 msgstr "Праслухоўванне недаступна"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Сцягнуць вылучэнне злева"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Парог шуму: "
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3882,8 +6280,18 @@ msgid "Ba&ss (dB):"
 msgstr "Падвышэнне (Дб):"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "Узмацненне басу"
+
+#: src/effects/BassTreble.cpp
 msgid "&Treble (dB):"
 msgstr "&Дыяпазон (Дб):"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Праўка пазнакі"
 
 #: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
@@ -3892,6 +6300,10 @@ msgstr "&Дыяпазон (Дб):"
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Узровень сціску:"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -3902,8 +6314,18 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Змена вышыні тону без змены тэмпу"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Змена тэмпу ў канцы (%)"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Змена вышыні тону без змены тэмпу"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
@@ -3958,17 +6380,36 @@ msgstr "Чашчыня (Гц)"
 msgid "from (Hz)"
 msgstr "ад"
 
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "to (Hz)"
+msgstr "ад"
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "да"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Адсоткавая змена:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Адсоткавая змена"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -3984,7 +6425,9 @@ msgstr "48"
 #  unimportant, not relevant).
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "н/д"
 
@@ -4012,6 +6455,7 @@ msgstr "Хуткасць звароту грамкружэлкі:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "З адной колькасці зваротаў у хвіліну"
@@ -4021,6 +6465,14 @@ msgstr "З адной колькасці зваротаў у хвіліну"
 msgctxt "change speed"
 msgid "&from"
 msgstr "ад"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "З адной колькасці зваротаў у хвіліну"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4124,6 +6576,19 @@ msgid "Click Removal"
 msgstr "Выдаленне пстрычак"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Поле імя павінна быць запоўнена"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "Пакажыце парог (ніжэй ? адчувальней):"
 
@@ -4135,9 +6600,17 @@ msgstr "Парог"
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "Макс. шырыня піка (вышэй ? адчувальней):"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 msgid "Compressor"
 msgstr "Кампрэсары"
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
 
 #. i18n-hint: usually leave this as is as dB doesn't get translated
 #: src/effects/Compressor.cpp
@@ -4155,6 +6628,20 @@ msgstr "%.1f з"
 msgid "%.1f secs"
 msgstr "%.1f з"
 
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
+msgstr "%.1f з"
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
@@ -4164,6 +6651,16 @@ msgstr "Суадносіны %.0f да 1"
 #, c-format
 msgid "Ratio %.1f to 1"
 msgstr "Суадносіны %.1f да 1"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "Тып шуму"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "Шум..."
 
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
@@ -4219,6 +6716,11 @@ msgstr "Парог: %d Дб"
 
 #: src/effects/Compressor.cpp
 #, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
 msgid "Attack Time %.2f secs"
 msgstr "Час нападу: %.1f з"
 
@@ -4228,11 +6730,35 @@ msgid "Release Time %.1f secs"
 msgstr "Працягласць згасання: %.1f c"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Абярыце дзеянне"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Абярыце дзеянне"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Абярыце дзеянне"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Канец"
 
@@ -4292,9 +6818,26 @@ msgstr "Розніца:"
 msgid "&Help"
 msgstr "&Даведка"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "ноль"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Немагчыма вызначыць"
 
 #. i18n-hint: dB abbreviates decibels
 #. * RMS abbreviates root mean square, a certain averaging method
@@ -4309,12 +6852,33 @@ msgid "Infinite dB difference"
 msgstr "Актуальныя адрозненні"
 
 #: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
 msgid "Foreground level too high"
 msgstr "Час завяршэння фрагмента задняга плану"
 
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "Час завяршэння фрагмента пярэдняга плану"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -4342,12 +6906,22 @@ msgid "%.2f dB"
 msgstr "%.1f Дб"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "No foreground measured"
+msgstr "Час завяршэння фрагмента задняга плану"
+
+#: src/effects/Contrast.cpp
 msgid "Foreground not yet measured"
 msgstr "Час завяршэння фрагмента задняга плану"
 
 #: src/effects/Contrast.cpp
 msgid "Measured background level"
 msgstr "Вымераны ўзровень задняга плану"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "No background measured"
+msgstr "Час завяршэння фрагмента пярэдняга плану"
 
 #: src/effects/Contrast.cpp
 msgid "Background not yet measured"
@@ -4401,6 +6975,16 @@ msgstr "Крытэры паспяховасці 1.4.7 па WCAG 2.0: няўда�
 msgid "Data gathered"
 msgstr "Дадзеныя сабраны"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast..."
 msgstr "Кантраст..."
@@ -4422,6 +7006,19 @@ msgid "Medium Overdrive"
 msgstr "Пацверджанне перазапісу"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Пацверджанне перазапісу"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Кампрэсар дынамічнага дыяпазону"
 
@@ -4432,6 +7029,96 @@ msgstr "Выраўноўвальнік"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Скажэнне"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Абмежавальнікі"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Пацверджанне перазапісу"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Пацверджанне перазапісу"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Пацверджанне перазапісу"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -4454,8 +7141,16 @@ msgid "Distortion"
 msgstr "Скажэнне"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Скажэнне"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -4470,8 +7165,21 @@ msgid "Clipping level"
 msgstr "Перагрузка"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Ужыць ланцужок эфектаў"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Парог:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -4486,6 +7194,14 @@ msgid "Repeat processing"
 msgstr "Пакетная ачыстка запісу голасу"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Ступень выраўноўвання"
 
@@ -4497,9 +7213,48 @@ msgstr "Абмежавальнікі"
 msgid "Wet level"
 msgstr "2-уровень"
 
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2-уровень"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "Тонавыя сігналы тэлефона..."
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -4509,7 +7264,9 @@ msgstr "Паслядоўнасць:"
 msgid "&Amplitude (0-1):"
 msgstr "Амплітуда (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Працягласць:"
 
@@ -4554,6 +7311,11 @@ msgstr "Рэха"
 msgid "Repeats the selected audio again and again"
 msgstr "Абраныя гукавыя дадзеныя экспартаваны ў %s"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "Час затрымкі (з):"
@@ -4574,7 +7336,8 @@ msgstr "Перадусталёўка"
 msgid "Export Effect Parameters"
 msgstr "&Змяніць параметры"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Не атрымалася адкрыць файл: \"%s\""
@@ -4598,6 +7361,12 @@ msgstr "&Змяніць параметры"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Немагчыма адкрыць/стварыць тэставы файл\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Рыхтуецца предпрослушіваніе"
@@ -4605,6 +7374,15 @@ msgstr "Рыхтуецца предпрослушіваніе"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Предпрослушіваніе"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -4641,10 +7419,30 @@ msgid "Factory Defaults"
 msgstr "Выкарыстоўваць &усюды"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr ""
 "Не атрымалася ініцыялізаваць кадавальнік FLAC\n"
 "Статут: %d"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -4669,6 +7467,23 @@ msgid "&Bypass"
 msgstr "Палосна-прапускалыя фільтры"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Дарожкі выраўнаваны"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Перамясціць &угару"
 
@@ -4685,6 +7500,24 @@ msgid "Move effect down in the rack"
 msgstr "Вобласць перамешчана з адной дарожкі ў іншую"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Вобласць перамешчана з адной дарожкі ў іншую"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Увядзіце назву новага ланцужка"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Затрымка"
@@ -4692,6 +7525,20 @@ msgstr "Затрымка"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Абярыце каманду"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "Кіраванне дзеяннямі па гісторыі"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Прайграванне"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -4752,14 +7599,33 @@ msgid "Options..."
 msgstr "Параметры..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Фільтры"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Імя"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Выконваецца рэверс"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Памылка: "
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "Транскрыпцыя"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -4821,6 +7687,18 @@ msgid "Graphic EQ"
 msgstr "Графічны EQ"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Узмацненне басу"
 
@@ -4829,12 +7707,30 @@ msgid "Bass Cut"
 msgstr "Узмацненне басу"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Treble Boost"
 msgstr "&Дыяпазон (Дб):"
 
 #: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Праўка пазнакі"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Filter Curve EQ needs a different name"
@@ -4855,6 +7751,10 @@ msgid "Effect Unavailable"
 msgstr "Праслухоўванне недаступна"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Макс. Дб"
 
@@ -4867,6 +7767,26 @@ msgstr "%3d Дб"
 msgid "Min dB"
 msgstr "Мін. Дб"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "Фільтры"
@@ -4874,6 +7794,11 @@ msgstr "Фільтры"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Крывыя"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Змена агінальнай"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -4884,8 +7809,46 @@ msgid "Interpolation type"
 msgstr "Інтэрпаляцыя:"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Лінейны маштаб"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Лінейны маштаб"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "&Працягласць праслухоўвання:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "&Працягласць праслухоўвання:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Выдаліць перадусталёўку"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Выдаліць перадусталёўку"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Інвертаванне"
 
 #: src/effects/Equalization.cpp
 msgid "Show grid lines"
@@ -4904,16 +7867,105 @@ msgid "D&efault"
 msgstr "&Зыходныя параметры"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Запусціць тэст прадукцыйнасці..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Error Loading EQ Curves"
 msgstr "Памылка пры захаванні праекта"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Ужываецца эфект эквалізаціі"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Curve not found"
 msgstr "Бібліятэка FFmpeg не знойдзена"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Кіраванне дзеяннямі па гісторыі"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Крывыя"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Курсор налева"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Імя"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Выдаліць"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Абраць..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "&Зыходныя параметры"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4921,14 +7973,42 @@ msgid "Rename '%s' to..."
 msgstr "Назва '%s' зменена на '%s'"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "Змяніць чашчыню дыск&ретізаціі дарожкі"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "Назва '%s' зменена на '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Шрыфт"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr "Перазапісаць існыя файлы"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "Перамясціць у&ніз"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Немагчыма экспартаваць дадзеныя ў %s"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4945,8 +8025,52 @@ msgid "Delete %d items?"
 msgstr "Створана паўтораў: %d"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Абярыце тэчку для захоўвання здымкаў"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Экспартаваць &пазнакі..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Немагчыма экспартаваць дадзеныя ў %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Канец запісу"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "Бібліятэка FFmpeg не знойдзена"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "Няма пазнак для экспарту."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -4960,9 +8084,18 @@ msgstr "Плыўнае згасанне"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Пстрыкніце і перацягніце для вылучэння гукавога фрагмента"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Пстрыкніце і перацягніце для вылучэння гукавога фрагмента"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Пошук перагрузкі"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -4984,13 +8117,37 @@ msgstr "Недастаткова месцы для стварэння гукав
 msgid "Invert"
 msgstr "Інвертаванне"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Эфекты Audio Unit"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Падагнаць максімальную амплітуду пад:"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -5009,6 +8166,27 @@ msgstr "Ужываецца эфект автопріглушенія..."
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Нармалізацыя"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -5038,6 +8216,10 @@ msgid "Noise"
 msgstr "Шум..."
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Тып шуму"
 
@@ -5050,16 +8232,73 @@ msgid "Second greatest"
 msgstr "Другая дарожка"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Маштаб па змаўчанні"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Маштаб па змаўчанні"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Прыгнечанне шуму"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Ва ўсіх дарожак павінна быць аднолькавая чашчыня сэмпліравання"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -5103,6 +8342,11 @@ msgstr "Зборка для канчатковых карыстачоў"
 msgid "&Frequency smoothing (bands):"
 msgstr "Чашчыня (Гц): "
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Чашчыня (Гц): "
+
 #: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "Адчувальнасць"
@@ -5116,8 +8360,9 @@ msgid "Step 1"
 msgstr "Этап 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Вылучыце некалькі секунд толькі шуму, так каб праграма ведала, што\n"
@@ -5139,6 +8384,27 @@ msgstr ""
 "Вылучыце тую частку дарожкі, да якой жадаеце ўжыць фільтр, пакажыце,\n"
 "колькі шуму адфільтраваць, а затым пстрыкніце мышкай па кнопцы ОК\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "Шум..."
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "&Выдаліць дарожкі"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Паменшыць акно"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "Пашыраныя параметры звесткі"
@@ -5155,17 +8421,74 @@ msgstr "&Памер аконнай функцыі"
 msgid "8"
 msgstr "48"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - па змаўчанні"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "Маштаб па змаўчанні"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Выдаліць шум"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -5180,6 +8503,11 @@ msgid "Noise re&duction (dB):"
 msgstr "Выдаленне шуму (Дб):"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "Адчувальнасць"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr "Чашчыня (Гц): "
 
@@ -5187,13 +8515,66 @@ msgstr "Чашчыня (Гц): "
 msgid "Attac&k/decay time (secs):"
 msgstr "Напад/згасанне (з):"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Напад/згасанне (з):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "Выдаліць"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Нармалізацыя"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Выдаленне шуму\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Выдаленне шуму\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Выдаленне шуму\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Remove DC offset (center on 0.0 vertically)"
@@ -5207,9 +8588,23 @@ msgstr "Падагнаць максімальную амплітуду пад:"
 msgid "Peak amplitude dB"
 msgstr "Новая віновая амплітуда (Дб):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Каэфіцыент згасання: "
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Каэфіцыент згасання: "
@@ -5218,17 +8613,60 @@ msgstr "Каэфіцыент згасання: "
 msgid "&Time Resolution (seconds):"
 msgstr "Час затрымкі (з):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Фейзеры"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Этапы:"
 
 #: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Этапы:"
+
+#: src/effects/Phaser.cpp
 msgid "&Dry/Wet:"
 msgstr "Да/пасля:"
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
@@ -5275,6 +8713,10 @@ msgid "Repair"
 msgstr "Аднавіць"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -5284,9 +8726,22 @@ msgstr ""
 "\n"
 "Наблізьце адлюстраванні да максімуму і абярыце вельмі кароткі адрэзак гукавых дадзеных."
 
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Паўтор..."
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -5310,6 +8765,10 @@ msgstr "Новая працягласць вылучэння: "
 msgid "New selection length: %s"
 msgstr "Новая працягласць вылучэння: "
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
 msgstr "Лакальна"
@@ -5319,12 +8778,50 @@ msgid "Vocal II"
 msgstr "Лакальна"
 
 #: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "Сярэдняе"
 
 #: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "Рэверберацыя"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Памер"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Напад/згасанне (з):"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -5335,12 +8832,30 @@ msgid "Da&mping (%):"
 msgstr "Глыбіня (%):"
 
 #: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Глыбіня (%):"
+
+#: src/effects/Reverb.cpp
 msgid "Wet &Gain (dB):"
 msgstr "&Узмацненне (Дб):"
 
 #: src/effects/Reverb.cpp
 msgid "Dr&y Gain (dB):"
 msgstr "&Узмацненне (Дб):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Стэрэа"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -5355,6 +8870,25 @@ msgstr "Рэверс"
 msgid "Reverses the selected audio"
 msgstr "Абраныя гукавыя дадзеныя экспартаваны ў %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Фільтры нізкіх чашчынь"
@@ -5362,6 +8896,16 @@ msgstr "Фільтры нізкіх чашчынь"
 #: src/effects/ScienFilter.cpp
 msgid "Highpass"
 msgstr "Фільтры верхніх чашчынь"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "З&агрузіть файл на FTP-сервер..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
@@ -5373,6 +8917,19 @@ msgstr ""
 msgid "&Filter Type:"
 msgstr "Фільтры"
 
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
 msgstr "Тып зборкі:"
@@ -5381,9 +8938,32 @@ msgstr "Тып зборкі:"
 msgid "Cutoff (Hz)"
 msgstr "ад"
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "C&utoff:"
+msgstr "ад"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Сінхранізаваць MIDI з гукам"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Працягласць:"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Працягласць:"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -5392,6 +8972,14 @@ msgstr "&Памер аконнай функцыі"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "&Памер аконнай функцыі"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -5407,6 +8995,15 @@ msgstr "Парог:"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "Па часе"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "Па часе"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -5445,11 +9042,20 @@ msgstr "&Зыходныя параметры"
 msgid "Restore Defaults"
 msgstr "Выкарыстоўваць &усюды"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Стварыць цішыню"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -5476,12 +9082,38 @@ msgid "Sliding Stretch"
 msgstr "Каэфіцыент згасання: "
 
 #: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
 msgstr "Змена тэмпу напачатку (%)"
 
 #: src/effects/TimeScale.cpp
 msgid "Final Tempo Change (%)"
 msgstr "Змена тэмпу ў канцы (%)"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Pitch Shift"
+msgstr "Зрушэнне вышыні тону"
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Pitch Shift"
+msgstr "Зрушэнне вышыні тону"
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
 
 #: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
 msgid "Logarithmic"
@@ -5500,6 +9132,10 @@ msgid "Sawtooth"
 msgstr "Зубцевідная"
 
 #: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Chirp"
 msgstr "&Імпульс..."
 
@@ -5508,12 +9144,30 @@ msgid "Tone"
 msgstr "Хваля..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Хваля:"
 
 #: src/effects/ToneGen.cpp
 msgid "&Frequency (Hz):"
 msgstr "Чашчыня (Гц):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Чашчыня ў герцах"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "Чашчыня ў герцах"
 
 #: src/effects/ToneGen.cpp
 msgid "Amplitude Start"
@@ -5532,8 +9186,20 @@ msgid "Truncate Detected Silence"
 msgstr "Выразанне цішыні"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "Выразанне цішыні"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -5543,15 +9209,37 @@ msgstr "Раз&дзяліць па цішыні"
 msgid "Tr&uncate to:"
 msgstr "Выразанне цішыні"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Кампрэсары"
+
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST Effects"
 msgstr "Эфекты VST"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Не атрымалася адкрыць бібліятэку для экспарту ў MP3!"
 
@@ -5559,17 +9247,44 @@ msgstr "Не атрымалася адкрыць бібліятэку для э�
 msgid "VST Effect Options"
 msgstr "Параметры эфекту"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Працягласць"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Сціск цішыні:"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Сціск цішыні:"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Graphical Mode"
 msgstr "Графічны EQ"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 #, c-format
@@ -5581,12 +9296,22 @@ msgid "Save VST Preset As:"
 msgstr "Захаваць праграму VST як:"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Загрузіць праграму VST:"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "Загрузіць праграму VST:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Праектныя файлы Tenacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Error Saving VST Presets"
@@ -5608,9 +9333,15 @@ msgstr "Памылка пры захаванні праекта"
 msgid "Unable to load presets file."
 msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Параметры эфекту"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
@@ -5628,6 +9359,14 @@ msgid "VST"
 msgstr "V&ST"
 
 #: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
 msgstr "Глыбіня (%):"
 
@@ -5643,9 +9382,19 @@ msgstr "Рэзананс"
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Зрушэнне чашчыні Wah (%):"
 
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Зрушэнне чашчыні Wah (%):"
+
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Audio Unit Effects"
+msgstr "Эфекты Audio Unit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Эфекты Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -5661,20 +9410,41 @@ msgid "Audio Unit Effect Options"
 msgstr "Эфекты Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Інтэрфейс"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Прылада ўваходу"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Шматпалосны"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "Созда&ніе"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "Імпартаваць перадусталёўкі"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -5750,6 +9520,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Немагчыма выдаліць '%s'"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Пераўтварэнне чашчыні сэмпліравання"
 
@@ -5758,15 +9533,60 @@ msgstr "Пераўтварэнне чашчыні сэмпліравання"
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Немагчыма выдаліць '%s'"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Немагчыма выдаліць '%s'"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Немагчыма выдаліць '%s'"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Эфекты VST"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "Эфекты VST"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Параметры эфекту"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -5774,6 +9594,7 @@ msgstr "Параметры эфекту"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "&LADSPA"
@@ -5783,16 +9604,57 @@ msgid "LV2 Effect Settings"
 msgstr "Параметры эфекту"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Generator"
 msgstr "Генератары"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
 
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Эфекты VST"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Эфекты"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -5806,6 +9668,24 @@ msgstr "Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Выснова Nyquist: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
@@ -5822,12 +9702,36 @@ msgstr ""
 "з несупадаючымі індывідуальнымі дарожкамі"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Выснова Nyquist: "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Ужываецца эфект автопріглушенія..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -5864,6 +9768,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist не перадаў гукавы сігнал.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Гэта версія Tenacity была скампілявана без падтрымкі %s."
@@ -5872,10 +9780,38 @@ msgstr "Гэта версія Tenacity была скампілявана без 
 msgid "Could not open file"
 msgstr "Не атрымалася адкрыць файл:"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Error in Nyquist code"
+msgstr "Памылка працягласці"
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Не атрымалася адкрыць файл: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Немагчыма адкрыць/стварыць тэставы файл\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -5896,6 +9832,22 @@ msgid "Lisp scripts"
 msgstr "Запыт Nyquist..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Не атрымалася адкрыць файл:"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "Час завяршэння фрагмента задняга плану"
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -5914,9 +9866,25 @@ msgstr "Абраць MIDI-файл..."
 msgid "Save file as"
 msgstr "Захаваць файлы"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Эфекты VST"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr ""
+"Выбачыце, але эфект немагчыма дастасаваць да стереодорожкам\n"
+"з несупадаючымі індывідуальнымі дарожкамі"
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, failed to load Vamp Plug-in."
@@ -5933,6 +9901,17 @@ msgstr "Параметры пашырэння"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Праграма"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Параметры эфекту"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -5958,6 +9937,16 @@ msgstr "Увесь гук прыглушаны."
 #, c-format
 msgid "Are you sure you want to export the file as \"%s\"?\n"
 msgstr "Вы ўпэўнены, што жадаеце захаваць файл як \"\n"
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
@@ -6025,10 +10014,25 @@ msgstr "Немагчыма экспартаваць"
 msgid "Show output"
 msgstr "Паказаць выснову"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "Зменная"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Каманда"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -6052,9 +10056,31 @@ msgid "Exporting the audio using command-line encoder"
 msgstr "Вылучанае экспартуецца праз кансольны кадавальнік"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "Каманда"
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "Бібліятэка FFmpeg не знойдзена"
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -6065,8 +10091,103 @@ msgstr ""
 "Зрабіце гэта ў дыялогу Параметры > Бібліятэк\"."
 
 #: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Бібліятэка FFmpeg:"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Абраныя гукавыя дадзеныя экспартаваны ў %s"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -6077,9 +10198,28 @@ msgstr "Абраныя гукавыя дадзеныя экспартаваны 
 msgid "Invalid sample rate"
 msgstr "Некарэктная чашчыня сэмпліравання"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Змена чашчыні сэмпліравання"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
 msgid "Sample Rates"
@@ -6087,7 +10227,8 @@ msgstr "Чашчыні сэмпліравання"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "Кбіт/з"
@@ -6100,9 +10241,43 @@ msgstr "Хуткасць струменя:"
 msgid "Quality (kbps):"
 msgstr "Якасць:"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "Кбіт/з"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "0"
 msgstr "60"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "120"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "145"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "145"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "48"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "9"
@@ -6121,6 +10296,10 @@ msgid "Constrained"
 msgstr "Сталая"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Гукавы файл..."
 
@@ -6129,8 +10308,44 @@ msgid "Low Delay"
 msgstr "Затрымка"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Сярэдняе"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -6151,6 +10366,11 @@ msgstr "Рэжымы"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "Узмацненне, Дб"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Cutoff:"
+msgstr "ад"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Open custom FFmpeg format options"
@@ -6197,6 +10417,20 @@ msgid "Replace preset '%s'?"
 msgstr "Выдаліць перадусталёўку '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Л"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "Асноўны мікс"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
 msgstr "Файлы M4A (AAC) (FFmpeg)"
 
@@ -6221,6 +10455,10 @@ msgid "Custom FFmpeg Export"
 msgstr "Экспарце праз FFmpeg"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "2-level"
 msgstr "2-уровень"
 
@@ -6231,6 +10469,14 @@ msgstr "4-уровень"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "8-level"
 msgstr "8-уровень"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Configure custom FFmpeg options"
@@ -6258,6 +10504,10 @@ msgid "Codec:"
 msgstr "Кодэк:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Formats"
 msgstr "Паказаць усе фарматы"
 
@@ -6266,12 +10516,56 @@ msgid "Show All Codecs"
 msgstr "Паказаць усе кодэкі"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Параметры пашырэння"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Мова:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Tag:"
 msgstr "Тэг:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
@@ -6290,12 +10584,132 @@ msgid "Sample Rate:"
 msgstr "Чашчыня сэмпліравання:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Profile:"
 msgstr "Профіль:"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "FLAC options"
 msgstr "Параметры FLAC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Кампрэсары"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Імя"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Выкарыстоўваць LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
 
 #. i18n-hint:  Abbreviates "Linear Predictive Coding",
 #. but this text needs to be kept very short
@@ -6307,11 +10721,40 @@ msgstr "Выкарыстоўваць LPC"
 msgid "MPEG container options"
 msgstr "Параметры кантэйнера MPEG"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Чашчыня сэмпліравання"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
 #. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
 #. compression.  It measures how big a chunk of audio is compressed in one piece.
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Packet Size:"
 msgstr "Памер пакета:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "You can't delete a preset without name"
+msgstr "Вы не можаце захаваць безназоўную перадусталёўку"
 
 #: src/export/ExportFFmpegDialogs.cpp
 #, c-format
@@ -6323,8 +10766,33 @@ msgid "You can't save a preset without a name"
 msgstr "Вы не можаце захаваць безназоўную перадусталёўку"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "Няма пазнак для экспарту."
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "Абярыце файл(ы) для пакетнай апрацоўкі..."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -6358,6 +10826,11 @@ msgstr "Разраднасць:"
 #: src/export/ExportFLAC.cpp
 msgid "FLAC Files"
 msgstr "Файлы FLAC"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Не атрымалася адкрыць файл: \"%s\""
 
 #: src/export/ExportFLAC.cpp
 #, c-format
@@ -6403,8 +10876,57 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(Найлепшая якасць)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(Найменшыя файлы)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -6415,7 +10937,8 @@ msgstr "Вар'яцка высокае"
 msgid "Extreme"
 msgstr "Вельмі высокае"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Як звычайна"
 
@@ -6436,6 +10959,11 @@ msgid "Constant"
 msgstr "Сталая"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "Joint Stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Stereo"
 msgstr "Стэрэа"
 
@@ -6452,14 +10980,19 @@ msgstr "Якасць"
 msgid "Channel Mode:"
 msgstr "Рэжым каналаў:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Выдалена лінія выразання"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Указанне размяшчэння LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity патрабуецца файл %s для запісу файлаў MP3."
 
 #: src/export/ExportMP3.cpp
@@ -6487,6 +11020,34 @@ msgid "Where is %s?"
 msgstr "Дзе знаходзіцца %s?"
 
 #: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Захоўваюцца дадзеныя праекта"
+
+#: src/export/ExportMP3.cpp
 msgid "Extended libraries"
 msgstr "Асноўныя бібліятэкі"
 
@@ -6511,9 +11072,19 @@ msgid "Unable to initialize MP3 stream"
 msgstr "Немагчыма ініцыялізаваць MP3-струмень"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Вылучанае экспартуецца пры %ld Кбіт/з"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
 msgstr "Вылучанае экспартуецца пры %ld Кбіт/з"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "Абраныя гукавыя дадзеныя экспартаваны ў %s"
 
 #: src/export/ExportMP3.cpp
 #, c-format
@@ -6521,9 +11092,33 @@ msgid "Exporting the audio with VBR quality %s"
 msgstr "Абраныя гукавыя дадзеныя экспартаваны ў %s"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Вылучанае экспартуецца пры %ld Кбіт/з"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Вылучанае экспартуецца пры %ld Кбіт/з"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "MP3 export library not found"
@@ -6542,8 +11137,18 @@ msgid "Cannot Export Multiple"
 msgstr "Экспарт у некалькі файлаў"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Каталог для экспарту:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -6578,6 +11183,16 @@ msgid "Using Label/Track Name"
 msgstr "Выкарыстоўваецца пазнака/ Назва дарожкі"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Выкарыстоўваецца пазнака/ Назва дарожкі"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Прэфікс імя файла"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
 msgstr "Прэфікс імя файла:"
 
@@ -6590,12 +11205,71 @@ msgid "Overwrite existing files"
 msgstr "Перазапісаць існыя файлы"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Choose a location to save the exported files"
 msgstr "Абярыце каталог для экспартуемых файлаў"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
 msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
@@ -6604,6 +11278,31 @@ msgstr "Захаваць як..."
 #: src/export/ExportOGG.cpp
 msgid "Ogg Vorbis Files"
 msgstr "Файлы Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -6616,6 +11315,10 @@ msgstr "Вылучанае экспартуецца ў файл Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Вылучанае экспартуецца ў файл Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -6634,8 +11337,28 @@ msgid "Other uncompressed files"
 msgstr "Іншыя несціснутыя файлы"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Памылка пры імпарце"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -6646,16 +11369,26 @@ msgstr "Немагчыма экспартаваць дадзеныя ў гэты
 msgid "Exporting the selected audio as %s"
 msgstr "Абраныя гукавыя дадзеныя экспартаваны ў %s"
 
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "Усе файлы|*|Усе падтрымоўваныя файлы|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -6665,11 +11398,11 @@ msgstr ""
 " Файл - Імпартаваць - MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "з'яўляецца файлам MIDI, а не гукавым. \n"
@@ -6678,18 +11411,25 @@ msgstr ""
 " Файл - Імпартаваць - MIDI."
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr ""
+"Не атрымалася ініцыялізаваць кадавальнік FLAC\n"
+"Статут: %d"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Гэта версія Tenacity была скампілявана без падтрымкі %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" з'яўляецца дарожкай гукавога CD. \n"
 "Tenacity не можа адкрыць яе напроста. \n"
@@ -6701,8 +11441,17 @@ msgstr ""
 #: src/import/Import.cpp
 #, c-format
 msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" з'яўляецца файлам Windows Media Audio. \n"
@@ -6712,10 +11461,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" з'яўляецца файлам Advanced Audio Coding. \n"
@@ -6724,10 +11473,25 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+"\"%s\" з'яўляецца файлам Windows Media Audio. \n"
+"Tenacity не можа адкрыць файл гэтага фармату з-за абмежаванняў,\n"
+"якія накладаюцца патэнтавым заканадаўствам. Вам прыйдзецца спачатку\n"
+"пераўтварыць яго ў зразумелы Tenacity фармат накшталт WAV or AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" з'яўляецца файлам Advanced Audio Coding. \n"
@@ -6738,10 +11502,23 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+"\"%s\" з'яўляецца файлам Wavpack. \n"
+"Tenacity не можа адкрыць файл гэтага фармату. Вам прыйдзецца спачатку\n"
+"пераўтварыць яго ў зразумелы Tenacity фармат накшталт WAV or AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -6755,10 +11532,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" з'яўляецца файлам Wavpack. \n"
@@ -6767,10 +11544,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" з'яўляецца файлам Dolby Digutal. \n"
@@ -6779,11 +11556,23 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" з'яўляецца файлам Ogg Speex.\n"
+"Tenacity не можа адкрыць файл гэтага фармату. Вам прыйдзецца спачатку\n"
+"пераўтварыць яго ў зразумелы Tenacity фармат накшталт WAV or AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" з'яўляецца файлам Ogg Speex.\n"
 "Tenacity не можа адкрыць файл гэтага фармату. Вам прыйдзецца спачатку\n"
@@ -6796,9 +11585,9 @@ msgstr "Бібліятэка FFmpeg не знойдзена"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -6806,6 +11595,32 @@ msgstr ""
 "'%s'.\n"
 "Калі ён несціснуты, паспрабуйце імпартаваць\n"
 "як беззаголовочный."
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Захоўваюцца дадзеныя праекта"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -6822,21 +11637,132 @@ msgid "Import Project"
 msgstr "Імпартаваць перадусталёўкі"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Не атрымалася знайсці тэчку з дадзенымі праекта: \"%s\""
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Праекты"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "Некарэктная чашчыня сэмпліравання"
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Некарэктная чашчыня сэмпліравання"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -6857,34 +11783,15 @@ msgstr "Немагчыма адкрыць/стварыць тэставы фай
 msgid "FFmpeg-compatible files"
 msgstr "Файлы, падтрымоўваныя FFmpeg"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Файлы FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Сумяшчальныя з GStreamer файлы"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Немагчыма адкрыць/стварыць тэставы файл"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Не атрымалася запусціць GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Назва пераназваць '%s' у '%s'"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Немагчыма адкрыць/стварыць тэставы файл"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer %s: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -6944,9 +11851,22 @@ msgstr "Не атрымалася адкрыць файл:"
 msgid "MP3 files"
 msgstr "MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -6973,8 +11893,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF і іншыя тыпы несціснутых дадзеных"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) signed 16 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -6985,12 +11999,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-bit float"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-bit float"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) signed 16 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 біт"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -7001,12 +12059,20 @@ msgid "24 bit DWVW"
 msgstr "24 біта"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -7016,6 +12082,33 @@ msgstr "Імпартуецца %s"
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "Файлы QuickTime"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Немагчыма захаваць файл з жанрамі."
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "Немагчыма выдаліць '%s'"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Немагчыма захаваць файл з жанрамі."
 
 #. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
 #: src/import/ImportRaw.cpp
@@ -7093,6 +12186,10 @@ msgstr "Чашчыня сэмпліравання:"
 msgid "&Import"
 msgstr "&Імпартаваць "
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -7113,6 +12210,7 @@ msgstr "правы"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -7137,6 +12235,7 @@ msgstr "Канец"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -7158,12 +12257,37 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Дарожка/вобласць зрушана на %s %.02f секунд"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Дарожка/вобласць зрушана на %s %.02f секунд"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Перасоўванне"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Clip B&oundaries"
+msgstr "Усталяваць левую мяжу вылучэння"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Усталяваць левую мяжу вылучэння"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "Усталяваць левую мяжу вылучэння"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -7180,6 +12304,11 @@ msgstr "Наступная прылада"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Наступная прылада"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "Усталяваць левую мяжу вылучэння"
 
 #: src/menus/ClipMenus.cpp
 msgid "Cursor to Prev Clip Boundary"
@@ -7279,7 +12408,8 @@ msgstr "У вылучаныя дарожкі запісана %.2f з з адз�
 msgid "Trim Audio"
 msgstr "Запіс гуку"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Падзяліць"
 
@@ -7299,6 +12429,11 @@ msgstr "Аб'яднана %.2f з пачынальна з t=%.2f"
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "Аб'яднаць"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Выдалена %.2f з пачынальна з t=%.2f"
 
 #: src/menus/EditMenus.cpp
 msgid "Detach"
@@ -7335,6 +12470,11 @@ msgstr "&Уставіць"
 #: src/menus/EditMenus.cpp
 msgid "Duplic&ate"
 msgstr "Пра&дубляваць"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "&Выдаліць дарожкі"
 
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
@@ -7391,32 +12531,8 @@ msgid "Delete Key&2"
 msgstr "Другая клавіша выдалення"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Панэль &мікшара"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Змяніць хуткасць прайгравання"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Павялічыць хуткасць прайгравання"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Паменшыць хуткасць прайгравання"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Канец запісу"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Павялічыць хуткасць прайгравання"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Паменшыць хуткасць прайгравання"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -7443,8 +12559,21 @@ msgid "&Full Screen (on/off)"
 msgstr "Поўнаэкранны рэжым"
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Экспартаваць &вылучанае..."
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Праўка пазнакі"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -7471,6 +12600,12 @@ msgid "Allegro file"
 msgstr "Усе файлы (*)|*"
 
 #: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export MIDI"
 msgstr "Экспарт MIDI"
 
@@ -7486,6 +12621,11 @@ msgstr "Імпарт пазнак"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Абраць MIDI-файл..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Усе файлы (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -7566,6 +12706,11 @@ msgid "&Labels..."
 msgstr "Па&пазнакі..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Экспартаваць MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Гукавы файл &без загалоўка (Raw)..."
 
@@ -7582,6 +12727,10 @@ msgstr "П&ечать..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "У&ыход"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -7614,6 +12763,10 @@ msgid "Nothing to do"
 msgstr "Няма чаго адмяніць"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Зачыніць актыўную дарожку"
 
@@ -7624,6 +12777,15 @@ msgstr "Немагчыма адкрыць файл праекта"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Пачатак запісу"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Audio Device Info"
+msgstr "Прылады MIDI"
 
 #: src/menus/HelpMenus.cpp
 msgid "MIDI Device Info"
@@ -7638,7 +12800,8 @@ msgid "&Getting Started"
 msgstr "Пачатак вылучэння:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "Праекты Tenacity"
 
 #: src/menus/HelpMenus.cpp
@@ -7646,8 +12809,17 @@ msgid "&Quick Help..."
 msgstr "&Даведка"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
 msgstr "\t-test (запусціць самодіагностіку)"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Au&dio Device Info..."
+msgstr "Прылады MIDI"
 
 #: src/menus/HelpMenus.cpp
 msgid "&MIDI Device Info..."
@@ -7657,13 +12829,15 @@ msgstr "Прылады MIDI"
 msgid "Show &Log..."
 msgstr "Паказаць &часопіс..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Пра праграму..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Нататка дададзена"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "Уставіць &тэкст у новую пазнаку"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -7783,6 +12957,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "Уставіць &тэкст у новую пазнаку"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Поме&ченные вобласці"
 
@@ -7817,6 +12995,11 @@ msgid "Label Split Delete"
 msgstr "Выдаліць з падзелам"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "Запоўніць ті&шынай"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "Стварыць цішыню"
 
@@ -7841,6 +13024,18 @@ msgstr "Праўка пазнакі"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "Праўка пазнакі"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -7883,8 +13078,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Пераключыць фокус дарожкі"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Новая..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -7899,6 +13102,10 @@ msgstr "Пашырэнні ад %i да %i"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "Созда&ніе"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -7956,6 +13163,10 @@ msgstr "&Запусціць тэст прадукцыйнасці..."
 msgid "Simulate Recording Errors"
 msgstr "Запіс"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -7976,6 +13187,16 @@ msgstr "Вылучэнне"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "да пачатку &дарожкі"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Запоўніць ті&шынай"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Нізкія дарожкі"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -8001,9 +13222,20 @@ msgstr "&Змяніць пазнакі"
 msgid "Set Project..."
 msgstr "Захаваць праект &як..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Зменная"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "Нізкія дарожкі"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "Інфармацыя"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -8062,6 +13294,20 @@ msgstr "Вылучэнне"
 #: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
 msgid "&Tracks"
 msgstr "Дорож&кі"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "Высокія дарожкі"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Вылучэнне"
 
 #: src/menus/SelectMenus.cpp
 msgid "R&egion"
@@ -8132,8 +13378,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Лінейны маштаб"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Вылучыць да пачатку дарожкі"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Бягучая пазіцыя:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -8271,6 +13526,14 @@ msgstr "Доўгі пераход курсора налева"
 msgid "Cursor Long Ju&mp Right"
 msgstr "Доўгі пераход курсора направа"
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
 msgstr "Кароткі пераход налева пры прайграванні"
@@ -8304,6 +13567,23 @@ msgstr "У&ернуть зыходныя панэлі"
 #, c-format
 msgid "Rendered all audio in track '%s'"
 msgstr "Усе дарожкі зведзены ў '%s'"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Render"
+msgstr "Звестка"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr "Звесці ў новую дарожку"
 
 #. i18n-hint: One or more audio tracks have been panned
 #: src/menus/TrackMenus.cpp
@@ -8434,6 +13714,11 @@ msgid "Synchronize MIDI with Audio"
 msgstr "Сінхранізаваць MIDI з гукам"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr "Сінхранізаваць MIDI з гукам"
+
+#: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
 msgstr "Узмацненне скорректірованно"
 
@@ -8458,14 +13743,20 @@ msgid "Created new label track"
 msgstr "Створаны новая дарожка для пазнак"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Створана новая дарожка часу"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Новая чашчыня сэмпліравання (Гц):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Уведзенае значэнне некарэктна"
 
@@ -8487,8 +13778,22 @@ msgid "Please select at least one audio track and one MIDI track."
 msgstr "Абярыце дзеянне"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Sync MIDI with Audio"
 msgstr "Сінхранізаваць MIDI з гукам"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -8531,6 +13836,11 @@ msgid "&Time Track"
 msgstr "Дарожка &часу"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Панэль &мікшара"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Падзяліць стэрэа на мана"
 
@@ -8569,6 +13879,10 @@ msgstr "&Прыглушыць усе дарожкі"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Вярнуць гучнасць усім дарожкам"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -8625,6 +13939,11 @@ msgstr "Па &часе пачатку"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "Па н&азванію"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "Вобласць перамешчана з адной дарожкі ў іншую"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -8696,7 +14015,9 @@ msgstr "Прайграць"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Запіс"
 
@@ -8709,8 +14030,27 @@ msgid "no label track at or below focused track"
 msgstr "Панарамаванне налева для актыўнай дарожкі"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Створаны новая дарожка для пазнак"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -8778,6 +14118,11 @@ msgid "&Timer Record..."
 msgstr "&Таймер запісу..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Запіс з актывацыяй па ўзроўні гучнасці"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Прайгравана&я вобласць"
 
@@ -8788,6 +14133,11 @@ msgstr "&Замкнуць"
 #: src/menus/TransportMenus.cpp
 msgid "&Unlock"
 msgstr "&Адамкнуць"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Канец запісу"
 
 #: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
@@ -8802,16 +14152,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Канец запісу"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "Запіс урэзкай (вкл/выкл)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Праграмны маніторынг запісу (вкл/выкл)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -8821,6 +14172,11 @@ msgstr "&Кіраванне"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "Прайграванне/Стоп"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -8938,6 +14294,11 @@ msgid "&Fit to Width"
 msgstr "&Змясціць у акне"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&Змясціць у акне"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Згарнуць усе дарожкі"
 
@@ -8981,6 +14342,18 @@ msgstr "Эфекты VST"
 msgid "&Window"
 msgstr " window"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
@@ -9006,7 +14379,7 @@ msgstr "Параметры..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Выйсці з Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -9053,7 +14426,8 @@ msgstr "&Падсістэма"
 msgid "Using:"
 msgstr "Выкарыстоўваецца:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Прайграванне"
 
@@ -9073,7 +14447,8 @@ msgstr "&Каналаў"
 msgid "Latency"
 msgstr "Затрымка"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "мс"
 
@@ -9102,17 +14477,37 @@ msgid "2 (Stereo)"
 msgstr "2 (стэрэа)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Каталогі"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Аднавіць праекты"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Каталогі"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Агляд..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -9163,8 +14558,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Абярыце размяшчэнне каталога для захоўвання часавых файлаў"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "Абярыце тэчку для захоўвання здымкаў"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -9181,10 +14585,16 @@ msgid "Directory %s is not writable"
 msgstr "У вас няма правоў на запіс у каталог %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr ""
 "Змены датычна каталога для захоўвання часавых файлаў \n"
 "не падзейнічаюць эфекту, пакуль праграма Tenacity не будзе перазагружана."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Новы каталог для часавых файлаў"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -9195,6 +14605,59 @@ msgid "Sorted by Effect Name"
 msgstr "Па назве"
 
 #: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Па назве"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Па назве"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "&LADSPA"
+msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Уключыць эфекты"
 
@@ -9203,16 +14666,118 @@ msgid "Effect Options"
 msgstr "Параметры эфекту"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Параметры пашырэння"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
 msgstr "Прылады"
 
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Імпарт"
+
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Параметры..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Фільтры"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Імпартаваць перадусталёўкі"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Перамясціць &угару"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Перамясціць у&ніз"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "Перамясціць &угару"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Перамясціць у&ніз"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Выдалены пазначаныя вобласці"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Каталог для экспарту:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Вылучэнне"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "Вы ўпэўнены, што жадаеце выдаліць %s?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Запіс гуку"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -9281,20 +14846,73 @@ msgid "Location of &Manual:"
 msgstr "&Размяшчэнне кіраўніцтва:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "&Дыяпазон лічыльніка/хвалевай формы (Дб):"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show e&xtra menus"
 msgstr "&Паказваць сетку ўздоўж восі Y"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "Паведамляць гукам пра завяршэнне &працяглых аперацый"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Параметры пашырэння"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Лінейка"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Імпарт/Экспарт"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Параметры..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -9307,6 +14925,10 @@ msgstr "Пашыраныя параметры звесткі"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Як звычайна"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -9324,9 +14946,22 @@ msgstr "Пры экспарце дарожак у гукавы файл"
 msgid "S&how Metadata Tags editor before export"
 msgstr "Адкрываць рэдактар &метададзеных перад экспартам"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Экспартаваць пазнакі як:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9338,6 +14973,18 @@ msgid "Preferences for KeyConfig"
 msgstr "Параметры..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Клавіятурныя камбінацыі"
 
@@ -9346,8 +14993,35 @@ msgid "View by:"
 msgstr "&Выгляд"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Імя"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Выгляд"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Выгляд"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Выгляд"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
@@ -9356,6 +15030,12 @@ msgstr "Клавіятурныя камбінацыі"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Short cut"
 msgstr "Нізкія дарожкі"
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "П&араметры..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -9370,7 +15050,15 @@ msgid "&Defaults"
 msgstr "&Зыходныя параметры"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Абярыце XML-файл, які змяшчае клавіятурныя камбінацыі Tenacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9379,8 +15067,21 @@ msgstr "Экспартаваць клавіятурныя камбінацыі �
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Загружана %d клавіятурных камбінацый\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -9393,6 +15094,38 @@ msgstr "Экспартаваць клавіятурныя камбінацыі �
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Экспартаваць клавіятурныя камбінацыі як:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -9438,6 +15171,16 @@ msgstr "У&казать..."
 msgid "Dow&nload"
 msgstr "Ска&чать"
 
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
 msgstr "Бібліятэкі"
@@ -9461,6 +15204,23 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Інтэрфейс"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Мінімальна магчымая чашчыня павінна быць зменнай велічынёй"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -9471,7 +15231,29 @@ msgid "Preferences for Module"
 msgstr "Параметры..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr ""
 "Змены датычна каталога для захоўвання часавых файлаў \n"
 "не падзейнічаюць эфекту, пакуль праграма Tenacity не будзе перазагружана."
@@ -9481,12 +15263,20 @@ msgid "Ask"
 msgstr "Пытаць мяне"
 
 #: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
 msgid "No modules were found"
 msgstr "Прылады не выяўлены"
 
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Мадуляцыя"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -9528,7 +15318,10 @@ msgstr "Перацягванне левай клавішай"
 msgid "Set Selection Range"
 msgstr "Усталяваць вобласць вылучэння"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-Пстрычка левай клавішай"
 
@@ -9615,6 +15408,15 @@ msgstr "Перацягванне левай клавішай"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Перамясціць вобласць з адной дарожкі ў іншую"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Перацягванне левай клавішай"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -9726,8 +15528,21 @@ msgstr "&Кароткі перыяд:"
 msgid "Lo&ng period:"
 msgstr "&Доўгі перыяд:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Параметры Tenacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -9741,6 +15556,11 @@ msgstr "Параметры..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Параметры..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -9801,12 +15621,21 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "&Накладанне: прайграваць іншыя дарожкі пры запісе новай"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "Праграмны маніторынг запісу (вкл/выкл)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Новая дарожка"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -9820,6 +15649,11 @@ msgstr "&Дыяпазон (Дб):"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Name newly recorded tracks"
 msgstr "Зводзяцца дарожкі"
+
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
@@ -9842,21 +15676,54 @@ msgid "System &Date"
 msgstr "Дата пачала"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Дата пачала"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Запіс з актывацыяй па ўзроўні гучнасці"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Дарожка для пазнак"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
+msgstr "Маштаб па змаўчанні"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
 msgstr "Маштаб па змаўчанні"
 
 #. i18n-hint: Grayscale color scheme for spectrograms
@@ -9875,18 +15742,41 @@ msgstr "Лінейны"
 msgid "Frequencies"
 msgstr "Чашчыня (Гц)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Вышыня тону (EAC)"
 
 #: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Мінімальная чашчыня павінна знаходзіцца ў межах ад 100 Гц да 100 000 Гц"
+
+#: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
+msgstr "Мінімальная чашчыня павінна знаходзіцца ў межах ад 100 Гц да 100 000 Гц"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
 msgstr "Мінімальная чашчыня павінна знаходзіцца ў межах ад 100 Гц да 100 000 Гц"
 
 #: src/prefs/SpectrogramSettings.cpp
 msgid "The range must be at least 1 dB"
 msgstr "Дыяпазон павінен быць роўны хоць бы 1 Дб"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -9918,12 +15808,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "М&аксімальная чашчыня (Гц):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "&Узмацненне (Дб):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "&Дыяпазон (Дб):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -9946,6 +15844,10 @@ msgid "1024 - default"
 msgstr "256 - па змаўчанні"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - найболей вузкапалосны"
 
@@ -9954,12 +15856,23 @@ msgid "Window &type:"
 msgstr "Т&іп аконнай функцыі"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Каэфіцыент згасання: "
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Вылучэнне"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Show a grid along the &Y-axis"
 msgstr "&Паказваць сетку ўздоўж восі Y"
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "FFT Find Notes"
+msgstr "&Знайсці ноты"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Minimum Amplitude (dB):"
@@ -10002,8 +15915,23 @@ msgid "The range must be a positive integer"
 msgstr "Дыяпазон павінен быць дадатнай зменнай"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Узмацненне павінна быць цэлай зменнай"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "The minimum amplitude (dB) must be an integer"
 msgstr "Мінімальная амплітуда (дб) павінна быць цэлай зменнай"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Максімальна магчымая чашчыня павінна быць зменнай велічынёй"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Максімальна магчымая чашчыня павінна быць зменнай велічынёй"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
@@ -10022,13 +15950,14 @@ msgid "Info"
 msgstr "Інфармацыя"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -10112,6 +16041,18 @@ msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "&Фокус перасоўваецца па дарожках цыклічна"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Пашыраныя параметры звесткі"
 
@@ -10132,6 +16073,10 @@ msgid "Spectrogram"
 msgstr "Спектраграмы"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "Пабудаваць графік нанова"
 
@@ -10146,6 +16091,10 @@ msgstr "Маштабаваць у &вылучэнне"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Маштаб па змаўчанні"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -10168,6 +16117,16 @@ msgid "50ths of Seconds"
 msgstr "секунд"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "секунд"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "секунд"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "мс"
 
@@ -10175,7 +16134,12 @@ msgstr "мс"
 msgid "Samples"
 msgstr "сэмплы"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Маштаб"
 
@@ -10184,12 +16148,42 @@ msgid "Preferences for Tracks"
 msgstr "Параметры..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Канец запісу"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "&Рэжым адлюстравання па змаўчанні:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "&Разраднасць па змаўчанні:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "сэмплы"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -10241,6 +16235,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "Звестцы &у стэрэа пры экспарце"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "Звестцы ў &мана пры экспарце"
 
@@ -10265,16 +16263,24 @@ msgid "Stopped"
 msgstr "Спыніць"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Прыпыніць"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Перайсці да пачатку дарожкі"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Перайсці да канца дарожкі"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Прыпыніць"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Вылучыць да пачатку дарожкі"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Вылучыць ад курсора да канца"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -10288,20 +16294,24 @@ msgstr "Новая дарожка"
 msgid "Append Record"
 msgstr "Запісаць у канец"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Вылучыць ад курсора да канца"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Вылучыць да пачатку дарожкі"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Прыпыніць"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Панэль &транскрыпцыі"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -10312,6 +16322,11 @@ msgstr "Хуткасць прайгравання"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Канец запісу"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "Бягучая пазіцыя:"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -10334,8 +16349,18 @@ msgid "Select Playback Device"
 msgstr "Хуткасць прайгравання"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Запоўніць ті&шынай"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Канец запісу"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "Праслухоўванне недаступна\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -10359,11 +16384,22 @@ msgstr "Абразаць усё па-за вылучаным"
 msgid "Silence audio selection"
 msgstr "Запоўніць цішынёй"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "Нізкія дарожкі"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Наблізіць"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Аддаліць"
 
@@ -10430,42 +16466,23 @@ msgstr "Індыкатар зап."
 msgid "&Playback Meter Toolbar"
 msgstr "Індыкатар воспр."
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Канец запісу"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Прайграванне"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Канец запісу"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Прайграванне"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Прайграванне"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Панэль &мікшара"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "Лінейка"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Запыт Nyquist..."
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Запыт Nyquist..."
@@ -10473,6 +16490,7 @@ msgstr "Запыт Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Запыт Nyquist..."
@@ -10480,9 +16498,24 @@ msgstr "Запыт Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Уключыць маніторынг"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Уключыць маніторынг"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Лінейка"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -10530,9 +16563,24 @@ msgstr "Прыліпаць да лінейкі"
 msgid "Length"
 msgstr "Працягласць"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Цэнтр"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -10559,6 +16607,10 @@ msgstr "Якія падвышаюцца басовыя чашчыні"
 msgid "Center Frequency"
 msgstr "Лінейны маштаб"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -10577,13 +16629,18 @@ msgstr "Панэль у&стройств"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Панэль %s Tenacity"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Пстрыкніце і перацягніце для змены вышыні дарожкі"
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Прылада"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -10601,7 +16658,8 @@ msgstr "Перасоўванне"
 msgid "Zoom Tool"
 msgstr "Маштабаванне"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Змена агінальнай"
 
@@ -10652,6 +16710,11 @@ msgid "&Next Tool"
 msgstr "Наступная прылада"
 
 #: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "Прайграванне на хуткасці"
+
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Playback Speed"
 msgstr "Хуткасць прайгравання"
 
@@ -10673,11 +16736,13 @@ msgstr "Перацягнуць межы адной і больш пазнак"
 msgid "Drag label boundary."
 msgstr "Перацягнуць межы пазнакі"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Пазнака зменена"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Праўка пазнакі"
 
@@ -10732,31 +16797,42 @@ msgstr "Зменены пазнакі"
 msgid "New label"
 msgstr "Нататка дададзена"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Актавай вышэй"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Актавай ніжэй"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Выкарыстоўвайце пстрычку для набліжэння па вертыкалі, Shift і пстрычка - для аддалення, перацягванне з націснутай кнопкай для вылучэння вобласці маштабавання."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Пстрычка правай клавішай"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Аддаліць"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-Пстрычка левай клавішай"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-Пстрычка левай клавішай"
 
@@ -10779,6 +16855,14 @@ msgid "Stretch"
 msgstr "Каэфіцыент згасання: "
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Аб'яднаны кліпы"
 
@@ -10790,7 +16874,8 @@ msgstr "Аб'яднаць"
 msgid "Expanded Cut Line"
 msgstr "Пашыраная лінія выразанняў"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Пашырыць"
 
@@ -10803,12 +16888,21 @@ msgid "Click and drag to edit the samples"
 msgstr "Пстрыкніце і перацягніце для рэдагавання сэмплаў"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "Сэмпл зрушаны"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Праўка сэмпла"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -10817,6 +16911,16 @@ msgstr "Наблізіць па кропцы"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Спектраграмы"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -10842,7 +16946,8 @@ msgstr "Ужываецца эфект автопріглушенія..."
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' зменена на %s"
@@ -10856,7 +16961,60 @@ msgid "Rat&e"
 msgstr "Чашчыня сэмпліравання"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 ч 060 м 060>0100 з"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -10877,7 +17035,8 @@ msgstr "Змяніць чашчыню"
 msgid "Set Rate"
 msgstr "Чашчыня сэмпліравання"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Універсальны"
 
@@ -10970,10 +17129,25 @@ msgid "Right, %dHz"
 msgstr "Правы, "
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f Дб"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "правы"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -10983,6 +17157,15 @@ msgstr "Пстрыкніце і перацягніце для рэгуляцыі
 msgid "Click and drag to rearrange sub-views"
 msgstr "Пстрыкніце і перацягніце для перасоўвання дарожкі ў часе"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Пстрыкніце і перацягніце для перасоўвання дарожкі ў часе"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Наблізіць"
@@ -10990,6 +17173,10 @@ msgstr "Наблізіць"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Маштаб"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -11035,12 +17222,28 @@ msgid "Set Range"
 msgstr "Усталяваць дыяпазон"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "Адлюстраванне"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Інтэрпаляцыя:"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
@@ -11060,9 +17263,8 @@ msgstr "Хуткая сінхронная інтэрпаляцыя"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Пстрыкніце і перацягніце для перасоўвання дарожкі ў часе"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -11113,6 +17315,21 @@ msgstr "Агінальная скарэктавана."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "&Панэлі"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Уключыць маніторынг"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Лінейка"
@@ -11128,6 +17345,11 @@ msgstr "Зачыніць актыўную дарожку"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Перамясціць дарожку ўніз"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Запыт Nyquist..."
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -11184,6 +17406,11 @@ msgstr "Пстрыкніце і перацягніце для вылучэння
 msgid "Click and drag to select audio"
 msgstr "Пстрыкніце і перацягніце для вылучэння гукавога фрагмента"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Пстрыкніце і перацягніце для перасоўвання дарожкі ў часе"
@@ -11205,6 +17432,10 @@ msgstr "У вылучаныя дарожкі запісана %.2f з з адз�
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "У вылучаныя дарожкі запісана %.2f з з адзнакі %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -11231,6 +17462,12 @@ msgstr "Каманда"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl-Пстрычка левай клавішай"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Абярыце дзеянне"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -11296,6 +17533,11 @@ msgid "%.2fx"
 msgstr "%.1f Дб"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
 msgstr " Абярыце дзеянне "
 
@@ -11307,6 +17549,14 @@ msgstr "Фільтры"
 msgid "&Clear"
 msgstr "Пра&чысціць"
 
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
 #: src/widgets/Grid.cpp
 msgid "Empty"
 msgstr "Пуста"
@@ -11315,13 +17565,28 @@ msgstr "Пуста"
 msgid "Backwards"
 msgstr "Назад"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Наперад"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Даведка ў Інтэрнэце"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Усе файлы (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -11360,6 +17625,13 @@ msgid "Refresh Rate"
 msgstr "Чашчыня сэмпліравання"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "Чашчыня абнаўлення індыкатара ў секундах [1-100]: "
 
@@ -11372,12 +17644,21 @@ msgid "Meter Style"
 msgstr "Індыкатар"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Фільтры"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Працягласць"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Аўтаматычнае аднаўленне пасля аварыі"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -11392,9 +17673,26 @@ msgid " Monitoring "
 msgstr "Адключыць маніторынг"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f Дб"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f Дб"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Please select an action"
@@ -11491,6 +17789,7 @@ msgstr "0100 ч 060 м 060 з+># сэмплаў"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "сэмплы"
@@ -11534,6 +17833,14 @@ msgstr "кінокадры пры 24 fps"
 msgid "01000,01000 frames|24"
 msgstr "01000,01000 кадраў|24"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr "чч:мм:сс + сэмплы"
+
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
@@ -11543,6 +17850,14 @@ msgstr "01000,01000 кадраў|24"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s+>30 frames|N"
 msgstr "0100 ч 060 м 060 з+>30 кадраў|N"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr "чч:мм:сс + сотні"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
@@ -11638,6 +17953,10 @@ msgstr "01000,01000 кадраў|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 ч 060 м 060>0100 з"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows frequency in kilohertz
 #: src/widgets/NumericTextCtrl.cpp
 msgid "kHz"
@@ -11650,6 +17969,10 @@ msgstr "Кгц"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 ч 060 м 060>0100 з"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -11665,15 +17988,60 @@ msgstr "Актавай ніжэй"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 кадраў|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 кадраў|24"
 
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "сотыя секунды"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -11717,6 +18085,11 @@ msgstr "Пацверджанне"
 msgid "Unable to write files to directory: %s."
 msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -11735,6 +18108,10 @@ msgid "Don't show this warning again"
 msgstr "Больш не паказваць гэта паведамленне"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-Бясконцасць"
 
@@ -11743,13 +18120,31 @@ msgid "-Infinity"
 msgstr "-Бясконцасць"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Пуста"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Запісаць у канец"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Наблізіць па вобласці"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Памылка ў LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -11767,11 +18162,20 @@ msgid "Value must not be greater than %s"
 msgstr "Значэнне зыходнага і канчатковага парогаў павінна быць больш нуля"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Створаны новы праект"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Каталогі"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Каталогі"
 
 #: src/xml/XMLFileReader.cpp
@@ -11792,16 +18196,49 @@ msgstr "Не атрымалася адкрыць файл:"
 msgid "Spectral edit multi tool"
 msgstr "Вылучэнне"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Фільтры"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Чашчыня (Гц)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Памылка"
@@ -11829,6 +18266,22 @@ msgstr "У чашчыню ў секундах"
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Мінімальная чашчыня павінна знаходзіцца ў межах ад 100 Гц да 100 000 Гц"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "Вылучэнне"
@@ -11841,9 +18294,27 @@ msgstr "Плыўнае згасанне"
 msgid "Applying Fade..."
 msgstr "Ужываецца..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Выкарыстоўваць &усюды"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -11870,8 +18341,16 @@ msgid "S-Curve Down"
 msgstr "Перамясціць у&ніз"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Пачатак"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -11880,6 +18359,14 @@ msgstr "Гучнасць"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Пачатак"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -11892,6 +18379,14 @@ msgstr "Лінейны"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Лінейны"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -11930,6 +18425,24 @@ msgstr "Перамясціць у&ніз"
 msgid "Error~%~%"
 msgstr "Памылка"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Паўтор..."
@@ -11937,6 +18450,10 @@ msgstr "Паўтор..."
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Знайсці перагрузкі..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Праекты Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -11950,6 +18467,23 @@ msgstr "Перагрузка"
 msgid "Reconstructing clips..."
 msgstr "Выконваецца выдаленне пстрычак і трэска..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Парог: %d Дб"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Дарожка для пазнак"
@@ -11957,6 +18491,21 @@ msgstr "Дарожка для пазнак"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Дарожка для пазнак"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -11990,6 +18539,19 @@ msgstr "Назва дарожкі"
 msgid "Fade direction"
 msgstr "Прыгнечанне шуму"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Затрымка"
@@ -12005,6 +18567,19 @@ msgstr "Тып клавішы"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "Rectangular"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Выдаленне шуму (Дб):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -12030,6 +18605,14 @@ msgstr "Пра&слухаць"
 msgid "Number of echoes"
 msgstr "Колькасць паўтораў: "
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Паўтарыць апошні эфект"
@@ -12041,6 +18624,10 @@ msgstr "Эквалайзер"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -12055,10 +18642,24 @@ msgstr "Пацверджанне перазапісу"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Немагчыма адкрыць файл з жанрамі."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Памылка (магчыма, файл не запісаны): %hs"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Памылка (магчыма, файл не запісаны): %hs"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -12089,10 +18690,50 @@ msgstr "Працягласць (з)"
 msgid "Length of label region (seconds)"
 msgstr "Працягласць (з)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Праўка пазнакі"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -12106,6 +18747,11 @@ msgstr "Адчапіць"
 msgid "Warnings only"
 msgstr "Папярэджанні"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -12114,6 +18760,12 @@ msgstr "Аб'яднаць пазнакі"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Аб'яднаць пазнакі"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -12132,13 +18784,46 @@ msgstr "Ужываецца эфект эквалізаціі"
 msgid "Dominic Mazzoni"
 msgstr "Аўтар - Дамінік Маццоні"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Чашчыня (Гц)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Мінімальная чашчыня павінна знаходзіцца ў межах ад 100 Гц да 100 000 Гц"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -12186,6 +18871,11 @@ msgid "Point after sound"
 msgstr "Joint Stereo"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "З адной працягласці ў секундах"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "З адной працягласці ў секундах"
 
@@ -12193,11 +18883,41 @@ msgstr "З адной працягласці ў секундах"
 msgid "Maximum leading silence"
 msgstr "Выразаецца цішыня..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Выразаецца цішыня..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Поле імя павінна быць запоўнена"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -12229,8 +18949,25 @@ msgid "Hard Clip"
 msgstr "Пошук перагрузкі"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Правы канал"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "&Дыяпазон (Дб):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -12251,6 +18988,14 @@ msgstr "Тып шуму"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Вылучэнне"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Stereo Linking"
@@ -12284,6 +19029,44 @@ msgstr "Напад/згасанне (з):"
 msgid "Decay (ms)"
 msgstr "Напад/згасанне (з):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Поле імя павінна быць запоўнена"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Зрушэнне вышыні тону"
@@ -12295,6 +19078,18 @@ msgstr "Ужываецца эфект выраўноўвання"
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Выкарыстоўваць &усюды"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -12319,7 +19114,8 @@ msgstr "MP3"
 msgid "HTML file"
 msgstr "MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Найменне файлаў:"
 
@@ -12336,9 +19132,24 @@ msgid "Disallow"
 msgstr "Не дазволена"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Не дазволена"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Немагчыма выдаліць '%s'"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -12349,16 +19160,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Абраць MIDI-файл..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Каталог для экспарту:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Абраць MIDI-файл..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Ствараецца хваля"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Фільтры"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -12371,6 +19224,10 @@ msgstr "Выдаліць дарожку"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Ствараецца імпульс"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -12389,8 +19246,20 @@ msgid "Swing amount"
 msgstr "Скажэнне"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Колькасць паўтораў: "
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -12413,12 +19282,54 @@ msgid "Beat sound"
 msgstr "Паўтор..."
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Выдаленне шуму"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Шум..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -12441,6 +19352,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Лінейны маштаб"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Чашчыня (Гц)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Амплітуда (0-1)"
 
@@ -12451,6 +19371,10 @@ msgstr "Немагчыма экспартаваць"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Ужываецца..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -12469,6 +19393,10 @@ msgid "HTML files"
 msgstr "MP3"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Праўка сэмпла"
 
@@ -12481,8 +19409,29 @@ msgid "Include header information"
 msgstr "Інфармацыя пра зборку"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Усё"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -12497,6 +19446,11 @@ msgstr "\t-help (гэта паведамленне)"
 msgid "Errors Only"
 msgstr "Памылка: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -12509,6 +19463,46 @@ msgstr "Правы канал"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "сэмплы"
 
@@ -12516,6 +19510,43 @@ msgstr "сэмплы"
 #, lisp-format
 msgid "~a seconds."
 msgstr "секунд"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -12534,6 +19565,10 @@ msgid "Value (dB)"
 msgstr "&Дыяпазон (Дб):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Лінейны"
 
@@ -12550,6 +19585,14 @@ msgid "Right (dB)"
 msgstr "Правы, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Лінейны"
 
@@ -12560,6 +19603,40 @@ msgstr "2 канала (стэрэа)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 канал (мана)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Памылка (магчыма, файл не запісаны): %hs"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -12574,8 +19651,40 @@ msgid "Select file"
 msgstr "Абраць MIDI-файл..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Памылка"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -12585,6 +19694,15 @@ msgstr "Немагчыма адкрыць файл з жанрамі."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Вылучэнне"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -12607,8 +19725,16 @@ msgid "Wet level (percent)"
 msgstr "2-уровень"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Ужываецца..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -12650,9 +19776,96 @@ msgstr "&Аналіз"
 msgid "Strength"
 msgstr "Фільтры"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Ужываецца эфект автопріглушенія..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -12686,6 +19899,146 @@ msgstr "Чашчыня (Гц)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Чашчыня (Гц)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Выйсці з Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Канал"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Памылка пры чытанні файла"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Панэль %s Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Запіс"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Каманда:"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Імпарт сродкамі QuickTime"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Немагчыма адкрыць файл з жанрамі.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Запіс\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Прайграванне\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Канец запісу\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Канец запісу\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Прайграванне\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Прайграванне\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Сумяшчальныя з GStreamer файлы"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Не атрымалася запусціць GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Назва пераназваць '%s' у '%s'"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Немагчыма адкрыць/стварыць тэставы файл"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer %s: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Змяніць хуткасць прайгравання"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Павялічыць хуткасць прайгравання"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Паменшыць хуткасць прайгравання"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Канец запісу"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Павялічыць хуткасць прайгравання"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Паменшыць хуткасць прайгравання"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Пра праграму..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Запіс з актывацыяй па ўзроўні гучнасці (вкл/выкл)"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Канец запісу"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Прайграванне"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Канец запісу"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Прайграванне"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Прайграванне"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Панэль &мікшара"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Пстрыкніце і перацягніце для перасоўвання дарожкі ў часе"
+
 #~ msgid "Program build date:"
 #~ msgstr "Дата зборкі праграмы: "
 
@@ -12696,10 +20049,6 @@ msgstr "Чашчыня (Гц)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "s"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Немагчыма адкрыць/стварыць тэставы файл"
 
 #, fuzzy
 #~ msgid "available"
@@ -12835,9 +20184,6 @@ msgstr "Чашчыня (Гц)"
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "Выконваецца ачыстка часавых файлаў"
 
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "Выконваецца ачыстка каталогаў з кэшам"
-
 #~ msgid "Renamed file: %s\n"
 #~ msgstr "Пераназваны файл: %s\n"
 
@@ -12945,9 +20291,6 @@ msgstr "Чашчыня (Гц)"
 
 #~ msgid "Projects"
 #~ msgstr "Праекты"
-
-#~ msgid "When saving a project that depends on other audio files"
-#~ msgstr "Пры захаванні праекта,які змяшчае вонкавыя файлы"
 
 #, fuzzy
 #~ msgid "&Low disk space at launch or new project"
@@ -13207,18 +20550,6 @@ msgstr "Чашчыня (Гц)"
 #~ msgstr "так"
 
 #, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "Audio Unit"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Эфекты"
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "Немагчыма захаваць файл з жанрамі."
-
-#, fuzzy
 #~ msgid "Save MIDI Device Info"
 #~ msgstr "Прылады MIDI"
 
@@ -13281,10 +20612,6 @@ msgstr "Чашчыня (Гц)"
 
 #~ msgid "Edit C&hains..."
 #~ msgstr "Змяніць це&ныркі..."
-
-#, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "Панэль &транскрыпцыі"
 
 #, fuzzy
 #~ msgid "&Tools"
@@ -13363,10 +20690,6 @@ msgstr "Чашчыня (Гц)"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "Транскрыпцыя"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "&Панэлі"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -13538,10 +20861,6 @@ msgstr "Чашчыня (Гц)"
 #~ msgstr "Час першаснага згасання"
 
 #, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "Імя"
-
-#, fuzzy
 #~ msgid "InterpolateLin"
 #~ msgstr "Інтэрпаляцыя:"
 
@@ -13597,10 +20916,6 @@ msgstr "Чашчыня (Гц)"
 #~ msgstr "Аддача (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Памер"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "Аддача (%):"
 
@@ -13615,10 +20930,6 @@ msgstr "Чашчыня (Гц)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Гучнасць"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Стэрэа"
 
 #, fuzzy
 #~ msgid "FilterType"
@@ -13659,10 +20970,6 @@ msgstr "Чашчыня (Гц)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "Выразанне цішыні"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Выконваецца рэверс"
 
 #~ msgid "C&ategory:"
 #~ msgstr "&Катэгорыя:"
@@ -13745,9 +21052,6 @@ msgstr "Чашчыня (Гц)"
 #, fuzzy
 #~ msgid "Host:"
 #~ msgstr "&Падсістэма"
-
-#~ msgid "&Length of preview:"
-#~ msgstr "&Працягласць праслухоўвання:"
 
 #, fuzzy
 #~ msgid "&Hardware Playthrough: Listen to input while recording or monitoring"
@@ -13857,9 +21161,6 @@ msgstr "Чашчыня (Гц)"
 
 #~ msgid " For even quicker answers, all the online resources above are <b>searchable</b>."
 #~ msgstr "Усе сеткавыя рэсурсы ўтрымоўваюць функцыю <b>пошуку</b>, так што знайсці адказ можна яшчэ хутчэй."
-
-#~ msgid "Edit Metadata"
-#~ msgstr "Праўка метададзеных"
 
 #~ msgid "Disk space remains for recording %d hours and %d minutes."
 #~ msgstr "Чакай да канца запісу: %d гадзін і %d мінуць."
@@ -14249,9 +21550,6 @@ msgstr "Чашчыня (Гц)"
 #~ msgid "Equalization..."
 #~ msgstr "Эквалайзер..."
 
-#~ msgid "Performing Equalization"
-#~ msgstr "Ужываецца эфект эквалізаціі"
-
 #~ msgid "Fading In"
 #~ msgstr "Выконваецца плыўнае нарастанне сігналу"
 
@@ -14339,10 +21637,6 @@ msgstr "Чашчыня (Гц)"
 #~ msgid "Applying Reverb"
 #~ msgstr "Ужываецца эфект выраўноўвання"
 
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "З&агрузіть файл на FTP-сервер..."
-
 #~ msgid "Silence..."
 #~ msgstr "Цішыня..."
 
@@ -14393,9 +21687,6 @@ msgstr "Чашчыня (Гц)"
 
 #~ msgid "Note length (seconds)"
 #~ msgstr "Працягласць ноты (з)"
-
-#~ msgid "Note velocity"
-#~ msgstr "Сіла націску ноты"
 
 #~ msgid "Extracting features: %s"
 #~ msgstr "Выманне дадзеных: %s"
@@ -14472,9 +21763,6 @@ msgstr "Чашчыня (Гц)"
 #~ msgstr ""
 #~ "Пры аднаўленні праекта ніводны файл на дыску не зменіцца, \n"
 #~ "пакуль вы не захаваеце праект."
-
-#~ msgid "Do Not Recover"
-#~ msgstr "Не аднаўляць"
 
 #~ msgid "Confirm?"
 #~ msgstr "Пацверджанне"
@@ -14664,9 +21952,6 @@ msgstr "Чашчыня (Гц)"
 
 #~ msgid "by Nasca Octavian Paul"
 #~ msgstr "Аўтар - Наска Актавіян Падлога"
-
-#~ msgid "Frequency Hertz"
-#~ msgstr "Чашчыня ў герцах"
 
 #~ msgid "Boost dB"
 #~ msgstr "Узмацненне ў дэцыбелах"

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -9,53 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Bulgarian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/bg/>\n"
+"Language-Team: Bulgarian <https://hosted.weblate.org/projects/tenacity/tenacity/bg/>\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Изход от Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Канал"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Грешка при отваряне на файл"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Грешка при зареждане на метаданни"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Лента с инструменти – Audacity %s"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Запис"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -65,6 +28,24 @@ msgstr "Не е възможно да се определи"
 #, c-format
 msgid "%s bytes"
 msgstr "байта"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -87,12 +68,63 @@ msgid "&Nyquist Workbench..."
 msgstr "Команда на Nyquist…"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Поставяне"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Поставяне"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Поставяне"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Поставяне"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Избиране"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -115,15 +147,37 @@ msgid "Show &Output"
 msgstr "Показване на резултата"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "&Ленти с инструменти"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "&Спиране"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Променлива"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Изходна амплитуда"
 
@@ -131,13 +185,38 @@ msgstr "Изходна амплитуда"
 msgid "Load Nyquist script"
 msgstr "Команда на Nyquist"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Предупреждение"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Команда на Nyquist"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -148,12 +227,20 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "от Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Ефекти"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "No matches found"
 msgstr "Не са намерени устройства"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
@@ -163,9 +250,15 @@ msgstr "неозаглавено"
 msgid "Nyquist Effect Workbench - "
 msgstr "Ефекти"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Нов"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Последно използвани файлове"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -199,7 +292,8 @@ msgstr "Копиране"
 msgid "Copy to clipboard"
 msgstr "Изрязване към клипборда"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Изрязване"
 
@@ -207,7 +301,8 @@ msgstr "Изрязване"
 msgid "Cut to clipboard"
 msgstr "Изрязване към клипборда"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Поставяне"
 
@@ -232,7 +327,8 @@ msgstr "Избиране"
 msgid "Select all text"
 msgstr "Избиране"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Отмяна"
 
@@ -240,9 +336,20 @@ msgstr "Отмяна"
 msgid "Undo last change"
 msgstr "Промяна на формата"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Връщане"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Промяна на формата"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "&Търсене на ноти"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -253,23 +360,46 @@ msgid "Match"
 msgstr "Пакет"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "Към:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Няма надписи за експортиране."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Нагоре"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Предишен инструмент"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Фокусиране и избиране на предишната писта"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Следващ инструмент"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Начало"
 
@@ -277,7 +407,8 @@ msgstr "Начало"
 msgid "Start script"
 msgstr "Команда на Nyquist"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Стоп"
 
@@ -285,15 +416,29 @@ msgstr "Стоп"
 msgid "Stop script"
 msgstr "Команда на Nyquist"
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Информация за компилата"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Да"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Не"
 
@@ -303,8 +448,9 @@ msgid "The Build"
 msgstr "За разработчици"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Команда:"
+#, fuzzy
+msgid "Version:"
+msgstr "Извършва се обръщане"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -314,13 +460,23 @@ msgstr "Тип на компилата:"
 msgid "Compiler:"
 msgstr "Компресор"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Префикс на инсталацията: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Папка за настройки: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Папка за настройки: "
 
 #: src/AboutDialog.cpp
@@ -339,7 +495,6 @@ msgstr "Смяна на честотата на дискретизация"
 msgid "MP3 Importing"
 msgstr "Импортиране на MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Импортиране и експортиране на Ogg Vorbis"
@@ -348,7 +503,6 @@ msgstr "Импортиране и експортиране на Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Поддръжка на етикети ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Импортиране и експортиране на FLAC"
@@ -366,14 +520,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Експортираща/импортираща библиотека FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Импортиране чрез QuickTime"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Функции"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Поддръжка на приставки"
 
@@ -388,6 +534,10 @@ msgstr "Възможност за промяна на височината и т
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Възможност за промяна на височината и темпото"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Функции"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -414,6 +564,18 @@ msgstr "Обвиваща крива"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Обвиваща крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Обвиваща крива"
 
@@ -425,6 +587,24 @@ msgstr "Обвиваща крива"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Обвиваща крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Обвиваща крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Обвиваща крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "качествен контрол"
@@ -432,8 +612,26 @@ msgstr "качествен контрол"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, graphic artist"
 msgstr "&Графичен еквалайзер"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Обвиваща крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Обвиваща крива"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -454,8 +652,26 @@ msgid "%s, graphics"
 msgstr "&Графичен еквалайзер"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Разработчици"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -490,14 +706,23 @@ msgid "%s Team Members"
 msgstr "Други бивши членове на екипа"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Други сътрудници"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Превод на български: Михаил Балабанов"
@@ -516,6 +741,26 @@ msgstr "Специални благодарности:"
 msgid "%s website: "
 msgstr "Първо стартиране на Tenacity "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Други сътрудници"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Щракнете и плъзнете, за да настроите относителния размер на стереопистите."
@@ -533,6 +778,7 @@ msgstr "Промяна на времевата скала"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Щракнете и плъзнете, за да редактирате отчетите"
@@ -540,9 +786,49 @@ msgstr "Щракнете и плъзнете, за да редактирате �
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Щракнете и плъзнете, за да промените височината на пистата."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Фокусиране и избиране на следващата писта"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Местене на пистата на&долу"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Затваряне на фокусираната писта"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
@@ -584,7 +870,17 @@ msgstr ""
 "Не може да се заключи регион след\n"
 "края на проекта."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Грешка"
 
@@ -608,7 +904,8 @@ msgstr ""
 "Това е еднократен въпрос след инсталация, по време на която сте указали нулиране на настройките"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Нулиране настройките на Tenacity"
 
 #: src/AudacityApp.cpp
@@ -623,8 +920,13 @@ msgstr ""
 "Файлът бе премахнат от списъка с последни файлове."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Инициализацията на библиотеката SQLite бе неуспешно.  Tenacity не може да продължи."
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -645,7 +947,7 @@ msgstr "&Отвори…"
 msgid "Open &Recent..."
 msgstr "Отвори последно използвани &файлове…"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Относно Tenacity…"
@@ -659,29 +961,33 @@ msgid "&File"
 msgstr "&Файл"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity не намери безопасно местоназначение за временните файлове.\n"
 "Моля, посочете директория в прозореца за настройка."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity не намери местоназначение за временните файлове.\n"
 "Моля, посочете подходяща директория в прозореца за настройка."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Tenacity ще се затвори. Стартирайте го отново, за да се използва новозададената временна директория."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -690,15 +996,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity не успя да заключи директорията за временни файлове.\n"
 "Тази папка може би се използва от друго копие на Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Желаете ли все пак да стартирате Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -706,19 +1014,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Грешка при заключване на временната папка"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Системата е открила друго стартирано копие на Tenacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Използвайте командите Нов или Отваряне в стартирания процес\n"
 "на Tenacity, за да отворите няколко проекта едновременно.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity вече е стартиран"
 
 #: src/AudacityApp.cpp
@@ -734,7 +1045,8 @@ msgstr ""
 "и може да се наложи рестартиране."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Неуспешно стартиране на Tenacity"
 
 #: src/AudacityApp.cpp
@@ -774,8 +1086,9 @@ msgstr ""
 "и може да се наложи рестартиране."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -807,7 +1120,8 @@ msgstr "изпълнение на автодиагностика"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Покажи версията на Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -817,9 +1131,10 @@ msgid "audio or project file name"
 msgstr "име на аудио файл или проект"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -833,16 +1148,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Проектни файлове на Tenacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Съобщение"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Грешка в конфигурацията на Tenacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -852,7 +1169,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Следният конфигурационен файл не може да бъде достъпен:\n"
 "\n"
@@ -864,12 +1181,15 @@ msgstr ""
 "\n"
 "Ако изберете \"Изход от Tenacity\", проектът ви може да остане в незаписано състояние, което ще бъде възстановено при следващото му отваряне."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Помощ"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Изход от Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -877,7 +1197,8 @@ msgid "&Retry"
 msgstr "&Опитай отново"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Дневник на Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -889,9 +1210,14 @@ msgstr "&Запази…"
 msgid "Cl&ear"
 msgstr "&Изчистване"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Затваряне"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -940,7 +1266,8 @@ msgid "Error Initializing Midi"
 msgstr "Грешка при инициализиране на MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity Аудио"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -954,40 +1281,18 @@ msgstr "Грешка при отваряне на звуковото устро�
 msgid "Out of memory!"
 msgstr "Недостиг на памет!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Авторегулирането на входното ниво спря. То не може да се подобри и още е твърде високо."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Авторегулирането на входното ниво понижи силата на звука до %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Авторегулирането на входното ниво спря. То не може да се подобри и още е твърде ниско."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Авторегулирането на входното ниво повиши силата на звука до %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Авторегулирането на входното ниво спря. Лимитът за анализи бе надхвърлен, без да се открие приемлива сила на звука. Тя още е твърде висока."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Авторегулирането на входното ниво спря. Лимитът за анализи бе надхвърлен, без да се открие приемлива сила на звука. Тя още е твърде ниска."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Авторегулирането на входното ниво спря. Изглежда %.2f е приемлива сила на звука."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Избор на входно устройство\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Избор на входно устройство\n"
 
 #: src/AudioIOBase.cpp
@@ -1030,8 +1335,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Край на запис\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Край на запис\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Край на запис\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Край на запис\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -1045,37 +1360,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Избор на входно устройство\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Избор на входно устройство\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Избор на входно устройство\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Не е възможно да се отвори файл с жанрове.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Избор на входно устройство\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Запис\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Честоти на дискретизация\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Възпроизвеждане\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Край на запис\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Край на запис\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Възпроизвеждане\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Възпроизвеждане\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1083,8 +1401,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Избор на входно устройство\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Избор на входно устройство\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Избор на входно устройство\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Избор на входно устройство\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1092,8 +1420,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Автоматично възстановяване след срив"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1105,12 +1434,14 @@ msgid "Recoverable &projects"
 msgstr "Възстановими проекти"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Избиране"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Име"
 
@@ -1121,6 +1452,10 @@ msgstr "Избиране"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Избиране"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1154,6 +1489,11 @@ msgstr "Запазване"
 #: src/BatchCommandDialog.cpp
 msgid "&Parameters"
 msgstr "П&араметри"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Отделяне"
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
@@ -1190,6 +1530,22 @@ msgstr "Ефекти"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Параметри"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Параметри"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1237,6 +1593,10 @@ msgid "Apply %s"
 msgstr "Прилагане на %s"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "Управление на кривите"
 
@@ -1245,6 +1605,17 @@ msgstr "Управление на кривите"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Избор на крива"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Надписи…"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Прилагане на верига"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1312,7 +1683,8 @@ msgstr "В&ъзстановяване на област"
 msgid "I&mport..."
 msgstr "&Импортиране…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Експортиране…"
 
@@ -1353,9 +1725,15 @@ msgstr "Местене на&горе"
 msgid "Move &Down"
 msgstr "Местене на&долу"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Запазване"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1401,11 +1779,38 @@ msgid "Benchmark"
 msgstr "&Измерване на производителността…"
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Брой на повторенията:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Затваряне"
 
@@ -1420,12 +1825,32 @@ msgid "Export Benchmark Data as:"
 msgstr "Експорт на спектрални данни като:"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "Максималният брой ноти трябва да е между 1 и 128"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "Максималният брой ноти трябва да е между 1 и 128"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "Максималният брой ноти трябва да е между 1 и 128"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Подготвя се мостра\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1434,17 +1859,104 @@ msgstr "Прилага се ефект „Повтаряне“\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Поставяне\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Записва се звук\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Крайна дата и час"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "За крайни потребители"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1465,9 +1977,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Първо трябва да изберете звук, който да бъде обработен."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Не е избрана верига"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1495,6 +2031,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Кодекът не бе намерен "
 
@@ -1512,10 +2053,24 @@ msgstr "Прилагане върху текущия &проект"
 msgid "Checkpointing %s"
 msgstr "Импортира се %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Не бе възможно да се записва във файл: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Не бе възможно да се запази проект. Може би в %s \n"
+"не може да се записва или дискът е пълен."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1532,6 +2087,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "Не е възможно да се премахне „%s“"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1627,6 +2186,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Изрязване към клипборда"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Липсващи файлове"
 
@@ -1635,10 +2199,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ако продължите, проектът няма да бъде запазен на диска. Това ли желаете?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1650,7 +2215,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Проверка за зависимости"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Няма"
 
@@ -1658,7 +2226,7 @@ msgstr "Няма"
 msgid "Rectangle"
 msgstr "Правоъгълник"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Триъгълник"
 
@@ -1672,17 +2240,58 @@ msgstr "Правоъгълен"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Добре дошли!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Поддръжката за FFmpeg не е компилирана в"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1704,8 +2313,8 @@ msgid "Locate FFmpeg"
 msgstr "Посочете FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity се нуждае от файла „%s“, за да импортира и експортира файлове чрез FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -1718,7 +2327,8 @@ msgstr "Местоположение на „%s“:"
 msgid "To find '%s', click here -->"
 msgstr "За да намерите „%s“, щракнете тук -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Преглед…"
 
@@ -1744,8 +2354,9 @@ msgid "FFmpeg not found"
 msgstr "Не е намерена FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1765,24 +2376,38 @@ msgstr "Това предупреждение да не се показва по
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Не бяха намерени съвместими с FFmpeg библиотеки."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Tenacity не успя да запише във файла:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Tenacity не успя да запише във файла:\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Tenacity не успя да запише във файла:\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1819,7 +2444,9 @@ msgstr "Да &не се копира звук"
 msgid "As&k"
 msgstr "&Запитване към потребителя"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Всички файлове (*)|*"
 
@@ -1828,6 +2455,11 @@ msgstr "Всички файлове (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Запазват се файловете с данни на проекта"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Библиотеки"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1840,6 +2472,10 @@ msgstr "Имена на файловете:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3 файлове"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1881,6 +2517,14 @@ msgstr "Автокорелация с куб. корен"
 msgid "Enhanced Autocorrelation"
 msgstr "Подобрена автокорелация"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Спектър"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1899,9 +2543,18 @@ msgstr "Логаритмична честота"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "дБ"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
 
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
@@ -1910,7 +2563,9 @@ msgstr "Увеличение"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "Хц"
 
@@ -1927,6 +2582,10 @@ msgstr "Хоризонтално стерео"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Курсор наляво"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1974,11 +2633,43 @@ msgstr "Не са избрани достатъчно данни."
 msgid "s"
 msgstr "с"
 
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Спектър"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Експорт на спектрални данни като:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Не бе възможно да се записва във файл: "
@@ -2054,6 +2745,26 @@ msgid "No Local Help"
 msgstr "Няма локална помощ"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "These are our support methods:"
 msgstr "Ето нашите методи за поддръжка:"
 
@@ -2083,6 +2794,14 @@ msgstr "Tenacity може да импортира незащитени файл�
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
 msgstr "Освен това може да прочетете помощта за импортиране на <a href=\"http://manual.audacityteam.org/man/FAQ:Opening_and_Saving_Files#midi\">MIDI файлове</a> и писти от <a href=\"http://manual.audacityteam.org/man/FAQ:Opening_and_Saving_Files#fromcd\">аудиокомпактдискове</a>."
 
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
 #: src/HistoryWindow.cpp
 msgid "History"
 msgstr "&Хронология…"
@@ -2100,6 +2819,10 @@ msgid "Used Space"
 msgstr "Дисково пространство"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Налични нива на отмяна"
 
@@ -2113,6 +2836,10 @@ msgid "&Discard"
 msgstr "&Отхвърляне"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Отхвърляне"
 
@@ -2120,11 +2847,30 @@ msgstr "&Отхвърляне"
 msgid "&Compact"
 msgstr "&Команда"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Хронология…"
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2140,7 +2886,9 @@ msgid "Track"
 msgstr "Писта"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Надпис"
 
@@ -2200,18 +2948,25 @@ msgstr "Ввъведете име на писта"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Писта с надписи"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Първо стартиране на Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Изберете език за интерфейса на Tenacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2221,7 +2976,8 @@ msgstr "Изберете език за интерфейса на Tenacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Избраният от вас език, %s (%s), не е същият като системния език, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Потвърждение"
 
@@ -2239,12 +2995,13 @@ msgstr ""
 "Старият файл е запазен като „%s“"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Отваря се проект на Tenacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Караоке в Tenacity%s"
 
 #: src/LyricsWindow.cpp
@@ -2295,19 +3052,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Смесване и обобщаване на писти"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Смесителен пулт на Tenacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Усилване"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Динамика"
 
@@ -2316,17 +3077,23 @@ msgid "Musical Instrument"
 msgstr "Музикален инструмент"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Панорамно изместване"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Изкл."
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Соло"
 
@@ -2334,15 +3101,18 @@ msgstr "Соло"
 msgid "Signal Level Meter"
 msgstr "Ниво на сигнала"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Усилването бе променено"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Преместен бе плъзгачът за динамика"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Извършено бе панорамиране"
 
@@ -2358,13 +3128,73 @@ msgid ""
 "Error: %s"
 msgstr "Не е възможно да се отвори/създаде пробен файл."
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Да"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy, c-format
+msgid "Module \"%s\" found."
+msgstr "Не е намерена FFmpeg"
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Няма"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Модулатор"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -2379,18 +3209,121 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "ГБ"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "дБ"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Презаписване на съществуващи файлове"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2419,6 +3352,16 @@ msgstr "Команда на Nyquist"
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Съжаляваме, не бе възможно да се зареди Vamp приставка."
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Показване на всички кодеци"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -2450,6 +3393,25 @@ msgstr "Да"
 msgid "E&nabled"
 msgstr "Да"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Да"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Избиране"
@@ -2458,7 +3420,8 @@ msgstr "Избиране"
 msgid "C&lear All"
 msgstr "&Изчистване"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Да"
 
@@ -2524,6 +3487,21 @@ msgstr "Грешка при отваряне на звуковото устро�
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "За чертане на спектър всички избрани писти трябва да са с еднаква честота на дискретизация."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Записан бе звук"
@@ -2531,6 +3509,28 @@ msgstr "Записан бе звук"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "Запис"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2558,11 +3558,11 @@ msgid "Inspecting project file data"
 msgstr "Инспектират се данните на файл с проект"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2605,11 +3605,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Внимание: липсващи файлове с псевдоними"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Проверката на проекта в папката „%s“ \n"
@@ -2634,12 +3634,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Внимание: липсващи обобщаващи файлове с псевдоними"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2697,7 +3697,8 @@ msgstr "Внимание: осиротели блокови файлове"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Ход на операцията"
 
@@ -2722,6 +3723,11 @@ msgstr "Внимание: проблеми при автоматично въз�
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<неозаглавено>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Проекти"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2760,11 +3766,96 @@ msgid ""
 msgstr "Не е възможно да се отвори/създаде пробен файл."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Не е възможно да се премахне „%s“"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Запазва се проект на Audacity"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Не е възможно да се инициализира MP3 поток"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не е възможно да се инициализира MP3 поток"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не е възможно да се инициализира MP3 поток"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не е възможно да се инициализира MP3 поток"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не е възможно да се инициализира MP3 поток"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не е възможно да се инициализира MP3 поток"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не е възможно да се инициализира MP3 поток"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Не е възможно да се инициализира MP3 поток"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2778,12 +3869,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Осиротял блоков файл: „%s“"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Не е възможно да се преименува „%s“ на „%s“."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Кодекът не бе намерен "
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Не е възможно да се премахне „%s“"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2794,9 +3906,9 @@ msgid "Error Writing to File"
 msgstr "Грешка при записване във файл"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2807,8 +3919,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "При запазване на &проекти"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Дневник на Audacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2818,10 +3939,10 @@ msgstr "(Възстановен)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Този файл е запазен с Audacity %s.\n"
 "Вие използвате Audacity %s. За да отворите файла, трябва да я надстроите до по-нова версия."
@@ -2829,6 +3950,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Не е възможно отварянето на файл с проект"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2843,6 +3968,10 @@ msgid "Unable to parse project information."
 msgstr "Не е възможно да се отвори/създаде пробен файл."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "При запазване на &проекти"
 
@@ -2851,12 +3980,35 @@ msgid "Error Saving Project"
 msgstr "Грешка при запазване на проект"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "При запазване на п&разен проект"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2864,8 +4016,24 @@ msgstr ""
 "За щастие следните проекти могат да бъдат възстановени автоматично:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Някои проекти не са запазени правилно при последното изпълнение на Audacity.\n"
+"За щастие следните проекти могат да бъдат възстановени автоматично:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Възстановен бе проект"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Директория за временни файлове"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2895,6 +4063,17 @@ msgstr "Внимание: празен проект"
 msgid "Insufficient Disk Space"
 msgstr "Дисково пространство"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -2912,6 +4091,25 @@ msgstr ""
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Запазване на проекта „%s“ като…"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2965,11 +4163,12 @@ msgid "Error Opening Project"
 msgstr "Грешка при отваряне на проект"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Опитвате се да отворите автоматично създаден архивен файл.\n"
 "Така може да предизвикате сериозна загуба на данни.\n"
@@ -3002,6 +4201,12 @@ msgid "Error Opening File or Project"
 msgstr "Грешка при отваряне на файл или проект"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Възстановен бе проект"
 
@@ -3027,12 +4232,33 @@ msgid "Error Importing"
 msgstr "Грешка при импортиране"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Запаз&ване на проект"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Не е възможно отварянето на файл с проект"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Команда"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3043,8 +4269,8 @@ msgid "Automatic database backup failed."
 msgstr "Автоматично възстановяване след срив"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Добре дошли в Audacity версия %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3079,6 +4305,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "Остава дисково пространство за записване на %d минути."
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -3091,6 +4321,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -3106,6 +4348,26 @@ msgstr "Хоризонтално стерео"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Вертикално стерео"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(най-добро качество)"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -3134,6 +4396,10 @@ msgstr "24-битов PCM"
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
 msgstr "32-битов с ПЗ"
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -3219,7 +4485,8 @@ msgstr "Предпочитания: "
 msgid "SelectionBar"
 msgstr "Лента „Селекция“"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Селекция"
 
@@ -3227,44 +4494,58 @@ msgstr "Селекция"
 msgid "Timer"
 msgstr "Време"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Инструменти"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Вход/изход"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Смесител"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Индикация"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Индикатор за възпроизвеждане"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Индикатор за запис"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Редактиране"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Устройство"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Възпроизвеждане със скорост"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "&Ленти с инструменти"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -3277,7 +4558,10 @@ msgstr "Линийка"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Писти"
 
@@ -3329,6 +4613,15 @@ msgstr "Високи писти"
 msgid "Choose a location to save screenshot images"
 msgstr "Изберете къде да се запазват екранните снимки"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "Съобщение"
+
 #: src/Sequence.cpp
 #, c-format
 msgid ""
@@ -3359,6 +4652,19 @@ msgstr "&Настройки…"
 msgid "Debu&g"
 msgstr "&Контрол"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "Включване на прилепването"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
 #: src/SoundActivatedRecord.cpp
 msgid "Sound Activated Record"
 msgstr "Записване, задействано от звук"
@@ -3368,7 +4674,8 @@ msgid "Activation level (dB):"
 msgstr "Задействащо ниво (дБ):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Добре дошли в Audacity!"
 
 #: src/SplashDialog.cpp
@@ -3495,19 +4802,45 @@ msgstr "Грешка при записване на файл с етикети"
 msgid "Unsuitable"
 msgstr "Да"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Директория за временни файлове"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity не успя да запише във файла:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3516,18 +4849,26 @@ msgstr ""
 "за писане."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity не успя да запише изображения във файла\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3537,9 +4878,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3548,8 +4889,9 @@ msgstr ""
 "Може би той не е в правилен формат PNG."
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity не успя да зареди подразбираната си тема.\n"
@@ -3587,24 +4929,40 @@ msgstr ""
 "вече присъстваха."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity не успя да запази файла:\n"
 "  %s"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "Леко"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Контраст…"
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Име на писта"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3613,7 +4971,11 @@ msgstr "Контраст…"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Продължителност"
 
@@ -3624,7 +4986,8 @@ msgid "Time Track"
 msgstr "Времева писта"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Записване с таймер в Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -3653,12 +5016,38 @@ msgid "Error in Duration"
 msgstr "Грешка в продължителността"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Автоматично възстановяване след срив"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Грешка в продължителността"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Експортиране по избор чрез FFmpeg"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "Грешка в продължителността"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "Записване с &таймер…"
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3668,7 +5057,8 @@ msgstr "Прилагане върху текущия &проект"
 msgid "Recording start:"
 msgstr "Начало на запис"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Продължителност:"
 
@@ -3689,7 +5079,8 @@ msgid "Action after Timer Recording:"
 msgstr "Записване с таймер в Audacity"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Ход на записването с таймер в Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -3724,6 +5115,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "Край на запис"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Грешка при запазване на проект"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Запис"
@@ -3743,6 +5158,7 @@ msgstr "099 дни 024 ч 060 м 060 с"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Начална дата и час"
@@ -3787,7 +5203,8 @@ msgstr "Не е възможно да се експортира"
 msgid "Export Project As:"
 msgstr "Експортиране"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Настройки"
 
@@ -3796,8 +5213,21 @@ msgid "After Recording completes:"
 msgstr "Индикатор за запис"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Изход от Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3812,7 +5242,8 @@ msgid "Scheduled to stop at:"
 msgstr "Избиране до началото"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Записване с таймер в Audacity – изчаква се началото"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3820,6 +5251,14 @@ msgstr "Записване с таймер в Audacity – изчаква се �
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Край на запис"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3830,12 +5269,18 @@ msgid "Recording Exported:"
 msgstr "Край на запис"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Записване с таймер в Audacity – изчаква се началото"
 
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "Стерео, 999999 Хц"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3865,6 +5310,14 @@ msgstr "Соло"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Избиране"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -3943,6 +5396,10 @@ msgstr "Местене на пистата на&горе"
 msgid "Move Track Down"
 msgstr "Местене на пистата на&долу"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3988,25 +5445,79 @@ msgstr "Няма достатъчно място за поставяне на с
 msgid "There is not enough room available to expand the cut line"
 msgstr "Няма достатъчно място за разгъване на линията на изрязване"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Прилага се…"
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Команда"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Команда"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Повтаряне на „%s“"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4021,12 +5532,20 @@ msgid "Compares a range on two tracks."
 msgstr "Компресиране според пиковете"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Закъснение (секунди): "
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Коефициент на затихване:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -4048,6 +5567,11 @@ msgstr "Писта"
 msgid "Track 1"
 msgstr "Писта"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Размер на прозореца:"
@@ -4059,6 +5583,22 @@ msgstr "От:"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "От:"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -4084,13 +5624,42 @@ msgstr "Отрязани отчети"
 msgid "Envelopes"
 msgstr "Обвиваща крива"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Надписи"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Филтър"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Формат:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -4100,6 +5669,10 @@ msgstr "Местене на пистата на&долу"
 msgid "Types:"
 msgstr "Филтър"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Коментари"
@@ -4107,6 +5680,18 @@ msgstr "Коментари"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Команда:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4125,6 +5710,11 @@ msgid "Number of Channels:"
 msgstr "Брой на повторенията:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Експортиране на няколко файла"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Експортиране на няколко файла"
 
@@ -4132,9 +5722,26 @@ msgstr "Експортиране на няколко файла"
 msgid "Builtin Commands"
 msgstr "Избор на команда"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Екип за поддръжка на Audacity %s"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Крайна дата и час"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -4176,11 +5783,22 @@ msgstr "Запаз&ване на проект"
 msgid "Saves a copy of current project."
 msgstr "Запаз&ване на проект"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Предпочитания: "
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Име"
 
@@ -4191,6 +5809,18 @@ msgstr "Предпочитания: "
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Стойност"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -4217,7 +5847,8 @@ msgstr "Цял екран – вкл./изкл."
 msgid "Toolbars"
 msgstr "&Ленти с инструменти"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Ефекти"
 
@@ -4261,6 +5892,10 @@ msgstr "Високи писти"
 msgid "All Tracks Plus"
 msgstr "Високи писти"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -4268,13 +5903,30 @@ msgid "White"
 msgstr "Бял"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Фон:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Грешка при опит за запазване на файл: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "Инструменти за &екранни снимки…"
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -4321,6 +5973,10 @@ msgid "High:"
 msgstr "ВЧ филтър"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "Ниски писти"
 
@@ -4333,7 +5989,8 @@ msgstr "Настройка"
 msgid "Add"
 msgstr "&Добавяне"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Премахване"
 
@@ -4354,6 +6011,11 @@ msgid "Selects a time range."
 msgstr "Изберете MIDI файл..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Изберете MIDI файл..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Моля, изберете действие"
 
@@ -4365,9 +6027,37 @@ msgstr "Избор на аудиохост"
 msgid "Set Clip"
 msgstr "Следващ инструмент"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Начало"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4386,9 +6076,14 @@ msgid "Edited Envelope"
 msgstr "Обвиваща крива"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Обвиваща крива"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4398,6 +6093,10 @@ msgstr "Разделяна на надписи"
 msgid "Label Index"
 msgstr "Редактиране на надпис"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Избиране"
@@ -4405,6 +6104,10 @@ msgstr "Избиране"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Редактирани бяха надписи"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4418,9 +6121,26 @@ msgstr "Честота на дискретизация"
 msgid "Resize:"
 msgstr "Смаляване"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Леко"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "Запаз&ване на проект"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4451,10 +6171,17 @@ msgid "Gain:"
 msgstr "Усилване"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Ниски писти"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Линейна"
 
@@ -4465,6 +6192,10 @@ msgstr "Нулиране"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "Време"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4494,13 +6225,28 @@ msgstr "Обработка на спектъра"
 msgid "Spectral Select"
 msgstr "Селекция"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Нова писта"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Моля, изберете действие"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Усилване"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -4522,6 +6268,10 @@ msgstr "Разрешаване на отрязани отчети"
 msgid "Auto Duck"
 msgstr "Автоприглушаване"
 
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -4536,12 +6286,18 @@ msgstr "Избрана е писта, която не съдържа звук. �
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Автоприглушаването изисква управляваща писта, поставена под избраната писта или писти."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Приглушаване:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "секунди"
 
@@ -4565,7 +6321,8 @@ msgstr "Вътрешно затихване – дължина:"
 msgid "Inner &fade up length:"
 msgstr "Вътрешно засилване – дължина:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Праг:"
 
@@ -4574,8 +6331,17 @@ msgid "Preview not available"
 msgstr "Няма мостра"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Свиване на селекцията отляво"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Праг за шум:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -4586,8 +6352,18 @@ msgid "Ba&ss (dB):"
 msgstr "Усилване (дБ):"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "Усилване на басите"
+
+#: src/effects/BassTreble.cpp
 msgid "&Treble (dB):"
 msgstr "&Обхват (дБ):"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Редактиране на надпис"
 
 #: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
@@ -4596,6 +6372,10 @@ msgstr "&Обхват (дБ):"
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Ниво:"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -4606,8 +6386,18 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Промяна на височината без промяна на темпото"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Промяна на темпото в края (%)"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Промяна на височината без промяна на темпото"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
@@ -4662,17 +6452,36 @@ msgstr "Честота (Хц)"
 msgid "from (Hz)"
 msgstr "от"
 
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "to (Hz)"
+msgstr "Отрязване:"
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "към"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Промяна в проценти:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Промяна в проценти"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -4684,7 +6493,9 @@ msgstr "48"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "–"
 
@@ -4712,6 +6523,7 @@ msgstr "Стандартни грамофонни обороти:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "От обороти в минута"
@@ -4721,6 +6533,14 @@ msgstr "От обороти в минута"
 msgctxt "change speed"
 msgid "&from"
 msgstr "от"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "От обороти в минута"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4824,6 +6644,19 @@ msgid "Click Removal"
 msgstr "Премахване на пукане"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Името не трябва да е празно"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "Изберете праг (по-нисък – по-чувствително):"
 
@@ -4843,6 +6676,10 @@ msgstr "Макс. ширина на пик"
 msgid "Compressor"
 msgstr "Компресор"
 
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
 #. i18n-hint: usually leave this as is as dB doesn't get translated
 #: src/effects/Compressor.cpp
 #, c-format
@@ -4857,6 +6694,20 @@ msgstr "%.2f с"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f с"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f с"
 
 #: src/effects/Compressor.cpp
@@ -4954,6 +6805,12 @@ msgstr "Моля, изберете действие"
 
 #: src/effects/Contrast.cpp
 msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid ""
 "Nothing to measure.\n"
 "Please select a section of a track."
 msgstr ""
@@ -4966,7 +6823,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Анализатор на контраст – измерва средноквадратичната разлика между звука в две селекции."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Край"
 
@@ -5026,6 +6884,18 @@ msgstr "Разлика:"
 msgid "&Help"
 msgstr "&Помощ"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "нула"
@@ -5070,6 +6940,10 @@ msgstr "Краен момент на предния план"
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "Краен момент на фона"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -5164,6 +7038,12 @@ msgstr "Критерии за успех 1.4.7 на WCAG 2.0: неизпълне
 msgid "Data gathered"
 msgstr "Данните са събрани"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Анализ на контраста (съответствие с WCAG 2)"
@@ -5189,6 +7069,19 @@ msgid "Medium Overdrive"
 msgstr "Потвърждаване на презаписване"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Потвърждаване на презаписване"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Компресор на динамичния обхват"
 
@@ -5199,6 +7092,96 @@ msgstr "Изравняване"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Изкривяване"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Ограничител"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Потвърждаване на презаписване"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Потвърждаване на презаписване"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Потвърждаване на презаписване"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -5221,8 +7204,16 @@ msgid "Distortion"
 msgstr "Изкривяване"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Изкривяване"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -5237,8 +7228,21 @@ msgid "Clipping level"
 msgstr "Отрязани отчети"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Прилагане на верига"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Изберете праг"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -5253,6 +7257,14 @@ msgid "Repeat processing"
 msgstr "Пакетна обработка с CleanSpeech"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Степен на изравняване"
 
@@ -5263,6 +7275,15 @@ msgstr "Ограничител"
 #: src/effects/Distortion.cpp
 msgid "Wet level"
 msgstr "2 нива"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2 нива"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -5289,6 +7310,16 @@ msgid "DTMF Tones"
 msgstr "Тонално набиране…"
 
 #: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Поредица за тонално набиране:"
 
@@ -5296,7 +7327,9 @@ msgstr "Поредица за тонално набиране:"
 msgid "&Amplitude (0-1):"
 msgstr "Амплитуда (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Продължителност:"
 
@@ -5341,6 +7374,11 @@ msgstr "Ехо"
 msgid "Repeats the selected audio again and again"
 msgstr "Избраният звук се експортира като %s"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "Закъснение (секунди): "
@@ -5361,7 +7399,8 @@ msgstr "Готови настройки:"
 msgid "Export Effect Parameters"
 msgstr "&Параметри"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Не бе възможно да се отвори файл: „%s“"
@@ -5385,6 +7424,12 @@ msgstr "&Параметри"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Не е възможно да се отвори/създаде пробен файл.\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Подготвя се мостра"
@@ -5392,6 +7437,15 @@ msgstr "Подготвя се мостра"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Възпроизвежда се мостра"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Команда на Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -5428,10 +7482,30 @@ msgid "Factory Defaults"
 msgstr "Връщане на подразбираните"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr ""
 "Кодерът за FLAC не се инициализира.\n"
 "Състояние: %d"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -5456,6 +7530,23 @@ msgid "&Bypass"
 msgstr "Лентов филтър"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Извършено бе подравняване"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Местене на&горе"
 
@@ -5472,6 +7563,24 @@ msgid "Move effect down in the rack"
 msgstr "Клип бе преместен в друга писта"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Клип бе преместен в друга писта"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Въведете име за новата верига"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Закъснение"
@@ -5481,8 +7590,17 @@ msgid "Some Command"
 msgstr "Избор на команда"
 
 #: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "&Manage"
 msgstr "Управление на кривите"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Възпроизвеждане"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -5543,14 +7661,33 @@ msgid "Options..."
 msgstr "Настройка…"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Филтър"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Име"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Извършва се обръщане"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Грешка: %s"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "Транскрипция"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -5612,12 +7749,36 @@ msgid "Graphic EQ"
 msgstr "Графичен еквалайзер"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Усилване на басите"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Усилване на басите"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -5652,6 +7813,10 @@ msgid "Effect Unavailable"
 msgstr "Няма мостра"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Макс. дБ"
 
@@ -5664,6 +7829,26 @@ msgstr "%3d дБ"
 msgid "Min dB"
 msgstr "Мин. дБ"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "Филтър"
@@ -5671,6 +7856,11 @@ msgstr "Филтър"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Рисуване на криви"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Рисуване"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -5732,10 +7922,41 @@ msgstr "Обработва се: "
 msgid "D&efault"
 msgstr "По по&дразбиране"
 
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Измерване на производителността…"
+
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
 msgid "unnamed"
 msgstr "без име"
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Error Loading EQ Curves"
@@ -5883,6 +8104,17 @@ msgstr "Експортирани криви"
 msgid "No curves exported"
 msgstr "Не бяха експортирани криви"
 
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
+
 #: src/effects/Fade.cpp
 msgid "Fade In"
 msgstr "Засилване"
@@ -5895,9 +8127,18 @@ msgstr "Затихване"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Щракнете и плъзнете, за да изберете звук"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Щракнете и плъзнете, за да изберете звук"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Търсене на отрязани отчети"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -5919,13 +8160,37 @@ msgstr "Няма достатъчно място за генериране на 
 msgid "Invert"
 msgstr "Инвертиране"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Ефекти Audio Unit"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Нормализиране на макс. амплитуда до:"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -5945,9 +8210,26 @@ msgstr "Обработва се: "
 msgid "&Normalize"
 msgstr "Нормализиране"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Независимо нормализиране на стереоканалите"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -5977,6 +8259,10 @@ msgid "Noise"
 msgstr "Шум:"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Тип на шума"
 
@@ -5989,16 +8275,73 @@ msgid "Second greatest"
 msgstr "Втора писта"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Подразбирано увеличение"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Подразбирано увеличение"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Намаляване на шум"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Всички писти трябва да са с еднаква честота на дискретизация"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -6057,8 +8400,9 @@ msgid "Step 1"
 msgstr "Стъпка 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Изберете няколко секунди само с шум, за да знае Audacity какво\n"
@@ -6084,9 +8428,20 @@ msgstr ""
 msgid "Noise:"
 msgstr "Шум:"
 
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Isolate"
 msgstr "&Изолиране"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Смаляване"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -6104,17 +8459,74 @@ msgstr "&Размер на прозореца"
 msgid "8"
 msgstr "48"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 – по подразбиране"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "Подразбирано увеличение"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Премахване на шум"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -6153,6 +8565,10 @@ msgid "Normalize"
 msgstr "Нормализиране"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
 msgstr "Извършва се центриране и нормализиране…\n"
 
@@ -6163,6 +8579,10 @@ msgstr "Извършва се центриране…\n"
 #: src/effects/Normalize.cpp
 msgid "Normalizing without removing DC offset...\n"
 msgstr "Извършва се нормализиране без центриране…\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 #, c-format
@@ -6209,9 +8629,14 @@ msgstr "Независимо нормализиране на стереокан�
 msgid "Paulstretch"
 msgstr "Paulstretch..."
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Коефициент на удължаване:"
@@ -6220,9 +8645,43 @@ msgstr "Коефициент на удължаване:"
 msgid "&Time Resolution (seconds):"
 msgstr "Времева разделителна способност (секунди): "
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Фейзър"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -6285,6 +8744,10 @@ msgid "Repair"
 msgstr "Поправяне"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -6313,6 +8776,10 @@ msgid "Repeat"
 msgstr "Повтаряне"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "Брой на повторенията:"
 
@@ -6334,6 +8801,10 @@ msgstr "Нова дължина на селекцията:"
 msgid "New selection length: %s"
 msgstr "Нова дължина на селекцията:"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
 msgstr "Локално"
@@ -6343,12 +8814,50 @@ msgid "Vocal II"
 msgstr "Локално"
 
 #: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "Средно"
 
 #: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "Реверберация"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Размер"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Време за атака/затихване"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -6359,12 +8868,30 @@ msgid "Da&mping (%):"
 msgstr "Дълбочина (%):"
 
 #: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Дълбочина (%):"
+
+#: src/effects/Reverb.cpp
 msgid "Wet &Gain (dB):"
 msgstr "&Усилване (дБ):"
 
 #: src/effects/Reverb.cpp
 msgid "Dr&y Gain (dB):"
 msgstr "&Усилване (дБ):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Стерео"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -6379,6 +8906,25 @@ msgstr "Обръщане"
 msgid "Reverses the selected audio"
 msgstr "Избраният звук се експортира като %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "НЧ филтър"
@@ -6388,12 +8934,35 @@ msgid "Highpass"
 msgstr "ВЧ филтър"
 
 #: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Ка&чване на файл…"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "За чертане на спектър всички избрани писти трябва да са с еднаква честота на дискретизация."
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
 msgstr "Филтър"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
@@ -6406,6 +8975,14 @@ msgstr "Отрязване:"
 #: src/effects/ScienFilter.cpp
 msgid "C&utoff:"
 msgstr "Отрязване:"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
@@ -6495,11 +9072,20 @@ msgstr "Подразбирани настройки"
 msgid "Restore Defaults"
 msgstr "Връщане на подразбираните"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Замяна с тишина"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -6524,6 +9110,10 @@ msgstr "При смесване към &моно при експортиране
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "Разтягане"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
 
 #: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
@@ -6582,6 +9172,14 @@ msgid "Tone"
 msgstr "Тон…"
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Вълна:"
 
@@ -6614,8 +9212,20 @@ msgid "Truncate Detected Silence"
 msgstr "Премахване на тишина"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "Премахване на тишина"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -6624,6 +9234,10 @@ msgstr "Разделяне в ти&хите места"
 #: src/effects/TruncSilence.cpp
 msgid "Tr&uncate to:"
 msgstr "Премахване на тишина"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
@@ -6638,10 +9252,20 @@ msgid "VST Effects"
 msgstr "Ефекти VST"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Scanning Shell VST"
 msgstr "Търсят се ефекти VST"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Не бе възможно да се отвори кодиращата библиотека за MP3!"
 
@@ -6649,17 +9273,44 @@ msgstr "Не бе възможно да се отвори кодиращата �
 msgid "VST Effect Options"
 msgstr "Настройки на ефекта"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Дължина"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Компресия на тишината:"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Компресия на тишината:"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Graphical Mode"
 msgstr "Графичен еквалайзер"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 #, c-format
@@ -6671,11 +9322,17 @@ msgid "Save VST Preset As:"
 msgstr "Запазване на VST програма като:"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Зареждане на VST програма:"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "Зареждане на VST програма:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Файлове с проекти на Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -6702,9 +9359,15 @@ msgstr "Грешка при зареждане на VST програма"
 msgid "Unable to load presets file."
 msgstr "Не е възможно да се отвори/създаде пробен файл."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Настройки на ефекта"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Не е възможно да се отвори/създаде пробен файл."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
@@ -6724,6 +9387,10 @@ msgstr "Ефекти V&ST"
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "Ефект „Уа-уа“"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -6751,6 +9418,11 @@ msgid "Audio Unit Effects"
 msgstr "Ефекти Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Ефекти Audio Unit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "Не бе възможно да се отвори файлът "
 
@@ -6763,20 +9435,41 @@ msgid "Audio Unit Effect Options"
 msgstr "Ефекти Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Интерфейс"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Избор на изходно устройство"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Многолентов"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Генериране"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "Импортиране"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -6852,6 +9545,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Не е възможно да се извлече описание на поток"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Не е възможно да се отвори/създаде пробен файл."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Смяна на честотата на дискретизация"
 
@@ -6859,6 +9557,21 @@ msgstr "Смяна на честотата на дискретизация"
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Не е възможно да се премахне „%s“"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Не е възможно да се извлече описание на поток"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Не е възможно да се извлече описание на поток"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Не е възможно да се отвори/създаде пробен файл."
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -6868,13 +9581,36 @@ msgstr "Ефекти Audio Unit"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Ефекти VST"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "Ефекти VST"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Настройки на ефекта"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -6882,6 +9618,7 @@ msgstr "Настройки на ефекта"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "Ефекти &LADSPA"
@@ -6889,6 +9626,23 @@ msgstr "Ефекти &LADSPA"
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
 msgstr "Настройки на ефекта"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
@@ -6904,13 +9658,27 @@ msgstr "%d криви бяха експортирани в %s\n"
 msgid "Generator"
 msgstr "Генератор"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Ефекти VST"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Ефекти"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -6926,6 +9694,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Изход от Nyquist:"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Подравнено по края на селекцията"
 
@@ -6938,12 +9724,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Съжаляваме, ефектът не може да бъде прилаган върху стереописти, в които каналите на пистата не си пасват."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Изход от Nyquist:"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Обработва се: "
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -7023,6 +9827,19 @@ msgid "Could not determine language"
 msgstr "Не бе възможно да се отвори файл:"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Не е възможно да се отвори/създаде пробен файл.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Въведете команда на Nyquist: "
 
@@ -7039,6 +9856,22 @@ msgstr "Команда на Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Команда на Nyquist"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Не бе възможно да се отвори файлът "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "Не е измерено ниво на предния план"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -7059,13 +9892,18 @@ msgstr "Изберете MIDI файл..."
 msgid "Save file as"
 msgstr "Запазване на файлове"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "неозаглавено"
 
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Ефекти VST"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -7086,6 +9924,17 @@ msgstr "Настройки на приставка"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Програма"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Общи настройки"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -7238,15 +10087,28 @@ msgid "Command Output"
 msgstr "Резултат от командата"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
 "Избрахте име на файл с непознато разширение.\n"
 "Желаете ли да продължите?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "Не е намерена FFmpeg"
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Не е възможно да се отвори/създаде пробен файл."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -7257,8 +10119,32 @@ msgstr ""
 "Можете да я конфигурирате в Предпочитания > Библиотеки."
 
 #: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Библиотека FFmpeg:"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -7269,6 +10155,59 @@ msgid ""
 msgstr ""
 "FFmpeg не може да намери аудиокодек 0x%x.\n"
 "Вероятно поддръжката за него не е компилирана."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -7289,7 +10228,8 @@ msgstr "Избраният звук се експортира като %s"
 msgid "Invalid sample rate"
 msgstr "Невалидна честота на дискретизация"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Предискретизиране"
 
@@ -7321,7 +10261,8 @@ msgstr "Честоти на дискретизация"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%i Кб/с"
@@ -7344,6 +10285,34 @@ msgstr "%.2f Кб/с"
 msgid "0"
 msgstr "60"
 
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "120"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "145"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "145"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "48"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "9"
 msgstr "96"
@@ -7361,6 +10330,10 @@ msgid "Constrained"
 msgstr "Постоянна"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Звук…"
 
@@ -7369,8 +10342,44 @@ msgid "Low Delay"
 msgstr "Закъснение"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Средно"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -7441,8 +10450,18 @@ msgid "Replace preset '%s'?"
 msgstr "Да бъде ли изтрита готовата настройка „%s“?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "ЛПК"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Основен"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LTP"
+msgstr "ЛПК"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -7550,6 +10569,10 @@ msgstr "Език:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Резервни битове"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -7846,6 +10869,17 @@ msgstr "Няма надписи за експортиране."
 msgid "Select xml file to export presets into"
 msgstr "Изберете XML файл, в който да се запазят готовите настройки"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Разпознаването на формата бе неуспешно"
@@ -7932,12 +10966,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(най-добро качество)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f Кб/с"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f Кб/с"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f Кб/с"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f Кб/с"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f Кб/с"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f Кб/с"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f Кб/с"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f Кб/с"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(по-малки файлове)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 # Много остроумно. :-/
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
@@ -7951,7 +11037,8 @@ msgstr "Много високо"
 
 # Един и същ низ се ползва за „качество“ (ср.р.),  „скорост“ (ж.р.) и „бутон
 # „Соло“ (м.р.). :-(
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Стандартно"
 
@@ -7992,14 +11079,19 @@ msgstr "Качество"
 msgid "Channel Mode:"
 msgstr "Режим на каналите:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Премахната бе линия на изрязване"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Посочете Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity се нуждае от файла %s, за да създава MP3 файлове."
 
 #: src/export/ExportMP3.cpp
@@ -8027,13 +11119,34 @@ msgid "Where is %s?"
 msgstr "Къде е %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Използвате lame_enc.dll v%d.%d. Тази версия не е съвместима с Audacity %d.%d.%d.\n"
 "Моля, изтеглете най-новата версия на библиотеката LAME."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Запазват се файловете с данни на проекта"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -8129,8 +11242,18 @@ msgid "Cannot Export Multiple"
 msgstr "Експортиране на няколко файла"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Местоположение за експортиране:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -8271,6 +11394,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Не може да се зададе качество за рендиране на QuickTime"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Не е възможно да се отвори/създаде пробен файл."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Не е възможно да се отвори/създаде пробен файл."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Не е възможно да се отвори/създаде пробен файл."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Не е възможно да се отвори/създаде пробен файл."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Не е възможно да се отвори/създаде пробен файл."
 
@@ -8281,6 +11424,10 @@ msgstr "Избраният звук се експортира във форма�
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Избраният звук се експортира във формат Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -8299,8 +11446,28 @@ msgid "Other uncompressed files"
 msgstr "Други некомпресирани файлове"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Грешка при импортиране"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -8328,11 +11495,11 @@ msgid "All supported files"
 msgstr "Всички файлове|*|Всички поддържани файлове|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "„%s“ е MIDI файл, а не аудиофайл. \n"
@@ -8340,11 +11507,11 @@ msgstr ""
 "но можете да го редактирате с Файл > Импортиране > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "„%s“ е MIDI файл, а не аудиофайл. \n"
 "Audacity не може да отвори такъв файл за възпроизвеждане,\n"
@@ -8355,18 +11522,18 @@ msgid "Select stream(s) to import"
 msgstr "Избор на потоци за импортиране"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Тази версия на Audacity не е компилирана с поддръжка за %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "„%s“ е песен от компактдиск. \n"
 "Audacity не може да отваря пряко данни от аудиокомпактдиск. \n"
@@ -8375,10 +11542,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "„%s“ е файл със списък за възпроизвеждане. \n"
@@ -8387,10 +11554,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ е файл във формата Windows Media Audio. \n"
@@ -8399,10 +11566,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ е файл във формата Advanced Audio Coding. \n"
@@ -8411,12 +11578,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "„%s“ е шифрован аудиофайл. \n"
@@ -8427,10 +11594,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ е мултимедиен файл на RealPlayer. \n"
@@ -8439,12 +11606,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "„%s“ е файл, базиран на ноти, а не аудиофайл. \n"
 "Audacity не може да отваря такива файлове. \n"
@@ -8453,10 +11620,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -8469,10 +11636,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ е аудиофайл във формата Wavpack. \n"
@@ -8481,10 +11648,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ е аудиофайл във формата Dolby Digital. \n"
@@ -8493,10 +11660,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ е аудиофайл във формата Ogg Speex. \n"
@@ -8505,10 +11672,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "„%s“ е видеофайл. \n"
@@ -8522,20 +11689,31 @@ msgstr "Не е намерена FFmpeg"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity не разпозна типа на файла „%s“.\n"
 "Ако е некомпресиран, опитайте с „Импортиране на некомпресирани данни“."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -8544,6 +11722,11 @@ msgstr ""
 "Следните импортиращи филтри би трябвало да поддържат тези файлове:\n"
 "%s.\n"
 "Никой от тях обаче не успя да разчете формата на файла."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Запазват се файловете с данни на проекта"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8560,8 +11743,57 @@ msgid "Import Project"
 msgstr "Импортиране"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Възникна вътрешна грешка в процеса на подравняване."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Невалидна честота на дискретизация"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8569,16 +11801,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Не бе намерена папката с данни за проекта: „%s“"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Проекти"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Невалидна честота на дискретизация"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Невалидна честота на дискретизация"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8608,36 +11898,6 @@ msgstr "Индекс[%02x] Кодек[%s], Език[%s], Скорост на п�
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC файлове"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Файлове, съвместими с GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Не е възможно да се отвори/създаде пробен файл."
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Стартирането на GStreamer бе неуспешно"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Не е възможно да се преименува „%s“ на „%s“."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Индекс[%02x] Кодек[%s], Език[%s], Скорост на предаване[%s], Канали[%d], Продължителност[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Не е възможно да се отвори/създаде пробен файл."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer %s: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -8697,6 +11957,14 @@ msgstr "Не бе възможно да се отвори файлът "
 msgid "MP3 files"
 msgstr "MP3 файлове"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis файлове"
@@ -8731,8 +11999,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF и други некомпресирани типове"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) – 16-битов PCM със знак"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-битов PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -8741,6 +12103,16 @@ msgstr "16-битов PCM"
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-битов PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-битов PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-битов PCM"
 
 # „Плаваща запетая“ е твърде дълго за мястото в панела на писта. :-(
 #: src/import/ImportPCM.cpp
@@ -8753,6 +12125,40 @@ msgid "64 bit float"
 msgstr "32-битов с ПЗ"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) – 16-битов PCM със знак"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 бита"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "16 бита"
 
@@ -8761,12 +12167,20 @@ msgid "24 bit DWVW"
 msgstr "24 бита"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-битов PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-битов PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -8877,6 +12291,10 @@ msgstr "Честота на дискретизация:"
 msgid "&Import"
 msgstr "&Импортиране"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -8897,6 +12315,7 @@ msgstr "надясно"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -8920,6 +12339,7 @@ msgstr "Край"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -8939,15 +12359,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Писти/клипове бяха преместени %s с %.02f секунди"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Писти/клипове бяха преместени %s с %.02f секунди"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Преместване"
 
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "Изрязване по &границите"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Изрязване по &границите"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "Изрязване по &границите"
 
 #: src/menus/ClipMenus.cpp
@@ -9068,7 +12508,8 @@ msgstr "Избраните писти бяха нулирани в отрязъ�
 msgid "Trim Audio"
 msgstr "Записва се звук"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Разделяне"
 
@@ -9189,32 +12630,8 @@ msgid "Delete Key&2"
 msgstr "Клавиш за изтриване 2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Лента „С&месител“"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Задаване скорост на възпроизвеждане"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "По-бързо възпроизвеждане"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "По-бавно възпроизвеждане"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Край на запис"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "По-бързо възпроизвеждане"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "По-бавно възпроизвеждане"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -9241,8 +12658,21 @@ msgid "&Full Screen (on/off)"
 msgstr "Цял екран – вкл./изкл."
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Избраният звук се експортира като %s"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Редактиране на надпис"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -9292,6 +12722,11 @@ msgstr "Импортиране на надписи"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Изберете MIDI файл..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Всички файлове (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -9394,6 +12829,10 @@ msgid "E&xit"
 msgstr "&Изход"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "Експорт на надписи като:"
 
@@ -9424,6 +12863,10 @@ msgid "Nothing to do"
 msgstr "Няма действия за анулиране"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Затваряне на фокусираната писта"
 
@@ -9434,6 +12877,10 @@ msgstr "Не е възможно отварянето на файл с прое�
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Начало на запис"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -9452,12 +12899,17 @@ msgid "&Getting Started"
 msgstr "Начало на селекцията:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Дневник на Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "Управление на кривите"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&Помощ"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -9475,11 +12927,8 @@ msgstr "Информация за &аудиоустройство…"
 msgid "Show &Log..."
 msgstr "Показване на &дневника…"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Относно Tenacity…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Добавен бе надпис"
 
@@ -9605,6 +13054,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "Постав&яне текст в нов надпис"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "О&бласти с надписи"
 
@@ -9669,6 +13122,18 @@ msgid "Label Join"
 msgstr "Редактиране на надпис"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Преход назад от лентите с инструменти към пистите"
 
@@ -9709,8 +13174,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Превключване на фокусираната писта"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Нов…"
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -9725,6 +13198,10 @@ msgstr "Приставки %i – %i"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "&Генериране"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -9808,6 +13285,16 @@ msgid "Set Track Status..."
 msgstr "към н&ачалото на пистата"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Замяна с ти&шина"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Ниски писти"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Предпочитания…"
 
@@ -9830,6 +13317,12 @@ msgstr "&Редактиране на надписи…"
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Запазване на проект к&ато…"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Променлива"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -9906,6 +13399,11 @@ msgid "In All &Sync-Locked Tracks"
 msgstr "Във всички с&инхронизирани писти"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Селекция"
+
+#: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "Възпроизве&жданa област"
 
@@ -9974,8 +13472,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Линейна честота"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Избиране до началото"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Позиция в звука:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -10112,6 +13619,14 @@ msgstr "Дълъг скок на курсора наляво"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "Дълъг скок на курсора надясно"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
@@ -10320,18 +13835,21 @@ msgid "Created new label track"
 msgstr "Създадена бе нова писта за надписи"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Тази версия на Audacity позволява само по една времева писта за всеки прозорец на проект."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Създадена бе нова времева писта"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Нова честота на дискретизация (Хц):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Въведената стойност е невалидна"
 
@@ -10411,6 +13929,11 @@ msgid "&Time Track"
 msgstr "&Времева писта"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Лента „С&месител“"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Раздел&яне на стерео в моно"
 
@@ -10449,6 +13972,10 @@ msgstr "&Изключване на всички писти"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Включване на всички писти"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -10580,7 +14107,9 @@ msgstr "Възпроизвеждане"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Запис"
 
@@ -10593,8 +14122,27 @@ msgid "no label track at or below focused track"
 msgstr "Панорамиране на фокусираната писта наляво"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Създадена бе нова писта за надписи"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -10662,6 +14210,11 @@ msgid "&Timer Record..."
 msgstr "Записване с &таймер…"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Записване, задействано от звук"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Възпроизве&жданa област"
 
@@ -10690,16 +14243,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "Зап&исване, задействано от звук (вкл./изкл.)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Фиксирана глава за възпроизвеждане"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "Н&аслагване (вкл./изкл.)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "С&офтуерен монитор на записа (вкл./изкл.)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Авторе&гулиране на входното ниво (вкл./изкл.)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -10709,6 +14263,11 @@ msgstr "&Вход/изход"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "&Възпроизвеждане"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -10826,6 +14385,11 @@ msgid "&Fit to Width"
 msgstr "&Побиране в прозореца"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&Побиране в прозореца"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "Св&иване на всички писти"
 
@@ -10869,6 +14433,18 @@ msgstr "Ефекти VST"
 msgid "&Window"
 msgstr "прозорец"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
@@ -10894,7 +14470,7 @@ msgstr "Предпочитания: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Изход от Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -10941,7 +14517,8 @@ msgstr "&Хост"
 msgid "Using:"
 msgstr "Използва се:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Възпроизвеждане"
 
@@ -10961,7 +14538,8 @@ msgstr "&Канали"
 msgid "Latency"
 msgstr "Закъснение"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "милисекунди"
 
@@ -10990,7 +14568,8 @@ msgid "2 (Stereo)"
 msgstr "2 (стерео)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Директории"
 
@@ -11003,8 +14582,22 @@ msgid "Default directories"
 msgstr "Директории"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Преглед…"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -11064,6 +14657,11 @@ msgstr "Избор на местоположение за запазване н�
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "Директорията %s не съществува. Желаете ли да бъде създадена?"
 
@@ -11077,7 +14675,8 @@ msgid "Directory %s is not writable"
 msgstr "В директорията %s не може да се записва"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Смяната на временната директория влиза в сила след рестартиране на Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -11092,11 +14691,57 @@ msgstr "Предпочитания: "
 msgid "Sorted by Effect Name"
 msgstr "Сортиране по име"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Сортиране по име"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Сортиране по име"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "Ефекти &LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Команда на Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -11107,16 +14752,33 @@ msgid "Effect Options"
 msgstr "Настройки на ефекта"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Настройки на приставка"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Ново търсене на ефекти VST при следващото стартиране на Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
 msgstr "Инструмент"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
 
 #. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
 #. * audio file import options
@@ -11259,6 +14921,10 @@ msgid "Location of &Manual:"
 msgstr "Местоположение на &упътването:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "&Обхват на индикатора и вълната в дБ:"
 
@@ -11271,12 +14937,57 @@ msgid "Show e&xtra menus"
 msgstr "&Мрежа по оста Y"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "З&вуков сигнал при завършване на дълги операции"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Опции за времева линия"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Линийка"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Импортиране/експортиране"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Предпочитания: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -11291,6 +15002,10 @@ msgstr "Разширени настройки за смесване"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Стандартно"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -11317,6 +15032,14 @@ msgstr "Игнориране на тишината в начала и завър
 msgid "Exported Label Style:"
 msgstr "Експорт на надписи като:"
 
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
+
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Keyboard"
@@ -11335,6 +15058,10 @@ msgid "Open a new project to modify keyboard shortcuts."
 msgstr "Отворете нов проект, за да променяте клавишните комбинации."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Клавишни комбинации"
 
@@ -11343,8 +15070,35 @@ msgid "View by:"
 msgstr "&Изглед"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Име"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Изглед"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Изглед"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Изглед"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
@@ -11353,6 +15107,12 @@ msgstr "Клавишни комбинации"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Short cut"
 msgstr "Ниски писти"
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Настройки…"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -11367,7 +15127,15 @@ msgid "&Defaults"
 msgstr "По по&дразбиране"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Изберете XML файл с клавишни комбинации на Audacity…"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11376,8 +15144,21 @@ msgstr "Грешка при импортиране на клавишните к�
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Заредени бяха %d клавишни комбинации\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -11390,6 +15171,38 @@ msgstr "Експорт на клавишни комбинации като:"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Грешка при експортиране на клавишните комбинации"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -11436,12 +15249,17 @@ msgid "Dow&nload"
 msgstr "&Изтегляне"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity автоматично откри валидни библиотеки на FFmpeg.\n"
 "Желаете ли все пак да ги посочите ръчно?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -11478,6 +15296,10 @@ msgstr "Закъснение на MIDI синтезатора (мс):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "Закъснението на MIDI синтезатора трябва да е цяло число"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -11488,7 +15310,29 @@ msgid "Preferences for Module"
 msgstr "Предпочитания: "
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Смяната на временната директория влиза в сила след рестартиране на Audacity"
 
 #: src/prefs/ModulePrefs.cpp
@@ -11506,6 +15350,10 @@ msgstr "Не са намерени устройства"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Модулатор"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -11547,7 +15395,10 @@ msgstr "Плъзгане"
 msgid "Set Selection Range"
 msgstr "Задаване на избрания диапазон"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift+щракване"
 
@@ -11634,6 +15485,15 @@ msgstr "Плъзгане"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Преместване на клип между пистите"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Плъзгане"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -11745,8 +15605,21 @@ msgstr "&Къс период:"
 msgid "Lo&ng period:"
 msgstr "Д&ълъг период:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Настройка на Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -11760,6 +15633,11 @@ msgstr "Предпочитания: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Предпочитания: "
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -11820,12 +15698,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "Наслагване: &възпроизвеждане на другите писти при запис на нова"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "С&офтуерен монитор на записа (вкл./изкл.)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Нова писта"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Избор на потоци за импортиране"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -11866,41 +15754,37 @@ msgid "System &Date"
 msgstr "Начална дата"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Авторегулиране на входното ниво"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Включва авторегулирането на входното ниво."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Желан пик:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "В рамките на:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Време за анализ:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "милисекунди (време за един анализ)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Брой последователни анализи:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 означава безкрайно"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Начална дата"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Записване, задействано от звук"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Нотна писта"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -11911,6 +15795,13 @@ msgstr "Време на кадър"
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
+msgstr "Подразбирано увеличение"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
 msgstr "Подразбирано увеличение"
 
 #. i18n-hint: Grayscale color scheme for spectrograms
@@ -11928,6 +15819,11 @@ msgstr "Линейна"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Честота (Хц)"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -11988,12 +15884,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Ма&ксимална честота (Хц):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "&Усилване (дБ):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "&Обхват (дБ):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -12016,12 +15920,21 @@ msgid "1024 - default"
 msgstr "256 – по подразбиране"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 – най-тясна честотна лента"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "&Тип на прозореца"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Коефициент на затихване:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -12110,13 +16023,14 @@ msgid "Info"
 msgstr "Информация"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -12204,6 +16118,18 @@ msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "„Преместване на фокуса“ преминава &циклично между пистите"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Разширени настройки за смесване"
 
@@ -12224,6 +16150,10 @@ msgid "Spectrogram"
 msgstr "Спектрограма"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "Обновяване"
 
@@ -12238,6 +16168,10 @@ msgstr "&Мащабиране до селекцията"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Подразбирано увеличение"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -12260,6 +16194,16 @@ msgid "50ths of Seconds"
 msgstr "секунди"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "секунди"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "секунди"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "милисекунди"
 
@@ -12267,7 +16211,12 @@ msgstr "милисекунди"
 msgid "Samples"
 msgstr "отчети"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Увеличение"
 
@@ -12276,8 +16225,29 @@ msgid "Preferences for Tracks"
 msgstr "Предпочитания: "
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "&Изписване името на пистата при вълновата форма"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Край на запис"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -12286,6 +16256,11 @@ msgstr "Подразбиран &режим на изгледа:"
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Подразбиран &формат на данните:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "отчети"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -12337,6 +16312,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "При смесване към &стерео при експортиране"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "При смесване към &моно при експортиране"
 
@@ -12361,16 +16340,24 @@ msgid "Stopped"
 msgstr "Стоп"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Пауза"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Превъртане до началото"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Превъртане до края"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Пауза"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Избиране до началото"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Избиране от курсора до края"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -12384,20 +16371,17 @@ msgstr "Нова писта"
 msgid "Append Record"
 msgstr "&Добавяне на запис"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Избиране от курсора до края"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Избиране до началото"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Пауза"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -12477,11 +16461,17 @@ msgstr "Нулиране на селекцията"
 msgid "Sync-Lock Tracks"
 msgstr "Синхронизиране на писти"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Увеличаване"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Умаляване"
 
@@ -12548,50 +16538,23 @@ msgstr "Индикатор за запис"
 msgid "&Playback Meter Toolbar"
 msgstr "Индикатор за възпроизвеждане"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Край на запис"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Възпроизвеждане"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Край на запис"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Не може да се управлява силата на входа. Използвайте системния смесител."
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Възпроизвеждане"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Възпроизвеждане"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Не може да се управлява силата на входа. Използвайте системния смесител."
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Лента „С&месител“"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "Линийка"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Команда на Nyquist"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Команда на Nyquist"
@@ -12599,6 +16562,7 @@ msgstr "Команда на Nyquist"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Команда на Nyquist"
@@ -12606,9 +16570,24 @@ msgstr "Команда на Nyquist"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Започване на наблюдение"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Започване на наблюдение"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Линийка"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -12656,9 +16635,24 @@ msgstr "Прилепване"
 msgid "Length"
 msgstr "Дължина"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Център"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -12685,6 +16679,10 @@ msgstr "Усилват се басовите честоти"
 msgid "Center Frequency"
 msgstr "Линейна честота"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -12703,8 +16701,8 @@ msgstr "Лента „У&стройство“"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Лента с инструменти – Audacity %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -12731,7 +16729,8 @@ msgstr "Преместване"
 msgid "Zoom Tool"
 msgstr "Увеличение"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Рисуване"
 
@@ -12807,11 +16806,13 @@ msgstr "Плъзнете една или повече граници на над
 msgid "Drag label boundary."
 msgstr "Плъзнете граница на надпис"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Променен бе надпис"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Редактиране на надпис"
 
@@ -12866,31 +16867,42 @@ msgstr "Редактирани бяха надписи"
 msgid "New label"
 msgstr "Добавен бе надпис"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "О&ктава нагоре"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Октава надол&у"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Щракнете за вертикално увеличаване, щракнете с Shift за умаляване; плъзнете, за да зададете област за увеличаване."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Щракване (десен бутон)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Умаляване"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift+щракване"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift+щракване"
 
@@ -12913,6 +16925,14 @@ msgid "Stretch"
 msgstr "Разтягане"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Слети бяха клипове"
 
@@ -12924,7 +16944,8 @@ msgstr "Сливане"
 msgid "Expanded Cut Line"
 msgstr "Разгъната бе линия на изрязване"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Разгъване"
 
@@ -12948,6 +16969,11 @@ msgstr "Преместени бяха отчети"
 msgid "Sample Edit"
 msgstr "Редактиране на отчети"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Увеличаване около точка"
@@ -12955,6 +16981,16 @@ msgstr "Увеличаване около точка"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "&Спектрограма"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -12980,7 +17016,8 @@ msgstr "Обработва се: "
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Пистата „%s“ бе преобразувана в %s"
@@ -12994,7 +17031,60 @@ msgid "Rat&e"
 msgstr "&Честота на дискретизация"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 ч 060 м 060>0100 с"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -13015,7 +17105,8 @@ msgstr "Промяна на честота"
 msgid "Set Rate"
 msgstr "Честота на дискретизация"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Универсален"
 
@@ -13108,10 +17199,25 @@ msgid "Right, %dHz"
 msgstr "Десен, "
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f дБ"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "надясно"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -13121,6 +17227,15 @@ msgstr "Щракнете и плъзнете, за да настроите от�
 msgid "Click and drag to rearrange sub-views"
 msgstr "Щракнете и плъзнете, за да местите пистата във времето"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Щракнете и плъзнете, за да местите пистата във времето"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Увеличаване"
@@ -13128,6 +17243,10 @@ msgstr "Увеличаване"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Увеличение"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -13173,12 +17292,28 @@ msgid "Set Range"
 msgstr "Задаване на диапазон"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "Изобразяване"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Интерполация:"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
@@ -13200,9 +17335,8 @@ msgstr "Бърза sinc интерполация"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Щракнете и плъзнете, за да местите пистата във времето"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -13253,6 +17387,21 @@ msgstr "Обвиващата крива бе променена."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "&Ленти с инструменти"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Започване на наблюдение"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Линийка"
@@ -13268,6 +17417,11 @@ msgstr "Затваряне на фокусираната писта"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Местене на пистата на&долу"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Команда на Nyquist"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -13324,6 +17478,11 @@ msgstr "Щракнете и плъзнете, за да изберете зву�
 msgid "Click and drag to select audio"
 msgstr "Щракнете и плъзнете, за да изберете звук"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Щракнете и плъзнете, за да местите пистата във времето"
@@ -13345,6 +17504,10 @@ msgstr "Избраните писти бяха нулирани в отрязъ�
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Избраните писти бяха нулирани в отрязък от %.2f секунди от %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -13371,6 +17534,12 @@ msgstr "Команда"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl+щракване"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Моля, изберете действие"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -13436,6 +17605,14 @@ msgid "%.2fx"
 msgstr "%.1f дБ"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"„%s“ не същестува.\n"
+"\n"
+"Желаете ли да бъде създаден?"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
 msgstr " Моля, изберете действие "
 
@@ -13463,13 +17640,28 @@ msgstr "Празно"
 msgid "Backwards"
 msgstr "Назад"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Напред"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Помощ в Интернет"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Всички файлове (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -13530,12 +17722,21 @@ msgid "Meter Style"
 msgstr "Индикация"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Филтър"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Продължителност"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Автоматично възстановяване след срив"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -13550,9 +17751,22 @@ msgid " Monitoring "
 msgstr "Спиране на наблюдението"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f дБ"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f дБ"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Show Log for Details"
@@ -13653,6 +17867,7 @@ msgstr "0100 ч 060 м 060 с+># отчета"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "отчети"
@@ -13814,6 +18029,10 @@ msgstr "01000,01000 кадъра|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 ч 060 м 060>0100 с"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows frequency in kilohertz
 #: src/widgets/NumericTextCtrl.cpp
 msgid "kHz"
@@ -13826,6 +18045,10 @@ msgstr "кХц"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 ч 060 м 060>0100 с"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -13841,17 +18064,47 @@ msgstr "Октава надол&у"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 кадъра|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in semitones and cents
 #: src/widgets/NumericTextCtrl.cpp
 msgid "semitones + cents"
 msgstr "Интервал в полутонове"
 
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 кадъра|24"
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
@@ -13860,6 +18113,11 @@ msgstr "За смяна на формата: десният бутон на ми
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "стотни от секундата"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -13903,6 +18161,11 @@ msgstr "Потвърждение"
 msgid "Unable to write files to directory: %s."
 msgstr "Не е възможно да се отвори/създаде пробен файл."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -13921,6 +18184,10 @@ msgid "Don't show this warning again"
 msgstr "Прескачане на това предупреждение в бъдеще"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-безкрайност"
 
@@ -13929,13 +18196,31 @@ msgid "-Infinity"
 msgstr "-безкрайност"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Празно"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "&Добавяне на запис"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Увеличаване на област"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Грешка в LOF файл"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -13953,11 +18238,20 @@ msgid "Value must not be greater than %s"
 msgstr "Началото и краят трябва да са по-големи от 0."
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Създаден бе нов проект"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Директории"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Директории"
 
 #: src/xml/XMLFileReader.cpp
@@ -13978,16 +18272,49 @@ msgstr "Не бе възможно да се отвори файлът "
 msgid "Spectral edit multi tool"
 msgstr "Селекция"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Филтър"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Честота (Хц)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Грешка"
@@ -14015,6 +18342,22 @@ msgstr "Към честота в секунди"
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Минималната честота трябва да е поне 0 Хц"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "Селекция"
@@ -14027,9 +18370,27 @@ msgstr "Затихване"
 msgid "Applying Fade..."
 msgstr "Прилага се…"
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "По подраз&биране"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -14056,8 +18417,16 @@ msgid "S-Curve Down"
 msgstr "Местене на&долу"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Начало"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -14066,6 +18435,14 @@ msgstr "Усилване"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Начало"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -14078,6 +18455,14 @@ msgstr "Линейна"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Линейна"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -14126,6 +18511,14 @@ msgstr "Усилването по честоти не може да бъде о�
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "Усилването по честоти не може да бъде отрицателно"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Повтаряне"
@@ -14133,6 +18526,10 @@ msgstr "Повтаряне"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Търсене на отрязани отчети…"
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Дневник на Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -14146,6 +18543,23 @@ msgstr "Отрязани отчети"
 msgid "Reconstructing clips..."
 msgstr "Премахва се пукане…"
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Праг %d дБ"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Нотна писта"
@@ -14153,6 +18567,21 @@ msgstr "Нотна писта"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Нотна писта"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -14186,6 +18615,19 @@ msgstr "Име на писта"
 msgid "Fade direction"
 msgstr "директно четене"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Закъснение"
@@ -14201,6 +18643,19 @@ msgstr "Закъснение"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "Правоъгълен"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "&Намаляване на шум (дБ):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -14226,6 +18681,14 @@ msgstr "&Мостра"
 msgid "Number of echoes"
 msgstr "Брой на повторенията:"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Повтаряне на последния ефект"
@@ -14237,6 +18700,10 @@ msgstr "Еквалайзер"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3 файлове"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -14251,10 +18718,24 @@ msgstr "Потвърждаване на презаписване"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Не е възможно да се отвори файл с жанрове."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Грешка (файлът може да не е записан): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Грешка (файлът може да не е записан): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -14285,10 +18766,50 @@ msgstr "Дължина (секунди)"
 msgid "Length of label region (seconds)"
 msgstr "Дължина (секунди)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Редактиране на надпис"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -14302,6 +18823,11 @@ msgstr "Отделяне"
 msgid "Warnings only"
 msgstr "Предупреждения"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -14310,6 +18836,12 @@ msgstr "Обединяване на надписи"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Обединяване на надписи"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -14328,13 +18860,46 @@ msgstr "Прилага се ефект „Еквалайзер“"
 msgid "Dominic Mazzoni"
 msgstr "от Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Честота (Хц)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Минималната честота трябва да е поне 0 Хц"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -14382,6 +18947,11 @@ msgid "Point after sound"
 msgstr "Свързано стерео"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "От дължина в секунди"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "От дължина в секунди"
 
@@ -14389,11 +18959,41 @@ msgstr "От дължина в секунди"
 msgid "Maximum leading silence"
 msgstr "Премахва се тишина…"
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Премахва се тишина…"
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Името не трябва да е празно"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -14425,8 +19025,25 @@ msgid "Hard Clip"
 msgstr "Търсене на отрязани отчети"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Десен канал"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "&Обхват (дБ):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -14488,6 +19105,44 @@ msgstr "Време за атака/затихване"
 msgid "Decay (ms)"
 msgstr "Време за атака/затихване"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Името не трябва да е празно"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Дължина на филтъра"
@@ -14499,6 +19154,18 @@ msgstr "Изравнява се силата на звука…"
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "По подраз&биране"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -14521,7 +19188,8 @@ msgstr "MP3 файлове"
 msgid "HTML file"
 msgstr "MP3 файлове"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Имена на файловете:"
 
@@ -14538,9 +19206,24 @@ msgid "Disallow"
 msgstr "Не е разрешено"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Не е разрешено"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Не е възможно да се премахне „%s“"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -14551,16 +19234,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Изберете MIDI файл..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Неизползвани филтри:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Изберете MIDI файл..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Генерира се тон"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Филтър"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -14573,6 +19298,10 @@ msgstr "Премахване на писта"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Генерира се сигнал с ЛЧМ"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -14591,8 +19320,20 @@ msgid "Swing amount"
 msgstr "Изкривяване"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Брой на повторенията:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -14615,12 +19356,54 @@ msgid "Beat sound"
 msgstr "Повтаряне"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Премахва се шум"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Долна граница на шума"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -14643,6 +19426,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Линейна честота"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Честота (Хц)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Амплитуда (0-1)"
 
@@ -14653,6 +19445,10 @@ msgstr "Не е възможно да се експортира"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Прилага се…"
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -14671,6 +19467,10 @@ msgid "HTML files"
 msgstr "MP3 файлове"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Редактиране на отчети"
 
@@ -14683,8 +19483,29 @@ msgid "Include header information"
 msgstr "Информация за компилата"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Всички"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -14699,6 +19520,11 @@ msgstr "\t-help (това съобщение)"
 msgid "Errors Only"
 msgstr "Грешка: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -14711,6 +19537,46 @@ msgstr "Десен канал"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "отчети"
 
@@ -14718,6 +19584,43 @@ msgstr "отчети"
 #, lisp-format
 msgid "~a seconds."
 msgstr "секунди"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -14736,6 +19639,10 @@ msgid "Value (dB)"
 msgstr "&Обхват (дБ):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Линейна"
 
@@ -14752,6 +19659,14 @@ msgid "Right (dB)"
 msgstr "Десен, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Линейна"
 
@@ -14762,6 +19677,40 @@ msgstr "2 канала (стерео)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 канал (моно)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Грешка (файлът може да не е записан): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -14776,8 +19725,40 @@ msgid "Select file"
 msgstr "Изберете MIDI файл..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Грешка"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -14787,6 +19768,15 @@ msgstr "Не е възможно да се отвори файл с жанров
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Селекция"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -14809,8 +19799,16 @@ msgid "Wet level (percent)"
 msgstr "2 нива"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Прилага се…"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -14852,9 +19850,96 @@ msgstr "&Анализ"
 msgid "Strength"
 msgstr "Филтър"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Обработва се: "
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -14888,6 +19973,193 @@ msgstr "Честота (Хц)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Честота (Хц)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Изход от Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Канал"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Грешка при отваряне на файл"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Грешка при зареждане на метаданни"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Лента с инструменти – Audacity %s"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Запис"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Команда:"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Импортиране чрез QuickTime"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Авторегулирането на входното ниво спря. То не може да се подобри и още е твърде високо."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Авторегулирането на входното ниво понижи силата на звука до %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Авторегулирането на входното ниво спря. То не може да се подобри и още е твърде ниско."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Авторегулирането на входното ниво повиши силата на звука до %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Авторегулирането на входното ниво спря. Лимитът за анализи бе надхвърлен, без да се открие приемлива сила на звука. Тя още е твърде висока."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Авторегулирането на входното ниво спря. Лимитът за анализи бе надхвърлен, без да се открие приемлива сила на звука. Тя още е твърде ниска."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Авторегулирането на входното ниво спря. Изглежда %.2f е приемлива сила на звука."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Не е възможно да се отвори файл с жанрове.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Запис\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Възпроизвеждане\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Край на запис\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Край на запис\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Възпроизвеждане\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Възпроизвеждане\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Файлове, съвместими с GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Не е възможно да се отвори/създаде пробен файл."
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Стартирането на GStreamer бе неуспешно"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Не е възможно да се преименува „%s“ на „%s“."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Индекс[%02x] Кодек[%s], Език[%s], Скорост на предаване[%s], Канали[%d], Продължителност[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Не е възможно да се отвори/създаде пробен файл."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer %s: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Задаване скорост на възпроизвеждане"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "По-бързо възпроизвеждане"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "По-бавно възпроизвеждане"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Край на запис"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "По-бързо възпроизвеждане"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "По-бавно възпроизвеждане"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Дневник на Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Относно Tenacity…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Авторе&гулиране на входното ниво (вкл./изкл.)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Авторегулиране на входното ниво"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Включва авторегулирането на входното ниво."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Желан пик:"
+
+#~ msgid "Within:"
+#~ msgstr "В рамките на:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Време за анализ:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "милисекунди (време за един анализ)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Брой последователни анализи:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 означава безкрайно"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Край на запис"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Възпроизвеждане"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Край на запис"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Не може да се управлява силата на входа. Използвайте системния смесител."
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Възпроизвеждане"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Възпроизвеждане"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Не може да се управлява силата на входа. Използвайте системния смесител."
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Лента „С&месител“"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Щракнете и плъзнете, за да местите пистата във времето"
+
 #~ msgid "Program build date:"
 #~ msgstr "Дата на компилиране: "
 
@@ -14901,10 +20173,6 @@ msgstr "Честота (Хц)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "s"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Не е възможно да се отвори/създаде пробен файл."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -15821,10 +21089,6 @@ msgstr "Честота (Хц)"
 #~ msgstr "Транскрипция"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "&Ленти с инструменти"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "Команда"
 
@@ -16078,10 +21342,6 @@ msgstr "Честота (Хц)"
 #~ msgstr "Обратна връзка (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Размер"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "Обратна връзка (%):"
 
@@ -16096,10 +21356,6 @@ msgstr "Честота (Хц)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Усилване"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Стерео"
 
 #, fuzzy
 #~ msgid "FilterType"
@@ -16144,10 +21400,6 @@ msgstr "Честота (Хц)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "Премахване на тишина"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Извършва се обръщане"
 
 #~ msgid "C&ategory:"
 #~ msgstr "&Категория:"
@@ -16956,10 +22208,6 @@ msgstr "Честота (Хц)"
 #, fuzzy
 #~ msgid "Applying Reverb"
 #~ msgstr "Изравнява се силата на звука…"
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "Ка&чване на файл…"
 
 #~ msgid "Silence..."
 #~ msgstr "Тишина…"

--- a/locale/bn.po
+++ b/locale/bn.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Bengali <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/bn/>\n"
+"Language-Team: Bengali <https://hosted.weblate.org/projects/tenacity/tenacity/bn/>\n"
 "Language: bn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,39 +17,258 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "&অডিওসিটি পরিচিতি..."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "চ্যানেল"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "&অডিওসিটি পরিচিতি..."
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
+#: libraries/lib-strings/Internat.cpp
 #, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "রেকর্ডিং হচ্ছে"
+msgid "Unable to determine"
+msgstr "নির্বাচনের শেষে"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
+#: libraries/lib-strings/Languages.cpp
+msgid "Simplified"
+msgstr ""
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
+
+#: modules/mod-null/ModNullCallback.cpp
+msgid "1st Experimental Command..."
+msgstr ""
+
+#: modules/mod-null/ModNullCallback.cpp
+msgid "2nd Experimental Command"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Nyquist Workbench..."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Redo\tCtrl+Y"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Cu&t\tCtrl+X"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Paste\tCtrl+V"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Cle&ar\tCtrl+L"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "নির্বাচন"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
 msgstr "ফন্ট..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Split &Vertically"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Split &Horizontally"
+msgstr "নির্বাচনের শেষে"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show S&cript"
+msgstr "সংরক্ষিত %s"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Show &Output"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Toolbar"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Stop\tF6"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "সংরক্ষিত %s"
+
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
+msgid "Output"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Load Nyquist script"
+msgstr "সংরক্ষিত %s"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+msgid "Warning"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Save Nyquist script"
+msgstr "সংরক্ষিত %s"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist Effect Workbench"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "No matches found"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist Effect Workbench - "
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "New"
+msgstr "নাম..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "সংরক্ষিত %s"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Open"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Open script"
+msgstr "সংরক্ষিত %s"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
 msgid "Save"
@@ -64,17 +282,41 @@ msgstr "সংরক্ষিত %s"
 msgid "Save As"
 msgstr "সংরক্ষিত %s"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Save script as..."
+msgstr "সংরক্ষিত %s"
+
 #: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
 msgid "Copy"
 msgstr "কপি"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Copy to clipboard"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "কাটো"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Cut to clipboard"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "সাঁটো"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Paste from clipboard"
+msgstr ""
+
+#. i18n-hint verb; to empty or erase
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+msgid "Clear"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Clear selection"
@@ -88,19 +330,225 @@ msgstr "নির্বাচন"
 msgid "Select all text"
 msgstr "নির্বাচন"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+msgid "Undo"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Undo last change"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+msgid "Redo"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "নির্বাচন"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Match"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to top S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Previous"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "নির্বাচন"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Next"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Start"
+msgstr "নির্বাচনের শুরুতে"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Start script"
+msgstr "সংরক্ষিত %s"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+msgid "Stop"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Stop script"
+msgstr "সংরক্ষিত %s"
+
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "ঠিক আছে"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "সক্রিয়"
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Disabled"
+msgstr "(নিষ্ক্রিয়)"
+
+#. i18n-hint: Information about when audacity was compiled follows
+#: src/AboutDialog.cpp
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "উল্টা করা হচ্ছে"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr "উইন্ডো"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Config folder:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Data folder:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Sample rate conversion"
 msgstr "নমুনা পরিবর্তন"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "আমদানী"
+
+#: src/AboutDialog.cpp
+msgid "Ogg Vorbis Import and Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "FLAC import and export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "MP2 export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "FFmpeg Import/Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "GPL License"
+msgstr ""
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -123,6 +571,18 @@ msgstr "খাম"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "খাম"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "খাম"
 
@@ -134,19 +594,141 @@ msgstr "খাম"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "খাম"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "খাম"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "খাম"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "খাম"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "খাম"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, Nyquist plug-ins"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, web developer"
 msgstr "খাম"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "স্বীকৃতি"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "DarkTenacity Customisation"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s Contributors"
+msgstr "খাম"
+
+#: src/AboutDialog.cpp
+msgid "Tenacity Special thanks:"
+msgstr ""
+
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "ডিরেক্টরি"
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s includes code from the following projects:"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s Team Members"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Contributors"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "অঙ্কুর প্রকল্পের পক্ষে মাহে আলম খান (makl10n@yahoo.com)"
@@ -155,11 +737,39 @@ msgstr "অঙ্কুর প্রকল্পের পক্ষে মাহ
 msgid "Translators"
 msgstr "অঙ্কুর প্রকল্পের পক্ষে মাহে আলম খান (makl10n@yahoo.com)"
 
+#: src/AboutDialog.cpp
+msgid "Special thanks:"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s website: "
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr ""
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Click and drag to adjust, double-click to reset"
+msgstr ""
 
 #. i18n-hint: This text is a tooltip on the icon (of a pin) representing
 #. the temporal position in the audio.
@@ -167,8 +777,71 @@ msgstr "&অডিওসিটি পরিচিতি..."
 msgid "Record/Play head"
 msgstr "রেকর্ডিং হচ্ছে"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click or drag to begin Seek"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click or drag to begin Scrub"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Move to Seek"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "নির্বাচন"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Move to Scrub. Drag to Seek."
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr "(নিষ্ক্রিয়)"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr "(নিষ্ক্রিয়)"
 
 #: src/AdornedRulerPanel.cpp
@@ -176,33 +849,341 @@ msgid "Timeline Options"
 msgstr "নির্বাচনের শেষে"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Enable dragging selection"
+msgstr "নির্বাচনের শেষে"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "রেকর্ডিং হচ্ছে"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "সমস্যা"
 
 #: src/AudacityApp.cpp
+#, c-format
+msgid "Failed to remove %s"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
+msgstr "প্লেব্যাক"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Tenacity is starting up..."
+msgstr ""
+
+#. i18n-hint: "New" is an action (verb) to create a NEW project
+#: src/AudacityApp.cpp src/BatchProcessDialog.cpp src/menus/FileMenus.cpp
+msgid "&New"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/AudacityApp.cpp src/menus/FileMenus.cpp
+msgid "&Open..."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Open &Recent..."
+msgstr ""
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "&Preferences..."
+msgstr "প্লেব্যাক"
 
 #: src/AudacityApp.cpp src/menus/FileMenus.cpp
 msgid "&File"
 msgstr "&ফাইল"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Please enter an appropriate directory in the preferences dialog."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity could not find a place to store temporary files.\n"
+"Please enter an appropriate directory in the preferences dialog."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Running two copies of Tenacity simultaneously may cause\n"
+"data loss or cause your system to crash.\n"
+"\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Do you still want to start Tenacity?"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Error Locking Temporary Folder"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "The system has detected that another copy of Tenacity is running.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Use the New or Open commands in the currently running Tenacity\n"
+"process to open multiple projects simultaneously.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Tenacity is already running"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
+
+#. i18n-hint: This displays a list of available options
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "this help message"
+msgstr "সক্রিয়"
+
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+msgid "run self diagnostics"
+msgstr ""
+
+#. i18n-hint: This displays the Audacity version
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "display Tenacity version"
+msgstr "খাম"
+
+#. i18n-hint: This is a list of one or more files that Audacity
+#. *           should open upon startup
+#: src/AudacityApp.cpp
+msgid "audio or project file name"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Audacity project (.aup3) files are not currently \n"
+"associated with Tenacity. \n"
+"\n"
+"Associate them, so they open on double-click?"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Audacity Project Files"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "নাম..."
+
+#: src/AudacityFileConfig.cpp
+#, fuzzy
+msgid "Tenacity Configuration Error"
+msgstr "%d চ্যানেল"
+
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
+msgid "Help"
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&অডিওসিটি পরিচিতি..."
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
-msgstr "%d চ্যানেল"
+msgid "&Retry"
+msgstr ""
 
-#: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
-msgstr "&অডিওসিটি পরিচিতি..."
+#: src/AudacityLogger.cpp
+msgid "Tenacity Log"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/Tags.cpp
+#, fuzzy
+msgid "&Save..."
+msgstr "সংরক্ষিত %s"
+
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Close"
+msgstr "বন্ধ"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "সংরক্ষিত %s"
+
+#: src/AudacityLogger.cpp
+#, c-format
+msgid "Couldn't save log to file: %s"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Could not find any audio devices.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid ""
+"You will not be able to play or record audio.\n"
+"\n"
+msgstr ""
 
 #: src/AudioIO.cpp
 #, c-format
@@ -210,13 +1191,71 @@ msgid "Error: %s"
 msgstr "সমস্যা:"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "Error Initializing Audio"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Error Initializing Midi"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "রেকর্ডিং হচ্ছে\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "রেকর্ডিং হচ্ছে\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Device info unavailable for: %d\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Device ID: %d\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Device name: %s\n"
+msgstr "নাম...\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -239,13 +1278,34 @@ msgid "Low Recording Latency: %g\n"
 msgstr "রেকর্ডিং হচ্ছে\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "রেকর্ডিং হচ্ছে\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
 msgstr "রেকর্ডিং হচ্ছে\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
+msgstr "রেকর্ডিং হচ্ছে\n"
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy
+msgid "Supported Rates:\n"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected recording device: %d - %s\n"
+msgstr "রেকর্ডিং হচ্ছে\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
 msgstr "রেকর্ডিং হচ্ছে\n"
 
 #: src/AudioIOBase.cpp
@@ -254,28 +1314,30 @@ msgid "Selected playback device: %d - %s\n"
 msgstr "প্লেব্যাক\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "রেকর্ডিং হচ্ছে\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
 msgstr "প্লেব্যাক\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "রেকর্ডিং হচ্ছে\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports input: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "রেকর্ডিং হচ্ছে\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "প্লেব্যাক\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "প্লেব্যাক\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -283,14 +1345,47 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "রেকর্ডিং হচ্ছে\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "রেকর্ডিং হচ্ছে\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
 msgstr "প্লেব্যাক\n"
 
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
+msgstr "প্লেব্যাক\n"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Automatic Crash Recovery"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
+"\n"
+"After recovery, save the projects to ensure changes are written to disk."
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Recoverable &projects"
+msgstr ""
+
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "নির্বাচন"
+
+#. i18n-hint: (noun).  It's the name of the project to recover.
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Name"
+msgstr "নাম..."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "&Discard Selected"
@@ -301,16 +1396,69 @@ msgid "&Recover Selected"
 msgstr "নির্বাচন"
 
 #: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "নির্বাচন"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "Select Command"
+msgstr "কমান্ড একশন"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Command"
+msgstr "কমান্ড একশন"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Edit Parameters"
+msgstr "প্লেব্যাক"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Use Preset"
+msgstr "প্লেব্যাক"
+
+#: src/BatchCommandDialog.cpp
+msgid "&Parameters"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "কমান্ড একশন"
 
 #: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Fade Ends"
+msgstr "গতি বৃদ্ধি"
+
+#: src/BatchCommands.cpp
 msgid "Import Macro"
 msgstr "আমদানী"
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Export Macro"
@@ -320,10 +1468,79 @@ msgstr "&অডিওসিটি পরিচিতি..."
 msgid "Effect"
 msgstr "সকল ফাইল (*)|*"
 
+#: src/BatchCommands.cpp
+msgid "Menu Command (With Parameters)"
+msgstr ""
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (No Parameters)"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Your batch command of %s was not recognized."
+msgstr ""
+
+# I guess in should be গেইন - mak
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Applied Macro"
+msgstr "লাভ"
+
 # I guess in should be গেইন - mak
 #: src/BatchCommands.cpp
 msgid "Apply Macro"
 msgstr "লাভ"
+
+# I guess in should be গেইন - mak
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Applied Macro '%s'"
+msgstr "লাভ"
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Apply '%s'"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid ""
+"Apply %s with parameter(s)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Test Mode"
+msgstr ""
+
+# I guess in should be গেইন - mak
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Apply %s"
+msgstr "লাভ"
+
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
 
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
@@ -331,30 +1548,290 @@ msgstr "লাভ"
 msgid "Select Macro"
 msgstr "নির্বাচন"
 
+# I guess in should be গেইন - mak
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "লাভ"
+
+# I guess in should be গেইন - mak
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "লাভ"
+
+# I guess in should be গেইন - mak
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to project"
+msgstr "লাভ"
+
 #: src/BatchProcessDialog.cpp
 msgid "&Project"
 msgstr "নির্বাচনের শুরুতে"
+
+# I guess in should be গেইন - mak
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to files..."
+msgstr "লাভ"
 
 #: src/BatchProcessDialog.cpp
 msgid "&Files..."
 msgstr "&ফাইল"
 
+#. i18n-hint: The Expand button makes the dialog bigger, with more in it
+#: src/BatchProcessDialog.cpp
+msgid "&Expand"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "No macro selected"
+msgstr "নির্বাচন"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "Applying '%s' to current project"
+msgstr "সংরক্ষিত %s"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Please save and close the current project first."
+msgstr "সংরক্ষিত %s"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Select file(s) for batch processing..."
+msgstr "নির্বাচনের শেষে"
+
+# I guess in should be গেইন - mak
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Applying..."
+msgstr "লাভ"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "File"
+msgstr "&ফাইল"
+
+#: src/BatchProcessDialog.cpp
+msgid "&Cancel"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Remo&ve"
+msgstr "মাঝে"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "নাম..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "আমদানী"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Edit Steps"
+msgstr ""
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "কমান্ড একশন"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+msgid "Parameters"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp
+msgid "&Insert"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "&Edit..."
 msgstr "&এডিট"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp
+#, fuzzy
+msgid "De&lete"
+msgstr "মোছো"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "Move &Up"
+msgstr "মোনো"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "Move &Down"
+msgstr "মোনো"
+
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "সংরক্ষিত %s"
 
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
+
+#. i18n-hint: This is the last item in a list.
+#: src/BatchProcessDialog.cpp
+msgid "- END -"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "%s changed"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Do you want to save the changes?"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Enter name of new macro"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Name of new macro"
+msgstr "চ্যানেল"
+
+#: src/BatchProcessDialog.cpp
+msgid "Name must not be blank"
+msgstr ""
+
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Names may not contain '%c' and '%c'"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of a file.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Are you sure you want to delete %s?"
+msgstr ""
+
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+msgid "Benchmark"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Number of Edits:"
+msgstr "চ্যানেল"
+
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "বন্ধ"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Export Benchmark Data as:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Preparing...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Performing %d edits...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -362,10 +1839,337 @@ msgid "Paste: %lld\n"
 msgstr "সাঁটো\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "%d চ্যানেল\n"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"You must first select some audio for '%s' to act on.\n"
+"\n"
+"Ctrl + A selects all audio."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid "No Audio Selected"
+msgstr "নির্বাচন"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Failed to set safe mode on primary connection to %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Failed to set safe mode on checkpoint connection to %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, fuzzy
+msgid "Checkpointing project"
+msgstr "সংরক্ষিত %s"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Checkpointing %s"
+msgstr ""
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Could not write to %s.\n"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Failed to create savepoint:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Failed to release savepoint:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Removing Dependencies"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copying audio data into project..."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Project Depends on Other Audio Files"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Dependencies"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/Dependencies.cpp
+msgid "Audio File"
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Disk Space"
+msgstr "ফাঁকা জায়গা:"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "নির্বাচনের শেষে"
+
+#: src/Dependencies.cpp
+msgid "Cancel Save"
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "লেবেল"
+
+#: src/Dependencies.cpp
+msgid "Do Not Copy"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Whenever a project depends on other files:"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Ask me"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "&Copy Names to Clipboard"
+msgstr ""
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Missing"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Dependency Check"
+msgstr ""
+
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "কোনটিই নয়"
 
@@ -373,15 +2177,211 @@ msgstr "কোনটিই নয়"
 msgid "Rectangle"
 msgstr "আয়তক্ষেত্র"
 
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Triangle"
+msgstr ""
+
+#: src/Dither.cpp
+msgid "Shaped"
+msgstr ""
+
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "আয়তকার"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "কাজ"
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "To find '%s', click here -->"
+msgstr ""
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Browse..."
+msgstr "বেছে নিন"
+
+#: src/FFmpeg.cpp
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
+msgstr ""
+
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "মোছো"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Do not show this warning again"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
+"Perhaps %s is not writable or the disk is full.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
 
 #: src/FileException.h
 msgid "File Error"
 msgstr "সমস্যা"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#. i18n-hint: %s will be the error message from the libsndfile software library
+#: src/FileFormats.cpp
+#, c-format
+msgid "Error (file may not have been written): %s"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy all audio into project (safest)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "সকল ফাইল (*)|*"
 
@@ -392,6 +2392,14 @@ msgid "AUP3 project files"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
@@ -399,12 +2407,57 @@ msgstr "একটি মিডি ফাইল নির্বাচন কর�
 msgid "XML files"
 msgstr "সকল ফাইল (*)|*"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "সকল ফাইল (*)|*"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
+
+#: src/FileNames.cpp
+#, c-format
+msgid "Directory %s does not have write permissions"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Frequency Analysis"
+msgstr ""
+
+#: src/FreqWindow.cpp src/prefs/SpectrumPrefs.h
+#, fuzzy
+msgid "Spectrum"
+msgstr "নির্বাচনের শেষে"
+
+#: src/FreqWindow.cpp
+msgid "Standard Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Cuberoot Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Enhanced Autocorrelation"
+msgstr ""
+
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+msgid "Cepstrum"
+msgstr ""
 
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
@@ -414,12 +2467,47 @@ msgstr "সকল ফাইল (*)|*"
 msgid "%s window"
 msgstr "উইন্ডো"
 
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Linear frequency"
+msgstr "লিনিয়ার"
+
+#: src/FreqWindow.cpp
+msgid "Log frequency"
+msgstr ""
+
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+msgid "Zoom"
+msgstr ""
+
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "হার্টজ্"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Scroll Horizontal"
+msgstr "নির্বাচনের শেষে"
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -427,16 +2515,128 @@ msgid "Zoom Horizontal"
 msgstr "নির্বাচনের শেষে"
 
 #: src/FreqWindow.cpp
+msgid "Cursor:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Algorithm:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Size:"
+msgstr ""
+
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Export..."
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "কাজ"
+
+#: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Replot..."
 msgstr "পুনরাবৃত্তি..."
 
 #: src/FreqWindow.cpp
+msgid "To plot the spectrum, all selected tracks must be the same sample rate."
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, c-format
+msgid "Too much audio was selected. Only the first %.1f seconds of audio will be analyzed."
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Not enough data selected."
+msgstr "নির্বাচন"
+
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "স্পেকট্রাম.লেখা"
+
+#: src/FreqWindow.cpp
+msgid "Export Spectral Data As:"
+msgstr ""
+
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid "Couldn't write to file: %s"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Frequency (Hz)\tLevel (dB)"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Lag (seconds)\tFrequency (Hz)\tLevel"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Plot Spectrum..."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Welcome!"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "নমুনা পরিবর্তন"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording Audio"
+msgstr "%d চ্যানেল"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
@@ -453,6 +2653,104 @@ msgstr "রেকর্ডিং হচ্ছে"
 msgid "Recording - Setting the Recording Level"
 msgstr "রেকর্ডিং হচ্ছে"
 
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HistoryWindow.cpp
+msgid "History"
+msgstr ""
+
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Manage History"
+msgstr "নির্বাচনের শেষে"
+
 #: src/HistoryWindow.cpp src/effects/TruncSilence.cpp plug-ins/vocalrediso.ny
 msgid "Action"
 msgstr "কাজ"
@@ -462,43 +2760,529 @@ msgid "Used Space"
 msgstr "ফাঁকা জায়গা:"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "(নিষ্ক্রিয়)"
+
+#: src/HistoryWindow.cpp
+msgid "&Levels to discard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Discard"
+msgstr "(নিষ্ক্রিয়)"
+
+#: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "(নিষ্ক্রিয়)"
 
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Compact"
+msgstr "সংরক্ষিত %s"
+
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the various editing steps
+#. that have been taken.
+#: src/HistoryWindow.cpp
+msgid "&History..."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.h
+#, fuzzy
+msgid "Internal Error"
+msgstr "সমস্যা"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "মোছো"
+
+#. i18n-hint: (noun).  A track contains waves, audio etc.
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Track"
+msgstr "মোনো"
+
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "লেবেল"
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Time"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/TimerRecordDialog.cpp
+msgid "End Time"
+msgstr ""
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Low Frequency"
+msgstr ""
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "High Frequency"
+msgstr ""
+
+#: src/LabelDialog.cpp
+msgid "New..."
+msgstr ""
+
+#: src/LabelDialog.cpp
+msgid "Press F2 or double click to edit cell contents."
+msgstr ""
+
+#: src/LabelDialog.cpp src/menus/FileMenus.cpp
+msgid "Select a text file containing labels"
+msgstr ""
+
+#: src/LabelDialog.cpp src/ProjectFileManager.cpp src/menus/FileMenus.cpp
+#, c-format
+msgid "Could not open file: %s"
+msgstr ""
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "No labels to export."
+msgstr "লেবেল"
+
+#: src/LabelDialog.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export Labels As:"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/LabelDialog.cpp
+msgid "New Label Track"
+msgstr ""
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Enter track name"
+msgstr "আনেকগুলি নমুনা পরিবর্তন"
+
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "রেকর্ড"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
+#. i18n-hint: Title on a dialog indicating that this is the first
+#. * time Audacity has been run.
+#: src/LangChoice.cpp
+msgid "Tenacity First Run"
+msgstr ""
+
+#: src/LangChoice.cpp
+msgid "Choose Language for Tenacity to use:"
+msgstr ""
+
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+msgid "Confirm"
+msgstr ""
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/Legacy.cpp
+#, c-format
+msgid ""
+"Converted a 1.0 project file to the new format.\n"
+"The old file has been saved as '%s'"
+msgstr ""
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Opening Tenacity Project"
+msgstr "সংরক্ষিত %s"
+
+#: src/LyricsWindow.cpp
+#, c-format
+msgid "Tenacity Karaoke%s"
+msgstr ""
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "বেছে নিন"
+
+#: src/Menus.cpp
+#, c-format
+msgid "&Undo %s"
+msgstr ""
+
+#: src/Menus.cpp src/menus/EditMenus.cpp
+msgid "&Undo"
+msgstr ""
+
+#: src/Menus.cpp
+#, c-format
+msgid "&Redo %s"
+msgstr ""
+
+#: src/Menus.cpp src/menus/EditMenus.cpp
+msgid "&Redo"
+msgstr ""
+
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "(নিষ্ক্রিয়)"
 
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
 msgstr "মিক্স"
 
+#: src/Mix.cpp src/menus/TrackMenus.cpp
+msgid "Mix and Render"
+msgstr ""
+
+#: src/Mix.cpp
+msgid "Mixing and rendering tracks"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr ""
+
 # I guess in should be গেইন - mak
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "লাভ"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "প্যান"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "নিরব"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved gain slider"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Moved velocity slider"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved pan slider"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/MixerBoard.cpp
+msgid "&Mixer Board..."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"Unable to load the \"%s\" module.\n"
+"\n"
+"Error: %s"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "সক্রিয়"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "কোনটিই নয়"
+
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Tenacity Module Loader"
+msgstr "খাম"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Note track.
+#: src/NoteTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Note Track"
+msgstr "রেকর্ড"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, c-format
+msgid "Overwrite the plug-in file %s?"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, c-format
+msgid ""
+"Failed to register:\n"
+"%s"
+msgstr ""
 
 #. i18n-hint A plug-in is an optional added program for a sound
 #. effect, or generator, or analyzer
@@ -513,9 +3297,33 @@ msgstr[1] "নির্বাচনের শেষে\n"
 msgid "Enable new plug-ins"
 msgstr "নির্বাচনের শেষে"
 
+#: src/PluginManager.h
+msgid "Nyquist Prompt"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "নির্বাচনের শেষে"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "সক্রিয়"
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
+msgid "&All"
+msgstr ""
 
 #. i18n-hint: Radio button to show just the currently disabled effects
 #: src/PluginRegistrationDialog.cpp
@@ -537,11 +3345,36 @@ msgstr "সক্রিয়"
 msgid "E&nabled"
 msgstr "সক্রিয়"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "সক্রিয়"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "নির্বাচন"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "C&lear All"
+msgstr "নির্বাচন"
+
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "সক্রিয়"
 
@@ -549,23 +3382,426 @@ msgstr "সক্রিয়"
 msgid "&Disable"
 msgstr "(নিষ্ক্রিয়)"
 
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Enabling effects or commands:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Enabling effect or command:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Effect or Command at %s failed to register:\n"
+"%s"
+msgstr ""
+
+#: src/Printing.cpp
+msgid "There was a problem printing."
+msgstr ""
+
 #: src/Printing.cpp
 msgid "Print"
 msgstr "মুদ্রণ"
+
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+#, c-format
+msgid "Actual Rate: %d"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/effects/Effect.cpp
+msgid ""
+"Error opening sound device.\n"
+"Try changing the audio host, playback device and the project sample rate."
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+#, fuzzy
+msgid "Recorded Audio"
+msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "রেকর্ড"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Inspecting project file data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no further changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "অগ্রগতি"
 
+#: src/ProjectFSCK.cpp
+msgid "Cleaning up unused directories in project data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to open the project's database"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to open database file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to discard connection"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Failed to restore connection"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to execute a project file command:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to prepare project file command:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to initialize the project file"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid "Unable to work with the blockfiles"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to attach destination database"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to bind SQL parameter"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -575,17 +3811,161 @@ msgstr "সংরক্ষিত %s"
 msgid "Error Writing to File"
 msgstr "রেকর্ডিং হচ্ছে"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write file %s.\n"
+"Perhaps disk is full or not writable.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Compacting project"
+msgstr "সংরক্ষিত %s"
+
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#. i18n-hint: E.g this is recovered audio that had been lost.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "(Recovered)"
+msgstr "রেকর্ড"
+
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Can't open project file"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to bind to blob"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to decode project document"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to parse project information."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "সংরক্ষিত %s"
 
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+msgid "Insufficient Disk Space"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -593,26 +3973,225 @@ msgid "Saved %s"
 msgstr "সংরক্ষিত %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy, c-format
+msgid "%sSave Project \"%s\" As..."
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
+
+#. i18n-hint: Heading: A warning that a project is about to be overwritten.
+#: src/ProjectFileManager.cpp
+msgid "Overwrite Project Warning"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Copy of Project"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+msgid "Can't open new empty project"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Error opening a new empty project"
+msgstr ""
+
+#: src/ProjectFileManager.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Select one or more files"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
 #: src/ProjectFileManager.cpp
 #, c-format
 msgid "%s is already open in another window."
 msgstr "%s আর একটি উইন্ডোতে খোলা রয়েছে."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error opening file"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"File may be invalid or corrupted: \n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Project was recovered"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Recover"
+msgstr "রেকর্ড"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy, c-format
+msgid "Imported '%s'"
+msgstr "আমদানী"
 
 #: src/ProjectFileManager.cpp
 msgid "Import"
 msgstr "আমদানী"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Failed to import project"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Importing"
+msgstr "আমদানী"
+
+#: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compacted project file"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectHistory.cpp
+#, fuzzy
+msgid "Created new project"
+msgstr "সংরক্ষিত %s"
+
+#: src/ProjectHistory.cpp
+msgid "Automatic database backup failed."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "Welcome to Tenacity version %s"
+msgstr ""
+
+#. i18n-hint: The first %s numbers the project, the second %s is the project name.
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%sSave changes to %s?"
+msgstr ""
+
+#: src/ProjectManager.cpp
+msgid "Save project before closing?"
+msgstr ""
+
+#: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "Disk space remaining for recording: %s"
+msgstr ""
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -628,6 +4207,53 @@ msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
+#. i18n-hint: This is an experimental feature where the main panel in
+#. Audacity is put on a notebook tab, and this is the name on that tab.
+#. Other tabs in that notebook may have instruments, patch panels etc.
+#: src/ProjectWindow.cpp
+msgid "Main Mix"
+msgstr ""
+
+#: src/ProjectWindow.cpp
+msgid "Horizontal Scrollbar"
+msgstr ""
+
+#: src/ProjectWindow.cpp
+msgid "Vertical Scrollbar"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "মান"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "মান"
@@ -636,9 +4262,100 @@ msgstr "মান"
 msgid "High Quality"
 msgstr "মান"
 
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+msgid "16-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+msgid "24-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "কমান্ড একশন"
+
+#: src/Screenshot.cpp
+msgid "Save images to:"
+msgstr ""
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "বেছে নিন"
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Resize Small"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Resize Large"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+msgid "White Bkgnd"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr "উইন্ডো"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "উইন্ডো"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture part of a project window"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -652,28 +4369,603 @@ msgstr "সকল ফাইল (*)|*"
 msgid "All Preferences"
 msgstr "প্লেব্যাক"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "নির্বাচনের শেষে"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Timer"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Tools"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "অঙ্কুর প্রকল্পের পক্ষে মাহে আলম খান (makl10n@yahoo.com)"
+
+#: src/Screenshot.cpp
+msgid "Mixer"
+msgstr ""
+
+#. i18n-hint: Noun (the meter is used for playback or record level monitoring)
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+msgid "Meter"
+msgstr ""
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Play Meter"
+msgstr "প্লেব্যাক"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Record Meter"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&এডিট"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+msgid "Device"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play-at-Speed"
+msgstr "প্লেব্যাক"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Scrub"
+msgstr ""
+
+#: src/Screenshot.cpp src/TrackPanel.cpp
+#, fuzzy
+msgid "Track Panel"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
+#. i18n-hint: "Tracks" include audio recordings but also other collections of
+#. * data associated with a time line, such as sequences of labels, and musical
+#. * notes
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
+#, fuzzy
+msgid "Tracks"
+msgstr "মোনো"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "রেকর্ড"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "রেকর্ড"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "নির্বাচনের শেষে"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "রেকর্ড"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "রেকর্ড"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "মোনো"
+
+#: src/Screenshot.cpp
+msgid "Choose a location to save screenshot images"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "সক্রিয়"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
+
+#: src/ShuttleGui.cpp src/effects/EffectUI.cpp
+msgid "&Preview"
+msgstr ""
+
+#: src/ShuttleGui.cpp
+msgid "Dry Previe&w"
+msgstr ""
+
+#: src/ShuttleGui.cpp
+#, fuzzy
+msgid "&Settings"
+msgstr "উল্টা করা হচ্ছে"
+
+#: src/ShuttleGui.cpp
+msgid "Debu&g"
+msgstr ""
+
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Nearest"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+msgid "Sound Activated Record"
+msgstr ""
+
+# I guess in should be গেইন - mak
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "লাভ"
+
+#: src/SplashDialog.cpp
+msgid "Welcome to Tenacity!"
+msgstr ""
+
+#: src/SplashDialog.cpp
+msgid "Don't show this again at start up"
+msgstr ""
+
+#: src/SqliteSampleBlock.cpp
+msgid "Connection to project file is null"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Artist Name"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Track Title"
+msgstr "মোনো"
+
+#: src/Tags.cpp
+msgid "Album Title"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Track Number"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/Tags.cpp
+msgid "Year"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Genre"
+msgstr ""
 
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "মন্তব্য"
 
+#: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "গতি বৃদ্ধি"
+
+#: src/Tags.cpp
+msgid "&Add"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "&Remove"
+msgstr "মাঝে"
+
+#: src/Tags.cpp
+msgid "Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&এডিট"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "নির্বাচন"
+
+#: src/Tags.cpp
+msgid "Template"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "&Load..."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Set De&fault"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Don't show this when exporting audio"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Edit Genres"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Unable to save genre file."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Reset Genres"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Are you sure you want to reset the genre list to defaults?"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Unable to open genre file."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Load Metadata As:"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Save Metadata As:"
+msgstr "সংরক্ষিত %s"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "রেকর্ডিং হচ্ছে"
+
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "সক্রিয়"
+
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not write file:\n"
+"  %s."
+msgstr ""
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not open file:\n"
+"  %s\n"
+"for writing."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not write images to file:\n"
+"  %s."
+msgstr ""
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Could not create directory:\n"
+"  %s"
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not save file:\n"
+"  %s"
+msgstr ""
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
+#. i18n-hint: Light meaning opposite of dark
+#: src/Theme.cpp
+#, fuzzy
+msgid "Light"
+msgstr "ডান"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+msgid "Custom"
+msgstr ""
+
+#. i18n-hint: This string is used to configure the controls which shows the recording
+#. * duration. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The string 'days' indicates that the first number in the control will be the number of days,
+#. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
+#. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
+#. * seconds.
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Duration"
+msgstr "কাজ"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "রেকর্ড"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record"
+msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
 msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/TimerRecordDialog.cpp
-msgid "Recording start:"
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
 msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "%d চ্যানেল"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Error in Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Error in Automatic Export"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Current Project"
+msgstr "সংরক্ষিত %s"
+
+#: src/TimerRecordDialog.cpp
+msgid "Recording start:"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "কাজ"
+
+#: src/TimerRecordDialog.cpp
 msgid "Recording end:"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Action after Timer Recording:"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/TimerRecordDialog.cpp
@@ -693,6 +4985,14 @@ msgid ""
 msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
@@ -700,9 +5000,74 @@ msgid ""
 "Recording exported: %s"
 msgstr "রেকর্ডিং হচ্ছে"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint a format string for days, hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: This string is used to configure the controls for times when the recording is
+#. * started and stopped. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
+#. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
+#: src/TimerRecordDialog.cpp
+msgid "Start Date and Time"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "নির্বাচনের শেষে"
+
+#: src/TimerRecordDialog.cpp
+msgid "End Date and Time"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "End Date"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Enable &Automatic Save?"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Project As:"
@@ -712,7 +5077,22 @@ msgstr "সংরক্ষিত %s"
 msgid "Select..."
 msgstr "নির্বাচন"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable Automatic &Export?"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Export Project As:"
+msgstr "সংরক্ষিত %s"
+
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "কাজ"
 
@@ -721,8 +5101,25 @@ msgid "After Recording completes:"
 msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -732,11 +5129,23 @@ msgstr "%d চ্যানেল"
 msgid "Scheduled to stop at:"
 msgstr "নির্বাচনের শুরুতে"
 
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr ""
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -746,6 +5155,32 @@ msgstr "রেকর্ডিং হচ্ছে"
 msgid "Recording Exported:"
 msgstr "রেকর্ডিং হচ্ছে"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "মোনো"
+
+#. i18n-hint: The %d is replaced by the number of the track.
+#. i18n-hint: compose a name identifying an unnamed track by number
+#: src/TrackPanelAx.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "Track %d"
+msgstr "মোনো"
+
 #. i18n-hint: This is for screen reader software and indicates that
 #. this track is muted. (The mute button is on.)
 #: src/TrackPanelAx.cpp
@@ -753,17 +5188,95 @@ msgid " Muted"
 msgstr "নিরব"
 
 #. i18n-hint: This is for screen reader software and indicates that
+#. this track is soloed. (The Solo button is on.)
+#: src/TrackPanelAx.cpp
+msgid " Soloed"
+msgstr ""
+
+#. i18n-hint: This is for screen reader software and indicates that
 #. this track is selected.
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "নির্বাচন"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Mute On"
+msgstr "নিরব"
+
+#: src/TrackPanelAx.cpp
+msgid " Solo On"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/TrackPanelResizeHandle.cpp
+msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
+msgstr ""
+
+#: src/TrackPanelResizeHandle.cpp
+msgid "Click and drag to resize the track."
+msgstr ""
+
+#: src/TrackUtilities.cpp
+msgid "Removed audio track(s)"
+msgstr ""
+
+#: src/TrackUtilities.cpp
+#, fuzzy
+msgid "Remove Track"
+msgstr "মোনো"
+
+#: src/TrackUtilities.cpp
+#, c-format
+msgid "Removed track '%s.'"
+msgstr ""
+
+#: src/TrackUtilities.cpp
+#, fuzzy
+msgid "Track Remove"
+msgstr "মোনো"
+
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' to Top"
+msgstr "মোনো"
+
 #: src/TrackUtilities.cpp
 msgid "Move Track to Top"
 msgstr "মোনো"
 
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' to Bottom"
+msgstr "মোনো"
+
 #: src/TrackUtilities.cpp
 msgid "Move Track to Bottom"
+msgstr "মোনো"
+
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' Up"
+msgstr "মোনো"
+
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' Down"
 msgstr "মোনো"
 
 #. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
@@ -775,17 +5288,167 @@ msgstr "মোনো"
 msgid "Move Track Down"
 msgstr "মোনো"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
+#. i18n-hint: Voice key is an experimental/incomplete feature that
+#. is used to navigate in vocal recordings, to move forwards and
+#. backwards by words.  So 'key' is being used in the sense of an index.
+#. This error message means that you've selected too short
+#. a region of audio to be able to use this feature.
+#: src/VoiceKey.cpp
+msgid "Selection is too small to use voice key."
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Results\n"
+msgstr ""
+
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Complete"
+msgstr ""
+
 #: src/WaveClip.cpp
 msgid "Resampling failed."
 msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to paste the selection"
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to expand the cut line"
+msgstr ""
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
+# I guess in should be গেইন - mak
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, fuzzy, c-format
+msgid "Applying %s..."
+msgstr "লাভ"
+
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
 
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "কমান্ড একশন"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "কমান্ড একশন"
+
+#. i18n-hint: %s will be the name of the effect which will be
+#. * repeated if this menu item is chosen
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
+#, fuzzy, c-format
+msgid "Repeat %s"
+msgstr "পুনরাবৃত্তি"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
+
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
 msgstr "সংকোচক..."
+
+#: src/commands/CompareAudioCommand.cpp
+msgid "Threshold:"
+msgstr ""
+
+#: src/commands/CompareAudioCommand.h
+msgid "Compares a range on two tracks."
+msgstr ""
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
+#, fuzzy
+msgid "Delay time (seconds):"
+msgstr "নির্বাচনের শেষে"
+
+#: src/commands/Demo.cpp
+msgid "Decay factor:"
+msgstr ""
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "Drag"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+msgid "Panel"
+msgstr ""
 
 # I guess in should be গেইন - mak
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
@@ -800,9 +5463,43 @@ msgstr "মোনো"
 msgid "Track 1"
 msgstr "মোনো"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "উইন্ডো"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Get Info"
+msgstr "মোনো"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Commands"
@@ -816,25 +5513,91 @@ msgstr "সকল ফাইল (*)|*"
 msgid "Preferences"
 msgstr "প্লেব্যাক"
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+msgid "Clips"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "খাম"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "লেবেল"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+msgid "Type:"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+msgid "Format:"
+msgstr ""
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "মোনো"
 
+#: src/commands/GetTrackInfoCommand.cpp
+msgid "Types:"
+msgstr ""
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "মন্তব্য"
 
+#: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command:"
+msgstr "কমান্ড একশন"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
+
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
 msgstr "আমদানী"
+
+#: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "File Name:"
+msgstr "নাম..."
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Export2"
@@ -844,9 +5607,51 @@ msgstr "&অডিওসিটি পরিচিতি..."
 msgid "Number of Channels:"
 msgstr "চ্যানেল"
 
+#: src/commands/ImportExportCommands.h
+msgid "Imports from a file."
+msgstr ""
+
+#: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Exports to a file."
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Builtin Commands"
+msgstr "কমান্ড একশন"
+
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+msgid "The Tenacity Team"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+msgid "Unknown built-in command name"
+msgstr ""
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "সক্রিয়"
+
 #: src/commands/OpenSaveCommands.cpp
 msgid "Open Project2"
 msgstr "সংরক্ষিত %s"
+
+#: src/commands/OpenSaveCommands.cpp
+msgid "Add to History"
+msgstr ""
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Save Project2"
@@ -860,6 +5665,15 @@ msgstr "লেবেল"
 msgid "Save Log"
 msgstr "সংরক্ষিত %s"
 
+#: src/commands/OpenSaveCommands.cpp
+msgid "Clear Log"
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+#, fuzzy
+msgid "Opens a project."
+msgstr "সংরক্ষিত %s"
+
 #: src/commands/OpenSaveCommands.h
 msgid "Saves a project."
 msgstr "সংরক্ষিত %s"
@@ -868,17 +5682,50 @@ msgstr "সংরক্ষিত %s"
 msgid "Saves a copy of current project."
 msgstr "সংরক্ষিত %s"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "প্লেব্যাক"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "নাম..."
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "প্লেব্যাক"
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "গতি বৃদ্ধি"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "নির্বাচন"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Window"
@@ -893,8 +5740,23 @@ msgid "Window Plus"
 msgstr "উইন্ডো"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "সকল ফাইল (*)|*"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -905,8 +5767,73 @@ msgid "Trackpanel"
 msgstr "নির্বাচনের শুরুতে"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "First Two Tracks"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Three Tracks"
+msgstr "নির্বাচন"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Four Tracks"
+msgstr "প্লেব্যাক"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Tracks Plus"
+msgstr "মোনো"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track Plus"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "All Tracks"
 msgstr "মোনো"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "All Tracks Plus"
+msgstr "মোনো"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
+#. i18n-hint:  This really means the color, not as in "white noise"
+#: src/commands/ScreenshotCommand.cpp
+msgctxt "color"
+msgid "White"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy, c-format
+msgid "Error trying to save file: %s"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "নির্বাচন"
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -928,13 +5855,35 @@ msgstr "নির্বাচনের শুরুতে"
 msgid "Selection Start"
 msgstr "নির্বাচনের শুরুতে"
 
+#: src/commands/SelectCommand.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Selection"
+msgstr "নির্বাচনের শুরুতে"
+
 #: src/commands/SelectCommand.cpp
 msgid "Selection End"
 msgstr "নির্বাচনের শেষে"
 
 #: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Start Time:"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/commands/SelectCommand.cpp
+msgid "End Time:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Frequencies"
 msgstr "নির্বাচন"
+
+#: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
@@ -945,17 +5894,92 @@ msgstr "নির্বাচন"
 msgid "Set"
 msgstr "নির্বাচন"
 
+#: src/commands/SelectCommand.cpp
+msgid "Add"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "মাঝে"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "First Track:"
+msgstr "রেকর্ড"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Track Count:"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/commands/SelectCommand.cpp
+msgid "Mode:"
+msgstr ""
+
 #: src/commands/SelectCommand.h
 msgid "Selects a time range."
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a range of tracks."
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
 #: src/commands/SelectCommand.h
 msgid "Selects Audio."
 msgstr "নির্বাচন"
 
+#: src/commands/SetClipCommand.cpp
+#, fuzzy
+msgid "Set Clip"
+msgstr "নির্বাচন"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Start:"
+msgstr ""
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
+
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
 msgstr "খাম"
+
+#: src/commands/SetEnvelopeCommand.cpp
+msgid "Time:"
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp src/menus/EditMenus.cpp
 msgid "Delete"
@@ -966,9 +5990,14 @@ msgid "Edited Envelope"
 msgstr "খাম"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "খাম"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -978,6 +6007,10 @@ msgstr "মোছো"
 msgid "Label Index"
 msgstr "লেবেল"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "নির্বাচন"
@@ -986,13 +6019,42 @@ msgstr "নির্বাচন"
 msgid "Edited Label"
 msgstr "মোছো"
 
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
 msgstr "সংরক্ষিত %s"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "Rate:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Resize:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "ডান"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "সংরক্ষিত %s"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -1007,6 +6069,10 @@ msgid "Set Track Status"
 msgstr "নির্বাচনের শুরুতে"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "বিরতি"
 
@@ -1019,22 +6085,185 @@ msgstr "মোনো"
 msgid "Gain:"
 msgstr "লাভ"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Set Track Visuals"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "লিনিয়ার"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Reset"
+msgstr "নির্বাচন"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Times 2"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Display:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "VZoom:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "VZoom Top:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "VZoom Bottom:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Use Spectral Prefs"
+msgstr "নির্বাচনের শেষে"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "নির্বাচনের শেষে"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "রেকর্ড"
+
+#: src/commands/SetTrackInfoCommand.h
+msgid "Sets various values for a track."
+msgstr ""
+
+#: src/effects/Amplify.cpp
+msgid "Amplify"
+msgstr ""
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 # I guess in should be গেইন - mak
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
 msgstr "লাভ"
+
+# I guess in should be গেইন - mak
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
+msgstr "লাভ"
+
+#: src/effects/Amplify.cpp
+msgid "&New Peak Amplitude (dB):"
+msgstr ""
+
+#: src/effects/Amplify.cpp
+msgid "Allo&w clipping"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Duck &amount:"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in seconds
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "seconds"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/effects/AutoDuck.cpp
+msgid "Ma&ximum pause:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
+msgid "&Threshold:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "Preview not available"
+msgstr "(নিষ্ক্রিয়)"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Simple tone control effect"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/effects/BassTreble.cpp
+msgid "Tone controls"
+msgstr ""
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -1044,9 +6273,75 @@ msgstr "গতি বৃদ্ধি"
 msgid "Ba&ss (dB):"
 msgstr "গতি বৃদ্ধি"
 
+#: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "লেবেল"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Volume (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/BassTreble.cpp
+msgid "Level"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "শব্দের গ্রাম পরিবর্তন"
+
+#: src/effects/ChangePitch.cpp
+msgid "Changes the pitch of a track without changing its tempo"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "মান"
+
+#: src/effects/ChangePitch.cpp
+msgid "Change Pitch without Changing Tempo"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
+
+#. i18n-hint: (noun) Musical pitch.
+#: src/effects/ChangePitch.cpp
+msgid "Pitch"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "from Octave"
+msgstr ""
 
 #. i18n-hint: changing musical pitch "from" one value "to" another
 #: src/effects/ChangePitch.cpp
@@ -1060,13 +6355,70 @@ msgctxt "change pitch"
 msgid "&to"
 msgstr "অভিমুখে"
 
+#: src/effects/ChangePitch.cpp
+msgid "to Octave"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "Semitones (half-steps)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "&Semitones (half-steps):"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "Frequency"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "অভিমুখে"
 
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+msgid "Percent C&hange:"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "চ্যানেল"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "প্র/ন"
 
@@ -1074,11 +6426,54 @@ msgstr "প্র/ন"
 msgid "Change Speed"
 msgstr "গতি পরিবর্তন"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "Changes the speed of a track, also changing its pitch"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "Change Speed, affecting both Tempo and Pitch"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "&Speed Multiplier:"
+msgstr ""
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
 msgctxt "change speed"
 msgid "&to"
 msgstr "অভিমুখে"
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "Selection Length"
+msgstr "নির্বাচনের শেষে"
 
 #: src/effects/ChangeSpeed.cpp
 msgid "C&urrent Length:"
@@ -1091,8 +6486,57 @@ msgstr "নির্বাচনের শেষে"
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
 msgctxt "change speed"
+msgid "from"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "&New Length:"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
 msgid "to"
 msgstr "অভিমুখে"
+
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Change Tempo"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Changes the tempo of a selection without changing its pitch"
+msgstr ""
+
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "মান"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Change Tempo without Changing Pitch"
+msgstr ""
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -1100,11 +6544,140 @@ msgctxt "change tempo"
 msgid "&to"
 msgstr "অভিমুখে"
 
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Length (seconds)"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "from"
+msgstr ""
+
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
 msgid "t&o"
 msgstr "অভিমুখে"
+
+#: src/effects/ChangeTempo.cpp
+#, c-format
+msgid "Length in seconds from %s, to"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, c-format
+msgid "Selection must be larger than %d samples."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+msgid "Threshold"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "সংকোচক..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.2f secs"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+msgid "&Noise Floor:"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+msgid "Noise Floor"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+msgid "&Ratio:"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
+msgstr "কাজ"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+msgid "&Attack Time:"
+msgstr ""
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+msgid "Attack Time"
+msgstr ""
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
@@ -1113,29 +6686,866 @@ msgstr "অভিমুখে"
 msgid "R&elease Time:"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Threshold %d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Attack Time %.2f secs"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Release Time %.1f secs"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/effects/Contrast.cpp
+msgid "You can only measure one track at a time."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Please select an audio track."
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
+#. i18n-hint noun
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "End"
+msgstr "প্যান"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Measure selection"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background end time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Mea&sure selection"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "নির্বাচন"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "প্লেব্যাক"
+
+#: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
+msgid "&Help"
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "indeterminate"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr "প্লেব্যাক"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Export Contrast Result As:"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Filename = %s."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "পুনরাবৃত্তি"
+
+#: src/effects/Contrast.cpp
+msgid "Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "ফন্ট..."
+
+#: src/effects/Distortion.cpp
+msgid "Hard Clipping"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Soft Clipping"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Expand and Compress"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Rectifier Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Limiter 1413"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Upper Threshold"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Parameter 1"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Parameter 2"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Number of repeats"
+msgstr "চ্যানেল"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion"
+msgstr "ইন্টারফেস"
+
+#: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
 #: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "ইন্টারফেস"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Threshold controls"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Parameter controls"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Clipping level"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Clipping threshold"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "ইন্টারফেস"
+
+#: src/effects/Distortion.cpp
+msgid "Output level"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Repeat processing"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "dB Limit"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "প্লেব্যাক"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "প্লেব্যাক"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "DTMF &sequence:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
+msgid "&Amplitude (0-1):"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "&Duration:"
+msgstr "কাজ"
+
+#: src/effects/DtmfGen.cpp
+msgid "&Tone/silence ratio:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Tone duration:"
+msgstr "%d চ্যানেল"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Silence duration:"
+msgstr "%d চ্যানেল"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
 msgstr "প্রতিধ্বনি"
 
 #: src/effects/Echo.cpp
+msgid "Repeats the selected audio again and again"
+msgstr ""
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
+#: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Echo.cpp
+msgid "D&ecay factor:"
+msgstr ""
+
+#: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "নির্বাচন"
 
+#: src/effects/Effect.cpp
+msgid "Export Effect Parameters"
+msgstr ""
+
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
+#, c-format
+msgid "Could not open file: \"%s\""
+msgstr ""
+
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+msgid "Error Saving Effect Presets"
+msgstr ""
+
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#, fuzzy, c-format
+msgid "Error writing to file: \"%s\""
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/effects/Effect.cpp
+msgid "Import Effect Parameters"
+msgstr ""
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, fuzzy, c-format
+msgid "%s: is not a valid presets file.\n"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Preparing preview"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/effects/Effect.cpp
+msgid "Previewing"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy, c-format
+msgid "Applied effect: %s"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid "Applied command: %s"
+msgstr ""
+
 #: src/effects/EffectManager.cpp
 msgid "Select Preset"
 msgstr "নির্বাচন"
 
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "&Preset:"
+msgstr "নির্বাচন"
+
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "User Presets"
+msgstr "নির্বাচন"
+
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "নির্বাচন"
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Current Settings"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/EffectManager.cpp
+msgid "Factory Defaults"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Effects Rack"
+msgstr "সকল ফাইল (*)|*"
+
+# I guess in should be গেইন - mak
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Apply"
+msgstr "লাভ"
+
+#: src/effects/EffectUI.cpp
+msgid "Latency: 0"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move Up"
+msgstr "মোনো"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect up in the rack"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move Down"
+msgstr "মোনো"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect down in the rack"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Remove effect from the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Name of the effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Latency: %4d"
+msgstr ""
+
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "কমান্ড একশন"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Manage"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "প্লেব্যাক"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -1144,8 +7554,46 @@ msgid "Start &Playback"
 msgstr "প্লেব্যাক"
 
 #: src/effects/EffectUI.cpp
+msgid "Preview effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Preview effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Skip backward"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Skip &Backward"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Skip forward"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Skip &Forward"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Enable"
 msgstr "সক্রিয়"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Save Preset..."
+msgstr "সংরক্ষিত %s"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "নির্বাচন"
+
+#: src/effects/EffectUI.cpp
+msgid "Defaults"
+msgstr ""
 
 #: src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
 msgid "Import..."
@@ -1155,16 +7603,90 @@ msgstr "আমদানী"
 msgid "Export..."
 msgstr "&অডিওসিটি পরিচিতি..."
 
+#: src/effects/EffectUI.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Options..."
+msgstr "কাজ"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "নাম..."
+
 #: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "নাম..."
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "উল্টা করা হচ্ছে"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "সমস্যা:"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Description: %s"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Are you sure you want to delete \"%s\"?"
+msgstr ""
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "সংরক্ষিত %s"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Preset name:"
+msgstr "নির্বাচন"
+
+#: src/effects/EffectUI.cpp
+msgid "You must specify a name"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid ""
+"Preset already exists.\n"
+"\n"
+"Replace?"
+msgstr ""
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
 #: src/effects/EffectUI.cpp
 msgid "Stop &Playback"
 msgstr "প্লেব্যাক"
+
+#: src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Play"
+msgstr "প্লেব্যাক"
+
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "লিনিয়ার"
+
+#: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Equalization"
@@ -1174,44 +7696,721 @@ msgstr "ইক্যুয়ালাইজেশন"
 msgid "Filter Curve EQ"
 msgstr "নির্বাচন"
 
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "গতি বৃদ্ধি"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "লেবেল"
 
 #: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "লেবেল"
 
 #: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "To apply Equalization, all selected tracks must have the same sample rate."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Track sample rate is too low for this effect."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Effect Unavailable"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&EQ Type:"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Draw Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Draw"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Interpolation type"
 msgstr "ইন্টারফেস"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "লিনিয়ার"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "লিনিয়ার"
+
+# I guess in should be গেইন - mak
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "লাভ"
+
+# I guess in should be গেইন - mak
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "লাভ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "নির্বাচন"
 
 #: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "নির্বাচন"
 
 #: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "ইনভার্ট"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Processing: "
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "D&efault"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Bench"
+msgstr ""
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/effects/Equalization.cpp
+msgid "Error Saving Equalization Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "নাম..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "নাম..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "মোছো"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "বেছে নিন"
+
+#: src/effects/Equalization.cpp
+msgid "De&faults"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "Rename '%s' to..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "নাম..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "Rename '%s'"
+msgstr "মোছো"
+
+#: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Same name"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "Overwrite existing curve '%s'?"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve exists"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Can't delete 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "মোছো"
+
+#: src/effects/Equalization.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Deletion"
+msgstr "নির্বাচনের শেষে"
 
 #: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete %d items?"
 msgstr "মোছো"
 
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Choose an EQ curve file"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Export EQ curves as..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Cannot Export 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "No curves exported"
+msgstr ""
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade In"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade Out"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/Fade.cpp
+msgid "Applies a linear fade-in to the selected audio"
+msgstr ""
+
+#: src/effects/Fade.cpp
+msgid "Applies a linear fade-out to the selected audio"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "Find Clipping"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "Clipping"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "&Start threshold (samples):"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "St&op threshold (samples):"
+msgstr ""
+
+#: src/effects/Generator.cpp
+msgid "There is not enough room available to generate the audio"
+msgstr ""
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "ইনভার্ট"
+
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "perceived loudness"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalizing Loudness...\n"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 #, c-format
 msgid "Analyzing: %s"
 msgstr "&এনালাইজ"
 
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, c-format
+msgid "Processing: %s"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Normalize"
+msgstr ""
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
+
+#. i18n-hint: not a color, but "white noise" having a uniform spectrum
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "White"
+msgstr ""
+
+#. i18n-hint: not a color, but "pink noise" having a spectrum with more power
+#. in low frequencies
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Pink"
+msgstr ""
+
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
+#: src/effects/Noise.cpp
+msgid "Noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "&Noise type:"
+msgstr "উইন্ডো"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Median"
+msgstr "মান"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Second greatest"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hann, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hann, Hann (default)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "নির্বাচনের শেষে"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "All noise profile data must have the same sample rate."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Selected noise profile is too short."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Noise reduction (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/NoiseReduction.cpp
+msgid "&Sensitivity:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Sensitivity"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Attac&k time (secs):"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Attack time"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "R&elease time (secs):"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Release time"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/effects/NoiseReduction.cpp
+msgid "&Frequency smoothing (bands):"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Frequency smoothing"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old Sensitivity"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Step 1"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid ""
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
+"then click Get Noise Profile:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "&Get Noise Profile"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Step 2"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Noise:"
+msgstr ""
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "মাঝে"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+msgid "Resid&ue"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -1225,21 +8424,339 @@ msgstr "উইন্ডো"
 msgid "Window si&ze:"
 msgstr "উইন্ডো"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "2048 (default)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "4 (default)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise Removal"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to remove noise.\n"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise re&duction (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "&Sensitivity (dB):"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Fr&equency smoothing (Hz):"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Attack/decay time"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "মাঝে"
+
+#: src/effects/Normalize.cpp
+msgid "Normalize"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Removing DC offset and Normalizing...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Removing DC offset...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Normalizing without removing DC offset...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Normalize peak amplitude to   "
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Peak amplitude dB"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
+#. i18n-hint: This is how many times longer the sound will be, e.g. applying
+#. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
+#. * will give an (approximately) 10 second sound
+#.
+#: src/effects/Paulstretch.cpp
+msgid "&Stretch Factor:"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "&Time Resolution (seconds):"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "ফেজার"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "&Stages:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Stages"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO Freq&uency (Hz):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO frequency in hertz"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO Sta&rt Phase (deg.):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO start phase in degrees"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "গভীরতা"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Feedbac&k (%):"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "&Output gain (dB):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Output gain (dB)"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/Repair.cpp
+msgid "Repair"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "পুনরাবৃত্তি"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "চ্যানেল"
+
+#: src/effects/Repeat.cpp
+#, fuzzy
+msgid "Current selection length: dd:hh:mm:ss"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Repeat.cpp
+#, fuzzy
+msgid "New selection length: dd:hh:mm:ss"
+msgstr "নির্বাচনের শেষে"
 
 #: src/effects/Repeat.cpp
 #, c-format
@@ -1251,9 +8768,100 @@ msgstr "নির্বাচনের শেষে"
 msgid "New selection length: %s"
 msgstr "নির্বাচনের শেষে"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Vocal I"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "মান"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "উল্টা"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "&Room Size (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Rever&berance (%):"
+msgstr "উল্টা"
+
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "গভীরতা (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "গভীরতা (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/effects/Reverb.cpp
+msgid "Stereo Wid&th (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -1264,11 +8872,207 @@ msgstr "উল্টা"
 msgid "Reverse"
 msgstr "উল্টা"
 
+#: src/effects/Reverse.cpp
+msgid "Reverses the selected audio"
+msgstr ""
+
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Classic Filters"
+msgstr ""
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "To apply a filter, all selected tracks must have the same sample rate."
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "গতি বৃদ্ধি"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Align MIDI to Audio"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "কাজ"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "কাজ"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size:"
+msgstr "উইন্ডো"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size"
+msgstr "উইন্ডো"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Silence Threshold:"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Silence Threshold"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Presmooth Time:"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Presmooth Time"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Line Time:"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time:"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Use Defaults"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Restore Defaults"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "পুনরাবৃত্তি"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
+#: src/effects/StereoToMono.cpp
+#, fuzzy
+msgid "Stereo To Mono"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -1278,25 +9082,301 @@ msgstr "রেকর্ডিং হচ্ছে"
 msgid "Resampling right channel"
 msgstr "চ্যানেল"
 
+#: src/effects/StereoToMono.cpp
+msgid "Mixing down to mono"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Sliding Stretch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "ইন্টারফেস"
+
+#: src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Sine"
+msgstr ""
+
+#: src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Square"
+msgstr ""
+
+#: src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Sawtooth"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
 #: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "গতি বৃদ্ধি"
+
+#: src/effects/ToneGen.cpp
+msgid "&Frequency (Hz):"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/effects/ToneGen.cpp
+msgid "Frequency Hertz End"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "নির্বাচনের শেষে"
 
 #: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "ইন্টারফেস"
 
 #: src/effects/TruncSilence.cpp
+msgid "Truncate Detected Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "পুনরাবৃত্তি"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Detect Silence"
+msgstr "পুনরাবৃত্তি"
+
+#: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "সংকোচক..."
 
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "VST Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+msgid "Could not load the library"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "VST Effect Options"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Buffer Size"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Latency Compensation"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Save VST Preset As:"
+msgstr "সংরক্ষিত %s"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Standard VST bank file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Standard VST program file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Error Saving VST Presets"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Load VST Preset:"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Error Loading VST Presets"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unable to load presets file."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Effect Settings"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unable to allocate memory when loading presets file."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unable to read presets file."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -1306,26 +9386,485 @@ msgstr "গভীরতা (%):"
 msgid "Reso&nance:"
 msgstr "রেজোনেন্স:"
 
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "রেজোনেন্স:"
+
+#: src/effects/Wahwah.cpp
+msgid "Wah Frequency Offse&t (%):"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wah frequency offset in percent"
+msgstr ""
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Could not find component"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Could not initialize component"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Audio Unit Effect Options"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "ইন্টারফেস"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "ইন্টারফেস"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "উইন্ডো"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Generic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Import Audio Unit Presets"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "নির্বাচন"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
 msgstr "কাজ"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Couldn't open \"%s\""
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Unable to read the preset from \"%s\""
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Failed to encode preset from \"%s\""
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Unable to store preset in config file"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid ""
+"Could not import \"%s\" preset\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Export Audio Unit Preset As %s:"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Standard Audio Unit preset file"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid ""
+"Could not export \"%s\" preset\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Export Audio Unit Presets"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Import Audio Unit Preset As %s:"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to set preset name"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to retrieve preset content"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to convert property list to XML data"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Failed to write XML preset to \"%s\""
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to convert preset to internal format"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to create property list for preset"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr ""
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+msgid "Audio Unit"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "LADSPA Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Provides LADSPA Effects"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "LADSPA Effect Options"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Effect Output"
+msgstr "সকল ফাইল (*)|*"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "LV2 Effect Settings"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Generator"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
+#: src/effects/lv2/LoadLV2.cpp
+#, fuzzy
+msgid "LV2 Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/nyquist/LoadNyquist.cpp
+#, fuzzy
+msgid "Nyquist Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
+
+# I guess in should be গেইন - mak
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Applying Nyquist Effect..."
+msgstr "লাভ"
+
+#. i18n-hint: It is acceptable to translate this the same as for "Nyquist Prompt"
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist Worker"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Ill-formed Nyquist plug-in header"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "নির্বাচনের শেষে"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist Error"
+msgstr "সমস্যা"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Debug Output: "
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "রেকর্ডিং হচ্ছে"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "plug-in"
+msgstr "নির্বাচনের শেষে"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned a list."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "Nyquist returned the value: %f"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "Nyquist returned the value: %d"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned too many audio channels.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned one audio channel as an array.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned an empty array.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned nil audio.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "This version of Audacity does not support Nyquist plug-in version %ld"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Could not open file"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
+#. i18n-hint: refers to programming "languages"
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Could not determine language"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr ""
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Enter Nyquist Command: "
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "&Load"
+msgstr ""
+
+#. i18n-hint: Nyquist is the name of a programming language
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist scripts"
+msgstr "সংরক্ষিত %s"
 
 #. i18n-hint: Lisp is the name of a programming language
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "সংরক্ষিত %s"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be loaded"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Value range:\n"
+"%s to %s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Value Error"
@@ -1339,9 +9878,490 @@ msgstr "একটি মিডি ফাইল নির্বাচন কর�
 msgid "Save file as"
 msgstr "সংরক্ষিত %s"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
+#: src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "Vamp Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "উল্টা করা হচ্ছে"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "No format specific options"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Export Audio"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp src/menus/EditMenus.cpp
+msgid "Edit Metadata Tags"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Exported Tags"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid "Are you sure you want to export the file as \"%s\"?\n"
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Sorry, pathnames longer than 256 characters not supported."
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid "A file named \"%s\" already exists. Replace?"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one mono file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one stereo file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down to one exported file according to the encoder settings."
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Advanced Mixing Options"
+msgstr "উল্টা করা হচ্ছে"
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Format Options"
+msgstr "কাজ"
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Channel: %2d"
+msgstr "চ্যানেল"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Output Channels: %2d"
+msgstr "%d চ্যানেল"
+
+#: src/export/Export.cpp
+msgid "Mixer Panel"
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"Unable to export.\n"
+"Error %s"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Show output"
+msgstr ""
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "কমান্ড একশন"
+
+#: src/export/ExportCL.cpp
+msgid "(external program)"
+msgstr ""
+
+#: src/export/ExportCL.cpp src/export/ExportPCM.cpp
+#, c-format
+msgid "Cannot export audio to %s"
+msgstr ""
+
+#: src/export/ExportCL.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/export/ExportCL.cpp
+msgid "Exporting the selected audio using command-line encoder"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Exporting the audio using command-line encoder"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "কমান্ড একশন"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "&OK"
+msgstr "ঠিক আছে"
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg Error"
+msgstr "সমস্যা"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Exporting selected audio as %s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
+#, c-format
+msgid "Exporting the audio as %s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "নমুনা পরিবর্তন"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+msgid "Bit Rate:"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "মান"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "On"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Constrained"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Audio"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Low Delay"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mediumband"
+msgstr "মান"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -1355,44 +10375,1775 @@ msgstr "সংকোচক..."
 msgid "Frame Duration:"
 msgstr "কাজ"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Vbr Mode:"
+msgstr ""
+
 # I guess in should be গেইন - mak
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "লাভ"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Current Format:"
+msgstr "নির্বাচনের শেষে"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Current Codec:"
+msgstr "নির্বাচনের শেষে"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Error Saving FFmpeg Presets"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Overwrite preset '%s'?"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Confirm Overwrite"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select format before saving a profile"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Preset '%s' does not exist."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Replace preset '%s'?"
+msgstr "মোছো"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Main"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Custom FFmpeg Export"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "4-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "8-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "নির্বাচন"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "নির্বাচন"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "সংরক্ষিত %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "নির্বাচন"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Codec:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "নির্বাচনের শেষে"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "ভাষা (Language):"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Quality:"
+msgstr "মান"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "কাজ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "সংকোচক..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "নাম..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "MPEG container options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Mux Rate:"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Packet Size:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "মোছো"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "No presets to export"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file to export presets into"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Failed to guess format"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Failed to find the codec"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "0 (fastest)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "8 (best)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "Level:"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "Bit depth:"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "FLAC Files"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid "FLAC export couldn't open %s"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "Exporting the selected audio as FLAC"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the audio as FLAC"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/export/ExportMP2.cpp
+#, fuzzy
+msgid "MP2 Files"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/export/ExportMP2.cpp
+msgid "Cannot export MP2 with this sample rate and bit rate"
+msgstr ""
+
+#: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
+msgid "Unable to open target file for writing"
+msgstr ""
+
+#: src/export/ExportMP2.cpp
+#, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr ""
+
+#: src/export/ExportMP2.cpp
+#, c-format
+msgid "Exporting the audio at %ld kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "মান"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "(নিষ্ক্রিয়)"
+
+#: src/export/ExportMP3.cpp
+msgid "Average"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Constant"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "নির্বাচন"
+
+#: src/export/ExportMP3.cpp
+msgid "Stereo"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Bit Rate Mode:"
+msgstr ""
 
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "মান"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "চ্যানেল"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "মাঝে"
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Tenacity needs the file %s to create MP3s."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr "কাজ"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "To find %s, click here -->"
+msgstr ""
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+msgid "To get a free copy of LAME, click here -->"
+msgstr ""
+
+#. i18n-hint: It's asking for the location of a file, for
+#. * example, "Where is lame_enc.dll?" - you could translate
+#. * "Where would I find the file %s" instead if you want.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Where is %s?"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/export/ExportMP3.cpp
+msgid "Could not open MP3 encoding library!"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Could not initialize MP3 encoding library!"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Not a valid or supported MP3 encoding library!"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Unable to initialize MP3 stream"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Exporting the audio with %s preset"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Exporting the audio with VBR quality %s"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Exporting the audio at %d Kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Export Multiple"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Cannot Export Multiple"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export files to:"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Create"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Options:"
+msgstr "কাজ"
+
+#: src/export/ExportMultiple.cpp
+msgid "Split files based on:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Include audio before first label"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "First file name:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "First file name"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Name files:"
+msgstr "সংরক্ষিত %s"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Using Label/Track Name"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/export/ExportMultiple.cpp
+msgid "Numbering before Label/Track Name"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Numbering after File name prefix"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "File name prefix:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "File name prefix"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Overwrite existing files"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Choose a location to save the exported files"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Continue to export remaining files?"
+msgstr ""
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Save As..."
+msgstr "সংরক্ষিত %s"
+
+#: src/export/ExportOGG.cpp
+msgid "Ogg Vorbis Files"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - rate or quality problem"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem with metadata"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem initialising"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem creating stream"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem with packets"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem with file"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Exporting the selected audio as Ogg Vorbis"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Exporting the audio as Ogg Vorbis"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "Header:"
+msgstr ""
+
 #: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
 msgid "Encoding:"
 msgstr "এনকোডিং:"
 
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Error Exporting"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "Cannot export audio in this format."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid "Exporting the selected audio as %s"
+msgstr ""
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "সকল ফাইল (*)|*"
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "নির্বাচনের শেষে"
+
+#: src/import/Import.cpp
+#, c-format
+msgid "This version of Tenacity was not compiled with %s support."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Couldn't import the project:\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Import Project"
 msgstr "সংরক্ষিত %s"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Couldn't find the project data folder: \"%s\""
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Failed to open %s"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Failed to seek to position %lld in %s"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Unable to read %lld samples from %s"
+msgstr ""
+
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/import/ImportLOF.cpp
+msgid "List of Files in basic text format"
+msgstr ""
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+msgid "Invalid window offset in LOF file."
+msgstr ""
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+#, fuzzy
+msgid "LOF Error"
+msgstr "সমস্যা"
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+#, fuzzy
+msgid "Invalid duration in LOF file."
+msgstr "ইক্যুয়ালাইজেশন"
+
+#: src/import/ImportLOF.cpp
+msgid "MIDI tracks cannot be offset individually, only audio files can be."
+msgstr ""
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+msgid "Invalid track offset in LOF file."
+msgstr ""
+
+#: src/import/ImportMIDI.cpp
+#, c-format
+msgid "Imported MIDI from '%s'"
+msgstr ""
+
+#: src/import/ImportMIDI.cpp
+#, fuzzy
+msgid "Import MIDI"
+msgstr "আমদানী"
+
+#: src/import/ImportMIDI.cpp
+#, c-format
+msgid "Could not open file %s: Filename too short."
+msgstr ""
+
+#: src/import/ImportMIDI.cpp
+#, c-format
+msgid "Could not open file %s: Incorrect filetype."
+msgstr ""
+
+#: src/import/ImportMIDI.cpp
+#, c-format
+msgid "Could not open file %s."
+msgstr ""
+
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Ogg Vorbis files"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Media read error"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Not an Ogg Vorbis file"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Vorbis version mismatch"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Invalid Vorbis bitstream header"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Internal logic fault"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 16 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 24 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "আমদানী"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to start QuickTime extraction"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to retrieve stream description"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get fill buffer"
+msgstr ""
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "আমদানী"
+
+#: src/import/ImportRaw.cpp
+msgid "Import Raw Data"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "No endianness"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Big-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Default endianness"
+msgstr "ডিরেক্টরি"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "1 Channel (Mono)"
+msgstr "চ্যানেল"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "2 Channels (Stereo)"
+msgstr "%d চ্যানেল"
 
 #: src/import/ImportRaw.cpp
 #, c-format
 msgid "%d Channels"
 msgstr "%d চ্যানেল"
+
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "চ্যানেল"
+
+#. i18n-hint: (noun)
+#: src/import/ImportRaw.cpp
+msgid "Start offset:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+msgid "bytes"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+msgid "Amount to import:"
+msgstr ""
+
+#. i18n-hint: (noun)
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Sample rate:"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Import"
+msgstr "আমদানী"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -1414,12 +12165,22 @@ msgstr "ডান"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
 msgid_plural "%s %d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/menus/ClipMenus.cpp
+msgid "start"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "end"
+msgstr "প্যান"
 
 #. i18n-hint:
 #. First two %s are each replaced with the noun "start"
@@ -1429,6 +12190,7 @@ msgstr[1] ""
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -1448,12 +12210,112 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+msgid "Time shifted clips to the right"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Time shifted clips to the left"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
+msgid "Time-Shift"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Previo&us Clip"
+msgstr "নির্বাচন"
+
+#: src/menus/ClipMenus.cpp
 msgid "Select Previous Clip"
+msgstr "নির্বাচন"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "N&ext Clip"
 msgstr "নির্বাচন"
 
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "নির্বাচন"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "নির্বাচন"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/ClipMenus.cpp
+msgid "Ne&xt Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/ClipMenus.cpp
+msgid "Time Shift &Left"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Time Shift &Right"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Pasted text from the clipboard"
+msgstr ""
+
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+msgid "Pasted from the clipboard"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Nothing to undo"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Nothing to redo"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Cut to the clipboard"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, c-format
+msgid "Deleted %.2f seconds at t=%.2f"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Pasting one type of track into another is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Copying stereo audio into a mono track is not allowed."
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Duplicated"
@@ -1463,6 +12325,30 @@ msgstr "ডুপলিকেট করা হয়েছে"
 msgid "Duplicate"
 msgstr "ডুপলিকেট"
 
+#: src/menus/EditMenus.cpp
+msgid "Split-cut to the clipboard"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Cut"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/EditMenus.cpp
+#, c-format
+msgid "Split-deleted %.2f seconds at t=%.2f"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Delete"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/EditMenus.cpp
+#, c-format
+msgid "Silenced selected tracks for %.2f seconds at %.2f"
+msgstr ""
+
 #. i18n-hint: verb
 #: src/menus/EditMenus.cpp
 msgctxt "command"
@@ -1470,8 +12356,137 @@ msgid "Silence"
 msgstr "পুনরাবৃত্তি"
 
 #: src/menus/EditMenus.cpp
+#, c-format
+msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "মোনো"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Split"
+msgstr "লেবেল"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split to new track"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/EditMenus.cpp
+msgid "Split New"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, c-format
+msgid "Joined %.2f seconds at t=%.2f"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Metadata Tags"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
 msgid "&Edit"
 msgstr "&এডিট"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+msgid "Cu&t"
+msgstr ""
+
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Delete"
+msgstr "মোছো"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "&Copy"
+msgstr "কপি"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "&Paste"
+msgstr "সাঁটো"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Duplic&ate"
+msgstr "ডুপলিকেট"
+
+#: src/menus/EditMenus.cpp
+msgid "R&emove Special"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut
+#: src/menus/EditMenus.cpp
+msgid "Spl&it Cut"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of DELETE
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split D&elete"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "নির্বাচন"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Tri&m Audio"
+msgstr "মোনো"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/EditMenus.cpp
+msgid "Sp&lit"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Split Ne&w"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+msgid "&Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+msgid "Detac&h at Silences"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "&Metadata..."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "প্লেব্যাক"
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -1482,28 +12497,12 @@ msgid "Delete Key&2"
 msgstr "মোছো"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "প্লেব্যাক"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "প্লেব্যাক"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "প্লেব্যাক"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "রেকর্ডিং হচ্ছে"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "রেকর্ডিং হচ্ছে"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "রেকর্ডিং হচ্ছে"
+msgid "De&vice"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "Change &Recording Device..."
@@ -1521,6 +12520,47 @@ msgstr "নমুনা পরিবর্তন"
 msgid "Change Recording Cha&nnels..."
 msgstr "শব্দের গ্রাম পরিবর্তন"
 
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export Selected Audio"
+msgstr "নির্বাচন"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "লেবেল"
+
+#: src/menus/FileMenus.cpp
+msgid "There are no label tracks to export."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Please select only one Note Track at a time."
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Please select a Note Track."
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "&অডিওসিটি পরিচিতি..."
+
 #: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
@@ -1530,8 +12570,34 @@ msgid "Allegro file"
 msgstr "সকল ফাইল (*)|*"
 
 #: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid "Imported labels from '%s'"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Import Labels"
+msgstr "আমদানী"
+
+#: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "সকল ফাইল (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -1540,6 +12606,32 @@ msgstr "একটি মিডি ফাইল নির্বাচন কর�
 #: src/menus/FileMenus.cpp
 msgid "Allegro files"
 msgstr "সকল ফাইল (*)|*"
+
+#: src/menus/FileMenus.cpp
+msgid "&Dangerous Reset..."
+msgstr ""
+
+#. i18n-hint: This is the name of the menu item on Mac OS X only
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Open Recent"
+msgstr "সংরক্ষিত %s"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Save Project"
+msgstr "সংরক্ষিত %s"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Save Project &As..."
+msgstr "সংরক্ষিত %s"
 
 #: src/menus/FileMenus.cpp
 msgid "&Backup Project..."
@@ -1554,12 +12646,75 @@ msgid "Export as MP&3"
 msgstr "&অডিওসিটি পরিচিতি..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export as &WAV"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export as &OGG"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Export Audio..."
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Expo&rt Selected Audio..."
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export &Labels..."
+msgstr "মোছো"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export &Multiple..."
 msgstr "&অডিওসিটি পরিচিতি..."
 
 #: src/menus/FileMenus.cpp
 msgid "Export MI&DI..."
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Labels..."
+msgstr "লেবেল"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/menus/FileMenus.cpp
+msgid "&Raw Data..."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+msgid "Pa&ge Setup..."
+msgstr ""
+
+#. i18n-hint: (verb) It's item on a menu.
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Print..."
+msgstr "মুদ্রণ"
+
+#. i18n-hint: (verb) It's item on a menu.
+#: src/menus/FileMenus.cpp
+msgid "E&xit"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -1571,28 +12726,212 @@ msgid "Save %s"
 msgstr "সংরক্ষিত %s"
 
 #: src/menus/HelpMenus.cpp
+#, c-format
+msgid "Unable to save %s"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Do you have these problems?"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Fix"
 msgstr "মিক্স"
+
+#: src/menus/HelpMenus.cpp
+msgid "Quick Fixes"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Nothing to do"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "নির্বাচন"
 
 #: src/menus/HelpMenus.cpp
+msgid "Can't select precisely"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Quick Fix..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Getting Started"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Manual"
 msgstr "&অডিওসিটি পরিচিতি..."
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&অডিওসিটি পরিচিতি..."
+msgid "&Quick Help..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Diagnostics"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Added label"
+msgstr "মোছো"
+
+#: src/menus/LabelMenus.cpp
+msgid "Paste Text to New Label"
+msgstr ""
+
+#. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
+#. regions.
+#: src/menus/LabelMenus.cpp
+msgid "Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Cut Labeled Audio"
+msgstr "লেবেল"
+
+#. i18n-hint: (verb) Audacity has just deleted the labeled audio regions
+#: src/menus/LabelMenus.cpp
+msgid "Deleted labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Delete Labeled Audio"
+msgstr "মোছো"
+
+#. i18n-hint: (verb) Audacity has just split cut the labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut on the labels
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just done a special kind of DELETE on
+#. the labeled audio regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Deleted labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of DELETE on labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Delete Labeled Audio"
+msgstr "মোছো"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Silenced labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Silence Labeled Audio"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+msgid "Copied labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Copy Labeled Audio"
+msgstr "সংকোচক..."
+
+#. i18n-hint: (verb) past tense.  Audacity has just split the labeled
+#. audio (a point or a region)
+#: src/menus/LabelMenus.cpp
+msgid "Split labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Labeled Audio"
+msgstr "নির্বাচন"
+
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+msgid "Joined labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Join Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+msgid "Detached labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Detach Labeled Audio"
+msgstr ""
 
 #: src/menus/LabelMenus.cpp
 msgid "&Labels"
 msgstr "লেবেল"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Edit Labels..."
+msgstr "মোছো"
 
 #: src/menus/LabelMenus.cpp
 msgid "Add Label at &Selection"
@@ -1603,6 +12942,24 @@ msgid "Add Label at &Playback Position"
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/LabelMenus.cpp
+msgid "Paste Te&xt to New Label"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "La&beled Audio"
+msgstr "নির্বাচন"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "&Cut"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Cut"
 msgstr "লেবেল"
 
@@ -1610,9 +12967,50 @@ msgstr "লেবেল"
 msgid "Label Delete"
 msgstr "মোছো"
 
+#. i18n-hint: (verb) A special way to cut out a piece of audio
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Split Cut"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Cut"
+msgstr "লেবেল"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Sp&lit Delete"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Delete"
+msgstr "মোছো"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "নির্বাচন"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Silence"
+msgstr "মোছো"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Co&py"
+msgstr ""
+
 #: src/menus/LabelMenus.cpp
 msgid "Label Copy"
 msgstr "লেবেল"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Spli&t"
+msgstr ""
 
 #: src/menus/LabelMenus.cpp
 msgid "Label Split"
@@ -1622,9 +13020,76 @@ msgstr "লেবেল"
 msgid "Label Join"
 msgstr "লেবেল"
 
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move F&orward from Toolbars to Tracks"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to &Previous Track"
+msgstr "নির্বাচন"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to &Next Track"
+msgstr "মোনো"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to &First Track"
+msgstr "মোনো"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to &Last Track"
+msgstr "মোনো"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to P&revious and Select"
+msgstr "নির্বাচন"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to N&ext and Select"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "&Toggle Focused Track"
+msgstr "মোনো"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Toggle Focuse&d Track"
+msgstr "মোনো"
+
+#: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
 #: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "প্রতিধ্বনি..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -1632,12 +13097,53 @@ msgid "&Repeat %s"
 msgstr "পুনরাবৃত্তি"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy, c-format
+msgid "Plug-in %d to %d"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/PluginMenus.cpp
+msgid "&Generate"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Generator"
+msgstr "পুনরাবৃত্তি"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Effe&ct"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "পুনরাবৃত্তি"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&এনালাইজ"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "পুনরাবৃত্তি"
+
+#: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
+msgid "T&ools"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Tool"
 msgstr "পুনরাবৃত্তি"
+
+#: src/menus/PluginMenus.cpp
+msgid "&Macros..."
+msgstr ""
 
 # I guess in should be গেইন - mak
 #: src/menus/PluginMenus.cpp
@@ -1657,8 +13163,16 @@ msgid "&Screenshot..."
 msgstr "নির্বাচন"
 
 #: src/menus/PluginMenus.cpp
+msgid "&Run Benchmark..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Simulate Recording Errors"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
 
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
@@ -1682,12 +13196,27 @@ msgid "Set Track Status..."
 msgstr "নির্বাচনের শুরুতে"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "মোনো"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "প্লেব্যাক"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Preference..."
 msgstr "প্লেব্যাক"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Clip..."
+msgstr "মোছো"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Envelope..."
@@ -1701,13 +13230,33 @@ msgstr "মোছো"
 msgid "Set Project..."
 msgstr "নির্বাচন"
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "সকল ফাইল (*)|*"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "রেকর্ড"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "মোনো"
+
+#: src/menus/PluginMenus.cpp
 msgid "Message..."
 msgstr "নাম..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Help..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Open Project..."
+msgstr "সংরক্ষিত %s"
 
 #: src/menus/PluginMenus.cpp
 msgid "Save Project..."
@@ -1721,13 +13270,97 @@ msgstr "বেছে নিন"
 msgid "Compare Audio..."
 msgstr "সংকোচক..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "নির্বাচন"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "কাজ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "নির্বাচন"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&None"
+msgstr "কোনটিই নয়"
+
 #: src/menus/SelectMenus.cpp
 msgid "Select None"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Tracks"
+msgstr "মোনো"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "মোনো"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Left at Playback Position"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Selection Left at Play Position"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Right at Playback Position"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/SelectMenus.cpp
+msgid "Set Selection Right at Play Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
 msgstr "নির্বাচনের শুরুতে"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "নির্বাচনের শেষে"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -1758,8 +13391,29 @@ msgid "To&ggle Spectral Selection"
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/SelectMenus.cpp
+msgid "Next &Higher Peak Frequency"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Next &Lower Peak Frequency"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+msgid "Store Cursor Pos&ition"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "At &Zero Crossings"
+msgstr "নির্বাচন"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Zero Crossing"
@@ -1768,6 +13422,18 @@ msgstr "নির্বাচন"
 #: src/menus/SelectMenus.cpp
 msgid "&Selection"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Off"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Nearest"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection to &Start"
@@ -1786,12 +13452,26 @@ msgid "Selection Extend &Right"
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set (or Extend) Le&ft Selection"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set (or Extend) Rig&ht Selection"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/SelectMenus.cpp
 msgid "Selection Contract L&eft"
 msgstr "নির্বাচনের শুরুতে"
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection Contract R&ight"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+msgid "&Cursor to"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection Star&t"
@@ -1818,6 +13498,16 @@ msgid "Cursor to Track Start"
 msgstr "নির্বাচনের শুরুতে"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &End"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track End"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/SelectMenus.cpp
 msgid "&Project Start"
 msgstr "নির্বাচনের শুরুতে"
 
@@ -1825,13 +13515,117 @@ msgstr "নির্বাচনের শুরুতে"
 msgid "Cursor to Project Start"
 msgstr "নির্বাচনের শুরুতে"
 
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Project E&nd"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Project End"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/SelectMenus.cpp
+msgid "&Cursor"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor &Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Right"
+msgstr "ডান"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Sh&ort Jump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Shor&t Jump Right"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long J&ump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long Ju&mp Right"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
+
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
 msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr ""
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+msgid "Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr ""
+
+#. i18n-hint: One or more audio tracks have been panned
+#: src/menus/TrackMenus.cpp
+msgid "Panned audio track(s)"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Pan Track"
 msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Zero"
+msgstr "নির্বাচনের শেষে"
 
 #: src/menus/TrackMenus.cpp
 msgid "Start to &Cursor/Selection Start"
@@ -1847,6 +13641,21 @@ msgstr "নির্বাচনের শুরুতে"
 
 #: src/menus/TrackMenus.cpp
 msgid "End to Selection En&d"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: In this and similar messages describing editing actions,
+#. the starting or ending points of tracks are re-"aligned" to other
+#. times, and the time selection may be "moved" too.  The first
+#. noun -- "start" in this example -- is the object of a verb (not of
+#. an implied preposition "from").
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to zero"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to zero"
 msgstr "নির্বাচনের শেষে"
 
 #. i18n-hint: This and similar messages give shorter descriptions of
@@ -1884,6 +13693,11 @@ msgid "Aligned end to cursor/selection start"
 msgstr "নির্বাচনের শুরুতে"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move End"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
 msgid "Align End"
 msgstr "নির্বাচনের শেষে"
 
@@ -1896,15 +13710,213 @@ msgid "Aligned end to selection end"
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to end"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to end"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move End to End"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
 msgid "Align End to End"
 msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved together"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/TrackMenus.cpp
+msgid "Aligned together"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move Together"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align Together"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronize MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Adjusted gain"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Adjusted Pan"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Created new audio track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "New Track"
+msgstr "রেকর্ড"
+
+#: src/menus/TrackMenus.cpp
+msgid "Created new stereo audio track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Created new label track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Created new time track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "New sample rate (Hz):"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "The entered value is invalid"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Resampling track %d"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/menus/TrackMenus.cpp
+msgid "Resampled audio track(s)"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "নির্বাচন"
 
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by time"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Time"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by name"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Name"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/TrackMenus.cpp
+msgid "Can't delete track with active audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Add &New"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Stereo Track"
+msgstr "নির্বাচন"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Label Track"
+msgstr "রেকর্ড"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Time Track"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix Stereo Down to &Mono"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x and Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix and Render to Ne&w Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Resample..."
+msgstr "নাম..."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Remo&ve Tracks"
+msgstr "রেকর্ড"
+
+#: src/menus/TrackMenus.cpp
+msgid "M&ute/Unmute"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "রেকর্ড"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Unmute All Tracks"
 msgstr "মোনো"
 
 #: src/menus/TrackMenus.cpp
@@ -1914,6 +13926,10 @@ msgstr "রেকর্ড"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -1940,15 +13956,95 @@ msgid "Pan Center"
 msgstr "মাঝে"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align End to End"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align &Together"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Move Selection with Tracks (on/off)"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
 msgid "Move Sele&ction and Tracks"
 msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "S&ort Tracks"
+msgstr "রেকর্ড"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "By &Start Time"
+msgstr "নাম..."
 
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "নাম..."
 
 #: src/menus/TrackMenus.cpp
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "&Track"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+msgid "Change P&an on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan &Left on Focused Track"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan &Right on Focused Track"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+msgid "Change Gai&n on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Increase Gain on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Decrease Gain on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Op&en Menu on Focused Track..."
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "M&ute/Unmute Focused Track"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Solo/Unsolo Focused Track"
+msgstr "মোনো"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Close Focused Track"
 msgstr "মোনো"
 
 #: src/menus/TrackMenus.cpp
@@ -1970,9 +14066,51 @@ msgstr "মোনো"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Playing"
+msgstr "পরিবর্তনশীল গতি"
+
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. is playing or recording or stopped, and whether it is paused;
+#. progressive verb form
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track"
+msgstr "নির্বাচন"
+
+#: src/menus/TransportMenus.cpp
+msgid "no label track at or below focused track"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "no labels in label track"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -1983,8 +14121,53 @@ msgid "Please select in a stereo track or two mono tracks."
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy, c-format
+msgid "Please select at least %d channels."
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Please select a time within a clip."
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+msgid "Tra&nsport"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pl&aying"
+msgstr ""
+
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "প্লেব্যাক"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "বিরতি"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "রেকর্ড"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -1993,6 +14176,73 @@ msgstr "রেকর্ড"
 #: src/menus/TransportMenus.cpp
 msgid "Record &New Track"
 msgstr "রেকর্ড"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Transport &Options"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "অঙ্কুর প্রকল্পের পক্ষে মাহে আলম খান (makl10n@yahoo.com)"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay"
+msgstr ""
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -2027,6 +14277,10 @@ msgid "Play Before an&d After Selection End"
 msgstr "নির্বাচনের শেষে"
 
 #: src/menus/TransportMenus.cpp
+msgid "Play C&ut Preview"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "&Play-at-Speed"
 msgstr "প্লেব্যাক"
 
@@ -2037,6 +14291,11 @@ msgstr "প্লেব্যাক"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play-at-Speed"
+msgstr "প্লেব্যাক"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview-at-Speed"
 msgstr "প্লেব্যাক"
 
 #: src/menus/TransportMenus.cpp
@@ -2055,9 +14314,74 @@ msgstr "প্লেব্যাক"
 msgid "Move to Pre&vious Label"
 msgstr "নির্বাচন"
 
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Move to Ne&xt Label"
+msgstr "নির্বাচন"
+
+#: src/menus/ViewMenus.cpp
+msgid "&View"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+msgid "&Zoom"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Zoom &In"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Zoom &Normal"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Zoom &Out"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Zoom to Selection"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/ViewMenus.cpp
+msgid "Zoom &Toggle"
+msgstr ""
+
 #: src/menus/ViewMenus.cpp
 msgid "Advanced &Vertical Zooming"
 msgstr "উল্টা করা হচ্ছে"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "T&rack Size"
+msgstr "মোনো"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Fit to Width"
+msgstr "নির্বাচনের শেষে"
+
+#: src/menus/ViewMenus.cpp
+msgid "Fit to &Height"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Collapse All Tracks"
+msgstr "মোনো"
+
+#: src/menus/ViewMenus.cpp
+msgid "E&xpand Collapsed Tracks"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Sk&ip to"
+msgstr ""
 
 #: src/menus/ViewMenus.cpp
 msgid "Selection Sta&rt"
@@ -2071,9 +14395,57 @@ msgstr "নির্বাচনের শুরুতে"
 msgid "Skip to Selection End"
 msgstr "নির্বাচনের শেষে"
 
+#: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "&Show Clipping (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+msgid "Show Effects Rack"
+msgstr ""
+
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr "উইন্ডো"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -2081,12 +14453,32 @@ msgstr "প্লেব্যাক"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "&অডিওসিটি পরিচিতি..."
+
+#: src/prefs/ApplicationPrefs.cpp
+msgid "&Check for Updates"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+msgid "Batch"
+msgstr ""
 
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Behaviors"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "Devices"
+msgstr ""
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
@@ -2098,26 +14490,100 @@ msgctxt "device"
 msgid "Interface"
 msgstr "ইন্টারফেস"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "Using:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Device:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "De&vice:"
+msgstr ""
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Cha&nnels:"
 msgstr "চ্যানেল"
 
+#: src/prefs/DevicePrefs.cpp
+msgid "Latency"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "milliseconds"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "&Buffer length:"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/DevicePrefs.cpp
+msgid "&Latency compensation:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "No audio interfaces"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "মোনো"
+
+#: src/prefs/DevicePrefs.cpp
+msgid "2 (Stereo)"
+msgstr ""
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "ডিরেক্টরি"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "প্লেব্যাক"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "ডিরেক্টরি"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "বেছে নিন"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -2140,6 +14606,24 @@ msgid "Bro&wse..."
 msgstr "বেছে নিন"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "&Macro output:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "নির্বাচন"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "কাজ"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
 msgstr "বেছে নিন"
 
@@ -2148,16 +14632,222 @@ msgid "&Free Space:"
 msgstr "ফাঁকা জায়গা:"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "Choose a location to place the temporary directory"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "কমান্ড একশন"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s does not exist. Create it?"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "New Temporary Directory"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not writable"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temp Directory Update"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
 msgstr "প্লেব্যাক"
 
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Publisher and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Type and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr ""
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Effect Options"
+msgstr "কাজ"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Plugin Options"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "ইন্টারফেস"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "আমদানী"
+
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Mime-types"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "সংরক্ষিত %s"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "মোনো"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "মোনো"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Move f&ilter up"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "মোনো"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "De&lete selected rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "নির্বাচন"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Do you really want to delete selected rule?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "%d চ্যানেল"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -2173,9 +14863,181 @@ msgstr "ইন্টারফেস"
 msgid "Preferences for GUI"
 msgstr "প্লেব্যাক"
 
+#: src/prefs/GUIPrefs.cpp
+msgid "-36 dB (shallow range for high-amplitude editing)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-48 dB (PCM range of 8 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-72 dB (PCM range of 12 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-84 dB (PCM range of 14 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-96 dB (PCM range of 16 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-120 dB (approximate limit of human hearing)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-145 dB (PCM range of 24 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "কাজ"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "Display"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "ভাষা (Language):"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Location of &Manual:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "গতি বৃদ্ধি"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "সক্রিয়"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+msgid "Show Scrub Ruler"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "সংরক্ষিত %s"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "প্লেব্যাক"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Mix down to Stereo or Mono"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Use Advanced Mixing Options"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Seconds"
+msgstr "নমুনা পরিবর্তন"
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Beats"
 msgstr "পুনরাবৃত্তি"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Exported Label Style:"
+msgstr "মোছো"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -2187,16 +15049,229 @@ msgid "Preferences for KeyConfig"
 msgstr "প্লেব্যাক"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Key Bindings"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "নাম..."
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by name"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Bindings"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Set"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Import..."
+msgstr "আমদানী"
+
+#: src/prefs/KeyConfigPrefs.cpp src/prefs/ThemePrefs.cpp
+msgid "&Defaults"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Error Importing Keyboard Shortcuts"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid "Loaded %d keyboard shortcuts\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Loading Keyboard Shortcuts"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Export Keyboard Shortcuts As:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Error Exporting Keyboard Shortcuts"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.h
+msgid "Key Config"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.cpp
 msgid "Preferences for Library"
 msgstr "প্লেব্যাক"
 
+#: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "MP3 Library Version:"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Library Version:"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Library:"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "নাম..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "ইন্টারফেস"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -2204,9 +15279,75 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "ইন্টারফেস"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/ModulePrefs.cpp
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Ask"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -2217,6 +15358,15 @@ msgid "Preferences for Mouse"
 msgstr "প্লেব্যাক"
 
 #: src/prefs/MousePrefs.cpp
+msgid "Mouse Bindings (default values, not configurable)"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Tool"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Command Action"
 msgstr "কমান্ড একশন"
 
@@ -2225,8 +15375,140 @@ msgid "Buttons"
 msgstr "বাটন"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Click"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Set Selection Point"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Drag"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Set Selection Range"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Shift-Left-Click"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Extend Selection Range"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Change scrub speed"
 msgstr "গতি পরিবর্তন"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom in on Point"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom in on a Range"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "same as right-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Right-Click"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom out one step"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Right-Drag"
+msgstr "ডান"
+
+#: src/prefs/MousePrefs.cpp
+msgid "same as left-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Shift-Drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom out on a Range"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom default"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clip left/right or between tracks"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Left-Drag"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "-Left-Drag"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clip up/down between tracks"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
+#. i18n-hint: The envelope is a curve that controls the audio loudness.
+#: src/prefs/MousePrefs.cpp
+msgid "Change Amplification Envelope"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp
 msgid "Pencil"
@@ -2241,20 +15523,122 @@ msgid "Alt-Left-Click"
 msgstr "Alt-বাম-ক্লিক"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Smooth at Sample"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Change Several Samples"
 msgstr "আনেকগুলি নমুনা পরিবর্তন"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Change ONE Sample only"
+msgstr "নমুনা পরিবর্তন"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Multi"
 msgstr "বহু"
 
 #: src/prefs/MousePrefs.cpp
+msgid "same as select tool"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "same as zoom tool"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Any"
 msgstr "যেকোন"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Scroll tracks up or down"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Shift-Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Scroll waveform"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "-Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom waveform in or out"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "-Shift-Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Vertical Scale Waveform (dB) range"
+msgstr "গতি বৃদ্ধি"
 
 #: src/prefs/PlaybackPrefs.cpp
 msgid "Preferences for Playback"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Effects Preview"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "&Length:"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: (noun) this is a preview of the cut
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Cut Preview"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
+#: src/prefs/PrefsDialog.cpp
+#, fuzzy
+msgid "Tenacity Preferences"
+msgstr "প্লেব্যাক"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -2265,24 +15649,186 @@ msgid "Preferences for Quality"
 msgstr "প্লেব্যাক"
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "অন্যান্য..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/prefs/QualityPrefs.cpp
+msgid "Default Sample &Rate:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+msgid "Default Sample &Format:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Con&verter:"
+msgstr "নমুনা পরিবর্তন"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+msgid "High-quality Conversion"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Conver&ter:"
+msgstr "নমুনা পরিবর্তন"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
 msgstr "প্লেব্যাক"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "রেকর্ড"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
 msgstr "গতি বৃদ্ধি"
 
+#. i18n-hint: start of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "Name newly recorded tracks"
+msgstr ""
+
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom Track &Name"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "লেবেল"
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "&Track Number"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System &Date"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "প্লেব্যাক"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Cross&fade:"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
+#. i18n-hint: New color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgctxt "spectrum prefs"
+msgid "Color (default)"
+msgstr ""
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr ""
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "লিনিয়ার"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -2290,8 +15836,52 @@ msgctxt "spectrum prefs"
 msgid "Inverse grayscale"
 msgstr "লিনিয়ার"
 
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Frequencies"
+msgstr "নির্বাচন"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
+#. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Pitch (EAC)"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Minimum frequency must be at least 0 Hz"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The range must be at least 1 dB"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Spectrograms"
 msgstr "নির্বাচনের শেষে"
 
 #: src/prefs/SpectrumPrefs.cpp
@@ -2303,17 +15893,220 @@ msgstr "প্লেব্যাক"
 msgid "&Use Preferences"
 msgstr "প্লেব্যাক"
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Mi&n Frequency (Hz):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Ma&x Frequency (Hz):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "গতি বৃদ্ধি"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Algorithm"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "A&lgorithm:"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &size:"
+msgstr "উইন্ডো"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "1024 - default"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr "উইন্ডো"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Zero padding factor:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "নির্বাচনের শেষে"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Minimum Amplitude (dB):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Global settings"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble spectral selection"
 msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The maximum frequency must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The minimum frequency must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The gain must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The range must be a positive integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The frequency gain must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The maximum number of notes must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr ""
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/prefs/ThemePrefs.cpp src/prefs/ThemePrefs.h
+msgid "Theme"
+msgstr ""
 
 #: src/prefs/ThemePrefs.cpp
 msgid "Preferences for Theme"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Info"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Save Files"
+msgstr "সংরক্ষিত %s"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Load Files"
+msgstr "সকল ফাইল (*)|*"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+msgid "Tracks Behaviors"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "প্লেব্যাক"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "নমুনা পরিবর্তন"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -2333,15 +16126,58 @@ msgid "Enable &dragging selection edges"
 msgstr "নির্বাচনের শেষে"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "উল্টা করা হচ্ছে"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "বাটন"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
 msgstr "ইন্টারফেস"
 
+#: src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.h
+#, fuzzy
+msgid "Waveform"
+msgstr "গতি বৃদ্ধি"
+
 #: src/prefs/TracksPrefs.cpp
 msgid "Spectrogram"
+msgstr "নির্বাচনের শেষে"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Fit to Width"
 msgstr "নির্বাচনের শেষে"
 
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
@@ -2349,16 +16185,169 @@ msgid "Zoom to Selection"
 msgstr "নির্বাচনের শেষে"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Zoom Default"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Seconds"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "5ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "10ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "20ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "50ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "100ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "500ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "MilliSeconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Samples"
 msgstr "নমুনা পরিবর্তন"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+msgid "Max Zoom"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Preferences for Tracks"
 msgstr "প্লেব্যাক"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Default &view mode:"
+msgstr "ডিরেক্টরি"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Default Waveform scale:"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "নমুনা পরিবর্তন"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Default audio track &name:"
+msgstr ""
+
+#. i18n-hint: The default name for an audio track.
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Audio Track"
+msgstr "মোনো"
+
+#: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
+msgid "Zoom Toggle"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preset 1:"
+msgstr "নির্বাচন"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preset 2:"
+msgstr "নির্বাচন"
+
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+msgid "Warnings"
+msgstr ""
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "প্লেব্যাক"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "সংরক্ষিত %s"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "সংরক্ষিত %s"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down to &mono during export"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down to &stereo during export"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
+
+#. i18n-hint: A waveform is a visual representation of vibration
+#: src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "Waveforms"
+msgstr "গতি বৃদ্ধি"
 
 #: src/prefs/WaveformPrefs.cpp
 msgid "Preferences for Waveforms"
@@ -2368,9 +16357,34 @@ msgstr "প্লেব্যাক"
 msgid "Waveform dB &range:"
 msgstr "গতি বৃদ্ধি"
 
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. is playing or recording or stopped, and whether it is paused;
+#. progressive verb form
+#: src/toolbars/ControlToolBar.cpp
+msgid "Stopped"
+msgstr ""
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Skip to Start"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Skip to End"
+msgstr "নির্বাচনের শেষে"
+
 #: src/toolbars/ControlToolBar.cpp
 msgid "Pause"
 msgstr "বিরতি"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "নির্বাচনের শেষে"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -2384,20 +16398,24 @@ msgstr "রেকর্ড"
 msgid "Append Record"
 msgstr "রেকর্ড"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "নির্বাচনের শেষে"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "নির্বাচনের শুরুতে"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "বিরতি"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "নির্বাচনের শুরুতে"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -2408,6 +16426,11 @@ msgstr "প্লেব্যাক"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "নমুনা পরিবর্তন"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -2430,8 +16453,24 @@ msgid "Select Playback Device"
 msgstr "প্লেব্যাক"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "নির্বাচন"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "%d চ্যানেল"
+
+#: src/toolbars/DeviceToolBar.cpp
+msgid "Device information is not available."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that manages devices
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "&Device Toolbar"
+msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/toolbars/EditToolBar.cpp
 msgid "Cut selection"
@@ -2442,8 +16481,57 @@ msgid "Copy selection"
 msgstr "নির্বাচনের শেষে"
 
 #: src/toolbars/EditToolBar.cpp
+msgid "Trim audio outside selection"
+msgstr ""
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Silence audio selection"
+msgstr "নির্বাচনের শেষে"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "নির্বাচন"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom In"
+msgstr ""
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom Out"
+msgstr "নির্বাচনের শেষে"
+
+#: src/toolbars/EditToolBar.cpp
 msgid "Fit selection to width"
 msgstr "নির্বাচনের শেষে"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Fit project to width"
+msgstr "নির্বাচনের শেষে"
+
+#: src/toolbars/EditToolBar.cpp
+msgid "Open Effects Rack"
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar for editing
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "&Edit Toolbar"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Meter"
@@ -2452,6 +16540,21 @@ msgstr "রেকর্ডিং হচ্ছে"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "প্লেব্যাক"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "রেকর্ড"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+msgid "Meter-Play"
+msgstr ""
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Level"
@@ -2473,39 +16576,74 @@ msgstr "রেকর্ডিং হচ্ছে"
 msgid "&Playback Meter Toolbar"
 msgstr "প্লেব্যাক"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "রেকর্ডিং হচ্ছে"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "প্লেব্যাক"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Scrub Ruler"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "রেকর্ডিং হচ্ছে"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "প্লেব্যাক"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "প্লেব্যাক"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+msgid "Scrubbing"
+msgstr ""
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Stop Scrubbing"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Start Scrubbing"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "নির্বাচনের শেষে"
 
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Hide Scrub Ruler"
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that enables Scrub or Seek playback and Scrub Ruler
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scru&b Toolbar"
+msgstr "রেকর্ডিং হচ্ছে"
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap-To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
+msgid "Audio Position"
+msgstr ""
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
@@ -2523,9 +16661,37 @@ msgstr "নির্বাচনের শেষে"
 msgid "Length and Center of Selection"
 msgstr "নির্বাচনের শেষে"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Length"
+msgstr "নির্বাচনের শেষে"
+
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "মাঝে"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -2535,10 +16701,38 @@ msgid "Selection %s. %s won't change."
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
+#. for selecting a time range of audio
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "&Selection Toolbar"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Center frequency and Width"
+msgstr ""
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Low and High Frequencies"
+msgstr ""
+
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Center Frequency"
+msgstr "নির্বাচন"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spe&ctral Selection Toolbar"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/toolbars/TimeToolBar.cpp
+msgid "Time"
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for viewing actual time of the cursor
@@ -2546,13 +16740,59 @@ msgstr "নির্বাচনের শুরুতে"
 msgid "&Time Toolbar"
 msgstr "রেকর্ডিং হচ্ছে"
 
+#. i18n-hint: %s will be replaced by the name of the kind of toolbar.
+#: src/toolbars/ToolBar.cpp
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/toolbars/ToolBar.cpp
+msgid "Click and drag to resize toolbar"
+msgstr ""
+
+#: src/toolbars/ToolDock.cpp
+msgid "ToolDock"
+msgstr ""
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Selection Tool"
+msgstr "নির্বাচনের শুরুতে"
+
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Envelope Tool"
 msgstr "খাম আনুষঙ্গিক সরঞ্জাম"
 
 #: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Time Shift Tool"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Zoom Tool"
+msgstr "নির্বাচনের শেষে"
+
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "Draw Tool"
+msgstr ""
+
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Multi-Tool"
 msgstr "বহু"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "বহু"
+
+#. i18n-hint: Clicking this menu item shows a toolbar
+#. that has some tools in it
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools Toolbar"
+msgstr "রেকর্ডিং হচ্ছে"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "&Selection Tool"
@@ -2563,14 +16803,73 @@ msgid "&Envelope Tool"
 msgstr "খাম আনুষঙ্গিক সরঞ্জাম"
 
 #: src/toolbars/ToolsToolBar.cpp
+msgid "&Draw Tool"
+msgstr ""
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Zoom Tool"
+msgstr "নির্বাচনের শেষে"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Time Shift Tool"
+msgstr "রেকর্ডিং হচ্ছে"
+
+#: src/toolbars/ToolsToolBar.cpp
 msgid "&Multi Tool"
 msgstr "বহু"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Previous Tool"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Next Tool"
+msgstr "বহু"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "পরিবর্তনশীল গতি"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Playback Speed"
+msgstr "প্লেব্যাক"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "প্লেব্যাক"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
 #: src/toolbars/TranscriptionToolBar.cpp
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "প্লেব্যাক"
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Modified Label"
+msgstr "মোছো"
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Label Edit"
+msgstr "লেবেল"
 
 #: src/tracks/labeltrack/ui/LabelTextHandle.cpp
 msgid "Click to edit label text"
@@ -2579,6 +16878,22 @@ msgstr "নির্বাচনের শুরুতে"
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "&Font..."
 msgstr "ফন্ট..."
+
+#. i18n-hint: (noun) This is the font for the label track.
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Label Track Font"
+msgstr "মোনো"
+
+#. i18n-hint: (noun) The name of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+msgid "Face name"
+msgstr ""
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+msgid "Face size"
+msgstr ""
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Cu&t Label text"
@@ -2600,13 +16915,58 @@ msgstr "মোছো"
 msgid "Deleted Label"
 msgstr "মোছো"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Edited labels"
+msgstr "মোছো"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "New label"
+msgstr "মোছো"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+msgid "Up &Octave"
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+msgid "Down Octa&ve"
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+msgid "Right-click for menu."
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom Reset"
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Alt-বাম-ক্লিক"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Alt-বাম-ক্লিক"
+
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+msgid "Click and drag to stretch selected region."
+msgstr ""
 
 #. i18n-hint: (noun) The track that is used for MIDI notes which can be
 #. dragged to change their duration.
@@ -2614,9 +16974,66 @@ msgstr "Alt-বাম-ক্লিক"
 msgid "Stretch Note Track"
 msgstr "রেকর্ড"
 
+#. i18n-hint: In the history list, indicates a MIDI note has
+#. been dragged to change its duration (stretch it). Using either past
+#. or present tense is fine here.  If unsure, go for whichever is
+#. shorter.
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+#, fuzzy
+msgid "Stretch"
+msgstr "নির্বাচনের শেষে"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merged Clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Expand"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Removed Cut Line"
+msgstr "মাঝে"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "Click and drag to edit the samples"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "নমুনা পরিবর্তন"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#, fuzzy
+msgid "Sample Edit"
+msgstr "নমুনা পরিবর্তন"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -2627,28 +17044,144 @@ msgid "&Spectrogram"
 msgstr "নির্বাচনের শেষে"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
 msgstr "নির্বাচনের শেষে"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "&Format"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "নমুনা পরিবর্তন"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Processing...   0%%"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Processing...   %i%%"
+msgstr ""
+
+#. i18n-hint: The strings name a track and a format
+#. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Changed '%s' to %s"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Format Change"
+msgstr "চ্যানেল"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Rat&e"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
 msgstr "অন্যান্য..."
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Changed '%s' to %s Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rate Change"
 msgstr "চ্যানেল"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Set Rate"
+msgstr "মোছো"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "বহু"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Ma&ke Stereo Track"
+msgstr "নির্বাচন"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Swap Stereo &Channels"
 msgstr "%d চ্যানেল"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Spl&it Stereo Track"
+msgstr "নির্বাচন"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Split Stereo to Mo&no"
+msgstr "নির্বাচনের শেষে"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Mono"
@@ -2669,6 +17202,16 @@ msgstr "চ্যানেল"
 #. i18n-hint: The string names a track
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
+msgid "Made '%s' a stereo track"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Make Stereo"
+msgstr ""
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
 msgid "Swapped Channels in '%s'"
 msgstr "%d চ্যানেল"
 
@@ -2676,9 +17219,26 @@ msgstr "%d চ্যানেল"
 msgid "Swap Channels"
 msgstr "%d চ্যানেল"
 
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Split stereo track '%s'"
+msgstr "নির্বাচন"
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Split Stereo to Mono '%s'"
+msgstr "নির্বাচনের শেষে"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split to Mono"
 msgstr "নির্বাচনের শেষে"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "মোনো,"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
@@ -2695,17 +17255,133 @@ msgstr "বাম,"
 msgid "Right, %dHz"
 msgstr "ডান,"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "ডান"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Click and drag to rearrange sub-views"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Rearrange sub-views"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom x1/2"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom x2"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "Wa&veform"
+msgstr "গতি বৃদ্ধি"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "&Wave Color"
+msgstr "চ্যানেল"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
 msgstr "চ্যানেল"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Change lower speed limit (%) to:"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Lower speed limit"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Change upper speed limit (%) to:"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Upper speed limit"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, c-format
+msgid "Set range to '%ld' - '%ld'"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Range"
+msgstr "মোছো"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set Display"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "ইন্টারফেস"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "লিনিয়ার"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "ইন্টারফেস"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -2714,6 +17390,11 @@ msgstr "নাম..."
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Logarithmic &Interpolation"
 msgstr "ইন্টারফেস"
+
+#. i18n-hint Appears on hovering mouse over clip affordance
+#: src/tracks/ui/AffordanceHandle.cpp
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -2724,17 +17405,171 @@ msgid "Move Track &Up"
 msgstr "মোনো"
 
 #: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track &Down"
+msgstr "মোনো"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track to &Top"
+msgstr "মোনো"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track to &Bottom"
+msgstr "মোনো"
+
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Set Track Name"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, c-format
+msgid "Renamed '%s' to '%s'"
+msgstr ""
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Name Change"
+msgstr "চ্যানেল"
+
+#: src/tracks/ui/EnvelopeHandle.cpp
+msgid "Click and drag to warp playback time"
+msgstr ""
+
+#: src/tracks/ui/EnvelopeHandle.cpp
+msgid "Click and drag to edit the amplitude envelope"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just adjusted the envelope .
+#: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Adjusted envelope."
+msgstr "খাম"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+msgid "&Scrub"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scrub &Ruler"
+msgstr ""
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Playing at Speed"
 msgstr "পরিবর্তনশীল গতি"
 
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Move mouse pointer to Seek"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Move mouse pointer to Scrub"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scru&bbing"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scrub Bac&kwards"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scrub For&wards"
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to move left selection boundary."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to move right selection boundary."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to move bottom selection frequency."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to move top selection frequency."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to move center selection frequency to a spectral peak."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to move center selection frequency."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to adjust frequency bandwidth."
+msgstr ""
+
 #. i18n-hint: These are the names of a menu and a command in that menu
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Edit, Preferences..."
 msgstr "প্লেব্যাক"
+
+#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac
+#: src/tracks/ui/SelectHandle.cpp
+#, c-format
+msgid "Multi-Tool Mode: %s for Mouse and Keyboard Preferences."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+msgid "Click and drag to set frequency bandwidth."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to select audio"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+msgid "Click and drag to move a track in time"
+msgstr ""
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+msgid "Could not shift between tracks"
+msgstr ""
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+msgid "Moved clips to another track"
+msgstr ""
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, c-format
+msgid "Time shifted tracks/clips right %.02f seconds"
+msgstr ""
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, c-format
+msgid "Time shifted tracks/clips left %.02f seconds"
+msgstr ""
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -2748,6 +17583,10 @@ msgstr "নির্বাচন"
 msgid "Ctrl+Click to deselect"
 msgstr "কমান্ড একশন"
 
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Open menu..."
+msgstr ""
+
 #. i18n-hint: Command names a modifier key on Macintosh keyboards
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Command+Click"
@@ -2758,13 +17597,162 @@ msgstr "কমান্ড একশন"
 msgid "Ctrl+Click"
 msgstr "Alt-বাম-ক্লিক"
 
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr ""
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, c-format
+msgid "%s to select or deselect track."
+msgstr ""
+
+#. i18n-hint: will substitute name of track for %s
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, c-format
+msgid "Moved '%s' up"
+msgstr ""
+
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' down"
+msgstr "মোনো"
+
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Move Track"
+msgstr "মোনো"
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Click to Zoom In, Shift-Click to Zoom Out"
+msgstr ""
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Drag to Zoom Into Region, Right-Click to Zoom Out"
+msgstr ""
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Left=Zoom In, Right=Zoom Out, Middle=Normal"
+msgstr ""
+
 #: src/widgets/AButton.cpp
 msgid "(disabled)"
 msgstr "(নিষ্ক্রিয়)"
 
+#: src/widgets/AButton.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Press"
+msgstr "নির্বাচন"
+
+#: src/widgets/AButton.cpp
+#, fuzzy
+msgid "Button"
+msgstr "বাটন"
+
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+msgid "Please choose an existing file."
+msgstr ""
+
+#: src/widgets/FileDialog/mac/FileDialogPrivate.mm
+#, fuzzy
+msgid "File type:"
+msgstr "গতি বৃদ্ধি"
+
+#: src/widgets/FileHistory.cpp
+msgid "&Clear"
+msgstr ""
+
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
+#: src/widgets/Grid.cpp
+msgid "Empty"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Forwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "সকল ফাইল (*)|*"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click to Start Monitoring"
+msgstr "নির্বাচনের শুরুতে"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click for Monitoring"
+msgstr "নির্বাচনের শুরুতে"
+
 #: src/widgets/Meter.cpp
 msgid "Click to Start"
 msgstr "নির্বাচনের শুরুতে"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click"
+msgstr "Alt-বাম-ক্লিক"
+
+#: src/widgets/Meter.cpp
+msgid "Stop Monitoring"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Start Monitoring"
+msgstr "নির্বাচনের শেষে"
 
 #: src/widgets/Meter.cpp
 msgid "Recording Meter Options"
@@ -2774,10 +17762,553 @@ msgstr "রেকর্ডিং হচ্ছে"
 msgid "Playback Meter Options"
 msgstr "প্লেব্যাক"
 
+#: src/widgets/Meter.cpp
+msgid "Refresh Rate"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter Style"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Type"
+msgstr "গতি বৃদ্ধি"
+
+#: src/widgets/Meter.cpp
+msgid "Orientation"
+msgstr ""
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+msgid "Automatic"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Horizontal"
+msgstr "নির্বাচনের শেষে"
+
+#: src/widgets/Meter.cpp
+msgid "Vertical"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Monitoring "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "নির্বাচনের শেষে"
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + hundredths"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>0100 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + milliseconds"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>01000 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + samples"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+># samples"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "নমুনা পরিবর্তন"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames (lots of
+#. * frames) at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at PAL
+#. * TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "kHz"
+msgstr "হার্টজ্"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in octaves
+#: src/widgets/NumericTextCtrl.cpp
+msgid "octaves"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "নির্বাচনের শেষে"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Cancel"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to cancel?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Cancel"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to stop?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Stop"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to close?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Close"
+msgstr ""
+
+#. i18n-hint: %s is replaced with a directory path.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#, c-format
+msgid "Unable to write files to directory: %s."
+msgstr ""
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
+#. i18n-hint: %s is replaced with 'Preferences > Directories'.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#, c-format
+msgid "You can change the directory in %s."
+msgstr ""
+
 #. i18n-hint: Hyperlink title that opens Preferences dialog on Directories page.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Preferences > Directories"
 msgstr "প্লেব্যাক"
+
+#: src/widgets/Warning.cpp
+msgid "Don't show this warning again"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Empty value"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "রেকর্ড"
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Not in range %d to %d"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "সমস্যা"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value not in range: %s to %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be less than %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be greater than %s"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
@@ -2787,16 +18318,72 @@ msgstr "নির্বাচন"
 msgid "Directory Dialog"
 msgstr "ডিরেক্টরি"
 
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "ডিরেক্টরি"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "সমস্যা:"
+
+#: src/xml/XMLFileReader.cpp
+#, c-format
+msgid "Could not load file: \"%s\""
+msgstr ""
+
+#: src/xml/XMLFileReader.cpp
+msgid "Could not parse XML"
+msgstr ""
+
 #: plug-ins/SpectralEditMulti.ny
 msgid "Spectral edit multi tool"
 msgstr "নির্বাচনের শেষে"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Filtering..."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "নির্বাচন"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "সমস্যা"
@@ -2809,14 +18396,75 @@ msgstr "নির্বাচনের শেষে"
 msgid "Gain (dB)"
 msgstr "গতি বৃদ্ধি"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aCenter frequency must be above 0 Hz."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "নির্বাচনের শেষে"
+
+#: plug-ins/StudioFadeOut.ny
+msgid "Studio Fade Out"
+msgstr ""
 
 # I guess in should be গেইন - mak
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "লাভ"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -2826,6 +18474,31 @@ msgstr "গতি বৃদ্ধি"
 msgid "Fade Up"
 msgstr "গতি বৃদ্ধি"
 
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Fade Down"
+msgstr "গতি বৃদ্ধি"
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve Up"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve Down"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Start/End as"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
+
 # I guess in should be গেইন - mak
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -2834,6 +18507,14 @@ msgstr "লাভ"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "নির্বাচনের শেষে"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -2848,12 +18529,25 @@ msgid "Linear Out"
 msgstr "লিনিয়ার"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
 msgstr "ইন্টারফেস"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic Out"
 msgstr "ইন্টারফেস"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Rounded In"
+msgstr "লিনিয়ার"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Rounded Out"
@@ -2868,16 +18562,149 @@ msgid "Cosine Out"
 msgstr "লিনিয়ার"
 
 #: plug-ins/adjustable-fade.ny
+msgid "S-Curve In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 #, lisp-format
 msgid "Error~%~%"
 msgstr "সমস্যা"
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
 
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "পুনরাবৃত্তি"
 
+#: plug-ins/beat.ny
+msgid "Finding beats..."
+msgstr ""
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "&অডিওসিটি পরিচিতি..."
+
+#: plug-ins/beat.ny
+msgid "Threshold Percentage"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Clip Fix"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Reconstructing clips..."
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Threshold of Clipping (%)"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+msgid "Crossfade Clips"
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+msgid "Crossfading..."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Crossfade Tracks"
+msgstr "নির্বাচন"
+
 #: plug-ins/crossfadetracks.ny
 msgid "Fade type"
+msgstr "গতি বৃদ্ধি"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Gain"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 1"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 2"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Custom Curve"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Custom curve"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Fade direction"
+msgstr "কাজ"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay"
 msgstr "গতি বৃদ্ধি"
 
 # I guess in should be গেইন - mak
@@ -2894,12 +18721,49 @@ msgid "Regular"
 msgstr "আয়তকার"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "গতি বৃদ্ধি"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "নির্বাচনের শেষে"
 
 #: plug-ins/delay.ny
+msgid "Pitch change effect"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Pitch/Tempo"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Pitch change per echo (semitones)"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "চ্যানেল"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -2914,8 +18778,45 @@ msgid "XML file"
 msgstr "সকল ফাইল (*)|*"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "রেকর্ড"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, lisp-format
+msgid "Error.~%Unable to open file~%~s"
+msgstr ""
+
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, lisp-format
+msgid "Error.~%File cannot be written:~%\"~a.txt\""
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
+
+#. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
+#: plug-ins/equalabel.ny
+msgid "Create labels based on"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Number & Interval"
@@ -2941,15 +18842,141 @@ msgstr "লেবেল"
 msgid "Length of label region (seconds)"
 msgstr "লেবেল"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "লেবেল"
 
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Message on completion"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Warnings only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
 msgstr "চ্যানেল"
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "point labels"
+msgstr "চ্যানেল"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
+#: plug-ins/highpass.ny
+msgid "High-Pass Filter"
+msgstr ""
+
+#: plug-ins/highpass.ny
+msgid "Performing High-Pass Filter..."
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+msgid "Frequency (Hz)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+msgid "Frequency must be at least 0.1 Hz."
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -2957,8 +18984,31 @@ msgid "Label Sounds"
 msgstr "লেবেল"
 
 #: plug-ins/label-sounds.ny
+msgid "Threshold level (dB)"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Threshold measurement"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
 msgid "Peak level"
 msgstr "প্লেব্যাক"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "প্লেব্যাক"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "প্লেব্যাক"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Minimum silence duration"
+msgstr "লেবেল"
 
 #: plug-ins/label-sounds.ny
 msgid "Minimum label interval"
@@ -2968,25 +19018,210 @@ msgstr "লেবেল"
 msgid "Label type"
 msgstr "লেবেল"
 
+#: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Point after sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum leading silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum trailing silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
+#. i18n-hint: '~a' will be replaced by a time duration
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Error.~%Selection must be less than ~a."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiting..."
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Type"
+msgstr "গতি বৃদ্ধি"
+
+#: plug-ins/limiter.ny
+msgid "Soft Limit"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Hard Limit"
+msgstr ""
+
+#. i18n-hint: clipping of wave peaks and troughs, not division of a track into clips
+#: plug-ins/limiter.ny
+msgid "Soft Clip"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Hard Clip"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "চ্যানেল"
+
 #: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "গতি বৃদ্ধি"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
+
+#: plug-ins/lowpass.ny
+msgid "Low-Pass Filter"
+msgstr ""
+
+#: plug-ins/lowpass.ny
+msgid "Performing Low-Pass Filter..."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Noise Gate"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "নির্বাচন"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Stereo Linking"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
 msgstr "নির্বাচন"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
+msgstr "নির্বাচন"
+
+#: plug-ins/noisegate.ny
+msgid "Gate threshold (dB)"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Gate frequencies above (kHz)"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Level reduction (dB)"
 msgstr "গতি বৃদ্ধি"
 
 #: plug-ins/noisegate.ny
+msgid "Attack (ms)"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Decay (ms)"
 msgstr "নির্বাচনের শেষে"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
 
 # I guess in should be গেইন - mak
 #: plug-ins/notch.ny
@@ -2997,6 +19232,26 @@ msgstr "লাভ"
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "লাভ"
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Nyquist Plug-in Installer"
+msgstr ""
 
 #. i18n-hint: "Browse..." is text on a button that launches a file browser.
 #: plug-ins/nyquist-plug-in-installer.ny
@@ -3015,7 +19270,8 @@ msgstr "সকল ফাইল (*)|*"
 msgid "HTML file"
 msgstr "সকল ফাইল (*)|*"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
@@ -3024,24 +19280,144 @@ msgid "All supported"
 msgstr "সকল ফাইল (*)|*"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Allow overwriting"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Disallow"
 msgstr "(নিষ্ক্রিয়)"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "(নিষ্ক্রিয়)"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Warning.~%Failed to copy some files:~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Plug-ins updated:"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Files copied to plug-ins folder:"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
 
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Unsupported file type:"
+msgstr "সকল ফাইল (*)|*"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Generating pluck sound..."
+msgstr "নমুনা পরিবর্তন"
+
+#: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "গতি বৃদ্ধি"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Duration (60s max)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm Track"
 msgstr "রেকর্ড"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Generating Rhythm..."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "চ্যানেল"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -3052,16 +19428,98 @@ msgid "Used if 'Number of bars' = 0"
 msgstr "চ্যানেল"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Start time offset"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Silence before first beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Beat sound"
 msgstr "পুনরাবৃত্তি"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "রেজোনেন্স:"
 
+#: plug-ins/rhythmtrack.ny
+msgid "Noise Click"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Risset Drum"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Generating Risset Drum..."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "নির্বাচনের শেষে"
+
+#: plug-ins/rissetdrum.ny
+msgid "Center frequency of noise (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Amount of noise in mix (percent)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Amplitude (0 - 1)"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
@@ -3070,6 +19528,10 @@ msgstr "নমুনা পরিবর্তন"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "&এনালাইজ"
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -3088,12 +19550,45 @@ msgid "HTML files"
 msgstr "সকল ফাইল (*)|*"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "নমুনা পরিবর্তন"
 
 #: plug-ins/sample-data-export.ny
 msgid "Time Indexed"
 msgstr "লেবেল"
+
+#: plug-ins/sample-data-export.ny
+msgid "Include header information"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "All"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -3108,6 +19603,11 @@ msgstr "সক্রিয়"
 msgid "Errors Only"
 msgstr "সমস্যা:"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -3120,6 +19620,46 @@ msgstr "চ্যানেল"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "নমুনা পরিবর্তন"
 
@@ -3127,6 +19667,43 @@ msgstr "নমুনা পরিবর্তন"
 #, lisp-format
 msgid "~a seconds."
 msgstr "নমুনা পরিবর্তন"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -3145,6 +19722,10 @@ msgid "Value (dB)"
 msgstr "গতি বৃদ্ধি"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "লিনিয়ার"
 
@@ -3161,24 +19742,124 @@ msgid "Right (dB)"
 msgstr "ডান,"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "লিনিয়ার"
+
+#: plug-ins/sample-data-export.ny
+msgid "2 channels (stereo)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "1 channel (mono)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
 msgstr "নমুনা পরিবর্তন"
 
 #: plug-ins/sample-data-import.ny
+msgid "Reading and rendering samples..."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Select file"
 msgstr "একটি মিডি ফাইল নির্বাচন করুন"
+
+#: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "সমস্যা"
 
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid "Error.~%Unable to open file"
+msgstr ""
+
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "নির্বাচনের শেষে"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 # I guess in should be গেইন - mak
 #: plug-ins/tremolo.ny
@@ -3189,10 +19870,44 @@ msgstr "লাভ"
 msgid "Waveform type"
 msgstr "গতি বৃদ্ধি"
 
+#: plug-ins/tremolo.ny
+msgid "Inverse Sawtooth"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Starting phase (degrees)"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 # I guess in should be গেইন - mak
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "লাভ"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Remove Vocals: to mono"
+msgstr "মাঝে"
+
+#: plug-ins/vocalrediso.ny
+msgid "Remove Vocals"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Isolate Vocals"
+msgstr "মাঝে"
 
 #: plug-ins/vocalrediso.ny
 msgid "Isolate Vocals and Invert"
@@ -3222,6 +19937,101 @@ msgstr "&এনালাইজ"
 msgid "Strength"
 msgstr "নির্বাচনের শেষে"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Processing Vocoder..."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Output choice"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Both Channels"
 msgstr "%d চ্যানেল"
@@ -3233,6 +20043,102 @@ msgstr "চ্যানেল"
 #: plug-ins/vocoder.ny
 msgid "Number of vocoder bands"
 msgstr "চ্যানেল"
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of original audio (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of white noise (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of Radar Needles (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Frequency of Radar Needles (Hz)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "&অডিওসিটি পরিচিতি..."
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "চ্যানেল"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "&অডিওসিটি পরিচিতি..."
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "রেকর্ডিং হচ্ছে"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "রেকর্ডিং হচ্ছে\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "প্লেব্যাক\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "রেকর্ডিং হচ্ছে\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "রেকর্ডিং হচ্ছে\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "প্লেব্যাক\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "প্লেব্যাক\n"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "প্লেব্যাক"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "প্লেব্যাক"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "প্লেব্যাক"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "রেকর্ডিং হচ্ছে"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "রেকর্ডিং হচ্ছে"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "রেকর্ডিং হচ্ছে"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&অডিওসিটি পরিচিতি..."
+
+#~ msgid "Recording Volume"
+#~ msgstr "রেকর্ডিং হচ্ছে"
+
+#~ msgid "Playback Volume"
+#~ msgstr "প্লেব্যাক"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "রেকর্ডিং হচ্ছে"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "প্লেব্যাক"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "প্লেব্যাক"
 
 #, fuzzy
 #~ msgid "Problem Report for Audacity"
@@ -3247,10 +20153,6 @@ msgstr "চ্যানেল"
 #~ msgstr "সমস্যা"
 
 #, fuzzy
-#~ msgid "Error Decoding File"
-#~ msgstr "রেকর্ডিং হচ্ছে"
-
-#, fuzzy
 #~ msgid "No Action"
 #~ msgstr "কাজ"
 
@@ -3263,18 +20165,6 @@ msgstr "চ্যানেল"
 #~ msgstr "&অডিওসিটি পরিচিতি..."
 
 #, fuzzy
-#~ msgid "Export as MP3"
-#~ msgstr "&অডিওসিটি পরিচিতি..."
-
-#, fuzzy
-#~ msgid "Export as Ogg"
-#~ msgstr "&অডিওসিটি পরিচিতি..."
-
-#, fuzzy
-#~ msgid "Export as WAV"
-#~ msgstr "&অডিওসিটি পরিচিতি..."
-
-#, fuzzy
 #~ msgid "Select to Ends"
 #~ msgstr "নির্বাচনের শেষে"
 
@@ -3284,16 +20174,8 @@ msgstr "চ্যানেল"
 #~ "/%s/%s.%s"
 #~ msgstr "রেকর্ডিং হচ্ছে"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "রেকর্ডিং হচ্ছে"
-
 #~ msgid "%s-old%d"
 #~ msgstr "%s-পুরাতন%d"
-
-#, fuzzy
-#~ msgid "Compress"
-#~ msgstr "সংকোচক..."
 
 #, fuzzy
 #~ msgid ""
@@ -3309,10 +20191,6 @@ msgstr "চ্যানেল"
 #, fuzzy
 #~ msgid "Sound Finder"
 #~ msgstr "পুনরাবৃত্তি"
-
-#, fuzzy
-#~ msgid "Gating audio..."
-#~ msgstr "নমুনা পরিবর্তন"
 
 # I guess in should be গেইন - mak
 #, fuzzy
@@ -3334,10 +20212,6 @@ msgstr "চ্যানেল"
 #, fuzzy
 #~ msgid "Zoom to Fit\tShift-Right-Click"
 #~ msgstr "Alt-বাম-ক্লিক"
-
-#, fuzzy
-#~ msgid "Click to unpin"
-#~ msgstr "নির্বাচনের শুরুতে"
 
 #, fuzzy
 #~ msgid "Click to pin"
@@ -3364,32 +20238,8 @@ msgstr "চ্যানেল"
 #~ msgstr "বাম"
 
 #, fuzzy
-#~ msgid "Right"
-#~ msgstr "ডান"
-
-#, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "নির্বাচনের শুরুতে"
-
-#, fuzzy
-#~ msgid "Transcri&ption"
-#~ msgstr "নির্বাচনের শুরুতে"
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "রেকর্ডিং হচ্ছে"
-
-#, fuzzy
 #~ msgid "Slider Playback"
 #~ msgstr "প্লেব্যাক"
-
-#, fuzzy
-#~ msgid "Change track name to:"
-#~ msgstr "আনেকগুলি নমুনা পরিবর্তন"
-
-#, fuzzy
-#~ msgid "and"
-#~ msgstr "প্যান"
 
 #, fuzzy
 #~ msgid ""
@@ -3413,20 +20263,12 @@ msgstr "চ্যানেল"
 #~ msgstr "উপরে"
 
 #, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "নাম..."
-
-#, fuzzy
 #~ msgid "Phase"
 #~ msgstr "ফেজার"
 
 #, fuzzy
 #~ msgid "Depth"
 #~ msgstr "গভীরতা"
-
-#, fuzzy
-#~ msgid "Reverberance"
-#~ msgstr "উল্টা"
 
 #, fuzzy
 #~ msgid "HfDamping"
@@ -3443,14 +20285,6 @@ msgstr "চ্যানেল"
 #~ msgstr "লাভ"
 
 #, fuzzy
-#~ msgid "Version"
-#~ msgstr "উল্টা করা হচ্ছে"
-
-#, fuzzy
-#~ msgid "Co&mbined Meter Toolbar"
-#~ msgstr "রেকর্ডিং হচ্ছে"
-
-#, fuzzy
 #~ msgid "Appen&d Record"
 #~ msgstr "রেকর্ড"
 
@@ -3459,24 +20293,12 @@ msgstr "চ্যানেল"
 #~ msgstr "মোনো"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "গতি বৃদ্ধি"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "Alt-বাম-ক্লিক"
-
-#, fuzzy
 #~ msgid "Recording Meter Preferences"
 #~ msgstr "রেকর্ডিং হচ্ছে"
 
 #, fuzzy
 #~ msgid "Playback Meter Preferences"
 #~ msgstr "প্লেব্যাক"
-
-#, fuzzy
-#~ msgid "NewName"
-#~ msgstr "নাম..."
 
 #, fuzzy
 #~ msgid "Spectral Selection lo&g(f)"
@@ -3495,20 +20317,12 @@ msgstr "চ্যানেল"
 #~ msgid "Phaser..."
 #~ msgstr "ফেজার..."
 
-#, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "উল্টা"
-
 #~ msgid "Author: "
 #~ msgstr "লেখক:"
 
 #, fuzzy
 #~ msgid "Change output device"
 #~ msgstr "গতি পরিবর্তন"
-
-#, fuzzy
-#~ msgid "Input Channels"
-#~ msgstr "%d চ্যানেল"
 
 #, fuzzy
 #~ msgid "Select Input Channels"

--- a/locale/bs.po
+++ b/locale/bs.po
@@ -8,87 +8,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Bosnian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/bs/>\n"
+"Language-Team: Bosnian <https://hosted.weblate.org/projects/tenacity/tenacity/bs/>\n"
 "Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
-"%100==4 ? 3 : 0);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-Country: BOSNIA HERZEGOVINA\n"
 "X-Poedit-Language: Bosnian\n"
 "X-Poedit-SourceCharset: iso-8859-1\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Ažuriraj Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Preskoči"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Instaliraj ažuriranje"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Dnevnik promjena"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Pročitajte više na GitHub-u"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Greška pri provjeri ažuriranja"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Povezivanje sa Audacity serverom za ažuriranja nije uspjelo."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Podaci o ažuriranju su koruptirani."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Greška pri preuzimanju ažuriranja."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Ne mogu otvoriti vezu za preuzimanje Audacity-ja."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s je sad dostupan!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Snimanje"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -98,6 +30,24 @@ msgstr "Nemoguće odrediti"
 #, c-format
 msgid "%s bytes"
 msgstr "%s bajta"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -114,6 +64,11 @@ msgstr "1. Eksperimentalna komanda..."
 #: modules/mod-null/ModNullCallback.cpp
 msgid "2nd Experimental Command"
 msgstr "2. Eksperimentalna komanda"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Dodavanje efekta Nyquist ..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Undo\tCtrl+Z"
@@ -220,7 +175,8 @@ msgid "Script"
 msgstr "Skripta"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Izlaz"
 
@@ -236,7 +192,12 @@ msgstr "Nyquist skripte (*.ny)|*.ny|Lisp skripte (*.lsp)|*.lsp|Svi fajlovi|*"
 msgid "Script was not saved."
 msgstr "Skripta nije sačuvana."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Upozorenje"
 
@@ -249,24 +210,56 @@ msgid "Find dialog"
 msgstr "Dijalog za pretraživanje"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango galerija ikona (ikone alatne trake)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "avtora Lelanda Luciusa"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "avtora Lelanda Luciusa"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Dodavanje efekta Nyquist ..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "No matches found"
+msgstr "Spojeni stereo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Dodavanje efekta Nyquist ..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Nova"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Otvori nedavne"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -300,7 +293,8 @@ msgstr "Kopiraj"
 msgid "Copy to clipboard"
 msgstr "Izreži u odlagalište"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Izreži"
 
@@ -308,7 +302,8 @@ msgstr "Izreži"
 msgid "Cut to clipboard"
 msgstr "Izreži u odlagalište"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Umetni"
 
@@ -333,7 +328,8 @@ msgstr "Izaberi"
 msgid "Select all text"
 msgstr "Izaberi"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Poništi"
 
@@ -341,20 +337,73 @@ msgstr "Poništi"
 msgid "Undo last change"
 msgstr "Promjena formata:"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&Ponovi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Promjena formata:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Match"
 msgstr "Paketni način"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to matching paren"
+msgstr "&Podudarajući Paren F8"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Nema oznaka za izvoz."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to higher S-expr"
+msgstr "&Higher S-expr F10"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Predhodni alat"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "&Prošli S-expr F11"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Naredni alat"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to next S-expr"
+msgstr "&Sljedeći S-expr F12"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Početak"
 
@@ -362,7 +411,8 @@ msgstr "Početak"
 msgid "Start script"
 msgstr "Nyquist komanda..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Zaustavi"
 
@@ -370,31 +420,136 @@ msgstr "Zaustavi"
 msgid "Stop script"
 msgstr "Nyquist komanda..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "&O programu"
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "U redu"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Omogućeno"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Onemogućeno"
 
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Komanda:"
+msgid "The Build"
+msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Version:"
+msgstr "Obrtanje"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr "Vrsta šuma"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "Direktorijum s postavkama:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "Direktorijum s postavkama:"
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Sample rate conversion"
 msgstr "Pretvarač frekvence uzimanja uzoraka"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "Greška pri uvozu"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Ogg Vorbis Import and Export"
+msgstr "Postavke izvoza Ogg Vorbis"
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FLAC import and export"
+msgstr "Postavke izvoza FLAC"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "Postavke izvoza MP2"
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export"
+msgstr "Greška LOF"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "Priključci %i do %i"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -421,6 +576,18 @@ msgstr "Ovojnica"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Ovojnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Ovojnica"
 
@@ -432,9 +599,51 @@ msgstr "Ovojnica"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Ovojnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Ovojnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Ovojnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "Grafički izjednačivač"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Ovojnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Ovojnica"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -455,8 +664,26 @@ msgid "%s, graphics"
 msgstr "Grafički izjednačivač"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Zasluge"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -474,6 +701,11 @@ msgstr "Drugi doprinosi"
 msgid "Tenacity Special thanks:"
 msgstr "Posebna zahvala:"
 
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "Direktoriji"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
@@ -487,14 +719,23 @@ msgid "%s Team Members"
 msgstr "Drugi zaslužni članovi ekipe"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Drugi doprinosi"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -517,6 +758,26 @@ msgstr "Posebna zahvala:"
 msgid "%s website: "
 msgstr "Prvo pokretanje programa Audacity"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Drugi doprinosi"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Kliknite i povucite, da poboljšate relativnu veličinu stereo traka."
@@ -527,9 +788,15 @@ msgstr "Kliknite i povucite, da poboljšate relativnu veličinu stereo traka."
 msgid "Record/Play head"
 msgstr "Kraj snimanja"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Postavke priključka"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kliknite i povucite, da bi promijenili uzorke"
@@ -537,17 +804,66 @@ msgstr "Kliknite i povucite, da bi promijenili uzorke"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Kliknite i povucite, da bi promijenili veličinu trake."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Pomjeri fokus na narednu traku"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Pomakni traku dolje"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Zatvori fokusiranu traku"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr " (onemogućeno)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr " (onemogućeno)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "Postavke priključka"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -558,10 +874,30 @@ msgid "Update display while playing"
 msgstr "&Ažuriraj ekran tokom izvođenja"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "Kraj snimanja"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Greška"
 
@@ -571,8 +907,36 @@ msgid "Failed to remove %s"
 msgstr "'%s' nije moguće odstraniti"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Postavke Audacity"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -591,6 +955,11 @@ msgstr "&Otvori ..."
 
 #: src/AudacityApp.cpp
 #, fuzzy
+msgid "Open &Recent..."
+msgstr "Otvori nedavne"
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
+#, fuzzy
 msgid "&About Tenacity..."
 msgstr "&O programu Audacity ..."
 
@@ -603,29 +972,33 @@ msgid "&File"
 msgstr "&Datoteka"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nije našao prostora za privremene datoteke.\n"
 "Molim, da unesete ispravan put do direktorija u dijalogu postavki."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nije našao prostora za privremene datoteke.\n"
 "Molim, da unesete ispravan put do direktorija u dijalogu postavki."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity se zatvara. Molimo, ponovo pokrenite Audacity, da biste mogli koristiti novi privremeni direktorij."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -634,36 +1007,91 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity ne može zaključti direktorije privremenih datoteka.\n"
 "Taj direktorij možda koristi drugi Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Želite li i dalje pokrenuti Audacity?"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Greška pri provjeri ažuriranja"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Sistem je detektovao, da se druga kopija Audacity već izvršava.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Upotrijebite naredbu Novi ilii Otvori u trenutno pokrenutom procesu Audacity,\n"
 "da otvorite više projekat istovremeno.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity je već pokrenut."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Projektne datoteke Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -683,7 +1111,8 @@ msgstr "\t-test (pokreni samodijagnostiku)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (prikaži verziju Audacity)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -693,9 +1122,10 @@ msgid "audio or project file name"
 msgstr "Nije moguće otvoriti datoteke projekta"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -708,29 +1138,73 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Projektne datoteke Audacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&Ponovno uzimanje uzorka ..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Snimanje zvuka"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Pomoć"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Zatvori Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Alatna traka Audacity - %s"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "&Spremi ..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Zatvori"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "Spremljeno "
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -759,7 +1233,26 @@ msgid "Error Initializing Audio"
 msgstr "Greška pri inicializaciji zvuka"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"Ne biste mogli reprodukovati ili snimati zvuk.\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "Greška pri inicializaciji zvuka"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Alatna traka Audacity - %s"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -769,10 +1262,27 @@ msgid ""
 "Error code: %s"
 msgstr "Greška pri otvaranju zvučnog uređaja."
 
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
+
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -810,8 +1320,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Kraj snimanja\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Kraj snimanja\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -825,37 +1345,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Kraj snimanja\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Brzina izvođenja\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Datoteku žanrova nije moguće otvoriti.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Brzina izvođenja\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Snimanje\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Frekvencije uzimanja uzoraka\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Reprodukcija\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Kraj snimanja\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Kraj snimanja\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Reprodukcija\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Reprodukcija\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -863,8 +1386,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Kraj snimanja\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Brzina izvođenja\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Brzina izvođenja\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -872,8 +1405,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatska obnova nakon kraha"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -885,12 +1419,14 @@ msgid "Recoverable &projects"
 msgstr "Obnovljivi projekti"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Izaberi"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Ime"
 
@@ -903,8 +1439,20 @@ msgid "&Recover Selected"
 msgstr "Izaberi"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Skip"
+msgstr "&Preskoči"
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "Nijedan lanac nije izabran"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -927,8 +1475,16 @@ msgid "&Parameters"
 msgstr "&Parametri"
 
 #: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "&Izaberi naredbu"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -957,6 +1513,22 @@ msgstr "Efe&kt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Uredi parametre"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Uredi parametre"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1003,11 +1575,30 @@ msgstr "Testni režim"
 msgid "Apply %s"
 msgstr "Primjeni %s"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Predefinisano"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Oznake ..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Lančano primjeni"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1063,13 +1654,43 @@ msgstr "Pre&kini"
 msgid "Remo&ve"
 msgstr "&Odstrani"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "&Ponovno uzimanje uzorka ..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "&Uvezi ..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "&Izvezi ..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Uredi žanrove"
 
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "&Naredba"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#, fuzzy
+msgid "Parameters"
+msgstr "&Parametri"
 
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp
 msgid "&Insert"
@@ -1091,9 +1712,15 @@ msgstr "Pomakni &gore"
 msgid "Move &Down"
 msgstr "Pomakni &dolje"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Spremi ..."
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1139,11 +1766,38 @@ msgid "Benchmark"
 msgstr "&Pokreni test brzine ..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Broj ponavljanja"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Zatvori"
 
@@ -1158,8 +1812,30 @@ msgid "Export Benchmark Data as:"
 msgstr "Izvozi spektralne podatke kao:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Priprema predslušanja\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1168,17 +1844,109 @@ msgstr "Izvođenje ponavljanja\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Umetni\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Snimanje zvuka\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Datum i vrijeme završetka"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
 
 #: src/BuildInfo.h
 #, fuzzy
@@ -1194,9 +1962,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Molimo, da prvo izaberete neki zvučni snimak."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Nijedan lanac nije izabran"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1222,6 +2014,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Izbor"
 
@@ -1235,9 +2032,28 @@ msgid "Checkpointing project"
 msgstr "Primjeni na trenutnem &projektu"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "Primjeni na trenutnem &projektu"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Ne može se upisati u datoteku: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity ne može pisati u datoteku:\n"
+"  %s."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1255,6 +2071,10 @@ msgid ""
 "%s"
 msgstr "'%s' nije moguće odstraniti"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "Odstranjivanje zavisnosti"
@@ -1262,6 +2082,25 @@ msgstr "Odstranjivanje zavisnosti"
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "Kopiranje zvučnih podatak u projekt ..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "Pri spremanju projekta, koji je ovisan od drugih zvučnih datoteka"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1276,8 +2115,27 @@ msgid "Disk Space"
 msgstr "Prostor na disku"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "Izbor"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "Obustavi snimanje"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Oznaka"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Do Not Copy"
+msgstr "Ne obnavljaj"
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1289,9 +2147,32 @@ msgstr "Kad god, je projekat ovisan od drugih datoteka:"
 msgid "Ask me"
 msgstr "Pitaj me"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "Izaberite datoteku MIDI ..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Izreži u odlagalište"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1302,10 +2183,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ako nastavite, vaš projekt neće biti sačuvan na disk. Da li  to zaista želite?"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "Provjera ovisnosti"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Prazno"
 
@@ -1313,7 +2206,7 @@ msgstr "Prazno"
 msgid "Rectangle"
 msgstr "Četvorougao"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trougao"
 
@@ -1327,31 +2220,165 @@ msgstr "Pravougaono"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Dobrodošli!"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Lokacija za %s:"
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "To find '%s', click here -->"
+msgstr "Ako želite potražiti %s, kliknite ovdje -->"
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Pregledaj ..."
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
-msgstr ""
-"Audacity ne može pisati u datoteku:\n"
-"  %s."
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr "Ako želite bezplatnu kopiju programa Lame, kliknite ovdje -->"
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
 msgstr ""
-"Audacity ne može pisati u datoteku:\n"
-"  %s."
 
-#: src/FileException.cpp
-#, c-format
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "Gdje je %s?"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "Nemoj više prikazivati ovo upozorenje"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity ne može pisati u datoteku:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+"Audacity ne može pisati u datoteku:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1369,10 +2396,29 @@ msgid "Error (file may not have been written): %s"
 msgstr "Greška (datoteka možda nije bila zapisana): %s"
 
 #: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr "Kopiranje zvučnih podatak u projekt ..."
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
 msgstr "Kopiranje zvučnih podatak u projekt ..."
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Sve datoteke (*)|*"
 
@@ -1383,6 +2429,14 @@ msgid "AUP3 project files"
 msgstr "Spremanje projektnih datoteka"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "Imenujte datoteke:"
 
@@ -1390,12 +2444,24 @@ msgstr "Imenujte datoteke:"
 msgid "XML files"
 msgstr "Datoteke MP3"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "Datoteke MP3"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -1422,6 +2488,14 @@ msgstr "Cuberoot autokorelacija"
 msgid "Enhanced Autocorrelation"
 msgstr "Proširena autokorelacija"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spektar"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1438,9 +2512,34 @@ msgstr "Linearna frekvencija"
 msgid "Log frequency"
 msgstr "Logaritamska frekvencija"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Povećanje"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1455,6 +2554,14 @@ msgstr "Vodoravni stereo"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Kazaljka lijevo"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Algorithm:"
@@ -1473,6 +2580,10 @@ msgid "&Function:"
 msgstr "Akcija"
 
 #: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Replot..."
 msgstr "Ponovi ..."
 
@@ -1489,11 +2600,48 @@ msgstr "Izbrano je previše zvuka. Samo prvih %.1f sekundi zvuka će biti analiz
 msgid "Not enough data selected."
 msgstr "Nedovoljno izabranih podataka."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Spektar"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Izvozi spektralne podatke kao:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Ne može se upisati u datoteku: "
@@ -1546,12 +2694,87 @@ msgstr "Zasjenčeni i meniji za uređivanje"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Izvezi datoteku"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Otvaranje projekta Audacity"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
 msgid "Burn to CD"
 msgstr "Zapeci na CD"
 
 #: src/HelpText.cpp
 msgid "No Local Help"
 msgstr "Nema lokalne pomoći"
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1570,6 +2793,10 @@ msgid "Used Space"
 msgstr "Prostor na disku"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Broj nivoa za opoziv"
 
@@ -1583,6 +2810,10 @@ msgid "&Discard"
 msgstr "&Odustani"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Odustani"
 
@@ -1590,15 +2821,39 @@ msgstr "&Odustani"
 msgid "&Compact"
 msgstr "&Naredba"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Istorija ..."
 
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
 #: src/InconsistencyException.h
 msgid "Internal Error"
 msgstr "(eksterni program)"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "Uređene oznake"
 
 #. i18n-hint: (noun).  A track contains waves, audio etc.
 #: src/LabelDialog.cpp
@@ -1606,7 +2861,9 @@ msgid "Track"
 msgstr "Traka"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Oznaka"
 
@@ -1663,19 +2920,47 @@ msgstr "Nova traka s oznakama"
 msgid "Enter track name"
 msgstr "Unesite ime trake"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "&Traka s oznakama"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Prvo pokretanje programa Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Izaberite jezik programa Audacity:"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Potvrdi"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "Greška pri spremanju datoteke: "
 
 #: src/Legacy.cpp
 #, c-format
@@ -1687,8 +2972,19 @@ msgstr ""
 "Stara datoteka je sačuvana pod imenom '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Otvaranje projekta Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Posebna zahvala:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Pregledaj ..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1708,6 +3004,17 @@ msgstr "P&onovi %s"
 msgid "&Redo"
 msgstr "&Ponovi"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "Onemogućeno"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
@@ -1721,29 +3028,77 @@ msgstr "&Miješanje i obrada"
 msgid "Mixing and rendering tracks"
 msgstr "Miješanje i obrada traka"
 
+#: src/MixerBoard.cpp
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr "Vremensko snimanje Audacity"
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Pojačanje"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Pomjeranje"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Utišaj"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
+
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Pomjeren potenciometar pojačanja"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Pomjeren potenciometar pojačanja"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Pomjeren potenciometar poravnanja"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "Alatna traka miksera"
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1753,13 +3108,73 @@ msgid ""
 "Error: %s"
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Omogućeno"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Prazno"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Alatna traka Audacity - %s"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1769,18 +3184,126 @@ msgstr "Notiraj traku"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Prepiši postojeće datoteke"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -1804,9 +3327,29 @@ msgstr[3] "Nažalost, priključak Vamp nije bilo moguće učitati.\n"
 msgid "Enable new plug-ins"
 msgstr "Nažalost, priključak Vamp nije bilo moguće učitati."
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Dodavanje efekta Nyquist ..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Nažalost, priključak Vamp nije bilo moguće učitati."
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "Omogućeno"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -1833,6 +3376,25 @@ msgstr "Omogućeno"
 msgid "E&nabled"
 msgstr "Omogućeno"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Omogućeno"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Izaberi"
@@ -1841,7 +3403,8 @@ msgstr "Izaberi"
 msgid "C&lear All"
 msgstr "O&čisti"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Omogućeno"
 
@@ -1880,6 +3443,14 @@ msgstr "Pri štampanju je došlo do problema."
 msgid "Print"
 msgstr "Štampaj"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgid "Actual Rate: %d"
@@ -1895,6 +3466,21 @@ msgstr "Greška pri otvaranju zvučnog uređaja. Molimo provjerite postavke izla
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Za crtanje spektra sve izabrane trake moraju imati jednak stepen uzorkovanja."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Snimljeni zvuk"
@@ -1903,9 +3489,99 @@ msgstr "Snimljeni zvuk"
 msgid "Record"
 msgstr "Snimi"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "Odmah zatvori projekt bez izmjena"
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Nije moguće otvoriti datoteke projekta"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Treat missing audio as silence (this session only)"
+msgstr "Popuni tišinom nedostajuće podatke za prikaz [samo za tu sesiju]"
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Fill in silence for missing display data (this session only)"
@@ -1915,11 +3591,88 @@ msgstr "Popuni tišinom nedostajuće podatke za prikaz [samo za tu sesiju]"
 msgid "Close project immediately with no further changes"
 msgstr "Odmah zatvori projekt bez daljnjih promjena"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Napredak"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "Čišćenje direktorija međumemorije"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning: Problems in Automatic Recovery"
+msgstr "Greška pri spremanju datoteke: "
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Prilagodi projekt"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1958,11 +3711,96 @@ msgid ""
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "'%s' nije moguće odstraniti"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Nije moguće inicijalizirati MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nije moguće inicijalizirati MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nije moguće inicijalizirati MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nije moguće inicijalizirati MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nije moguće inicijalizirati MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nije moguće inicijalizirati MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nije moguće inicijalizirati MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Nije moguće inicijalizirati MP3 tok"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1971,12 +3809,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Nije moguće inicijalizirati MP3 tok"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "'%s' nije moguće preimenovati u '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "'%s' nije moguće odstraniti"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1987,9 +3851,9 @@ msgid "Error Writing to File"
 msgstr "Greška pri spremanju datoteke: "
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2000,8 +3864,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Kreiran nov projekt"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Alatna traka Audacity - %s"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2009,9 +3882,21 @@ msgstr "Alatna traka Audacity - %s"
 msgid "(Recovered)"
 msgstr "(obnovljeno)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Nije moguće otvoriti datoteke projekta"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2026,14 +3911,62 @@ msgid "Unable to parse project information."
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Sačuvaj projekt"
 
-#: src/ProjectFileManager.cpp
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Izvođenje efekta: %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "&Sačuvaj projekt"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
+msgstr ""
+"Zadnji put, kada je upotrebljavan Audacity, neki projekti nisu bili pravilno sačuvani.\n"
+"Srećom. sljedeći projekti će biti obnovljeni automatski:"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
 msgstr ""
 "Zadnji put, kada je upotrebljavan Audacity, neki projekti nisu bili pravilno sačuvani.\n"
 "Srećom. sljedeći projekti će biti obnovljeni automatski:"
@@ -2042,9 +3975,42 @@ msgstr ""
 msgid "Project Recovered"
 msgstr "Projekt je bio obnovljen"
 
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Direktorij privremenih datoteka"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "&Sačuvaj projekt"
+
 #: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "Prostor na disku"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -2052,9 +4018,34 @@ msgid "Saved %s"
 msgstr "Snimljeno %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Sačuvaj projekt &kao ..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2062,9 +4053,21 @@ msgid "Overwrite Project Warning"
 msgstr "Prepiši postojeće datoteke"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Sačuvaj projekt &kao ..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -2087,6 +4090,23 @@ msgstr "Izaberite jednu ili više zvučnih datoteka ..."
 msgid "%s is already open in another window."
 msgstr "Projekt %s je već otvoren u drugom prozoru."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Greška pri otvaranju datoteke."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Greška pri otvaranju datoteke."
@@ -2103,6 +4123,17 @@ msgid ""
 msgstr ""
 "Datoteka je možda neispravna ili oštećena: \n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Greška pri otvaranju datoteke."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -2130,12 +4161,33 @@ msgid "Error Importing"
 msgstr "Greška pri uvozu"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Sačuvaj projekt"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Nije moguće otvoriti datoteke projekta"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Naredba"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2146,8 +4198,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatska obnova nakon kraha"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Dobrodošli u Audacity verzije %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2161,9 +4213,23 @@ msgid "Save project before closing?"
 msgstr "Želite li spremiti promjene prije izlaza?"
 
 #: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "Disk space remaining for recording: %s"
 msgstr "Preostali prostor na disku dovoljan je za snimanje %d minuta."
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -2183,6 +4249,18 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -2198,6 +4276,26 @@ msgstr "Vodoravni stereo"
 msgid "Vertical Scrollbar"
 msgstr "Uspravni stereo"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "Kvalitet:"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Kvalitet"
@@ -2205,6 +4303,10 @@ msgstr "Kvalitet"
 #: src/Resample.cpp
 msgid "High Quality"
 msgstr "Kvalitet"
+
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
 
 #. i18n-hint: Audio data bit depth (precision): 16-bit integers
 #: src/SampleFormat.cpp
@@ -2221,9 +4323,87 @@ msgstr "24-bitni PCM"
 msgid "32-bit float"
 msgstr "32-bitni realni"
 
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "Unknown format"
+msgstr "Nepoznata greška"
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "Izaberite lokaciju, gdje će biti spremljene izvezene datoteke."
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "Želite li spremiti promjene?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Izaberi ..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "Veličina vrste slova"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "Veličina vrste slova"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "White Bkgnd"
+msgstr "bijelo"
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr " prozor"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "Vrsta prozora:"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "Primjeni na trenutnem &projektu"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "Alat"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -2237,7 +4417,13 @@ msgstr "Sve datoteke (*)|*"
 msgid "All Preferences"
 msgstr "Postavke ..."
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Izbor"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Izbor"
 
@@ -2245,47 +4431,153 @@ msgstr "Izbor"
 msgid "Timer"
 msgstr "Krajnje vrijeme"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Alati"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "Prepis"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mikser"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Mjerač"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Mjerač izvođenja"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Mjerač snimanja"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&Uredi"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Uređaj"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Izvodi-pri-brzini"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "Alatna traka za uređivanje"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
 msgstr "Podprozor s trakom"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Trake"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "&Trake"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "Nova traka"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "Izvedi jednu sekundu"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "&Trake"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "&Trake"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "Trake"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "Izaberite lokaciju, gdje će biti spremljene izvezene datoteke."
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (ova poruka)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
@@ -2303,8 +4595,32 @@ msgstr "&Opcije ..."
 msgid "Debu&g"
 msgstr "Nađi g&reške"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "Uključi Skoči-na"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Sound Activated Record"
+msgstr "Vremensko snimanje Audacity"
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "Pojačanje (dB):"
+
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "&Dobrodošli u Audacity!"
 
 #: src/SplashDialog.cpp
@@ -2344,6 +4660,19 @@ msgid "Comments"
 msgstr "Komentari"
 
 #: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "Nivo:"
+
+#: src/Tags.cpp
 msgid "&Add"
 msgstr "&Dodaj"
 
@@ -2356,12 +4685,27 @@ msgid "Genres"
 msgstr "Žanrovi"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&Uredi"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "Ponovo postavi"
+
+#: src/Tags.cpp
 msgid "Template"
 msgstr "Šablon"
 
 #: src/Tags.cpp
 msgid "&Load..."
 msgstr "&Učitaj ..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "Pod&razumijevano"
 
 #: src/Tags.cpp
 msgid "Don't show this when exporting audio"
@@ -2388,26 +4732,67 @@ msgid "Unable to open genre file."
 msgstr "Datoteku žanrova nije moguće otvoriti."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Load Metadata As:"
+msgstr "Spremi metapodatke kao:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Uredi metapodatke"
+
+#: src/Tags.cpp
 msgid "Save Metadata As:"
 msgstr "Spremi metapodatke kao:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Greška pri otvaranju datoteke."
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "Omogućeno"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Direktorij privremenih datoteka"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity ne može pisati u datoteku:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2416,18 +4801,26 @@ msgstr ""
 "za pisanje."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity nije mogao zapisati slike u datoteku:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -2437,9 +4830,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -2448,8 +4841,9 @@ msgstr ""
 "Možda je nepravilan zapis png?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "S Audacity nije bilo moguće pročitati podrazumijevanu temu.\n"
@@ -2487,18 +4881,41 @@ msgstr ""
 "su bile već prisutne."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Nije moguće spremiti datoteku:\n"
 "  %s"
 
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+#, fuzzy
+msgid "Classic"
+msgstr "Boja (klasična)"
+
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "Slabo"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Ime trake"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2507,12 +4924,24 @@ msgstr "Slabo"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Trajanje"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "&vremenska traka"
+
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Vremensko snimanje Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -2520,8 +4949,60 @@ msgid "Save Timer Recording As"
 msgstr "Snimanje"
 
 #: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "Izvođenje efekta: %s"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "Snimanje zvuka"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Automatska obnova nakon kraha"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Greška pri spremanju datoteke: "
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Automatska obnova nakon kraha"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "Greška pri spremanju datoteke: "
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "Snimanje"
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -2530,6 +5011,12 @@ msgstr "Primjeni na trenutnem &projektu"
 #: src/TimerRecordDialog.cpp
 msgid "Recording start:"
 msgstr "Početak snimanja"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "Trajanje"
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
@@ -2545,6 +5032,11 @@ msgstr "Automatska obnova nakon kraha"
 
 #: src/TimerRecordDialog.cpp
 msgid "Action after Timer Recording:"
+msgstr "Vremensko snimanje Audacity"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Vremensko snimanje Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -2564,12 +5056,44 @@ msgid ""
 msgstr "Kraj snimanja"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "Snimanje"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
 "\n"
 "Recording exported: %s"
 msgstr "Kraj snimanja"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Snimanje"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
@@ -2590,16 +5114,32 @@ msgstr "0100 dana 024 č 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Datum i vrijeme početka"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "Početno vrijeme"
 
 #: src/TimerRecordDialog.cpp
 msgid "End Date and Time"
 msgstr "Datum i vrijeme završetka"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date"
+msgstr "Datum i vrijeme završetka"
+
+#: src/TimerRecordDialog.cpp
 msgid "Automatic Save"
+msgstr "Automatska obnova nakon kraha"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
 msgstr "Automatska obnova nakon kraha"
 
 #: src/TimerRecordDialog.cpp
@@ -2622,7 +5162,8 @@ msgstr "Nije moguće izvoziti"
 msgid "Export Project As:"
 msgstr "Izvezi oznake kao:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcije ..."
 
@@ -2631,8 +5172,21 @@ msgid "After Recording completes:"
 msgstr "Mjerač snimanja"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Zatvori Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -2646,11 +5200,24 @@ msgstr "Snimanje zvuka"
 msgid "Scheduled to stop at:"
 msgstr "Izbor do početka"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr "Vremensko snimanje Audacity"
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Kraj snimanja"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -2661,8 +5228,19 @@ msgid "Recording Exported:"
 msgstr "Kraj snimanja"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Vremensko snimanje Audacity"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -2692,6 +5270,15 @@ msgstr "Solo"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Izaberi"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "Izaberi-Zvuk"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -2770,6 +5357,10 @@ msgstr "Pomakni traku gore"
 msgid "Move Track Down"
 msgstr "Pomakni traku dolje"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -2815,21 +5406,80 @@ msgstr "Nema dovoljno prostora, da bi priljepili izbor"
 msgid "There is not enough room available to expand the cut line"
 msgstr "Nema dovoljno prostora, da bi raširili liniju reza"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Primjena ..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Izaberite naredbu"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "&Naredba"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ponovi %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -2839,6 +5489,15 @@ msgstr "Kopiraj oznake"
 msgid "Threshold:"
 msgstr "Prag:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "Stvorena nova zvučna traka"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Kašnjenje (sekundi):"
@@ -2846,6 +5505,10 @@ msgstr "Kašnjenje (sekundi):"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Faktor opadanja: "
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -2867,9 +5530,38 @@ msgstr "Traka"
 msgid "Track 1"
 msgstr "Traka"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Vrsta prozora:"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -2895,13 +5587,56 @@ msgstr "Rezanje"
 msgid "Envelopes"
 msgstr "Ovojnica"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Oznake"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Mjerač"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Format:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "Pomakni traku dolje"
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "Mjerač"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
 
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
@@ -2910,6 +5645,18 @@ msgstr "Komentari"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Komanda:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -2928,6 +5675,11 @@ msgid "Number of Channels:"
 msgstr "Broj ponavljanja"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Izvoz više"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Izvoz više"
 
@@ -2935,9 +5687,26 @@ msgstr "Izvoz više"
 msgid "Builtin Commands"
 msgstr "Izaberite naredbu"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Ekipa Audacity %s za podršku"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Datum i vrijeme završetka"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -2979,17 +5748,45 @@ msgstr "&Sačuvaj projekt"
 msgid "Saves a copy of current project."
 msgstr "&Sačuvaj projekt"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Postavke ..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Ime"
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "Postavke ..."
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "Nivo:"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3008,8 +5805,18 @@ msgid "Window Plus"
 msgstr "Vrsta prozora:"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "Alat"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "Efe&kt"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Scriptables"
@@ -3051,6 +5858,10 @@ msgstr "Trake"
 msgid "All Tracks Plus"
 msgstr "Podprozor s trakom"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -3058,9 +5869,30 @@ msgid "White"
 msgstr "bijelo"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Greška pri spremanju datoteke: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Slika ekrana ..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -3103,6 +5935,14 @@ msgid "Select Frequencies"
 msgstr "Frekvencija (Hz)"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&Trake"
 
@@ -3114,6 +5954,12 @@ msgstr "Izaberi"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "&Dodaj"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&Odstrani"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -3132,6 +5978,11 @@ msgid "Selects a time range."
 msgstr "Izaberite datoteku MIDI ..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Izaberite datoteku MIDI ..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Stvorena nova zvučna traka"
 
@@ -3143,9 +5994,37 @@ msgstr "Trajanje tišine:"
 msgid "Set Clip"
 msgstr "Naredni alat"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Početak"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -3164,9 +6043,14 @@ msgid "Edited Envelope"
 msgstr "Ovojnica"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Ovojnica"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -3176,6 +6060,10 @@ msgstr "Oznake razdvajanja"
 msgid "Label Index"
 msgstr "Uredi oznaku"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Izaberi"
@@ -3183,6 +6071,10 @@ msgstr "Izaberi"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Uređene oznake"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -3196,9 +6088,26 @@ msgstr "Postavi frekvenciju"
 msgid "Resize:"
 msgstr "Veličina vrste slova"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Slabo"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Sačuvaj projekt"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -3213,6 +6122,10 @@ msgid "Set Track Status"
 msgstr "Ime trake"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "Pauza"
 
@@ -3225,10 +6138,17 @@ msgid "Gain:"
 msgstr "Pojačanje"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&Trake"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linearan"
 
@@ -3237,8 +6157,21 @@ msgid "Reset"
 msgstr "Ponovo postavi"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Krajnje vrijeme"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
 msgstr "Prikaz"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -3270,12 +6203,26 @@ msgstr "Še&ma"
 msgid "Set Track"
 msgstr "Nova traka"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Stvorena nova zvučna traka"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Pojačaj"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "Pojačanje (dB):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "Pojačanje (dB):"
 
 #: src/effects/Amplify.cpp
@@ -3289,6 +6236,10 @@ msgstr "Dozvoli rezanje"
 #: src/effects/AutoDuck.cpp
 msgid "Auto Duck"
 msgstr "Automatski spusti"
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
 
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
@@ -3304,12 +6255,18 @@ msgstr "Izbrali ste traku, koja ne sadrži zvuk. Automatsko spuštanje može pro
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Automatski spusti treba kontrolnu traku, koja se mora nalaziti ispod izabranih traka."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Količina spusta:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekundi"
 
@@ -3333,7 +6290,8 @@ msgstr "Dužina unutrašnjeg poslabljenja:"
 msgid "Inner &fade up length:"
 msgstr "Dužina unutrašnjeg jačanja:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Prag:"
 
@@ -3342,8 +6300,17 @@ msgid "Preview not available"
 msgstr "Predposlušanje nije raspoloživo"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Skupi izbor s lijeva"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Prag za šum: "
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3354,12 +6321,31 @@ msgid "Ba&ss (dB):"
 msgstr "Pojačanje (dB):"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "Pojačanje niskih tonova"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "Nivo:"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Uredi oznaku"
+
+#: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
 msgstr "Nivo:"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Nivo:"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -3370,13 +6356,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Promijeni visinu tona brez spremembe tempa"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Kvalitet"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Promijeni visinu tona brez spremembe tempa"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "Visina tona (EAC)"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -3410,13 +6418,40 @@ msgstr "Poltoni:"
 msgid "Frequency"
 msgstr "Frekvencija (Hz)"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "do"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Sprememba v odstotkih"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "Sprememba v odstotkih"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -3428,7 +6463,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "Nije raspoloživo"
 
@@ -3447,6 +6484,32 @@ msgstr "Promijeni brzinu s uticajem na tempo i visinu tona"
 #: src/effects/ChangeSpeed.cpp
 msgid "&Speed Multiplier:"
 msgstr "Izvoz više"
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -3468,6 +6531,12 @@ msgstr ""
 msgid "Current length of selection."
 msgstr "Odsjeci datoteku na izbor"
 
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
+
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
 msgstr "Dužina"
@@ -3487,8 +6556,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "Promijena tempa bez promjene visine tona"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "Kvalitet"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "Promijena tempa bez promjene visine tona"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -3499,6 +6593,12 @@ msgstr "do"
 #: src/effects/ChangeTempo.cpp
 msgid "Length (seconds)"
 msgstr "Dužina (u sekundama)"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "from"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -3516,15 +6616,101 @@ msgid "Click Removal"
 msgstr "Odstranjivanje kliktanja"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Ime ne smije biti prazno"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "Izaberite prag (niže znači veća osjetljivost):"
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "Prag:"
 
 #: src/effects/ClickRemoval.cpp
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "Najveća širina šiljka (više znači veću osjetljivost):"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Kompresor ..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "Trajanje napada: %.1f s"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "Vrsta šuma"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "šum ..."
+
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "Trajanje"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "Trajanje"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -3532,6 +6718,14 @@ msgstr "Trajanje"
 #. * sound dies away.  So this means 'onset duration'.
 #: src/effects/Compressor.cpp
 msgid "&Attack Time:"
+msgstr "Vrijeme napada:"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
 msgstr "Vrijeme napada:"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -3548,10 +6742,26 @@ msgstr "Vrijeme opadanja: "
 msgid "Release Time"
 msgstr "Vrijeme opadanja: "
 
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "Prag: %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -3564,29 +6774,272 @@ msgid "Release Time %.1f secs"
 msgstr "Vrijeme opadanja: %.1f s"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Stvorena nova zvučna traka"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Stvorena nova zvučna traka"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Stvorena nova zvučna traka"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Kraj"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "Nivo:"
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "Izbor tišine"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "Datum i vrijeme završetka"
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "Izbor tišine"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "R&eset"
 msgstr "Ponovo postavi"
 
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "Postavke ..."
+
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&Pomoć"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Nemoguće odrediti"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr ""
+"Nije moguće kreirati direktorij:\n"
+"  %s"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Izvezi oznake kao:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "Preimenovano '%s' u '%s'"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "Ponovi"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "&Podrazumijevano"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Vrsta slova ..."
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -3597,12 +7050,124 @@ msgid "Soft Clipping"
 msgstr "Pokaži rezanje"
 
 #: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Kompresor dinamičkog opsega"
 
 #: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "Izravnjivač "
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "Trajanje"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Nađi porezano"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -3625,8 +7190,16 @@ msgid "Distortion"
 msgstr "Trajanje"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Brza sinhrona interpolacija"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -3641,8 +7214,26 @@ msgid "Clipping level"
 msgstr "Rezanje"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Lančano primjeni"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Prag:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "Trajanje"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -3653,12 +7244,69 @@ msgid "Repeat processing"
 msgstr "Procesiranje automatskog spuštanja ..."
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Stepen izravnavanja"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "Nađi porezano"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Brzina izvođenja"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Brzina izvođenja"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "DTMF tonovi..."
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -3668,7 +7316,9 @@ msgstr "DTMF sekvenca:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplituda (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Trajanje"
 
@@ -3681,12 +7331,29 @@ msgid "Duty cycle:"
 msgstr "Ciklus djelovanja:"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Trajanje tona:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Trajanje tišine:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -3695,6 +7362,11 @@ msgstr "Odjek"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Izvoženje izbranog zvuka kao %s"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -3705,6 +7377,10 @@ msgid "D&ecay factor:"
 msgstr "Faktor opadanja: "
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "Predefinisano"
 
@@ -3712,7 +7388,8 @@ msgstr "Predefinisano"
 msgid "Export Effect Parameters"
 msgstr "&Uredi parametre"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Greška pri otvaranju datoteke: \"%s\""
@@ -3736,6 +7413,12 @@ msgstr "&Uredi parametre"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Testne datoteke nije moguće otvoriti/kreirati\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Priprema predslušanja"
@@ -3743,6 +7426,15 @@ msgstr "Priprema predslušanja"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Predslušanje"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -3766,6 +7458,11 @@ msgstr "Predefinisano"
 msgid "User Presets"
 msgstr "Postavke efekta"
 
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "&Podrazumijevano"
+
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
 msgstr "Postavke efekta"
@@ -3775,8 +7472,28 @@ msgid "Factory Defaults"
 msgstr "&Podrazumijevano"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr "Nažalost, priključa Vamp se nije uspio inicijalizirati."
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -3795,6 +7512,27 @@ msgid "Latency: 0"
 msgstr "Latencija"
 
 #: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Poravnato"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Pomakni &gore"
 
@@ -3811,6 +7549,24 @@ msgid "Move effect down in the rack"
 msgstr "Snimak premješten na drugu traku"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Snimak premješten na drugu traku"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Unesite ime novog lanca"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Latencija"
@@ -3818,6 +7574,20 @@ msgstr "Latencija"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Izaberite naredbu"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "Upravljanje istorijom "
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Reprodukcija"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3834,6 +7604,16 @@ msgid "&Preview effect"
 msgstr "Predslušanje prije izrezanog područja:"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Skoči na početak"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Skoči na početak"
+
+#: src/effects/EffectUI.cpp
 msgid "Skip forward"
 msgstr "Skoči na početak"
 
@@ -3848,6 +7628,11 @@ msgstr "Omogućeno"
 #: src/effects/EffectUI.cpp
 msgid "Save Preset..."
 msgstr "Spremi kao ..."
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "Predefinisano"
 
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
@@ -3866,9 +7651,24 @@ msgid "Options..."
 msgstr "Opcije ..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Mjerač"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Ime"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Obrtanje"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Greška:"
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -3876,9 +7676,19 @@ msgid "Description: %s"
 msgstr "Prepis"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "About"
+msgstr "&O programu"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "Da li ste sigurni, da želite izbrisati %s?"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "Spremi kao ..."
 
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
@@ -3931,6 +7741,18 @@ msgid "Graphic EQ"
 msgstr "Grafički izjednačivač"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Pojačanje niskih tonova"
 
@@ -3939,8 +7761,35 @@ msgid "Bass Cut"
 msgstr "Pojačanje niskih tonova"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "Uredi oznaku"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Uredi oznaku"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -3955,16 +7804,55 @@ msgid "Effect Unavailable"
 msgstr "Predposlušanje nije raspoloživo"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Najveći dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Najmanji dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "Mjerač"
+
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Nacrtaj krivulje"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Alat za crtanje"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -3975,8 +7863,54 @@ msgid "Interpolation type"
 msgstr "Brza sinhrona interpolacija"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Linearna frekvencija"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Linearna frekvencija"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "Dužina predslušanja:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Dužina predslušanja:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Predefinisano"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Predefinisano"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Obrni"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Processing: "
@@ -3987,8 +7921,106 @@ msgid "D&efault"
 msgstr "&Podrazumijevano"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Pokreni test brzine ..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Izvođenje efekta: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Izvođenje izjednačavanja"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Upravljanje istorijom "
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Nacrtaj krivulje"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Kazaljka lijevo"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Ime"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Izbriši"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Izaberi ..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "Pod&razumijevano"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3996,14 +8028,42 @@ msgid "Rename '%s' to..."
 msgstr "Preimenovano '%s' u '%s'"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "&Ponovno uzimanje uzorka ..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "Preimenovano '%s' u '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Ime vrste slova"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr "Prepiši postojeće datoteke"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "Pomakni &dolje"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Ne mogu izvesti zvuk u %s"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4020,8 +8080,51 @@ msgid "Delete %d items?"
 msgstr "Ponovljeno %d-puta"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Stare datoteke automatskog spremanja nije mogoće odstraniti"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Izvezi oz&nake ..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Ne mogu izvesti zvuk u %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Kraj snimanja"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "Nema oznaka za izvoz."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -4035,9 +8138,18 @@ msgstr "Utišavaj"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Kliknite i povucite, da izaberete zvuk"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Kliknite i povucite, da izaberete zvuk"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Nađi porezano"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -4051,13 +8163,47 @@ msgstr "Početni prag (uzorci):"
 msgid "St&op threshold (samples):"
 msgstr "Krajnji prag (uzorci):"
 
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "Nema dovoljno prostora, da bi priljepili izbor"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Obrni"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Dodavanje efekta Nyquist ..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normaliziraj najveću amplitudu na"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -4076,6 +8222,31 @@ msgstr "Procesiranje automatskog spuštanja ..."
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normaliziraj"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -4101,6 +8272,10 @@ msgid "Noise"
 msgstr "šum ..."
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Vrsta šuma"
 
@@ -4113,16 +8288,73 @@ msgid "Second greatest"
 msgstr "sekundi"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Podrazumijevano uvećanje"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Podrazumijevano uvećanje"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Odstranjivanje šuma (dB):"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Sve trake moraju imati jednaku frekvenciju uzimanja uzoraka."
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -4130,6 +8362,11 @@ msgstr "Izbor je premli za upotrebo glasovnog ključa."
 
 #: src/effects/NoiseReduction.cpp
 msgid "&Noise reduction (dB):"
+msgstr "Odstranjivanje šuma (dB):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
 msgstr "Odstranjivanje šuma (dB):"
 
 #: src/effects/NoiseReduction.cpp
@@ -4160,6 +8397,11 @@ msgstr "Vrijeme opadanja: "
 msgid "&Frequency smoothing (bands):"
 msgstr "Glađenje frekvencija (Hz):"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Glađenje frekvencija (Hz):"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "Osjetljivost"
@@ -4173,8 +8415,9 @@ msgid "Step 1"
 msgstr "1. korak"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Izaberite nekoliko sekundi čistog šuma, da Audacity zna, šta treba odstranit,\n"
@@ -4197,6 +8440,27 @@ msgstr ""
 "Izaberite sav zvuk, koga želite prefiltrirati, izaberite koliko šuma želite\n"
 "odstraniti i na to kliknite U redu', da odstranite šum.\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "šum ..."
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "O&dstrani trake:"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Veličina vrste slova"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "Napredne mogućnosti miješanja"
@@ -4208,6 +8472,11 @@ msgstr "Vrsta prozora:"
 #: src/effects/NoiseReduction.cpp
 msgid "Window si&ze:"
 msgstr "Vrsta prozora:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
 
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
@@ -4221,17 +8490,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - podrazumijevano"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "Podrazumijevano uvećanje"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Odstranjivanje šuma"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -4246,6 +8561,11 @@ msgid "Noise re&duction (dB):"
 msgstr "Odstranjivanje šuma (dB):"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "Osjetljivost"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr "Glađenje frekvencija (Hz):"
 
@@ -4253,13 +8573,70 @@ msgstr "Glađenje frekvencija (Hz):"
 msgid "Attac&k/decay time (secs):"
 msgstr "Vrijeme napada/opadanja (v sekundama):"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Vrijeme napada/opadanja (v sekundama):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&Odstrani"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Normaliziraj"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Odstranjivanje šuma\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Odstranjivanje šuma\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Odstranjivanje šuma\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -4269,9 +8646,23 @@ msgstr "Normaliziraj najveću amplitudu na"
 msgid "Peak amplitude dB"
 msgstr "Nova vršna amplituda (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Faktor opadanja: "
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Faktor opadanja: "
@@ -4280,29 +8671,94 @@ msgstr "Faktor opadanja: "
 msgid "&Time Resolution (seconds):"
 msgstr "Kašnjenje (sekundi):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Fazor"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Stepeni:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Stepeni:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "Frekvencija LFO (Hz):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "Frekvencija LFO (Hz):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "Početna faza LFO (step.):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "Početna faza LFO (step.):"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Dubina:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "Odziv (%):"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "&Output gain (dB):"
@@ -4317,6 +8773,10 @@ msgid "Repair"
 msgstr "Popravi"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -4326,9 +8786,22 @@ msgstr ""
 "\n"
 "Povećajte izbor i izaberite mali dio sekunde za popravku."
 
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Ponovi"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -4352,6 +8825,68 @@ msgstr "Nova dužina izbora:"
 msgid "New selection length: %s"
 msgstr "Nova dužina izbora:"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Odstrani traku"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "Big-endian"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Large Room"
+msgstr "&Velike ikone"
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Obrnuto"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Veličina"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Vrijeme napada/opadanja (v sekundama):"
+
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
 msgstr "Odziv (%):"
@@ -4359,6 +8894,34 @@ msgstr "Odziv (%):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "Dubina (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Dubina (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Izlazni kanali: %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Izlazni kanali: %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Stereo"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -4373,13 +8936,98 @@ msgstr "Obrnuto"
 msgid "Reverses the selected audio"
 msgstr "Izvoženje izbranog zvuka kao %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Prenesi datoteku &na server ..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "Za crtanje spektra sve izabrane trake moraju imati jednak stepen uzorkovanja."
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Mjerač"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Poravnaj kraj s krajem izbora"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Trajanje"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Trajanje"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -4388,6 +9036,14 @@ msgstr "Vrsta prozora:"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "Vrsta prozora:"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -4403,6 +9059,15 @@ msgstr "Prag:"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "Razvrstaj po vremenu"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "Razvrstaj po vremenu"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -4441,15 +9106,28 @@ msgstr "&Podrazumijevano"
 msgid "Restore Defaults"
 msgstr "&Podrazumijevano"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Tišina"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "&Stereo u mono"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -4466,6 +9144,43 @@ msgstr "Pretvaranje sterea u mono"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "Faktor opadanja: "
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "Brza sinhrona interpolacija"
 
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
@@ -4492,12 +9207,40 @@ msgid "Tone"
 msgstr "Ton ..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Talasni oblik:"
 
 #: src/effects/ToneGen.cpp
 msgid "&Frequency (Hz):"
 msgstr "Frekvencija (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Frekvencija (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "Frekvencija (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Amplituda (0-1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Amplituda (0-1)"
 
 #: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
@@ -4508,8 +9251,20 @@ msgid "Truncate Detected Silence"
 msgstr "Presjeci tišinu"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "Presjeci tišinu"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -4519,11 +9274,38 @@ msgstr "Izaberi-Tišina"
 msgid "Tr&uncate to:"
 msgstr "Presjeci tišinu"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Kompresor ..."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "Efe&kt"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Greška pri otvaranju biblioteke za MP3 kodiranje!"
 
@@ -4531,8 +9313,32 @@ msgstr "Greška pri otvaranju biblioteke za MP3 kodiranje!"
 msgid "VST Effect Options"
 msgstr "Postavke efekta"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Dužina"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
+msgstr "Kombinacija tastera"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
 msgstr "Kombinacija tastera"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -4540,32 +9346,96 @@ msgid "Graphical Mode"
 msgstr "Grafički izjednačivač"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Spremi govor kao:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Izvezi datoteku"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Izvezi datoteku"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Projektne datoteke Audacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "Izvođenje efekta: %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Učitaj datoteke"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Izaberite datoteku MIDI ..."
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "Izvođenje efekta: %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Postavke efekta"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "Wah-wah"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -4576,8 +9446,29 @@ msgid "Reso&nance:"
 msgstr "Rezonancija:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Rezonancija:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Razlika u frekvenciji wah (%):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Razlika u frekvenciji wah (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Postavke efekta"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Postavke efekta"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -4592,16 +9483,42 @@ msgid "Audio Unit Effect Options"
 msgstr "Postavke efekta"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Interfejs"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Ulazni uređaj"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr " prozor"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Generisanje"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Izvezi datoteku"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -4677,19 +9594,74 @@ msgid "Failed to retrieve preset content"
 msgstr "'%s' nije moguće odstraniti"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Pretvarač frekvence uzimanja uzoraka"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "'%s' nije moguće odstraniti"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "'%s' nije moguće odstraniti"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "'%s' nije moguće odstraniti"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Slanje izvještaja o rušenju nije uspjelo"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Zvučna datoteka"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efe&kt"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "Efe&kt"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Postavke efekta"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -4697,6 +9669,7 @@ msgstr "Postavke efekta"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "Efe&kt"
@@ -4705,13 +9678,59 @@ msgstr "Efe&kt"
 msgid "LV2 Effect Settings"
 msgstr "Postavke efekta"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Generisanje"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efe&kt"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Dodavanje efekta Nyquist ..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -4727,6 +9746,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Izlaz Nyquista:"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Poravnato s krajem izbora"
 
@@ -4739,12 +9776,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Nažalost, efekt se ne može izvesti na stereo trakama, jer se trake ne slažu."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Izlaz Nyquista:"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Procesiranje automatskog spuštanja ..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -4787,6 +9842,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist nije vratio zvuk.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "U toj verziji Audacity podrška za %s nije prevedena."
@@ -4795,10 +9854,37 @@ msgstr "U toj verziji Audacity podrška za %s nije prevedena."
 msgid "Could not open file"
 msgstr "Greška pri otvaranju datoteke: "
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Greška pri otvaranju datoteke: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Testne datoteke nije moguće otvoriti/kreirati\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -4819,6 +9905,21 @@ msgid "Lisp scripts"
 msgstr "Nyquist komanda..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Greška pri otvaranju datoteke: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -4837,9 +9938,18 @@ msgstr "Izaberite datoteku MIDI ..."
 msgid "Save file as"
 msgstr "Spremi datoteke"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Efe&kt"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -4857,6 +9967,22 @@ msgstr "Nažalost, priključa Vamp se nije uspio inicijalizirati."
 msgid "Plugin Settings"
 msgstr "Postavke priključka"
 
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektogrami"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Postavke efekta"
+
 #: src/export/Export.cpp
 msgid "Export Audio"
 msgstr "Izvezi datoteku"
@@ -4868,6 +9994,14 @@ msgstr "Uredi oznake metapodataka"
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "Izvezi"
+
+#: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -4941,6 +10075,11 @@ msgid "Output Channels: %2d"
 msgstr "Izlazni kanali: %2d"
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "Podprozor s trakom"
+
+#: src/export/Export.cpp
 #, c-format
 msgid ""
 "Unable to export.\n"
@@ -4951,10 +10090,25 @@ msgstr "Nije moguće izvoziti"
 msgid "Show output"
 msgstr "Pokaži izlaz"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "Promjenjiva"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Izaberite naredbu"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -4985,9 +10139,128 @@ msgstr "Izlaz komande"
 msgid "&OK"
 msgstr "U &redu"
 
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Greška LOF"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Izvoženje izbranog zvuka kao %s"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -4998,7 +10271,8 @@ msgstr "Izvoženje izbranog zvuka kao %s"
 msgid "Invalid sample rate"
 msgstr "Nevažeća frekvencija uzimanja uzoraka"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Ponovo uzmi uzorke"
 
@@ -5028,7 +10302,8 @@ msgstr "Frekvencije uzimanja uzoraka"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "kb/s"
@@ -5040,6 +10315,51 @@ msgstr "Bitna brzina:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Kvalitet:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "kb/s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -5054,6 +10374,10 @@ msgid "Constrained"
 msgstr "Konstanta"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Zvuk ..."
 
@@ -5062,8 +10386,44 @@ msgid "Low Delay"
 msgstr "Vrsta tastera"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Big-endian"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -5086,6 +10446,14 @@ msgid "Application:"
 msgstr "Lančano primjeni"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "Primjeni na trenutnem &projektu"
 
@@ -5094,21 +10462,432 @@ msgid "Current Codec:"
 msgstr "Primjeni na trenutnem &projektu"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "Izvođenje efekta: %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Prepiši postojeće datoteke"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "Potvrdi"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "Stvorena nova zvučna traka"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Direktorij %s ne postoji. Želite li ga kreirati?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "Preimenovano '%s' u '%s'"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "Glavni miješani zvuk"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "Greška LOF"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Nivo:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Nivo:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Nivo:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "Predefinisano"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Učitaj datoteke"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Izvezi oznake kao:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Izvezi oznake kao:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Primjeni na trenutnem &projektu"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Postavke priključka"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Jezik:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "Kvalitet:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Frekvencije uzimanja uzoraka"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Sve datoteke (*)|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Postavite FLAC opcije"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Kompresor ..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Ime"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Izbor do kraja"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Postavi frekvenciju"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "Ime trake"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "Preimenovano '%s' u '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "Nema oznaka za izvoz."
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "Izberite datoteke za grupnu obradu ..."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Slanje izvještaja o rušenju nije uspjelo"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -5137,6 +10916,18 @@ msgstr "Bitovska dubina:"
 #: src/export/ExportFLAC.cpp
 msgid "FLAC Files"
 msgstr "Datoteke FLAC"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Greška pri otvaranju datoteke: \"%s\""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr "Nažalost, priključa Vamp se nije uspio inicijalizirati."
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
@@ -5168,7 +10959,74 @@ msgstr "Izvoz izabranog zvuka pri %ld kb/s"
 msgid "Exporting the audio at %ld kbps"
 msgstr "Izvoz izabranog zvuka pri %ld kb/s"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standardno"
 
@@ -5193,6 +11051,11 @@ msgid "Joint Stereo"
 msgstr "Spojeni stereo"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Režim bitovske brzine:"
 
@@ -5205,14 +11068,19 @@ msgstr "Kvalitet"
 msgid "Channel Mode:"
 msgstr "Kanalski režim:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Linija reza odstranjena"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Nađi Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity zahtijeva datoteku %s za stvaranje datoteke MP3."
 
 #: src/export/ExportMP3.cpp
@@ -5238,6 +11106,38 @@ msgstr "Ako želite bezplatnu kopiju programa Lame, kliknite ovdje -->"
 #, c-format
 msgid "Where is %s?"
 msgstr "Gdje je %s?"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Spremanje projektnih datoteka"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "MP3 Files"
@@ -5310,6 +11210,14 @@ msgstr ""
 "Kombinacije frekvencije uzimanja uzoraka projekta (%d) i bitovskog uzimanja uzoraka (%d kb/s)\n"
 "zapis MP3 ne podpira.  "
 
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
 msgstr "Izvoz više"
@@ -5319,8 +11227,18 @@ msgid "Cannot Export Multiple"
 msgstr "Izvoz više"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Lokacija  za izvoz:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -5343,6 +11261,11 @@ msgid "First file name:"
 msgstr "Ime prve datoteke:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Ime prve datoteke:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "Imenujte datoteke:"
 
@@ -5351,7 +11274,22 @@ msgid "Using Label/Track Name"
 msgstr "Upotreba oznake/imena trake"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Upotreba oznake/imena trake"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Prefiks imena datoteke:"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "Prefiks imena datoteke:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "Prefiks imena datoteke:"
 
 #: src/export/ExportMultiple.cpp
@@ -5369,6 +11307,31 @@ msgstr "Izaberite lokaciju, gdje će biti spremljene izvezene datoteke."
 
 #: src/export/ExportMultiple.cpp
 #, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
 msgid ""
 "\"%s\" doesn't exist.\n"
 "\n"
@@ -5382,6 +11345,27 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "Spremi kao ..."
@@ -5389,6 +11373,31 @@ msgstr "Spremi kao ..."
 #: src/export/ExportOGG.cpp
 msgid "Ogg Vorbis Files"
 msgstr "Datoteke Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -5402,6 +11411,14 @@ msgstr "Izvoz izabranog zvuka u Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Izvoz izabranog zvuka u Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Zaglavlje:"
@@ -5411,8 +11428,33 @@ msgid "Encoding:"
 msgstr "Kodiranje: "
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "Izaberite bilo koju nekompresovanu zvučnu datoteku ..."
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Greška pri uvozu"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -5423,23 +11465,55 @@ msgstr "Ne mogu izvoziti zvuk u tom formatu."
 msgid "Exporting the selected audio as %s"
 msgstr "Izvoženje izbranog zvuka kao %s"
 
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "Frekvencije uzimanja uzoraka"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Nažalost, priključa Vamp se nije uspio inicijalizirati."
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "U toj verziji Audacity podrška za %s nije prevedena."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 " \"%s\" je traka zvučnog CD.\n"
 "Audacity ne može direktno otvoriti audio CD.\n"
@@ -5448,10 +11522,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" je datoteka spiska izvođenja.\n"
@@ -5460,10 +11534,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvučna datoteka Windows Media Audio. \n"
@@ -5472,10 +11546,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je datoteka Advanced Audio Coding. \n"
@@ -5484,12 +11558,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" je šifrirana zvučna datoteka, tipično iz Internet muzičke trgovine. \n"
@@ -5499,15 +11573,130 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je medijska datoteka RealPlayer. \n"
 "Audacity ne može otvoriti ovaj zaštićeni format.\n"
 "Morate  je pretvoriti u  podržanu vrstu zvučnih datoteka, kao što su WAV i AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+"\"%s\" je zvučna datoteka Windows Media Audio. \n"
+"Audacity tu vrstu datoteka ne može otvoriti zbog patentnih ograničenja.\n"
+"Morate je pretvoriti u podržani zvučni zapis, kao što su WAV i AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" je zvučna datoteka Windows Media Audio. \n"
+"Audacity tu vrstu datoteka ne može otvoriti zbog patentnih ograničenja.\n"
+"Morate je pretvoriti u podržani zvučni zapis, kao što su WAV i AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" je medijska datoteka RealPlayer. \n"
+"Audacity ne može otvoriti ovaj zaštićeni format.\n"
+"Morate  je pretvoriti u  podržanu vrstu zvučnih datoteka, kao što su WAV i AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" je zvučna datoteka Windows Media Audio. \n"
+"Audacity tu vrstu datoteka ne može otvoriti zbog patentnih ograničenja.\n"
+"Morate je pretvoriti u podržani zvučni zapis, kao što su WAV i AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" je zvučna datoteka Windows Media Audio. \n"
+"Audacity tu vrstu datoteka ne može otvoriti zbog patentnih ograničenja.\n"
+"Morate je pretvoriti u podržani zvučni zapis, kao što su WAV i AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" je zvučna datoteka Windows Media Audio. \n"
+"Audacity tu vrstu datoteka ne može otvoriti zbog patentnih ograničenja.\n"
+"Morate je pretvoriti u podržani zvučni zapis, kao što su WAV i AIFF."
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Spremanje projektnih datoteka"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5524,21 +11713,132 @@ msgid "Import Project"
 msgstr "Izvezi oznake kao:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Datoteke s podacima projekta nije moguće naći: \"%s\""
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Frekvencija projekta (Hz):"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "Nevažeća frekvencija uzimanja uzoraka"
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Nevažeća frekvencija uzimanja uzoraka"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5555,21 +11855,19 @@ msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 msgid "Unable to read %lld samples from %s"
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Datoteke FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Testne datoteke nije moguće otvoriti/kreirati"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "'%s' nije moguće preimenovati u '%s'"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -5629,9 +11927,22 @@ msgstr "Greška pri otvaranju datoteke: \"%s\""
 msgid "MP3 files"
 msgstr "Datoteke MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Datoteke Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -5658,12 +11969,120 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF i druge nekompresovane vrste"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bitni PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-bitni PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-bitni PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bitni PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bitni PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -5674,12 +12093,49 @@ msgid "64 bit float"
 msgstr "32-bitni realni"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16-bitno"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "16-bitno"
 
 #: src/import/ImportPCM.cpp
 msgid "24 bit DWVW"
 msgstr "24-bitno"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
@@ -5689,9 +12145,51 @@ msgstr "16-bitni PCM"
 msgid "8 bit DPCM"
 msgstr "16-bitni PCM"
 
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "Uvezeno '%s'"
+
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "Datoteke QuickTime"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Datoteku žanrova nije moguće spremiti."
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "'%s' nije moguće odstraniti"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Datoteku žanrova nije moguće spremiti."
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "Uvezi sirove podatke"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -5707,6 +12205,13 @@ msgstr "Nebitan endian"
 #. know the correct technical word.
 #: src/import/ImportRaw.cpp
 msgid "Little-endian"
+msgstr "little-endian"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
 msgstr "little-endian"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
@@ -5727,6 +12232,15 @@ msgstr "2 kanala (Stereo)"
 #, c-format
 msgid "%d Channels"
 msgstr "%d kanala"
+
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Kanal"
 
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
@@ -5750,6 +12264,10 @@ msgstr "Brzina uzimanja uzoraka:"
 msgid "&Import"
 msgstr "&Uvezi"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -5770,6 +12288,7 @@ msgstr "desno"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -5795,6 +12314,7 @@ msgstr "Kraj"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -5818,12 +12338,36 @@ msgstr[2] ""
 msgstr[3] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Vremenski pomjerene trake/snimci %s  %.02f sekundi"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Vremenski pomjerene trake/snimci %s  %.02f sekundi"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Vremenski pomak"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "clip not moved"
+msgstr "Skripta nije sačuvana."
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "na početak izbora"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -5840,6 +12384,26 @@ msgstr "Naredni alat"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Naredni alat"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "Predhodni alat"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "Primjeni na trenutnem &projektu"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "Naredni alat"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "na početak izbora"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -5873,6 +12437,11 @@ msgstr "Izreži u odlagalište"
 #, c-format
 msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Izbrisanih %.2f sekundi u t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasting one type of track into another is not allowed."
+msgstr "Kopiranje stereo zvuka u mono traku nije dozvoljeno."
 
 #: src/menus/EditMenus.cpp
 msgid "Copying stereo audio into a mono track is not allowed."
@@ -5923,7 +12492,8 @@ msgstr "Utišane izbrane trake za %.2f sekundu pri %.2f"
 msgid "Trim Audio"
 msgstr "Snimanje zvuka"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Razdvoji"
 
@@ -5943,6 +12513,15 @@ msgstr "Spojeno %.2f sekundi pri t=%.2f"
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "Spoji"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Izbrisanih %.2f sekundi u t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
@@ -5976,6 +12555,11 @@ msgstr "&Umetni"
 msgid "Duplic&ate"
 msgstr "U&dvostruči"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "O&dstrani trake:"
+
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
 msgid "Spl&it Cut"
@@ -5985,6 +12569,12 @@ msgstr "&Razdvoji s rezom"
 #: src/menus/EditMenus.cpp
 msgid "Split D&elete"
 msgstr "Razdvoji s &brisanjem"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "Označena područja utišanja"
 
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
@@ -6005,9 +12595,19 @@ msgstr "Razdvoji u n&ovu"
 msgid "&Join"
 msgstr "&Spoji"
 
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "Izaberi-Tišina"
+
 #: src/menus/EditMenus.cpp
 msgid "&Metadata..."
 msgstr "Uredi metapodatke"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "&Postavke ..."
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -6018,32 +12618,8 @@ msgid "Delete Key&2"
 msgstr "DeleteKey2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Alatna traka miksera"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Reprodukcija"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Reprodukcija"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Reprodukcija"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Kraj snimanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Kraj snimanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Kraj snimanja"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -6065,9 +12641,26 @@ msgstr "Smještanje zvuka u međumemoriju"
 msgid "Change Recording Cha&nnels..."
 msgstr "Promijeni visinu tona"
 
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Izvezi iz&bor ..."
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Uredi oznaku"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -6082,12 +12675,28 @@ msgid "Please select a Note Track."
 msgstr "Stvorena nova zvučna traka"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "&Izvezi ..."
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "Izaberite datoteku MIDI ..."
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "Sve datoteke (*)|*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "&Izvezi ..."
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -6101,6 +12710,11 @@ msgstr "Uvezi oznaku"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Izaberite datoteku MIDI ..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Sve datoteke (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -6118,6 +12732,12 @@ msgstr "Spremi kao ..."
 #: src/menus/FileMenus.cpp
 msgid "Open Recent"
 msgstr "Otvori nedavne"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "Spremi datoteke"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -6198,6 +12818,10 @@ msgid "E&xit"
 msgstr "&Zatvori"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "Izvezi oznake kao:"
 
@@ -6228,6 +12852,10 @@ msgid "Nothing to do"
 msgstr "Nema ništa da se poništi"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Zatvori fokusiranu traku"
 
@@ -6240,6 +12868,18 @@ msgid "Recording stops and starts"
 msgstr "Početak snimanja"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "&Pomoć"
 
@@ -6248,7 +12888,8 @@ msgid "&Getting Started"
 msgstr "Početak izbora:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "Alatna traka Audacity - %s"
 
 #: src/menus/HelpMenus.cpp
@@ -6256,16 +12897,34 @@ msgid "&Quick Help..."
 msgstr "&Pomoć"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
 msgstr "\t-test (pokreni samodijagnostiku)"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&O programu Audacity ..."
+msgid "Au&dio Device Info..."
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Dodana oznaka"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "Pomjeri fokus na narednu traku"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -6381,6 +13040,15 @@ msgid "Add Label at &Playback Position"
 msgstr "Dodaj oznaku na mjestu &emitovanja"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "Pomjeri fokus na narednu traku"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Snimljeni zvuk"
 
@@ -6415,6 +13083,11 @@ msgid "Label Split Delete"
 msgstr "Razdvoji s brisanjem"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "Označena područja utišanja"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "Tišina"
 
@@ -6439,6 +13112,23 @@ msgstr "Uredi oznaku"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "Uredi oznaku"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "Pomjeri fokus na narednu traku"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -6477,8 +13167,17 @@ msgid "Toggle Focuse&d Track"
 msgstr "Uključi/isključi fokusiranu traku"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Novi ..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Unknown"
+msgstr "Nepoznata greška"
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -6495,6 +13194,10 @@ msgid "&Generate"
 msgstr "&Generisanje"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
 msgstr "Generator tona"
 
@@ -6503,8 +13206,18 @@ msgid "Effe&ct"
 msgstr "Efe&kt"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "Generator tona"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&Analiziraj"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "Generator tona"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -6542,6 +13255,10 @@ msgstr "&Pokreni test brzine ..."
 msgid "Simulate Recording Errors"
 msgstr "Snimanje"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -6562,6 +13279,16 @@ msgstr "Izaberi"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "Ime trake"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Trajanje tišine:"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&Trake"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -6587,9 +13314,20 @@ msgstr "&Uredi oznake"
 msgid "Set Project..."
 msgstr "Sačuvaj projekt &kao ..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Promjenjiva"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "&Trake"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "Informacije"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -6621,6 +13359,27 @@ msgid "Screenshot (short format)..."
 msgstr "&Slika ekrana ..."
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Postavi tačku izbora"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Položaj zvuka:"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Postavi tačku izbora"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "Izaberi"
+
+#: src/menus/SelectMenus.cpp
 msgid "&None"
 msgstr "&Ništa"
 
@@ -6633,8 +13392,21 @@ msgid "&Tracks"
 msgstr "&Trake"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "Trake"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Sync-Locked"
 msgstr "Izaberi-Zvuk"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
@@ -6653,8 +13425,18 @@ msgid "Set Selection Right at Play Position"
 msgstr "Postavi tačku izbora i emituj"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "Izbor do početka"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "Izbor do početka"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "Ime trake"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -6693,8 +13475,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Linearna frekvencija"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Izbor do početka"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Položaj zvuka:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -6831,6 +13622,40 @@ msgstr "Dugi skok kazaljke lijevo"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "Dugi skok kazaljke desno"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "Alat"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
@@ -6982,6 +13807,15 @@ msgid "Align Together"
 msgstr "Poravnaj trake zajedno"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "Poravnaj kraj s krajem izbora"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
 msgstr "Prilagođeno pojačanje"
 
@@ -7006,10 +13840,21 @@ msgid "Created new label track"
 msgstr "Stvorena nova datoteka s oznakama"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Stvorena nova vremenska traka"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Brzina uzimanja uzoraka:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Unesena vrijednost nije ispravna"
 
@@ -7029,6 +13874,25 @@ msgstr "Ponovno uzmi uzorke trake"
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "Stvorena nova zvučna traka"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "Poravnaj kraj s krajem izbora"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -7051,6 +13915,11 @@ msgid "Can't delete track with active audio"
 msgstr "Traku s aktivnim zvukom nije moguće izbrisati"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&Nova"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "Pomjeri traku"
 
@@ -7067,8 +13936,18 @@ msgid "&Time Track"
 msgstr "&vremenska traka"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Alatna traka miksera"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Pretvaranje sterea u mono"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x and Render"
+msgstr "&Miješanje i obrada"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix and Render to Ne&w Track"
@@ -7087,6 +13966,11 @@ msgid "M&ute/Unmute"
 msgstr "Utišaj/odvrni fokusiranu traku"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "&Raširi sve trake"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
 msgstr "&Raširi sve trake"
 
@@ -7097,6 +13981,10 @@ msgstr "&Trake"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Raširi sve trake"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -7121,6 +14009,11 @@ msgstr "Srednje"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Center"
 msgstr "Srednje"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "Trake"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
@@ -7149,6 +14042,11 @@ msgstr "Početno vrijeme"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "Ime"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "Snimak premješten na drugu traku"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -7220,7 +14118,9 @@ msgstr "Izvođenje"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Snimanje"
 
@@ -7233,8 +14133,27 @@ msgid "no label track at or below focused track"
 msgstr "Pomakni lijevo na fokusiranoj traci"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Stvorena nova datoteka s oznakama"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -7263,9 +14182,34 @@ msgstr "Prepis"
 msgid "Pl&aying"
 msgstr "Izvođenje"
 
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "Izvodi-pri-brzini"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Pauza"
+
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "Snimanje"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "Snimi"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -7276,8 +14220,71 @@ msgid "Record &New Track"
 msgstr "O&dstrani trake:"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Snimanje"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Kraj snimanja"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "Prepis"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Kraj snimanja"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "Prepis"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&ay"
+msgstr "Izvođenje"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -7395,6 +14402,11 @@ msgid "&Fit to Width"
 msgstr "Na veličinu pr&ozora"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "Na veličinu pr&ozora"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Sažmi sve trake"
 
@@ -7419,12 +14431,57 @@ msgid "Skip to Selection End"
 msgstr "na kraj izbora"
 
 #: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
 msgstr "Pokaži rezanje"
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "Efe&kt"
 
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr " prozor"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Kraj snimanja"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -7432,7 +14489,7 @@ msgstr "Postavke ..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Ažuriraj Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -7457,6 +14514,11 @@ msgid "&Don't apply effects in batch mode"
 msgstr "&Ne primjenjuj efekte u paketnom režimu"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "Uređaj"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
 msgstr "Postavke ..."
 
@@ -7466,11 +14528,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Interfejs"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "Koristeći:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Reprodukcija"
 
@@ -7490,7 +14558,8 @@ msgstr "Kanal"
 msgid "Latency"
 msgstr "Latencija"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisekundi"
 
@@ -7503,6 +14572,15 @@ msgid "&Latency compensation:"
 msgstr "Kombinacija tastera"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Odstrani zvučne trake"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "1 (mono)"
 
@@ -7511,17 +14589,37 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Direktoriji"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Obnovi projekte"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Direktoriji"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Pregledaj ..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -7552,6 +14650,11 @@ msgid "Temporary files directory"
 msgstr "Direktorij privremenih datoteka"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Akcija"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory cannot be on a FAT drive."
 msgstr "Direktorij privremenih datoteka"
 
@@ -7568,8 +14671,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Izberite lokacijo, gdje će biti privremeni direktorij"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "&Izaberi naredbu"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -7586,8 +14698,14 @@ msgid "Directory %s is not writable"
 msgstr "Direktorij %s nije upisiv"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Promjene u privremenom direktoriju neće biti efektivne do narednog starta Audacityja."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Novi privremeni direktorij"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -7597,11 +14715,36 @@ msgstr "Postavke ..."
 msgid "Sorted by Effect Name"
 msgstr "Razvrstaj po imenu"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Razvrstaj po imenu"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Razvrstaj po imenu"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "Efe&kt"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -7611,17 +14754,141 @@ msgstr "Efe&kt"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "Efe&kt"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Postavke efekta"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Postavke priključka"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Brza sinhrona interpolacija"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Uvezi"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Postavke ..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Vrsta šuma"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Izvezi oznake kao:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Pomakni &gore"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Pomakni &dolje"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "Pomakni &gore"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Pomakni &dolje"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Izbrisana označena područja"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Lokacija  za izvoz:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Izaberi"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "Da li ste sigurni, da želite izbrisati %s?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Snimanje zvuka"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -7646,6 +14913,11 @@ msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (opseg PCM za 8-bitne uzorke)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (opseg PCM za 16-bitn uzorke)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
 msgstr "-96 dB (opseg PCM za 16-bitn uzorke)"
 
@@ -7665,13 +14937,101 @@ msgstr "-120 dB (približna granica čovjekovog sluha)"
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (opseg PCM za 24-bitne uzorke)"
 
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Akcija"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "From Internet"
+msgstr "Pomoć na Internetu"
+
 #: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
 msgid "Display"
 msgstr "Prikaz"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Jezik:"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "Lokacija za %s:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Talasni oblik (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "\t-help (ova poruka)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "&Zapiskaj na kraju daljnjih operacija"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Postavke priključka"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Uključi mjerač"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "Izvezi oznake kao:"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Postavke ..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -7684,6 +15044,10 @@ msgstr "Napredne mogućnosti miješanja"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Standardno"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -7701,9 +15065,22 @@ msgstr "Prilikom izvoza traka u zvučnu datoteku"
 msgid "S&how Metadata Tags editor before export"
 msgstr "Prikaži &uređivač metapodataka prije izvoza"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Izvezi oznake kao:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -7715,6 +15092,18 @@ msgid "Preferences for KeyConfig"
 msgstr "Postavke ..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Tasteri za kratice"
 
@@ -7723,12 +15112,49 @@ msgid "View by:"
 msgstr "&Pogled"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Ime"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Pogled"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Pogled"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Pogled"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
 msgstr "Tasteri za kratice"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Opcije ..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -7743,7 +15169,15 @@ msgid "&Defaults"
 msgstr "&Podrazumijevano"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Izaberite datoteku XML s kraticama Audacity ..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -7752,8 +15186,21 @@ msgstr "Izvezi kratice kao:"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Učitano %d tastaturnih prečica\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -7767,6 +15214,38 @@ msgstr "Izvezi kratice kao:"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Izvezi kratice kao:"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "Kombinacija tastera"
@@ -7776,12 +15255,72 @@ msgid "Preferences for Library"
 msgstr "Postavke ..."
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "MP3 verzija biblioteke:"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "MP3 verzija biblioteke:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "Greška LOF"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "&Spremi ..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "Datoteke MP3"
 
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "Postavke ..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Interfejs"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -7789,17 +15328,77 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Interfejs"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Najmanja frekvencija mora biti pozitivni cijeli broj"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "Postavke ..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Promjene u privremenom direktoriju neće biti efektivne do narednog starta Audacityja."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "Pitaj me"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -7841,7 +15440,10 @@ msgstr "Lijevi-povuci"
 msgid "Set Selection Range"
 msgstr "Postavi opseg izbora"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-lijevi-klik"
 
@@ -7928,6 +15530,15 @@ msgstr "Lijevi-povuci"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Pomjeri snimak gore/dolje među trakama"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Lijevi-povuci"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -8031,9 +15642,34 @@ msgstr "Predslušanje nakon izrezanog područja:"
 msgid "Seek Time when playing"
 msgstr "Vrijeme pretrage pri reprodukciji"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Postavke Audacity"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -8042,6 +15678,11 @@ msgstr "Postavke ..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Postavke ..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -8060,12 +15701,32 @@ msgid "Default Sample &Format:"
 msgstr "Podrazumijevani oblik uzorca:"
 
 #: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Pretvarač frekvence uzimanja uzoraka"
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Con&verter:"
 msgstr "Pretvarač frekvence uzimanja uzoraka"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Visokokvalitetna sinhrona interpolacija:"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "Pretvarač frekvence uzimanja uzoraka"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -8080,8 +15741,30 @@ msgid "Preferences for Recording"
 msgstr "Postavke ..."
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Nova traka"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Snimanje"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -8092,9 +15775,19 @@ msgstr "Nivo:"
 msgid "Name newly recorded tracks"
 msgstr "Miješanje i obrada traka"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Ime trake"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Uredi oznaku"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -8105,8 +15798,48 @@ msgid "&Track Number"
 msgstr "Broj trake"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Kraj snimanja"
+#, fuzzy
+msgid "System &Date"
+msgstr "Sistem"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "System T&ime"
+msgstr "Sistem"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Postavke ..."
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Notiraj traku"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
 
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -8136,14 +15869,42 @@ msgstr "Obrnute nijanse sive"
 msgid "Frequencies"
 msgstr "Frekvencija (Hz)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Visina tona (EAC)"
 
 #: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Najmanja frekvencija mora biti bar 0 Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "Najmanja frekvencija mora biti bar 0 Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Najmanja frekvencija mora biti bar 0 Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "Najmanja frekvencija mora biti bar 0 Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -8162,6 +15923,10 @@ msgstr "Postavke ..."
 msgid "&Use Preferences"
 msgstr "Postavke ..."
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "Najmanja frekvencija (Hz):"
@@ -8169,6 +15934,24 @@ msgstr "Najmanja frekvencija (Hz):"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "Najviša frekvencija (Hz):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Izlazni kanali: %2d"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Pojačanje (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -8191,12 +15974,52 @@ msgid "1024 - default"
 msgstr "256 - podrazumijevano"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "32768 - most narrowband"
+msgstr "8 - najšire"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "Vrsta prozora:"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Faktor opadanja: "
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Izbor"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "Nova vršna amplituda (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -8213,6 +16036,36 @@ msgstr "Maksimalna frekvencija mora biti cijeli broj"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "The minimum frequency must be an integer"
 msgstr "Najmanja frekvencija mora biti pozitivni cijeli broj"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Maksimalna frekvencija mora biti cijeli broj"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Maksimalna frekvencija mora biti cijeli broj"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Maksimalna frekvencija mora biti cijeli broj"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Najmanja frekvencija mora biti pozitivni cijeli broj"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Maksimalna frekvencija mora biti cijeli broj"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Maksimalna frekvencija mora biti cijeli broj"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
@@ -8231,13 +16084,14 @@ msgid "Info"
 msgstr "Informacije"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -8255,6 +16109,12 @@ msgstr ""
 "[Samo kontrolna alatna traka i boje na \n"
 "traci s talasnim oblikom su trenutno promijenjene, čak i ako slika\n"
 "prikazuje druge ikone.]"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
 #. * so keep it as is
@@ -8292,6 +16152,11 @@ msgid "Preferences for TracksBehaviors"
 msgstr "Ponašanja"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "uzorci"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
 msgstr "Višestruko"
 
@@ -8309,12 +16174,33 @@ msgid "Enable &dragging selection edges"
 msgstr "Omogući &prevlačenje lijeve i desne ivice izbora"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "\"Pomjeri fokus na trakama\" &ciklično kruži po trakama"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Napredne mogućnosti miješanja"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Dugme"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -8328,6 +16214,14 @@ msgstr "Talasni oblik"
 msgid "Spectrogram"
 msgstr "Spektogrami"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "Na veličinu pr&ozora"
@@ -8339,6 +16233,10 @@ msgstr "&Povećaj do izbora"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Podrazumijevano uvećanje"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -8361,6 +16259,16 @@ msgid "50ths of Seconds"
 msgstr "sekundi"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "sekundi"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "sekundi"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "milisekundi"
 
@@ -8368,7 +16276,12 @@ msgstr "milisekundi"
 msgid "Samples"
 msgstr "uzorci"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Povećanje"
 
@@ -8377,12 +16290,42 @@ msgid "Preferences for Tracks"
 msgstr "Postavke ..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Kraj snimanja"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "Podrazumijevana frekvencija uzimanja uzoraka:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Podrazumijevani oblik uzorca:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "uzorci"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -8405,9 +16348,46 @@ msgstr "Predefinisano"
 msgid "Preset 2:"
 msgstr "Predefinisano"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "Upozorenje"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "Postavke ..."
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&Sačuvaj projekt"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&Sačuvaj projekt"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "Pretvaranje sterea u mono"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "Pretvaranje sterea u mono"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -8430,16 +16410,24 @@ msgid "Stopped"
 msgstr "Zaustavi"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pauza"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Skoči na početak"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Skoči na kraj"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pauza"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Izbor do početka"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Izbor do kraja"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -8453,20 +16441,24 @@ msgstr "Nova traka"
 msgid "Append Record"
 msgstr "Snimi"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Izbor do kraja"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Izbor do početka"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pauza"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Alatna traka prepisa"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -8477,6 +16469,11 @@ msgstr "Brzina izvođenja"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Kraj snimanja"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "Položaj zvuka:"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -8499,8 +16496,18 @@ msgid "Select Playback Device"
 msgstr "Brzina izvođenja"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Trajanje tišine:"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Kraj snimanja"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "Predposlušanje nije raspoloživo\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -8524,11 +16531,22 @@ msgstr "Odsjeci izvan izbora"
 msgid "Silence audio selection"
 msgstr "Izbor tišine"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "&Trake"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Povećaj"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Umanji"
 
@@ -8539,6 +16557,11 @@ msgstr "Prilagodi označeno prozoru"
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "Prilagodi cijeli projekt u prozot"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "Efe&kt"
 
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
@@ -8591,38 +16614,24 @@ msgstr "Mjerač snimanja"
 msgid "&Playback Meter Toolbar"
 msgstr "Mjerač izvođenja"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Kraj snimanja"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Reprodukcija"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Uključi mjerač"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Kraj snimanja"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Reprodukcija"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Reprodukcija"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Alatna traka miksera"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Nyquist komanda..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Nyquist komanda..."
@@ -8630,6 +16639,7 @@ msgstr "Nyquist komanda..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Nyquist komanda..."
@@ -8637,9 +16647,24 @@ msgstr "Nyquist komanda..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Počni praćenje"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Počni praćenje"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Isključi mjerač"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -8675,6 +16700,10 @@ msgstr "Postavi (ili proširi) lijevu granicu izbora"
 msgid "Length and Center of Selection"
 msgstr "Odsjeci datoteku na izbor"
 
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Snap To"
 msgstr "Skoči na ..."
@@ -8683,9 +16712,24 @@ msgstr "Skoči na ..."
 msgid "Length"
 msgstr "Dužina"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Srednje"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -8712,6 +16756,10 @@ msgstr "Pojačanje niskih frekvencija"
 msgid "Center Frequency"
 msgstr "Linearna frekvencija"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -8730,8 +16778,8 @@ msgstr "Alatna traka uređaja"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Alatna traka Audacity - %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -8758,7 +16806,8 @@ msgstr "Alat za vremenski pomak"
 msgid "Zoom Tool"
 msgstr "Alat za povećanje"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Alat za crtanje"
 
@@ -8834,11 +16883,13 @@ msgstr "Povucite jednu ili više granica oznaka"
 msgid "Drag label boundary."
 msgstr "Povucite granicu oznake"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Promijenjena oznaka"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Uredi oznaku"
 
@@ -8893,31 +16944,42 @@ msgstr "Uređene oznake"
 msgid "New label"
 msgstr "Dodana oznaka"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Povisi za oktavu"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Snizi za oktavu"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Kliknite za vertikalno povećanje, kliknite s Shift-om za umanjenje, povlačite za kreiranje odgovarajućega područja za uvećanje."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Desni klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Umanji"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-lijevi-klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-lijevi-klik"
 
@@ -8940,6 +17002,14 @@ msgid "Stretch"
 msgstr "Faktor opadanja: "
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Spojeni snimci"
 
@@ -8951,7 +17021,8 @@ msgstr "Spoji"
 msgid "Expanded Cut Line"
 msgstr "Proširena linija reza"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Proširi"
 
@@ -8964,12 +17035,21 @@ msgid "Click and drag to edit the samples"
 msgstr "Kliknite i povucite, da bi promijenili uzorke"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "Pomjeren uzorak"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Uređivanje uzorka"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -8978,6 +17058,16 @@ msgstr "Povećaj na tački"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Spektogrami"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -9003,7 +17093,8 @@ msgstr "Procesiranje automatskog spuštanja ..."
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Promijenjeno: '%s' v %s"
@@ -9017,7 +17108,60 @@ msgid "Rat&e"
 msgstr "Postavi frekvenciju"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 č 060 m 060>01000 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 č 060 m 060>01000 s"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -9038,7 +17182,8 @@ msgstr "Promjena tempa"
 msgid "Set Rate"
 msgstr "Postavi frekvenciju"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Višestruko"
 
@@ -9057,6 +17202,11 @@ msgstr "Razdvoji stereo traku"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Pretvaranje sterea u mono"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -9126,6 +17276,27 @@ msgstr "Lijevo, "
 msgid "Right, %dHz"
 msgstr "Desno, "
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "desno"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "Kliknite i povucite, da poboljšate relativnu veličinu stereo traka."
@@ -9133,6 +17304,15 @@ msgstr "Kliknite i povucite, da poboljšate relativnu veličinu stereo traka."
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "Kliknite i povucite, da bi pomjerili traku u vremenu"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Kliknite i povucite, da bi pomjerili traku u vremenu"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -9142,6 +17322,10 @@ msgstr "Povećaj"
 msgid "Zoom x2"
 msgstr "Povećanje"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "Talasni oblik"
@@ -9149,6 +17333,11 @@ msgstr "Talasni oblik"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Talasni oblik"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -9181,16 +17370,37 @@ msgid "Set Range"
 msgstr "Postavi opseg"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "Prikaz"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Brza sinhrona interpolacija"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "Linearan"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Brza sinhrona interpolacija"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -9202,9 +17412,8 @@ msgstr "Brza sinhrona interpolacija"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Kliknite i povucite, da bi pomjerili traku u vremenu"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -9255,6 +17464,21 @@ msgstr "Prilagođena ovojnica."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Alatna traka za uređivanje"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Počni praćenje"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Uključi mjerač"
@@ -9270,6 +17494,16 @@ msgstr "Zatvori fokusiranu traku"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Pomakni traku dolje"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Nyquist komanda..."
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Skoči na početak"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -9322,6 +17556,11 @@ msgstr "Kliknite i povucite, da izaberete zvuk"
 msgid "Click and drag to select audio"
 msgstr "Kliknite i povucite, da izaberete zvuk"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Kliknite i povucite, da bi pomjerili traku u vremenu"
@@ -9343,6 +17582,10 @@ msgstr "Utišane izbrane trake za %.2f sekundu pri %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Utišane izbrane trake za %.2f sekundu pri %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -9369,6 +17612,12 @@ msgstr "&Naredba"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl-lijevi-klik"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Stvorena nova zvučna traka"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -9415,11 +17664,31 @@ msgstr "Pritisnite"
 msgid "Button"
 msgstr "Dugme"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
 #. i18n-hint: One-letter abbreviation for Right, in the Pan slider
 #. i18n-hint: One-letter abbreviation for Right, in VU Meter
 #: src/widgets/ASlider.cpp src/widgets/Meter.cpp
 msgid "R"
 msgstr "D"
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" ne postoji.\n"
+"\n"
+"Da li je želite kreirati?"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
@@ -9446,8 +17715,32 @@ msgid "Empty"
 msgstr "Prazno"
 
 #: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Skoči na početak"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Pomoć na Internetu"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Sve datoteke (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -9486,6 +17779,13 @@ msgid "Refresh Rate"
 msgstr "Postavi frekvenciju"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "Brzina osvježavanja mjerača na sekundu [1-100]: "
 
@@ -9498,12 +17798,21 @@ msgid "Meter Style"
 msgstr "Mjerač"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Mjerač"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Trajanje"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Automatska obnova nakon kraha"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -9516,6 +17825,33 @@ msgstr "Vertikalno ravnalo"
 #: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr "Zaustavi praćenje"
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Stvorena nova zvučna traka"
 
 #. i18n-hint: Format string for displaying time in seconds. Change the comma
 #. * in the middle to the 1000s separator for your locale, and the 'seconds'
@@ -9555,6 +17891,25 @@ msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 dana 024 č 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "čč:mm:ss + uzorci"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 č 060 m 060>01000 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
@@ -9591,6 +17946,7 @@ msgstr "0100 č 060 m 060 s+># uzorci"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "uzorci"
@@ -9752,6 +18108,15 @@ msgstr "kadrovi 01000,01000|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 č 060 m 060>01000 s"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -9759,6 +18124,10 @@ msgstr "0100 č 060 m 060>01000 s"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 č 060 m 060>01000 s"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -9774,15 +18143,76 @@ msgstr "Snizi za oktavu"
 msgid "100>01000 octaves|1.442695041"
 msgstr "kadrovi 01000,01000|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "kadrovi 01000,01000|24"
 
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "Za promjenu formata koristite desni taster miša ili taster kontekstnog menija"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "sekundi"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Vrijeme opadanja: "
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "Krajnje vrijeme"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Cancel"
+msgstr "Pre&kini"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to cancel?"
@@ -9814,6 +18244,11 @@ msgstr "Potvrdi"
 msgid "Unable to write files to directory: %s."
 msgstr "Testne datoteke nije moguće otvoriti/kreirati"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -9831,14 +18266,44 @@ msgstr "Obnovi projekte"
 msgid "Don't show this warning again"
 msgstr "Nemoj više prikazivati ovo upozorenje"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
 #: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Prazno"
 
 #: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Snimi"
+
+#: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Povećaj na području"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Greška LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -9856,12 +18321,26 @@ msgid "Value must not be greater than %s"
 msgstr "Početak i kraj moraju biti veći od 0."
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Kreiran nov projekt"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
 msgstr "Direktoriji"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "Dijalog za pretraživanje"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "Greška:"
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
@@ -9876,16 +18355,49 @@ msgstr "Greška pri otvaranju datoteke: "
 msgid "Spectral edit multi tool"
 msgstr "Izbor"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Dužina"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Frekvencija (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Greška"
@@ -9900,8 +18412,34 @@ msgstr "Izlazni kanali: %2d"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Najmanja frekvencija mora biti bar 0 Hz"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -9914,6 +18452,28 @@ msgstr "Utišavaj"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Primjena ..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -9940,8 +18500,16 @@ msgid "S-Curve Down"
 msgstr "Pomakni &dolje"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Početak"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -9950,6 +18518,14 @@ msgstr "Pojačanje"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Početak"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -9962,6 +18538,14 @@ msgstr "Linearan"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Linearan"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -10000,6 +18584,24 @@ msgstr "Pomakni &dolje"
 msgid "Error~%~%"
 msgstr "Greška"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Ponovi"
@@ -10007,6 +18609,10 @@ msgstr "Ponovi"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Nađi rez ..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Alatna traka Audacity - %s"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -10020,6 +18626,23 @@ msgstr "Rezanje"
 msgid "Reconstructing clips..."
 msgstr "Odstranjivanje kliktanja ..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Prag: %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Notiraj traku"
@@ -10027,6 +18650,21 @@ msgstr "Notiraj traku"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Notiraj traku"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -10060,6 +18698,19 @@ msgstr "Ime trake"
 msgid "Fade direction"
 msgstr "Izbor"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Vrsta tastera"
@@ -10077,6 +18728,19 @@ msgid "Regular"
 msgstr "Pravougaono"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Odstranjivanje šuma (dB):"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Kašnjenje (sekundi):"
 
@@ -10089,12 +18753,24 @@ msgid "Pitch/Tempo"
 msgstr "Visina tona (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
 msgstr "Pre&gled"
 
 #: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "Broj ponavljanja"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -10109,18 +18785,40 @@ msgid "XML file"
 msgstr "Datoteke MP3"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "Snimi"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Datoteku žanrova nije moguće otvoriti."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Greška (datoteka možda nije bila zapisana): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Greška (datoteka možda nije bila zapisana): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -10151,18 +18849,67 @@ msgstr "Dužina (u sekundama)"
 msgid "Length of label region (seconds)"
 msgstr "Dužina (u sekundama)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Uredi oznaku"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "Kombinacija tastera"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "Upozorenje"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -10172,6 +18919,17 @@ msgstr "Oznake spajanja"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Oznake spajanja"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -10185,13 +18943,46 @@ msgstr "Izvođenje izjednačavanja"
 msgid "Dominic Mazzoni"
 msgstr "Odstranjivanje šuma Dominica Mazzonija"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvencija (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Najmanja frekvencija mora biti bar 0 Hz"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -10215,6 +19006,11 @@ msgid "Average level"
 msgstr "Prosječno"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "Brzina izvođenja"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "Najveće trajanje tišine:"
 
@@ -10235,14 +19031,57 @@ msgid "Point after sound"
 msgstr "Spojeni stereo"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "Spojeni stereo"
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Presjecanje tišine..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Presjecanje tišine..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Ime ne smije biti prazno"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -10270,8 +19109,25 @@ msgid "Hard Clip"
 msgstr "Nađi porezano"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Desni kanal"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Nivo:"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -10292,6 +19148,14 @@ msgstr "Vrsta šuma"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Izbor"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Stereo Linking"
@@ -10325,6 +19189,44 @@ msgstr "Vrijeme napada/opadanja (v sekundama):"
 msgid "Decay (ms)"
 msgstr "Vrijeme napada/opadanja (v sekundama):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Ime ne smije biti prazno"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Primjena izravnjivača ..."
@@ -10332,6 +19234,22 @@ msgstr "Primjena izravnjivača ..."
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "Primjena izravnjivača ..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -10354,7 +19272,8 @@ msgstr "Datoteke MP3"
 msgid "HTML file"
 msgstr "Datoteke MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Imenujte datoteke:"
 
@@ -10371,9 +19290,24 @@ msgid "Disallow"
 msgstr "Onemogućeno"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Onemogućeno"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "'%s' nije moguće odstraniti"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -10384,16 +19318,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Izaberite datoteku MIDI ..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Lokacija  za izvoz:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Izaberite datoteku MIDI ..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Generisanje tona"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Vrsta šuma"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -10408,8 +19384,40 @@ msgid "Generating Rhythm..."
 msgstr "Generisanje piska"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Broj ponavljanja"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -10432,12 +19440,54 @@ msgid "Beat sound"
 msgstr "Ponovi"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Odstranjivanje šuma"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "šum ..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -10448,12 +19498,25 @@ msgid "Generating Risset Drum..."
 msgstr "Generisanje šuma"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Kašnjenje (sekundi):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "Linearna frekvencija"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Frekvencija (Hz)"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -10466,6 +19529,10 @@ msgstr "Nije moguće izvoziti"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Primjena ..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -10484,6 +19551,10 @@ msgid "HTML files"
 msgstr "Datoteke MP3"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Uređivanje uzorka"
 
@@ -10492,8 +19563,34 @@ msgid "Time Indexed"
 msgstr "Uredi oznaku"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "S&ve"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -10508,6 +19605,11 @@ msgstr "\t-help (ova poruka)"
 msgid "Errors Only"
 msgstr "Greška:"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -10520,6 +19622,46 @@ msgstr "Desni kanal"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "uzorci"
 
@@ -10527,6 +19669,43 @@ msgstr "uzorci"
 #, lisp-format
 msgid "~a seconds."
 msgstr "sekundi"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -10545,6 +19724,10 @@ msgid "Value (dB)"
 msgstr "Nivo:"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Linearan"
 
@@ -10561,6 +19744,14 @@ msgid "Right (dB)"
 msgstr "Desno, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Linearan"
 
@@ -10571,6 +19762,40 @@ msgstr "2 kanala (Stereo)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 kanal (Mono)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Greška (datoteka možda nije bila zapisana): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -10585,8 +19810,40 @@ msgid "Select file"
 msgstr "Izaberite datoteku MIDI ..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Greška"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -10596,6 +19853,15 @@ msgstr "Datoteku žanrova nije moguće otvoriti."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Izbor"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -10613,9 +19879,21 @@ msgstr "Zupčasti"
 msgid "Starting phase (degrees)"
 msgstr "Početna faza LFO (step.):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Primjena ..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -10657,9 +19935,96 @@ msgstr "&Analiziraj"
 msgid "Strength"
 msgstr "Dužina"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Procesiranje automatskog spuštanja ..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -10693,6 +20058,132 @@ msgstr "Frekvencija (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Frekvencija (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Ažuriraj Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Instaliraj ažuriranje"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Dnevnik promjena"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Pročitajte više na GitHub-u"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Povezivanje sa Audacity serverom za ažuriranja nije uspjelo."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Podaci o ažuriranju su koruptirani."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Greška pri preuzimanju ažuriranja."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Ne mogu otvoriti vezu za preuzimanje Audacity-ja."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s je sad dostupan!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Snimanje"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Komanda:"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Datoteku žanrova nije moguće otvoriti.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Snimanje\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Reprodukcija\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Kraj snimanja\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Kraj snimanja\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Reprodukcija\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Reprodukcija\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "'%s' nije moguće preimenovati u '%s'"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Testne datoteke nije moguće otvoriti/kreirati"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Reprodukcija"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Reprodukcija"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Reprodukcija"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Kraj snimanja"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Kraj snimanja"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Kraj snimanja"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&O programu Audacity ..."
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Kraj snimanja"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Kraj snimanja"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Reprodukcija"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Kraj snimanja"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Reprodukcija"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Reprodukcija"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Kliknite i povucite, da bi pomjerili traku u vremenu"
+
 #~ msgid "Program build date:"
 #~ msgstr "Datum izrade programa: "
 
@@ -10722,12 +20213,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgid "Unknown assertion"
 #~ msgstr "Nepoznata tvrdnja"
 
-#~ msgid "Unknown error"
-#~ msgstr "Nepoznata greška"
-
-#~ msgid "Failed to send crash report"
-#~ msgstr "Slanje izvještaja o rušenju nije uspjelo"
-
 #, fuzzy
 #~ msgid "available"
 #~ msgstr "Promjenjiva"
@@ -10756,14 +20241,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Failed to copy tags"
 #~ msgstr "'%s' nije moguće odstraniti"
-
-#, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "Izaberite bilo koju nekompresovanu zvučnu datoteku ..."
-
-#, fuzzy
-#~ msgid "decode an autosave file"
-#~ msgstr "Stare datoteke automatskog spremanja nije mogoće odstraniti"
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -10814,10 +20291,6 @@ msgstr "Frekvencija (Hz)"
 #~ "/%s/%s.%s"
 #~ msgstr "Snimanje"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "Snimanje"
-
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
 #~ msgstr "U ovoj verziji Audacity podrška za Ogg Vorbis nije uključena."
 
@@ -10837,9 +20310,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "Čiščenje privremenih datoteka"
-
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "Čišćenje direktorija međumemorije"
 
 #~ msgid "%s-old%d"
 #~ msgstr "%s-stari%d"
@@ -10876,10 +20346,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Stare datoteke automatskog spremanja nije mogoće odstraniti"
 
 #, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Kompresor ..."
-
-#, fuzzy
 #~ msgid ""
 #~ "MP3 Decoding Failed:\n"
 #~ "\n"
@@ -10903,9 +20369,6 @@ msgstr "Frekvencija (Hz)"
 
 #~ msgid "Audio cache"
 #~ msgstr "Zvučna međumemorija"
-
-#~ msgid "When saving a project that depends on other audio files"
-#~ msgstr "Pri spremanju projekta, koji je ovisan od drugih zvučnih datoteka"
 
 #, fuzzy
 #~ msgid "Silence Finder"
@@ -11004,10 +20467,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "&Ažuriraj ekran tokom izvođenja"
 
 #, fuzzy
-#~ msgid "Disable Scrub Ruler"
-#~ msgstr "Isključi mjerač"
-
-#, fuzzy
 #~ msgid "Enable Scrub Ruler"
 #~ msgstr "Uključi mjerač"
 
@@ -11074,10 +20533,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Datoteke automatskog spremanja nije moguće kreirati: "
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "Odstrani traku"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "Odstranjivanje kliktanja ..."
 
@@ -11115,18 +20570,6 @@ msgstr "Frekvencija (Hz)"
 
 #~ msgid "false"
 #~ msgstr "netačno"
-
-#, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "Zvučna datoteka"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Dodavanje efekta Nyquist ..."
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "Datoteku žanrova nije moguće spremiti."
 
 #, fuzzy
 #~ msgid "Unable to save MIDI device info"
@@ -11186,10 +20629,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Uredi &lance ..."
 
 #, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "Alatna traka prepisa"
-
-#, fuzzy
 #~ msgid "&Tools"
 #~ msgstr "Alati"
 
@@ -11211,10 +20650,6 @@ msgstr "Frekvencija (Hz)"
 #~ "Error opening sound device.\n"
 #~ "Try changing the audio host, recording device and the project sample rate."
 #~ msgstr "Greška pri otvaranju zvučnog uređaja. Molimo provjerite postavke izlaznog uređaja i brzinu uzimanja uzoraka projekta."
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "Snimanje"
 
 #, fuzzy
 #~ msgid "Slider Playback"
@@ -11248,10 +20683,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "Prepis"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "Alatna traka za uređivanje"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -11328,10 +20759,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Dužina"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Izbor do kraja"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "na kraj izbora"
 
@@ -11390,10 +20817,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Sprememba v odstotkih"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "Vrijeme napada:"
-
-#, fuzzy
 #~ msgid "ReleaseTime"
 #~ msgstr "Vrijeme opadanja: "
 
@@ -11408,14 +20831,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Duty Cycle"
 #~ msgstr "Ciklus djelovanja:"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Amplituda (0-1)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "Ime"
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -11467,10 +20882,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Odziv (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Veličina"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "Odziv (%):"
 
@@ -11485,14 +20896,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Pojačanje"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Stereo"
-
-#, fuzzy
-#~ msgid "FilterType"
-#~ msgstr "Mjerač"
 
 #, fuzzy
 #~ msgid "RatePercentChangeStart"
@@ -11521,10 +20924,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "Presjeci tišinu"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Obrtanje"
 
 #~ msgid ""
 #~ "The keyboard shortcut '%s' is already assigned to:\n"
@@ -11562,10 +20961,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Snimi"
 
 #, fuzzy
-#~ msgid "&Mono"
-#~ msgstr "Mono"
-
-#, fuzzy
 #~ msgid "&Left Channel"
 #~ msgstr "Lijevi kanal"
 
@@ -11583,10 +20978,6 @@ msgstr "Frekvencija (Hz)"
 
 #~ msgid "&Use custom mix (for example to export a 5.1 multichannel file)"
 #~ msgstr "&Upotrijebi miješanje po mjeri (npr. za izvoz višekanalne datoteke 5.1)"
-
-#, fuzzy
-#~ msgid "&Length of preview:"
-#~ msgstr "Dužina predslušanja:"
 
 #, fuzzy
 #~ msgid "Add &Track Number"
@@ -11640,9 +21031,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgid "Emeritus Developers"
 #~ msgstr "Zaslužni programeri"
 
-#~ msgid "Edit Metadata"
-#~ msgstr "Uredi metapodatke"
-
 #~ msgid "Disk space remains for recording %d hours and %d minutes."
 #~ msgstr "Preostali prostor na disku dovoljan je za snimanje %d sati i %d minuta."
 
@@ -11661,10 +21049,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "R&ight Channel"
 #~ msgstr "Desni kanal"
-
-#, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "Pojačanje (dB):"
 
 #, fuzzy
 #~ msgid "&Enable level control"
@@ -11719,12 +21103,6 @@ msgstr "Frekvencija (Hz)"
 #~ "  %s"
 
 #, fuzzy
-#~ msgid "Current directory:"
-#~ msgstr ""
-#~ "Nije moguće kreirati direktorij:\n"
-#~ "  %s"
-
-#, fuzzy
 #~ msgid "Directory doesn't exist."
 #~ msgstr "Direktorij %s ne postoji. Želite li ga kreirati?"
 
@@ -11765,17 +21143,8 @@ msgstr "Frekvencija (Hz)"
 #~ msgid "Command Line Export Setup"
 #~ msgstr "Postavke izvoza iz komandne linije"
 
-#~ msgid "Specify FLAC Options"
-#~ msgstr "Postavite FLAC opcije"
-
-#~ msgid "FLAC Export Setup"
-#~ msgstr "Postavke izvoza FLAC"
-
 #~ msgid "Specify MP2 Options"
 #~ msgstr "Postavite MP2 Opcije"
-
-#~ msgid "MP2 Export Setup"
-#~ msgstr "Postavke izvoza MP2"
 
 #~ msgid "Specify MP3 Options"
 #~ msgstr "Odredi MP3 opcije"
@@ -11788,9 +21157,6 @@ msgstr "Frekvencija (Hz)"
 
 #~ msgid "Specify Ogg Vorbis Options"
 #~ msgstr "Navedite opcije Ogg Vorbis"
-
-#~ msgid "Ogg Vorbis Export Setup"
-#~ msgstr "Postavke izvoza Ogg Vorbis"
 
 #~ msgid "Uncompressed Export Setup"
 #~ msgstr "Postavke nekompresovanog izvoza"
@@ -11837,9 +21203,6 @@ msgstr "Frekvencija (Hz)"
 
 #~ msgid "&Audio Track"
 #~ msgstr "&Zvučna traka"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "Visokokvalitetna sinhrona interpolacija:"
 
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "Brza sinhrona interpolacija"
@@ -11922,9 +21285,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgid "Equalization..."
 #~ msgstr "Izjednačavanje ..."
 
-#~ msgid "Performing Equalization"
-#~ msgstr "Izvođenje izjednačavanja"
-
 #~ msgid "Fading In"
 #~ msgstr "Pojačavanje glasnosti"
 
@@ -11986,24 +21346,12 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "&Preimenuj"
 
 #, fuzzy
-#~ msgid "Load preset:"
-#~ msgstr "Učitaj datoteke"
-
-#, fuzzy
 #~ msgid "Change name to:"
 #~ msgstr "Promijeni oznaku trake u:"
 
 #, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "Obrnuto"
-
-#, fuzzy
 #~ msgid "Applying Reverb"
 #~ msgstr "Primjena izravnjivača ..."
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "Prenesi datoteku &na server ..."
 
 #~ msgid "Silence..."
 #~ msgstr "Tišina ..."
@@ -12071,9 +21419,6 @@ msgstr "Frekvencija (Hz)"
 
 #~ msgid "Recovering a project will not change any files on disk before you save it."
 #~ msgstr "Obnova projekta neće promijeniti nijednu datoteku na disku, sve dok ga ne snimite."
-
-#~ msgid "Do Not Recover"
-#~ msgstr "Ne obnavljaj"
 
 #, fuzzy
 #~ msgid "Change output device"

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-05 05:22+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
-"Language-Team: Catalan <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/ca/>\n"
+"Language-Team: Catalan <https://hosted.weblate.org/projects/tenacity/tenacity/ca/>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,81 +18,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Actualitza el Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Omet"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Instal·la l’actualització"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Registre de canvis"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Llegiu-ne més al GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "S’ha produït un error en comprovar si hi ha actualitzacions"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "No s’ha pogut connectar al servidor d’actualitzacions del Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Les dades d’actualització eren malmeses."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "S’ha produït un error en baixar l’actualització."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "No s’ha pogut obrir l’enllaç de baixada del Tenacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "El Tenacity %s és disponible."
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Enregistrament"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "No es pot determinar"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr ""
 
 #. i18n-hint: Abbreviation for Kilo bytes
 #: libraries/lib-strings/Internat.cpp
 #, c-format
 msgid "%s KB"
 msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -215,8 +165,14 @@ msgstr "A&tura\tF6"
 msgid "&About"
 msgstr "Quant &a"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Desa l'script"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Sortida"
 
@@ -232,7 +188,12 @@ msgstr "Scripts Nyquist (*.ny)|*.ny|Scripts Lisp (*.lsp)|*.lsp|Tots els fitxers|
 msgid "Script was not saved."
 msgstr "No s'ha desat l'script."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Advertència"
 
@@ -253,11 +214,16 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galeria d’icones Tango (icones de la barra d’eines)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "© 2009 de Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Mòdul externe del Tenacity que ofereix un EID senzill per a crear efectes."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -280,7 +246,8 @@ msgstr "Sense títol"
 msgid "Nyquist Effect Workbench - "
 msgstr "Banc de treball d'efectes Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nou"
 
@@ -320,7 +287,8 @@ msgstr "Copia"
 msgid "Copy to clipboard"
 msgstr "Copia al porta-retalls"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Retalla"
 
@@ -328,7 +296,8 @@ msgstr "Retalla"
 msgid "Cut to clipboard"
 msgstr "Retalla al porta-retalls"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Enganxa"
 
@@ -353,7 +322,8 @@ msgstr "Selecciona-ho tot"
 msgid "Select all text"
 msgstr "Selecciona tot el text"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Desfés"
 
@@ -361,7 +331,8 @@ msgstr "Desfés"
 msgid "Undo last change"
 msgstr "Desfés l'últim canvi"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Refés"
 
@@ -418,7 +389,8 @@ msgid "Go to next S-expr"
 msgstr "Vés a l’expressió simbòlica següent"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Començament"
 
@@ -426,7 +398,8 @@ msgstr "Començament"
 msgid "Start script"
 msgstr "Inicia l'script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Atura"
 
@@ -441,7 +414,8 @@ msgid "About %s"
 msgstr "Quant al %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "D’acord"
 
@@ -449,11 +423,13 @@ msgstr "D’acord"
 msgid "Build Information"
 msgstr "Informació del muntatge"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Habilitat"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Inhabilitat"
 
@@ -463,8 +439,9 @@ msgid "The Build"
 msgstr "El muntatge"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Id. de consignació:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versió: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -474,22 +451,28 @@ msgstr "Tipus de construcció:"
 msgid "Compiler:"
 msgstr "Compilador:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefix de la instal·lació:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Carpeta dels paràmetres:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Carpeta dels paràmetres:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Compatibilitat amb formats de fitxers"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Biblioteca d'interfície gràfica multiplataforma"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -503,7 +486,6 @@ msgstr "Conversió de la freqüència de mostratge"
 msgid "MP3 Importing"
 msgstr "Importació MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importació i exportació Ogg Vorbis"
@@ -512,7 +494,6 @@ msgstr "Importació i exportació Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Compatibilitat amb les etiquetes ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importació i exportació FLAC"
@@ -530,14 +511,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importació i exportació FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importació a través de GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Funcionalitats"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Compatibilitat amb el connector"
 
@@ -552,6 +525,10 @@ msgstr "Compatibilitat amb el canvi d'altura i tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Compatibilitat amb el canvi extrem d'altura i tempo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Funcionalitats"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -670,16 +647,22 @@ msgstr "%s, gràfics"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (incorpora %s, %s, %s, %s i %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Un programari gratuït, de codi obert i multiplataforma per a enregistrar i "
-"editar sons."
+msgstr "Un programari gratuït, de codi obert i multiplataforma per a enregistrar i editar sons."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Crèdits"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -728,6 +711,7 @@ msgstr "Lloc web i gràfics"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Traducció al català: Francesc Busquets, Robert Buj, Pau Bosch i Adolfo Jayme"
@@ -745,6 +729,22 @@ msgstr "Agraïments especials:"
 #, c-format
 msgid "%s website: "
 msgstr "Lloc web del %s: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Contribuïdors del Tenacity"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -767,6 +767,7 @@ msgstr "Línia del temps"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Feu clic o arrossegueu per començar la recerca"
@@ -774,6 +775,7 @@ msgstr "Feu clic o arrossegueu per començar la recerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Feu clic o arrossegueu per començar el rastreig"
@@ -781,6 +783,7 @@ msgstr "Feu clic o arrossegueu per començar el rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Feu clic i moveu per rastrejar. Feu clic i arrossegueu per recercar."
@@ -788,6 +791,7 @@ msgstr "Feu clic i moveu per rastrejar. Feu clic i arrossegueu per recercar."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Moveu per recercar"
@@ -795,6 +799,7 @@ msgstr "Moveu per recercar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Moveu per rastrejar"
@@ -851,6 +856,21 @@ msgstr ""
 "No es pot bloquejar el fragment\n"
 "més enllà del final del projecte."
 
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Error"
+msgstr "Error"
+
 #: src/AudacityApp.cpp
 #, c-format
 msgid "Failed to remove %s"
@@ -871,7 +891,8 @@ msgstr ""
 "Aquesta pregunta només es fa una vegada, després d'una instal·lació on heu demanat restablir les preferències."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Reinicialitza les preferències del Tenacity"
 
 #: src/AudacityApp.cpp
@@ -886,7 +907,8 @@ msgstr ""
 "S’ha eliminat de la llista de fitxers recents."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "No s’ha pogut inicialitzar la biblioteca SQLite. El Tenacity no pot continuar."
 
 #: src/AudacityApp.cpp
@@ -911,7 +933,7 @@ msgstr "&Obre…"
 msgid "Open &Recent..."
 msgstr "Obre un fitxer &recent..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&Quant al Tenacity…"
 
@@ -924,20 +946,33 @@ msgid "&File"
 msgstr "&Fitxer"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "El Tenacity no ha pogut trobar cap lloc per a desar-hi els fitxers temporals.\n"
 "Indiqueu un directori adient al diàleg de preferències."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid ""
+"Tenacity could not find a place to store temporary files.\n"
+"Please enter an appropriate directory in the preferences dialog."
+msgstr ""
+"El Tenacity no ha pogut trobar cap lloc per a desar-hi els fitxers temporals.\n"
+"Indiqueu un directori adient al diàleg de preferències."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "El Tenacity es tancarà ara. Reinicieu-lo per a començar a utilitzar el directori temporal nou."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -946,16 +981,18 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "El Tenacity no ha estat capaç de blocar la carpeta de fitxers\n"
 "temporals. Pot ser que aquesta carpeta estigui en ús\n"
 "per alguna altra còpia del Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Encara voleu iniciar el Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -963,24 +1000,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "S'ha produït un error en bloquejar la carpeta de fitxers temporals"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "El sistema ha detectat que hi ha una altra còpia del Tenacity en funcionament.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Per a obrir diversos projectes de forma simultània podeu utilitzar les\n"
 "ordres «Nou» o «Obre» del procés actual del Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "El Tenacity ja s’està executant"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Fallada d’inici del Tenacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -1000,7 +1085,8 @@ msgstr "executa l’autodiagnòstic"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "mostra la versió del Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1010,9 +1096,10 @@ msgid "audio or project file name"
 msgstr "nom de fitxer d'àudio o de projecte"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1025,24 +1112,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Fitxers de projecte del Tenacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Missatge"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Error de configuració del Tenacity"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Ajuda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Surt del Tenacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Registre del Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1054,7 +1165,8 @@ msgstr "&Desa..."
 msgid "Cl&ear"
 msgstr "&Neteja"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "Tan&ca"
 
@@ -1109,62 +1221,34 @@ msgid "Error Initializing Midi"
 msgstr "S'ha produït un error en inicialitzar el MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audio del Tenacity"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "S'ha exhaurit la memòria!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
 msgstr ""
-"S’ha aturat l’ajustament automàtic del nivell d’enregistrament. No és "
-"possible optimitzar-lo més. Encara és massa alt."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr ""
-"L’ajustament automàtic del nivell d’enregistrament ha abaixat el volum a %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr ""
-"S’ha aturat l’ajustament automàtic del nivell d’enregistrament. No és "
-"possible optimitzar-lo més. Encara és massa baix."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr ""
-"L’ajustament automàtic del nivell d’enregistrament ha apujat el volum a %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr ""
-"S’ha aturat l’ajustament automàtic del nivell d’enregistrament. S’ha excedit "
-"el nombre total d’anàlisis sense trobar un volum acceptable. Encara és massa "
-"alt."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr ""
-"S’ha aturat l’ajustament automàtic del nivell d’enregistrament. S’ha excedit "
-"el nombre total d’anàlisis sense trobar un volum acceptable. Encara és massa "
-"baix."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr ""
-"S’ha aturat l’ajustament automàtic del nivell d’enregistrament. %.2f sembla "
-"un volum acceptable."
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "Seleccioneu el dispositiu d'enregistrament\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Nombre de dispositiu de reproducció per defecte: %d\n"
 
 #: src/AudioIOBase.cpp
 msgid "No devices found\n"
@@ -1207,8 +1291,18 @@ msgstr "Latència d’enregistrament baixa: %g\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Latència de reproducció baixa: %g\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
 msgid "High Recording Latency: %g\n"
 msgstr "Latència d’enregistrament alta: %g\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "High Playback Latency: %g\n"
+msgstr "Latència de reproducció alta: %g\n"
 
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
@@ -1222,45 +1316,39 @@ msgstr "Dispositiu d’enregistrament seleccionat: %d - %s\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "No s’ha trobat cap dispositiu d’enregistrament per a «%s».\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Dispositiu de reproducció seleccionat: %d - %s\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "No es pot obrir el fitxer de gèneres.\n"
+#, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "No s’ha trobat cap dispositiu de reproducció per a «%s».\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Mescladors disponibles:\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Taxes admeses:\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
-msgid "%d - %s\n"
-msgstr "%s - %s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Simula errors d'enregistrament\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volum de reproducció\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Volum d'enregistrament\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Volum d'enregistrament\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Volum de reproducció: %s (emulat)\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Volum de reproducció: %s (emulat)\n"
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1268,17 +1356,28 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Seleccioneu el dispositiu d'enregistrament\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "No s’ha trobat cap dispositiu d’enregistrament per a «%s».\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
 msgstr "Seleccioneu el dispositiu de reproducció\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
+msgstr "No s’ha trobat cap dispositiu de reproducció per a «%s».\n"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Automatic Crash Recovery"
 msgstr "Recuperació automàtica de fallades"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1290,12 +1389,14 @@ msgid "Recoverable &projects"
 msgstr "Projectes recuperables"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Selecciona"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nom"
 
@@ -1349,9 +1450,19 @@ msgstr "&Paràmetres"
 msgid "&Details"
 msgstr "&Detalls"
 
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "Choose command"
+msgstr "Alguna ordre"
+
 #: src/BatchCommands.cpp
 msgid "MP3 Conversion"
 msgstr "Conversió MP3"
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Fade Ends"
+msgstr "Fosa d'obertura"
 
 #: src/BatchCommands.cpp
 msgid "Import Macro"
@@ -1372,6 +1483,20 @@ msgstr "Exporta el MIDI"
 #: src/BatchCommands.cpp
 msgid "Effect"
 msgstr "Efecte"
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (With Parameters)"
+msgstr "Paràmetres d'&edició"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (No Parameters)"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
 #: src/BatchCommands.cpp src/CommonCommandFlags.cpp
@@ -1438,6 +1563,12 @@ msgstr "Gestiona les macros"
 msgid "Select Macro"
 msgstr "Seleccioneu la macro"
 
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Macros…"
+
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
 msgstr "Aplica la macro a:"
@@ -1500,11 +1631,16 @@ msgstr "Elimi&na"
 msgid "&Rename..."
 msgstr "Canvia el &nom..."
 
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
 msgid "I&mport..."
 msgstr "I&mporta..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xporta..."
 
@@ -1545,7 +1681,8 @@ msgstr "Mou am&unt"
 msgid "Move &Down"
 msgstr "Mou a&vall"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "De&sa"
 
@@ -1628,7 +1765,8 @@ msgid "Run"
 msgstr "Executa"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Tanca"
 
@@ -1664,6 +1802,11 @@ msgstr ""
 #: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "S’està preparant…\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1771,11 +1914,6 @@ msgid "No revision identifier was provided"
 msgstr "No s’ha proporcionat cap identificador d’esmena"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Data i hora d'acabament"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Muntatge de depuració (nivell de depuració %d)"
@@ -1789,6 +1927,17 @@ msgstr "Muntatge de llançament (nivell de depuració %d)"
 #, fuzzy
 msgid ", 64 bits"
 msgstr "24 bits"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, fuzzy, c-format
+msgid ""
+"You must first select some audio for '%s' to act on.\n"
+"\n"
+"Ctrl + A selects all audio."
+msgstr ""
+"Heu de seleccionar àudio abans de poder fer aquesta acció.\n"
+"(No funcionarà la selecció d’altres tipus de pista.)"
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1823,6 +1972,21 @@ msgstr ""
 "\n"
 "2. Quan hàgiu obtenit el perfil de soroll, seleccioneu l’àudio que voleu modificar\n"
 "i feu servir %s per a modificar-lo."
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr ""
+"Heu de seleccionar àudio abans de poder fer aquesta acció.\n"
+"(No funcionarà la selecció d’altres tipus de pista.)"
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1866,6 +2030,16 @@ msgid "Could not write to %s.\n"
 msgstr "No s'ha pogut escriure al fitxer: %s\n"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity no ha pogut escriure un fitxer.\n"
+"Potser no es pot escriure a %s o bé el disc està ple."
+
+#: src/DBConnection.cpp
 #, c-format
 msgid ""
 "Failed to create savepoint:\n"
@@ -1884,6 +2058,10 @@ msgid ""
 msgstr ""
 "No s'ha pogut registrar:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1994,10 +2172,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Si ho feu, el vostre projecte no es desarà al disc. És això el que voleu?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2009,13 +2188,53 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Comprovació de dependències"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Cap"
 
 #: src/Dither.cpp
+msgid "Rectangle"
+msgstr ""
+
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Triangle"
+msgstr ""
+
+#: src/Dither.cpp
 msgid "Shaped"
 msgstr "Modelat"
+
+#: src/FFT.cpp
+msgid "Rectangular"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
@@ -2042,9 +2261,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "La compilació s'ha fet sense el suport a FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2066,11 +2286,9 @@ msgid "Locate FFmpeg"
 msgstr "Ubicació de FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"El Tenacity necessita el fitxer «%s» per a importar i exportar àudio a "
-"través de FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "El Tenacity necessita el fitxer «%s» per a importar i exportar àudio a través de FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2082,7 +2300,8 @@ msgstr "Ubicació de «%s»:"
 msgid "To find '%s', click here -->"
 msgstr "Per a trobar «%s», feu clic aquí →"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Navega…"
 
@@ -2108,8 +2327,9 @@ msgid "FFmpeg not found"
 msgstr "No s'ha trobat FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2129,25 +2349,34 @@ msgstr "No tornis a mostrar aquesta advertència"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "No s'han trobat biblioteques FFmpeg compatibles."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "El Tenacity no ha pogut obrir un fitxer a %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "El Tenacity no ha pogut llegir d’un fitxer a %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity ha escrit amb èxit un fitxer a %s però ha fallat el canvi de nom a %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2166,6 +2395,16 @@ msgid "Error (file may not have been written): %s"
 msgstr "Error (podria ser que el fitxer no s'hagués escrit): %s"
 
 #: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr "&Copia tot el so dins del projecte (el més segur)"
+
+#: src/FileFormats.cpp
+#, fuzzy
+msgid "&Read uncompressed files from original location (faster)"
+msgstr "Llegeix els fitxers &directament de l'original (més ràpid)"
+
+#: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
 msgstr "&Copia tot el so dins del projecte (el més segur)"
 
@@ -2177,7 +2416,9 @@ msgstr "&No copiïs cap so"
 msgid "As&k"
 msgstr "&Pregunta-m'ho"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Tots els fitxers"
 
@@ -2186,6 +2427,10 @@ msgstr "Tots els fitxers"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Fitxers de projecte AUP3"
+
+#: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr "Biblioteques enllaçades dinàmicament"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -2198,6 +2443,10 @@ msgstr "Fitxers de text"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Fitxers XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2239,6 +2488,14 @@ msgstr "Autocorrelació d’arrel cúbica"
 msgid "Enhanced Autocorrelation"
 msgstr "Autocorrelació millorada"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Espectre"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2255,9 +2512,35 @@ msgstr "Freqüència lineal"
 msgid "Log frequency"
 msgstr "Freqüència logarítmica"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "si"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Desplaçament"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "Augmenta el zoom"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2268,6 +2551,11 @@ msgstr "Horitzontal"
 #, fuzzy
 msgid "Zoom Horizontal"
 msgstr "Horitzontal"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cursor:"
+msgstr "Posiciona el &cursor"
 
 #: src/FreqWindow.cpp
 msgid "Peak:"
@@ -2303,19 +2591,33 @@ msgstr "&Redibuixa..."
 
 #: src/FreqWindow.cpp
 msgid "To plot the spectrum, all selected tracks must be the same sample rate."
-msgstr ""
-"Per a traçar l’espectre, cal que totes les pistes seleccionades tinguin la "
-"mateixa freqüència de mostratge."
+msgstr "Per a traçar l’espectre, cal que totes les pistes seleccionades tinguin la mateixa freqüència de mostratge."
 
 #: src/FreqWindow.cpp
 #, c-format
 msgid "Too much audio was selected. Only the first %.1f seconds of audio will be analyzed."
-msgstr ""
-"Hi ha massa àudio seleccionat. Només s’analitzaran els primers %.1f segons."
+msgstr "Hi ha massa àudio seleccionat. Només s’analitzaran els primers %.1f segons."
 
 #: src/FreqWindow.cpp
 msgid "Not enough data selected."
 msgstr "No s’han seleccionat prou dades."
+
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f s (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f s (%d Hz) (%s) = %.3f"
 
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
@@ -2339,7 +2641,8 @@ msgstr "espectre.txt"
 msgid "Export Spectral Data As:"
 msgstr "Exporta les dades de l'espectre com a:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "No s’ha pogut escriure al fitxer: %s"
@@ -2416,15 +2719,11 @@ msgstr "No hi ha cap ajuda local disponible"
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
-msgstr ""
-"<br><br>La versió del Tenacity que utilitzeu és una <b>versió de prova "
-"alfa</b>."
+msgstr "<br><br>La versió del Tenacity que utilitzeu és una <b>versió de prova alfa</b>."
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
-msgstr ""
-"<br><br>La versió del Tenacity que utilitzeu és una <b>versió de prova "
-"beta</b>."
+msgstr "<br><br>La versió del Tenacity que utilitzeu és una <b>versió de prova beta</b>."
 
 #: src/HelpText.cpp
 msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
@@ -2521,11 +2820,30 @@ msgstr "Descarta"
 msgid "&Compact"
 msgstr "&Ordre"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Historial..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2541,7 +2859,9 @@ msgid "Track"
 msgstr "Pista"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -2601,7 +2921,8 @@ msgstr "Introduïu el nom de la pista"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Pista d'etiquetes"
 
@@ -2612,11 +2933,13 @@ msgstr "No s'han pogut llegir una o més etiquetes."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "És la primera vegada que s'executa Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Trieu la llengua que voleu que utilitzi el Tenacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2626,9 +2949,15 @@ msgstr "Trieu la llengua que voleu que utilitzi el Tenacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "L'idioma que heu escollit, %s (%s), no és el mateix que l'idioma del sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirma"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "S'ha produït un error en desar el projecte"
 
 #: src/Legacy.cpp
 #, c-format
@@ -2640,13 +2969,19 @@ msgstr ""
 "El fitxer antic ha estat desat com a «%s»"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "S’està obrint el projecte del Tenacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke del Tenacity%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Navega..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2692,19 +3027,23 @@ msgid "Mixing and rendering tracks"
 msgstr "S'estan mesclant i renderitzant les pistes"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Taula de mescles del Tenacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Guany"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocitat"
 
@@ -2713,28 +3052,43 @@ msgid "Musical Instrument"
 msgstr "Instrument musical"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balanç"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Silenci"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr " Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Vúmetre de nivell del senyal"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "S'ha mogut el botó lliscant de guany"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "S'ha mogut el botó lliscant d'intensitat de nota"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "S'ha mogut el botó lliscant de la panoràmica"
 
@@ -2768,9 +3122,9 @@ msgstr ""
 "No es carregarà."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2803,12 +3157,20 @@ msgstr ""
 "\n"
 "Utilitzeu només mòduls provinents de fonts en què confieu"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Sí"
 
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
+#, fuzzy
+msgid "No"
+msgstr "Cap"
+
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Carregador de mòduls del Tenacity"
 
 #: src/ModuleManager.cpp
@@ -3049,7 +3411,8 @@ msgstr "&Selecciona-ho tot"
 msgid "C&lear All"
 msgstr "&Neteja-ho tot"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Habilita"
 
@@ -3079,6 +3442,15 @@ msgstr ""
 "\n"
 "%s"
 
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"Effect or Command at %s failed to register:\n"
+"%s"
+msgstr ""
+"No s'ha pogut registrar:\n"
+"%s"
+
 #: src/Printing.cpp
 msgid "There was a problem printing."
 msgstr "Hi ha hagut un problema en imprimir."
@@ -3102,11 +3474,30 @@ msgstr ""
 msgid "Actual Rate: %d"
 msgstr "Freqüència real: %d"
 
+#: src/ProjectAudioManager.cpp src/effects/Effect.cpp
+msgid ""
+"Error opening sound device.\n"
+"Try changing the audio host, playback device and the project sample rate."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr "Totes les pistes seleccionades per a enregistrar han de tenir la mateixa freqüència de mostratge"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
 msgstr ""
-"Totes les pistes seleccionades per a enregistrar han de tenir la mateixa "
-"freqüència de mostratge"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
 
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
@@ -3124,6 +3515,15 @@ msgstr "Enregistra"
 #: src/ProjectAudioManager.cpp
 msgid "Dropouts"
 msgstr "Abandonaments"
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
 
 #: src/ProjectAudioManager.cpp
 msgid "Turn off dropout detection"
@@ -3144,10 +3544,7 @@ msgstr "Tanca el projecte ara mateix sense fer cap canvi"
 
 #: src/ProjectFSCK.cpp
 msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
-msgstr ""
-"Continua amb les reparacions indicades al registre i comprova si hi ha més "
-"errors. Això desarà el projecte en el seu estat actual, tret que tanqueu el "
-"projecte de forma immediata en algun advertiment d’error posterior."
+msgstr "Continua amb les reparacions indicades al registre i comprova si hi ha més errors. Això desarà el projecte en el seu estat actual, tret que tanqueu el projecte de forma immediata en algun advertiment d’error posterior."
 
 #: src/ProjectFSCK.cpp
 msgid "Warning - Problems Reading Sequence Tags"
@@ -3158,11 +3555,11 @@ msgid "Inspecting project file data"
 msgstr "S’estan inspeccionant les dades del fitxer de projecte"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3198,19 +3595,18 @@ msgstr "Tracta l’àudio mancant com a silenci (només durant aquesta sessió)"
 
 #: src/ProjectFSCK.cpp
 msgid "Replace missing audio with silence (permanent immediately)."
-msgstr ""
-"Substitueix l’àudio mancant per silenci (de manera immediata i permanent)."
+msgstr "Substitueix l’àudio mancant per silenci (de manera immediata i permanent)."
 
 #: src/ProjectFSCK.cpp
 msgid "Warning - Missing Aliased File(s)"
 msgstr "Advertència - Falten fitxers referenciats per àlies"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "La comprovació del projecte de la carpeta «%s»\n"
@@ -3235,12 +3631,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Advertència - Falten fitxers de resums d'àlies"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3265,8 +3661,7 @@ msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Replace missing audio with silence (permanent immediately)"
-msgstr ""
-"Substitueix l’àudio mancant per silenci (de manera immediata i permanent)"
+msgstr "Substitueix l’àudio mancant per silenci (de manera immediata i permanent)"
 
 #: src/ProjectFSCK.cpp
 msgid "Warning - Missing Audio Data Block File(s)"
@@ -3299,7 +3694,8 @@ msgstr "Advertència - Fitxers de blocs orfes"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progrés"
 
@@ -3313,8 +3709,7 @@ msgid ""
 "\n"
 "Select 'Help > Diagnostics > Show Log...' to see details."
 msgstr ""
-"La comprovació del projecte ha detectat incoherències de fitxers durant el "
-"procés de recuperació automàtica.\n"
+"La comprovació del projecte ha detectat incoherències de fitxers durant el procés de recuperació automàtica.\n"
 "\n"
 "Trieu Ajuda ▸ Diagnòstics ▸ Mostra el registre per a veure’n els detalls."
 
@@ -3325,6 +3720,11 @@ msgstr "Advertència: Hi ha hagut problemes durant la recuperació automàtica"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<projecte sense nom>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projecte %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3368,12 +3768,105 @@ msgid ""
 msgstr "No es pot llegir el fitxer dels valors predefinits."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"No s’ha pogut actualitzar el fitxer del projecte.\n"
+"Ha fallat l’ordre següent:\n"
+"\n"
+"%s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Aquest no és un fitxer de projecte del Tenacity"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+"El projecte s’ha creat amb una versió més recent del Tenacity.\n"
+"\n"
+"Haureu d’actualitzar el programa per a obrir-lo."
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
 msgstr "No s’ha pogut inicialitzar el fitxer del projecte"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "No es pot iniciar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "No es pot iniciar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "No es pot iniciar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "No es pot iniciar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "No es pot iniciar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "No es pot iniciar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
+msgstr "No es pot iniciar el flux de dades MP3"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: src/ProjectFileIO.cpp
@@ -3386,8 +3879,37 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Fitxer de blocs orfe: «%s»"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to attach destination database"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "No s’ha pogut vincular el paràmetre SQL"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"No s’ha pogut actualitzar el fitxer del projecte.\n"
+"Ha fallat l’ordre següent:\n"
+"\n"
+"%s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3398,9 +3920,9 @@ msgid "Error Writing to File"
 msgstr "S’ha produït un error en escriure al fitxer"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3411,6 +3933,19 @@ msgstr ""
 msgid "Compacting project"
 msgstr "S’està compactant el projecte"
 
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr "[Projecte %02i] Tenacity «%s»"
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
+
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
@@ -3418,18 +3953,21 @@ msgstr "(recuperat)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Aquest fitxer s’ha desat amb el Tenacity %s.\n"
-"Esteu utilitzant el Tenacity %s. Per a obrir aquest fitxer, heu d’"
-"actualitzar el programa a una versió més recent."
+"Esteu utilitzant el Tenacity %s. Per a obrir aquest fitxer, heu d’actualitzar el programa a una versió més recent."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "No es pot obrir el fitxer de projecte"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3444,6 +3982,10 @@ msgid "Unable to parse project information."
 msgstr "No es pot llegir el fitxer dels valors predefinits."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Quan es desen els &projectes"
 
@@ -3452,12 +3994,35 @@ msgid "Error Saving Project"
 msgstr "S'ha produït un error en desar el projecte"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Quan es desa un projecte &buit"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3465,8 +4030,23 @@ msgstr ""
 "Per sort, els projectes següents poden ser recuperats de manera automàtica:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Alguns projectes no es van desar bé l'última vegada que es va executar Audacity.\n"
+"Per sort, els projectes següents poden ser recuperats de manera automàtica:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "S’ha recuperat el projecte"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr "No és possible desar projectes a les unitats FAT."
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3496,6 +4076,17 @@ msgstr "Avís: el projecte està buit"
 msgid "Insufficient Disk Space"
 msgstr "L’espai al disc és insuficient"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3506,8 +4097,7 @@ msgid ""
 "The project was not saved because the file name provided would overwrite another project.\n"
 "Please try again and select an original name."
 msgstr ""
-"El projecte no s’ha desat perquè el nom de fitxer que heu proporcionat "
-"podria sobreescriure un altre projecte.\n"
+"El projecte no s’ha desat perquè el nom de fitxer que heu proporcionat podria sobreescriure un altre projecte.\n"
 "Torneu a intentar-ho i seleccioneu un nom original."
 
 #: src/ProjectFileManager.cpp
@@ -3516,14 +4106,26 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sAnomena i desa el projecte «%s»…"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
-"«Desa el projecte» només és per a un projecte del Tenacity, no per a un "
-"fitxer d’àudio.\n"
-"Per a un fitxer d’àudio que s’obrirà en altres aplicacions, utilitzeu "
-"«Exporta».\n"
+"«Desa el projecte» només és per a un projecte del Tenacity, no per a un fitxer d’àudio.\n"
+"Per a un fitxer d’àudio que s’obrirà en altres aplicacions, utilitzeu «Exporta».\n"
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -3535,14 +4137,22 @@ msgid ""
 "The project was not saved because the selected project is open in another window.\n"
 "Please try again and select an original name."
 msgstr ""
-"El projecte no s’ha desat perquè el projecte seleccionat està obert en una "
-"altra finestra.\n"
+"El projecte no s’ha desat perquè el projecte seleccionat està obert en una altra finestra.\n"
 "Torneu a intentar-ho i seleccioneu un nom original."
 
 #: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "%sAnomena i desa la còpia sense pèrdua del projecte «%s»"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
+"El projecte no s’ha desat perquè el nom de fitxer que heu proporcionat podria sobreescriure un altre projecte.\n"
+"Torneu a intentar-ho i seleccioneu un nom original."
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -3570,14 +4180,14 @@ msgid "Error Opening Project"
 msgstr "S'ha produït un error en obrir el projecte"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
-"Esteu intentant obrir un fitxer de còpia de seguretat que es va crear "
-"automàticament.\n"
+"Esteu intentant obrir un fitxer de còpia de seguretat que es va crear automàticament.\n"
 "En fer això es podria produir una pèrdua de dades important.\n"
 "\n"
 "En comptes de fer això, obriu el corresponent fitxer de projecte Tenacity."
@@ -3608,6 +4218,12 @@ msgid "Error Opening File or Project"
 msgstr "S'ha produït un error en obrir el fitxer o el projecte"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "S'ha recuperat el projecte"
 
@@ -3633,12 +4249,33 @@ msgid "Error Importing"
 msgstr "S'ha produït un error en importar"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Estableix el projecte"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "No es pot obrir el fitxer de projecte"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Ordre"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3649,8 +4286,8 @@ msgid "Automatic database backup failed."
 msgstr "Desament automàtic habilitat:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Us donem la benvinguda al Tenacity %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3709,6 +4346,12 @@ msgstr[1] "%d minuts"
 msgid "%s and %s."
 msgstr "%s i %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3723,6 +4366,21 @@ msgstr "Barra de desplaçament horitzontal"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Barra de desplaçament vertical"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -3832,6 +4490,11 @@ msgid "All Effects"
 msgstr "Tots els efectes"
 
 #: src/Screenshot.cpp
+#, fuzzy
+msgid "All Scriptables"
+msgstr "Script"
+
+#: src/Screenshot.cpp
 msgid "All Preferences"
 msgstr "Totes les preferències"
 
@@ -3839,7 +4502,8 @@ msgstr "Totes les preferències"
 msgid "SelectionBar"
 msgstr "Barra de selecció"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Selecció espectral"
 
@@ -3847,42 +4511,56 @@ msgstr "Selecció espectral"
 msgid "Timer"
 msgstr "Temps:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Eines"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "Traductors"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mesclador"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Vúmetre"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Vúmetre de reproducció"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Vúmetre d'enregistrament"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Edita"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Dispositiu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Reprodueix a velocitat"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Rastreja"
 
@@ -3897,7 +4575,10 @@ msgstr "Regle"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Pistes"
 
@@ -3966,6 +4647,11 @@ msgstr ""
 "La seqüència té un fitxer de blocs que excedeix el nombre màxim de %s mostres per bloc.\n"
 "Es trunca a aquesta durada màxima."
 
+#: src/Sequence.cpp
+#, fuzzy
+msgid "Warning - Truncating Overlong Block File"
+msgstr "Advertència - Fitxers de blocs orfes"
+
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
 msgstr "&Previsualitza"
@@ -4003,7 +4689,8 @@ msgid "Activation level (dB):"
 msgstr "Nivell d'activació (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Us donem la benvinguda al Tenacity."
 
 #: src/SplashDialog.cpp
@@ -4104,8 +4791,7 @@ msgstr "Restableix els gèneres"
 
 #: src/Tags.cpp
 msgid "Are you sure you want to reset the genre list to defaults?"
-msgstr ""
-"Segur que voleu reinicialitzar la llista de gèneres als valors per defecte?"
+msgstr "Segur que voleu reinicialitzar la llista de gèneres als valors per defecte?"
 
 #: src/Tags.cpp
 msgid "Unable to open genre file."
@@ -4139,10 +4825,18 @@ msgstr ""
 "El directori de fitxers temporals és a una unitat formatada com a FAT.\n"
 "S’ha reinicialitzat la ubicació per defecte."
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "El Tenacity no ha pogut escriure al fitxer:\n"
@@ -4162,9 +4856,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4173,18 +4867,28 @@ msgstr ""
 "per a escriure-hi."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "El Tenacity no ha pogut escriure les imatges al fitxer:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+"S'ha escrit el tema a:\n"
+"  %s."
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4194,9 +4898,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4205,8 +4909,9 @@ msgstr ""
 "Potser té un format PNG incorrecte."
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "El Tenacity no ha pogut carregar el tema per defecte.\n"
@@ -4235,7 +4940,15 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "El Tenacity no ha pogut desar el fitxer:\n"
@@ -4274,7 +4987,11 @@ msgstr "Personalitzat"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Durada"
 
@@ -4285,12 +5002,23 @@ msgid "Time Track"
 msgstr "Pista de temps"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Enregistrament programat del Tenacity"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
 msgstr "Desca l'enregistrament temporitzat com"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+"El projecte no s’ha desat perquè el nom de fitxer que heu proporcionat podria sobreescriure un altre projecte.\n"
+"Torneu a intentar-ho i seleccioneu un nom original."
 
 #: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
@@ -4330,8 +5058,7 @@ msgid ""
 "Planned recording duration:   %s\n"
 "Recording time remaining on disk:   %s"
 msgstr ""
-"No teniu prou espai lliure de disc per a completar aquest enregistrament "
-"temporitzat, d’acord amb els paràmetres actuals.\n"
+"No teniu prou espai lliure de disc per a completar aquest enregistrament temporitzat, d’acord amb els paràmetres actuals.\n"
 "\n"
 "Voleu continuar?\n"
 "\n"
@@ -4350,7 +5077,8 @@ msgstr "Projecte actual"
 msgid "Recording start:"
 msgstr "Començament de l'enregistrament:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Durada:"
 
@@ -4371,7 +5099,8 @@ msgid "Action after Timer Recording:"
 msgstr "Acció posterior a l'enregistrament temporitzat:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Progrés de l’enregistrament temporitzat del Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4381,6 +5110,65 @@ msgstr "S'ha aturat l'enregistrament temporitzat."
 #: src/TimerRecordDialog.cpp
 msgid "Timer Recording completed."
 msgstr "S'ha completat l'enregistrament temporitzat."
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Recording saved: %s"
+msgstr "S'ha desat l'enregistrament:"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "Error en desar el projecte d'enregistrament temporitzat"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Recording exported: %s"
+msgstr "S'ha exportat l'enregistrament:"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Exporta l'enregistrament"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Timer Recording"
+msgstr "Desca l'enregistrament temporitzat com"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 dies 024 h 060 m 060 s"
 
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
@@ -4392,6 +5180,7 @@ msgstr "099 dies 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data i hora d'inici"
@@ -4436,16 +5225,23 @@ msgstr "Voleu habilitar l'&exportació automàtica?"
 msgid "Export Project As:"
 msgstr "Exporta el projecte com a:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcions"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "After Recording completes:"
+msgstr "S'ha completat l'enregistrament temporitzat."
 
 #: src/TimerRecordDialog.cpp
 msgid "Do nothing"
 msgstr "No facis res"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Surt del Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4457,11 +5253,21 @@ msgid "Shutdown system"
 msgstr "Apaga el sistema"
 
 #: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
 msgstr "Durada de l'enregistrament:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Scheduled to stop at:"
+msgstr "Selecciona fins al començament"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Enregistrament temporitzat del Tenacity. S’està esperant per començar"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4469,6 +5275,14 @@ msgstr "Enregistrament temporitzat del Tenacity. S’està esperant per comença
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "L'enregistrament començarà d'aquí:"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -4479,7 +5293,8 @@ msgid "Recording Exported:"
 msgstr "S'ha exportat l'enregistrament:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Enregistrament temporitzat del Tenacity. S’està esperant"
 
 #: src/TrackInfo.cpp
@@ -4509,10 +5324,26 @@ msgid " Muted"
 msgstr " Silenciat"
 
 #. i18n-hint: This is for screen reader software and indicates that
+#. this track is soloed. (The Solo button is on.)
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Soloed"
+msgstr " Solo"
+
+#. i18n-hint: This is for screen reader software and indicates that
 #. this track is selected.
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr " seleccionat"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "Selecciona la sincronització bloquejada"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -4551,13 +5382,36 @@ msgstr "S’ha eliminat la pista «%s»."
 msgid "Track Remove"
 msgstr "Elimina la pista"
 
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' to Top"
+msgstr "Mou la pista al capdamunt"
+
 #: src/TrackUtilities.cpp
 msgid "Move Track to Top"
 msgstr "Mou la pista al capdamunt"
 
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' to Bottom"
+msgstr "Mou la pista al capdavall"
+
 #: src/TrackUtilities.cpp
 msgid "Move Track to Bottom"
 msgstr "Mou la pista al capdavall"
+
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' Up"
+msgstr "Mou amunt"
+
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' Down"
+msgstr "Mou avall"
 
 #. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
 #: src/TrackUtilities.cpp
@@ -4567,6 +5421,10 @@ msgstr "Mou la pista amunt"
 #: src/TrackUtilities.cpp
 msgid "Move Track Down"
 msgstr "Mou la pista avall"
+
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
 
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
@@ -4601,6 +5459,11 @@ msgstr "Canvis de direcció   -- significa: %1.4f  sd: (%1.4f)\n"
 msgid "Calibration Complete"
 msgstr "S'ha completat el calibratge"
 
+#: src/WaveClip.cpp
+#, fuzzy
+msgid "Resampling failed."
+msgstr "S'està canviant la freqüència de mostreig de la pista %d"
+
 #: src/WaveTrack.cpp
 msgid "There is not enough room available to paste the selection"
 msgstr "No hi ha prou espai per enganxar la selecció"
@@ -4609,25 +5472,79 @@ msgstr "No hi ha prou espai per enganxar la selecció"
 msgid "There is not enough room available to expand the cut line"
 msgstr "No hi ha prou espai disponible per expandir la línia del retall"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "S'està aplicant %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Ordre per lots"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Ordre"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repeteix %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4637,6 +5554,15 @@ msgstr "Compara l'àudio"
 msgid "Threshold:"
 msgstr "Llindar:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "Compressió basada en pics"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Temps de retard (segons):"
@@ -4644,6 +5570,10 @@ msgstr "Temps de retard (segons):"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Factor de caiguda:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -4664,6 +5594,11 @@ msgstr "Pista 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Pista 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -4689,6 +5624,10 @@ msgstr "Fins a la Y:"
 msgid "Relative To:"
 msgstr "En relació a:"
 
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
 msgstr "Obtén la informació"
@@ -4705,13 +5644,48 @@ msgstr "Menús"
 msgid "Preferences"
 msgstr "Preferències"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Escapçament dels pics"
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Envelopes"
+msgstr "Envolupant"
+
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiquetes"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Tipus:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Projecte actual"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -4737,13 +5711,31 @@ msgstr "Comentaris"
 msgid "Command:"
 msgstr "Ordre:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Proporciona ajuda sobre una ordre."
 
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Import2"
+msgstr "Importa"
+
 #: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
 msgid "File Name:"
 msgstr "Nom de fitxer:"
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Export2"
+msgstr "Exporta"
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Number of Channels:"
@@ -4761,17 +5753,45 @@ msgstr "Exporta a un fitxer."
 msgid "Builtin Commands"
 msgstr "Ordres integrades"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "L’equip del Tenacity"
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
+msgstr "Proporciona els efectes incorporats del Tenacity"
 
 #: src/commands/LoadCommands.cpp
 msgid "Unknown built-in command name"
 msgstr "Nom d'orde integrada desconegut"
 
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "Mostra els missatges"
+
+#: src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "Open Project2"
+msgstr "Obre un projecte..."
+
 #: src/commands/OpenSaveCommands.cpp
 msgid "Add to History"
 msgstr "Afegeix a l'historial"
+
+#: src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "Save Project2"
+msgstr "De&sa el projecte"
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Save Copy"
@@ -4797,11 +5817,22 @@ msgstr "Desa un projecte."
 msgid "Saves a copy of current project."
 msgstr "Desa un projecte."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Obtén la preferència"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nom:"
 
@@ -4838,6 +5869,11 @@ msgid "Full Window"
 msgstr "Tota la finestra"
 
 #: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Window Plus"
+msgstr "Captura la finestra amb afegitons"
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
@@ -4845,9 +5881,15 @@ msgstr "Pantalla completa"
 msgid "Toolbars"
 msgstr "Barres d'eines"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efectes"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Script"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -4870,8 +5912,27 @@ msgid "First Four Tracks"
 msgstr "Primeres quatre pistes"
 
 #: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Tracks Plus"
+msgstr "Quadre de pistes"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track Plus"
+msgstr "Primera pista"
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "All Tracks"
 msgstr "Totes les pistes"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "All Tracks Plus"
+msgstr "Totes les pistes"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
 
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
@@ -4884,12 +5945,31 @@ msgid "Path:"
 msgstr "Camí:"
 
 #: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Capture What:"
+msgstr "Ha fallat la captura!"
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Fons:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy, c-format
+msgid "Error trying to save file: %s"
+msgstr "S'ha produït un error en escriure al fitxer: «%s»"
 
 #: src/commands/ScreenshotCommand.h
 msgid "Takes screenshots."
 msgstr "Pren captures de pantalla."
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Select Time"
+msgstr "Seleccioneu un fitxer"
 
 #: src/commands/SelectCommand.cpp
 msgid "Project Start"
@@ -4916,6 +5996,16 @@ msgid "Selection End"
 msgstr "Acabament de la selecció"
 
 #: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Start Time:"
+msgstr "Comença a l'instant"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "End Time:"
+msgstr "Acaba a l'instant"
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Frequencies"
 msgstr "Seleccioneu les freqüències"
 
@@ -4927,6 +6017,11 @@ msgstr "Alt:"
 msgid "Low:"
 msgstr "Baix:"
 
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Select Tracks"
+msgstr "Selecciona les pistes..."
+
 #. i18n-hint verb, imperative
 #: src/commands/SelectCommand.cpp
 msgid "Set"
@@ -4936,7 +6031,8 @@ msgstr "Estableix"
 msgid "Add"
 msgstr "Afegeix"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Elimina"
 
@@ -4948,9 +6044,58 @@ msgstr "Primera pista:"
 msgid "Track Count:"
 msgstr "Nombre de pistes:"
 
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Mode:"
+msgstr "Mode:"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a time range."
+msgstr "Seleccioneu un fitxer"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Seleccioneu les freqüències"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a range of tracks."
+msgstr "Selecciona les pistes..."
+
 #: src/commands/SelectCommand.h
 msgid "Selects Audio."
 msgstr "Selecciona l'àudio."
+
+#: src/commands/SetClipCommand.cpp
+#, fuzzy
+msgid "Set Clip"
+msgstr "Estableix el clip..."
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
 
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
@@ -4959,6 +6104,11 @@ msgstr "Començament:"
 #: src/commands/SetClipCommand.h
 msgid "Sets various values for a clip."
 msgstr "Estableix diversos valors per a un clip."
+
+#: src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Set Envelope"
+msgstr "Estableix l'envolupant..."
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Time:"
@@ -4973,13 +6123,23 @@ msgid "Edited Envelope"
 msgstr "S'ha ajustat l'envolupant."
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Envolupant"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
 msgstr "Estableix l'etiqueta"
+
+#: src/commands/SetLabelCommand.cpp
+#, fuzzy
+msgid "Label Index"
+msgstr "Text de l'etiqueta"
 
 #: src/commands/SetLabelCommand.cpp
 msgid "End:"
@@ -5010,6 +6170,14 @@ msgid "Resize:"
 msgstr "Redimensiona:"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Amplada:"
 
@@ -5038,6 +6206,10 @@ msgid "Unnamed"
 msgstr "Sense nom"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Focused"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Audio"
 msgstr "Estableix l'àudio de la pista"
 
@@ -5053,13 +6225,21 @@ msgstr "Panoramització:"
 msgid "Set Track Visuals"
 msgstr "Estableix els aspectes visuals de la pista"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineal"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Restableix"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Temps:"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "HalfWave"
@@ -5074,6 +6254,11 @@ msgid "Scale:"
 msgstr "Escala:"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "Eina de zoom"
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
 msgstr "Eina de zoom"
 
@@ -5082,8 +6267,19 @@ msgid "VZoom Bottom:"
 msgstr "Eina de zoom"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Use Spectral Prefs"
+msgstr "Selecció espectral"
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Selecció espectral"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5118,6 +6314,10 @@ msgid "Allo&w clipping"
 msgstr "Permet l'escapçament dels pics"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Redueix el volum d'una o més pistes tan aviat com el volum de la pista marcada com a \"control\" arriba a un determinat nivell"
 
@@ -5135,12 +6335,18 @@ msgstr "Heu seleccionat una pista que no conté àudio. AutoDuck només pot proc
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "L'Auto Duck necessita una pista de control situada sota la pista o pistes seleccionades."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Quantitat de \"Duck\":"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segons"
 
@@ -5164,7 +6370,8 @@ msgstr "Durada del fàding final interior:"
 msgid "Inner &fade up length:"
 msgstr "Durada del fàding inicial interior:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Llindar:"
 
@@ -5175,6 +6382,11 @@ msgstr "La previsualització no està disponible"
 #: src/effects/BassTreble.cpp
 msgid "Bass and Treble"
 msgstr "Baixos i aguts"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Simple tone control effect"
+msgstr "Contracció de la selecció a l'&esquerra"
 
 #: src/effects/BassTreble.cpp
 msgid "Tone controls"
@@ -5207,6 +6419,10 @@ msgstr "&Volum(dB):"
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Nivell"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -5283,6 +6499,10 @@ msgid "from (Hz)"
 msgstr "des de (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "fins a (Hz)"
 
@@ -5290,17 +6510,23 @@ msgstr "fins a (Hz)"
 msgid "t&o"
 msgstr "fins a"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Canvi percentual:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Canvi percentual"
 
 #: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
 msgid "&Use high quality stretching (slow)"
 msgstr "Utilitza l'estirament d'alta qualitat (lent)"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -5312,7 +6538,9 @@ msgstr "8"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "no aplicable"
 
@@ -5340,6 +6568,7 @@ msgstr "RPM de vinil estàndard:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "A partir de les RPM"
@@ -5352,6 +6581,7 @@ msgstr "des de"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Fins a les rpm"
@@ -5448,6 +6678,11 @@ msgctxt "change tempo"
 msgid "t&o"
 msgstr "fins a"
 
+#: src/effects/ChangeTempo.cpp
+#, fuzzy, c-format
+msgid "Length in seconds from %s, to"
+msgstr "Durada (segons):"
+
 #: src/effects/ClickRemoval.cpp
 msgid "Click Removal"
 msgstr "Eliminació de clics"
@@ -5482,8 +6717,19 @@ msgid "Max Spike Width"
 msgstr "Amplada màxima dels pics"
 
 #: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Compressió:"
+
+#: src/effects/Compressor.cpp
 msgid "Compresses the dynamic range of audio"
 msgstr "Comprimeix l'interval dinàmic de l'àudio"
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -5493,6 +6739,20 @@ msgstr "%.2f s"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f s"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f s"
 
 #: src/effects/Compressor.cpp
@@ -5590,6 +6850,12 @@ msgstr "Seleccioneu una pista d'àudio."
 
 #: src/effects/Contrast.cpp
 msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid ""
 "Nothing to measure.\n"
 "Please select a section of a track."
 msgstr ""
@@ -5602,7 +6868,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analitzador de contrast, per mesurar diferències de volum RMS entre dues seccions d'àudio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Acabament"
 
@@ -5662,9 +6929,32 @@ msgstr "&Diferència:"
 msgid "&Help"
 msgstr "&Ajuda"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "indeterminada"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -5681,6 +6971,27 @@ msgstr "La diferència és indeterminada."
 #, c-format
 msgid "Difference = %.2f RMS dB."
 msgstr "Diferència = %.2f RMS dB."
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Difference = infinite RMS dB."
+msgstr "Diferència = %.2f RMS dB."
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground level too high"
+msgstr "Temps d'acabament del primer pla"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background level too high"
+msgstr "Temps d'acabament del fons"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -5701,8 +7012,19 @@ msgstr "Diferència actual"
 msgid "Measured foreground level"
 msgstr "S'ha mesurat el nivell de la regió de primer pla"
 
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
+
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
+msgstr "No s'ha mesurat cap regió de primer pla"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground not yet measured"
 msgstr "No s'ha mesurat cap regió de primer pla"
 
 #: src/effects/Contrast.cpp
@@ -5711,6 +7033,11 @@ msgstr "S'ha mesurat el nivell de la regió de fons"
 
 #: src/effects/Contrast.cpp
 msgid "No background measured"
+msgstr "No s'ha mesurat cap regió de fons"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background not yet measured"
 msgstr "No s'ha mesurat cap regió de fons"
 
 #: src/effects/Contrast.cpp
@@ -5761,9 +7088,20 @@ msgstr "Barem d'èxit 1.4.7 de WCAG 2.0: Fallit"
 msgid "Data gathered"
 msgstr "Dades recollides"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Anàlisi del contrast (per complir amb WCAG 2)"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Contrast alt"
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -5809,9 +7147,27 @@ msgstr "Distorsió de rectificador"
 msgid "Hard Limiter 1413"
 msgstr "Limitador fort 1413"
 
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
 #: src/effects/Distortion.cpp src/effects/Equalization.cpp
 msgid "Walkie-talkie"
 msgstr "Transceptor portàtil"
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Light Crunch Overdrive"
@@ -5922,6 +7278,10 @@ msgid "Drive"
 msgstr "Càrrega"
 
 #: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Llindar d'escapçament"
 
@@ -5940,6 +7300,14 @@ msgstr "Nivell de sortida"
 #: src/effects/Distortion.cpp
 msgid "Repeat processing"
 msgstr "Repeteix el processament"
+
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
@@ -5990,6 +7358,12 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "Genera tons duals multifreqüència (DTMF) com els que produeixen els telèfons de tecles"
 
 #: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Seqüència DTMF:"
 
@@ -5997,7 +7371,9 @@ msgstr "Seqüència DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitud (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Durada:"
 
@@ -6018,6 +7394,12 @@ msgstr "%.1f s"
 msgid "Tone duration:"
 msgstr "Durada dels tons:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
+
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Durada dels silencis:"
@@ -6036,7 +7418,8 @@ msgstr "Eco"
 msgid "Repeats the selected audio again and again"
 msgstr "Repeteix l'àudio seleccionat una vegada i una altra"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "El valor sol·licitat supera la capacitat de la memòria."
 
@@ -6060,7 +7443,8 @@ msgstr "Valor predefinit"
 msgid "Export Effect Parameters"
 msgstr "Exporta els paràmetres de l’efecte"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "No s’ha pogut obrir el fitxer: «%s»"
@@ -6084,6 +7468,12 @@ msgstr "Paràmetres d'&edició"
 msgid "%s: is not a valid presets file.\n"
 msgstr "«%s» no és un camí fins al fitxer vàlid.\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "S’està preparant la previsualització"
@@ -6091,6 +7481,15 @@ msgstr "S’està preparant la previsualització"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Previsualització"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "N&yquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -6159,6 +7558,11 @@ msgstr ""
 "%s\n"
 "\n"
 "Trobareu més informació a Ajuda->Mostra el registre"
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Command failed to initialize"
+msgstr "S'ha produït un error en iniciar l'efecte"
 
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
@@ -6369,6 +7773,11 @@ msgstr "Atura la re&producció"
 msgid "Play"
 msgstr "Reprodueix"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
@@ -6394,12 +7803,32 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "Ajusta els nivells de volum de determinades freqüències"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Baixos (dB):"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Baixos"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -6410,26 +7839,57 @@ msgid "Treble Cut"
 msgstr "Aguts"
 
 #: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Filter Curve EQ needs a different name"
 msgstr "La corba d'equalització necessita un nom diferent"
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
+msgstr "Per a aplicar l’equalització, cal que totes les pistes seleccionades tinguin la mateixa freqüència de mostratge."
+
+#: src/effects/Equalization.cpp
+msgid "Track sample rate is too low for this effect."
 msgstr ""
-"Per a aplicar l’equalització, cal que totes les pistes seleccionades tinguin "
-"la mateixa freqüència de mostratge."
 
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "L'efecte no està disponible"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "dB màx."
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "dB mín."
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
 
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
@@ -6510,8 +7970,16 @@ msgid "D&efault"
 msgstr "Per d&efecte"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &multiprocés"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -6623,6 +8091,11 @@ msgid "Same name"
 msgstr "El mateix nom"
 
 #: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "Overwrite existing curve '%s'?"
+msgstr "Sobreescriu els fitxers existents"
+
+#: src/effects/Equalization.cpp
 msgid "Curve exists"
 msgstr "La corba ja existeix"
 
@@ -6719,6 +8192,10 @@ msgid "Find Clipping"
 msgstr "Troba pics escapçats (clipping)"
 
 #: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
 msgid "Clipping"
 msgstr "Escapçament dels pics"
 
@@ -6747,12 +8224,25 @@ msgid "Builtin Effects"
 msgstr "Efectes predefinits"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Proporciona els efectes incorporats del Tenacity"
 
 #: src/effects/LoadEffects.cpp
 msgid "Unknown built-in effect name"
 msgstr "Nom d'efecte integrat desconegut"
+
+#: src/effects/Loudness.cpp
+msgid "perceived loudness"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Sets the loudness of one or more tracks"
@@ -6767,13 +8257,35 @@ msgstr "S'està normalitzant sense eliminar el desplaçament sobre el zero...\n"
 msgid "Analyzing: %s"
 msgstr "Anàlisi: %s"
 
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "S'està &processant: "
+
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normalitza"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Normalitza els canals estèreo per separat"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -6821,8 +8333,37 @@ msgid "Second greatest"
 msgstr "Segona pista"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Hann, Hann (per defecte)"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (per defecte)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -6854,15 +8395,11 @@ msgstr "Advertència: els tipus de finestra no són els mateixos que per a l'an�
 
 #: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
-msgstr ""
-"Totes les dades dels perfils de soroll han de tenir la mateixa freqüència de "
-"mostratge."
+msgstr "Totes les dades dels perfils de soroll han de tenir la mateixa freqüència de mostratge."
 
 #: src/effects/NoiseReduction.cpp
 msgid "The sample rate of the noise profile must match that of the sound to be processed."
-msgstr ""
-"La freqüència de mostratge del perfil de soroll s’ha de correspondre amb la "
-"del so a processar."
+msgstr "La freqüència de mostratge del perfil de soroll s’ha de correspondre amb la del so a processar."
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -6921,13 +8458,13 @@ msgid "Step 1"
 msgstr "Pas 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Seleccioneu uns quants segons on només hi hagi soroll, perquè el Tenacity\n"
-"sàpiga què és el que cal filtrar. Després feu clic a Obtén el perfil del "
-"soroll:"
+"sàpiga què és el que cal filtrar. Després feu clic a Obtén el perfil del soroll:"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Get Noise Profile"
@@ -6975,13 +8512,66 @@ msgstr "Tipus de &finestres"
 msgid "Window si&ze:"
 msgstr "&Mida de la finestra"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "16"
+msgstr "6"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "32"
+msgstr "3"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "64"
+msgstr "6"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (per defecte)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Passos per finestra"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7052,6 +8642,10 @@ msgid "Normalizing without removing DC offset...\n"
 msgstr "S'està normalitzant sense eliminar el desplaçament sobre el zero...\n"
 
 #: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 #, c-format
 msgid "Analyzing first track of stereo pair: %s"
 msgstr "S'està analitzant la primera pista del parell estèreo: %s"
@@ -7081,12 +8675,32 @@ msgid "&Remove DC offset (center on 0.0 vertically)"
 msgstr "Corregeix el desplaçament respecte al zero (centra verticalment a 0,0)"
 
 #: src/effects/Normalize.cpp
+#, fuzzy
+msgid "&Normalize peak amplitude to   "
+msgstr "Pic d'amplitud nou (dB):"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Peak amplitude dB"
+msgstr "Pic d'amplitud nou (dB):"
+
+#: src/effects/Normalize.cpp
 msgid "N&ormalize stereo channels independently"
 msgstr "Normalitza els canals estèreo per separat"
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Estira"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Factor d'estirament:"
@@ -7094,6 +8708,40 @@ msgstr "Factor d'estirament:"
 #: src/effects/Paulstretch.cpp
 msgid "&Time Resolution (seconds):"
 msgstr "Resolució de temps (segons):"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
@@ -7140,6 +8788,11 @@ msgid "Depth in percent"
 msgstr "Profunditat percentual"
 
 #: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Feedbac&k (%):"
+msgstr "Rever&beració (%):"
+
+#: src/effects/Phaser.cpp
 msgid "Feedback in percent"
 msgstr "Retroalimentació percentual"
 
@@ -7177,11 +8830,9 @@ msgid ""
 "\n"
 "The more surrounding audio, the better it performs."
 msgstr ""
-"La reparació es fa a partir de dades d’àudio que estan fora del fragment de "
-"la selecció.\n"
+"La reparació es fa a partir de dades d’àudio que estan fora del fragment de la selecció.\n"
 "\n"
-"Seleccioneu un fragment net però que estigui a tocar d’un fragment amb àudio."
-"\n"
+"Seleccioneu un fragment net però que estigui a tocar d’un fragment amb àudio.\n"
 "\n"
 "Com més àudio hi hagi als voltants del fragment, millor serà el resultat."
 
@@ -7206,8 +8857,27 @@ msgid "New selection length: dd:hh:mm:ss"
 msgstr "Durada de la selecció nova: dd:hh:mm:ss"
 
 #: src/effects/Repeat.cpp
+#, c-format
+msgid "Current selection length: %s"
+msgstr "Durada de selecció actual: %s"
+
+#: src/effects/Repeat.cpp
+#, c-format
+msgid "New selection length: %s"
+msgstr "Durada de selecció nova: %s"
+
+#: src/effects/Repeat.cpp
 msgid "Warning: No repeats."
 msgstr "Avís: no hi ha cap repetició."
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Eliminador de veu"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "Bathroom"
@@ -7302,6 +8972,11 @@ msgstr "Inverteix l'àudio seleccionat"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Temps SBSMS / Estirament de l'altura"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -7331,9 +9006,7 @@ msgstr "Realitza un filtratge IIR que emula els filtres analògics"
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
-msgstr ""
-"Per a aplicar un filtre, totes les pistes seleccionades han de tenir la "
-"mateixa freqüència de mostratge."
+msgstr "Per a aplicar un filtre, totes les pistes seleccionades han de tenir la mateixa freqüència de mostratge."
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
@@ -7460,6 +9133,11 @@ msgstr "Utilitza els valors per defecte"
 msgid "Restore Defaults"
 msgstr "Restaura els valors per defecte"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -7555,6 +9233,14 @@ msgid "Tone"
 msgstr "To"
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "&Ona:"
 
@@ -7599,12 +9285,20 @@ msgid "Automatically reduces the length of passages where the volume is below a 
 msgstr "Redueix automàticament la durada dels passatges que tinguin un volum inferior al nivell indicat"
 
 #: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Detecta el silenci"
 
 #: src/effects/TruncSilence.cpp
 msgid "Tr&uncate to:"
 msgstr "Trunca a:"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
@@ -7619,7 +9313,8 @@ msgid "VST Effects"
 msgstr "Efectes VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Afegeix la capacitat d’utilitzar efectes VST amb el Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -7631,7 +9326,8 @@ msgstr "S'està comprovant el shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "S'estan registrant %d de %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "No s'ha pogut carregar la biblioteca"
 
@@ -7643,15 +9339,25 @@ msgstr "Opcions dels efectes VST"
 msgid "Buffer Size"
 msgstr "Mida de la memòria intermèdia"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Mida de la &memòria intermèdia (de 8 a 1.048.576 mostres):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Compensació de latència"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Activa la &compensació"
 
@@ -7677,7 +9383,18 @@ msgid "Save VST Preset As:"
 msgstr "Desa el valor predefinit VST com a:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Exporta els valors predefinits d'Audio Unit"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Exporta els valors predefinits d'Audio Unit"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Fitxers de projecte d'Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -7704,7 +9421,8 @@ msgstr "S'ha produït un error en carregar els valors predefinits VST"
 msgid "Unable to load presets file."
 msgstr "No es pot carregar el fitxer dels valors predefinits."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Paràmetres de l’efecte"
 
@@ -7720,6 +9438,12 @@ msgstr "No es pot llegir el fitxer dels valors predefinits."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Aquest fitxer de paràmetres es va enregistrar des de %s.  Voleu continuar?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -7755,7 +9479,8 @@ msgid "Audio Unit Effects"
 msgstr "Efectes d'Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Proporciona suport per utilitzar els efectes d'Audio Unit a Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -7771,12 +9496,25 @@ msgid "Audio Unit Effect Options"
 msgstr "Opcions de l'efecte d'Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Interfície de l'usuari"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Selecciona la &interfície"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Tota la finestra"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
@@ -7824,6 +9562,14 @@ msgid "Unable to store preset in config file"
 msgstr "No es pot llegir el fitxer dels valors predefinits."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not import \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "No s'ha pogut trobar la carpeta de dades del projecte: «%s»"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Export Audio Unit Preset As %s:"
 msgstr "Exporta els valors predefinits d'Audio Unit"
@@ -7831,6 +9577,14 @@ msgstr "Exporta els valors predefinits d'Audio Unit"
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Standard Audio Unit preset file"
 msgstr "Exporta els valors predefinits d'Audio Unit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not export \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "No s'ha pogut trobar la carpeta de dades del projecte: «%s»"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Export Audio Unit Presets"
@@ -7850,6 +9604,11 @@ msgid "Failed to retrieve preset content"
 msgstr "No es pot obtenir la descripció del flux de dades"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "No s’ha pogut obrir la base de dades del projecte"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Les dades XML estan buides al cap de la conversió"
 
@@ -7860,8 +9619,31 @@ msgstr ""
 "No s'ha pogut registrar:\n"
 "%s"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "No es pot obtenir la descripció del flux de dades"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "No es pot obtenir la descripció del flux de dades"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "No es pot llegir el fitxer dels valors predefinits."
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Efectes d'Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efectes LADSPA"
@@ -7871,16 +9653,23 @@ msgid "Provides LADSPA Effects"
 msgstr "Proveeix efectes LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "El Tenacity ja no utilitza vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Opcions dels efectes LADSPA"
 
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s: %s"
@@ -7888,6 +9677,14 @@ msgstr "%s: %s"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Sortida de l’efecte"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "&LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -7897,6 +9694,10 @@ msgstr "Paràmetres dels efectes LV2"
 #, c-format
 msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Mida de la &memòria intermèdia (de 8 a 1.048.576 mostres):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -7920,12 +9721,20 @@ msgstr "%d corbes s'han exportat a %s\n"
 msgid "Generator"
 msgstr "Generador"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+#, fuzzy
+msgid "LV2"
+msgstr "LV&2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efectes LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Proporciona suport per utilitzar efectes LV2 amb Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -7933,12 +9742,37 @@ msgid "Nyquist Effects"
 msgstr "Efectes Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Proporciona suport per utilitzar efectes Nyquist amb Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
 msgstr "S'està aplicant l'efecte Nyquist..."
+
+#. i18n-hint: It is acceptable to translate this the same as for "Nyquist Prompt"
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist Worker"
+msgstr "Banc de treball &Nyquist..."
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Ill-formed Nyquist plug-in header"
+msgstr "Connectors Nyquist"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -7958,12 +9792,36 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "No es pot aplicar l'efecte a pistes estèreo quan els dos canals no coincideixen."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Sortida de depuració: "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Processament completat."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr "El codificador MP3 ha retornat l'error %ld"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -7996,12 +9854,32 @@ msgid "Nyquist returned an empty array.\n"
 msgstr "Nyquist ha retornat una seqüència buida.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned nil audio.\n"
+msgstr "."
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
 msgstr "[Avís: Nyquist ha retornat una cadena UTF-8 no vàlida que ha estat convertida a Latin-1]"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "This version of Audacity does not support Nyquist plug-in version %ld"
+msgstr "Aquesta versió del Tenacity no s’ha compilat amb la compatibilitat per a %s."
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Could not open file"
 msgstr "No s'ha pogut obrir el fitxer"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Error in Nyquist code"
@@ -8082,7 +9960,8 @@ msgstr "Seleccioneu un fitxer"
 msgid "Save file as"
 msgstr "Anomena i desa el fitxer"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "sense títol"
 
@@ -8091,7 +9970,8 @@ msgid "Vamp Effects"
 msgstr "Efectes Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Proporciona suport per utilitzar efectes Vamp amb Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -8113,6 +9993,13 @@ msgstr "Ajusts del connector"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+#, fuzzy
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -8154,8 +10041,7 @@ msgid ""
 msgstr ""
 "Esteu a punt d’exportar un fitxer %s amb el nom «%s».\n"
 "\n"
-"Normalment aquests fitxers acaben en «%s», i alguns programes no obren "
-"fitxers amb extensions no estàndard.\n"
+"Normalment aquests fitxers acaben en «%s», i alguns programes no obren fitxers amb extensions no estàndard.\n"
 "\n"
 "Segur que voleu exportar el fitxer amb aquest nom?"
 
@@ -8167,6 +10053,18 @@ msgstr "No es permet l'ús de noms de camí de més de 256 caràcters."
 #, c-format
 msgid "A file named \"%s\" already exists. Replace?"
 msgstr "Ja existeix un fitxer amb el nom «%s».  Voleu substituir-lo?"
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one mono file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one stereo file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down to one exported file according to the encoder settings."
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Advanced Mixing Options"
@@ -8223,6 +10121,11 @@ msgstr "Mostra la sortida"
 msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
 msgstr "Les dades es canalitzaran cap al canal d’entrada estàndard. «%f» utilitza el nom del fitxer definit a la finestra d’exportació."
 
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
 #: src/export/ExportCL.cpp
 msgid "Find path to command"
 msgstr "Troba el camí a l'ordre"
@@ -8245,6 +10148,11 @@ msgid "Exporting the selected audio using command-line encoder"
 msgstr "S'està exportant l'àudio seleccionat mitjançant el codificador de línia d'ordres"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Exporting the audio using command-line encoder"
+msgstr "S'està exportant l'àudio seleccionat mitjançant el codificador de línia d'ordres"
+
+#: src/export/ExportCL.cpp
 msgid "Command Output"
 msgstr "Sortida de l'ordre"
 
@@ -8259,9 +10167,27 @@ msgstr ""
 "Voleu continuar?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "S'ha trobat el mòdul «%s»."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr ""
+"No s’ha pogut carregar el mòdul «%s».\n"
+"\n"
+"Error: %s"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -8282,6 +10208,11 @@ msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
 msgstr "FFmpeg : ERROR - No s'ha pogut afegir el flux de dades d'àudio al fitxer de sortida «%s»."
 
 #: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr "FFmpeg : ERROR - No es poden escriure les capçaleres al fitxer de sortida «%s» Codi d'error %d."
+
+#: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
 msgstr "FFmpeg : ERROR - No es poden escriure les capçaleres al fitxer de sortida «%s» Codi d'error %d."
@@ -8294,8 +10225,15 @@ msgid ""
 "Support for this codec is probably not compiled in."
 msgstr ""
 "El FFmpeg no ha pogut trobar el còdec d’àudio 0x%x.\n"
-"És probable que aquest còdec no estigui admès en la compilació del FFmpeg "
-"que esteu fent servir."
+"És probable que aquest còdec no estigui admès en la compilació del FFmpeg que esteu fent servir."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -8352,11 +10290,17 @@ msgstr "S'ha intentat exportar %d canals, però el format de sortida seleccionat
 msgid "Exporting selected audio as %s"
 msgstr "S'està exportant l'àudio seleccionat com a %s"
 
+#: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio as %s"
+msgstr "Exportació de l’àudio com a FLAC"
+
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
 msgid "Invalid sample rate"
 msgstr "Freqüència incorrecta"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Torna a fer el mostratge"
 
@@ -8375,8 +10319,7 @@ msgid ""
 "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the current output file format. "
 msgstr ""
-"La combinació de freqüència de mostratge (%d) i taxa de bits (%d kb/s) del "
-"projecte no\n"
+"La combinació de freqüència de mostratge (%d) i taxa de bits (%d kb/s) del projecte no\n"
 "l’admet el format de fitxer de sortida actual. "
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
@@ -8387,6 +10330,14 @@ msgstr "Hauríeu de tornar a mostrejar-ho a algun dels valors que es mostren a c
 msgid "Sample Rates"
 msgstr "Freqüències de mostratge"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Taxa de bits:"
@@ -8394,6 +10345,44 @@ msgstr "Taxa de bits:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualitat:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr "0"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr "3"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr "5"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr "6"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr "9"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -8408,6 +10397,10 @@ msgid "Constrained"
 msgstr "Constant"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Àudio"
 
@@ -8416,8 +10409,44 @@ msgid "Low Delay"
 msgstr "Retard baix"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr "5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr "10 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr "20 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr "40 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr "60 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Pistes mitjanes"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -8488,8 +10517,17 @@ msgid "Replace preset '%s'?"
 msgstr "Voleu eliminar el valor predefinit «%s»?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "do"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principal"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -8597,6 +10635,10 @@ msgstr "Idioma:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Acumulador de bits"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -8730,6 +10772,11 @@ msgstr ""
 "0 - per defecte\n"
 "mín. - 1\n"
 "màx. - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Utilitza LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -8889,6 +10936,17 @@ msgstr "No hi ha cap etiqueta per exportar."
 msgid "Select xml file to export presets into"
 msgstr "Seleccioneu el fitxer XML on s'exportaran els valors predefinits"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "No s'ha pogut endevinar el format"
@@ -8954,9 +11012,7 @@ msgstr "Fitxers MP2"
 
 #: src/export/ExportMP2.cpp
 msgid "Cannot export MP2 with this sample rate and bit rate"
-msgstr ""
-"No es pot exportar a MP2 amb aquests valors de freqüència de mostratge i "
-"taxa de bits"
+msgstr "No es pot exportar a MP2 amb aquests valors de freqüència de mostratge i taxa de bits"
 
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
@@ -8993,8 +11049,20 @@ msgid "145-185 kbps"
 msgstr "145-185 kb/s"
 
 #: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr "110-150 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr "95-135 kb/s"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
 msgstr "80-120 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr "65-105 kb/s"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -9017,7 +11085,17 @@ msgstr "Estàndard, 170-210 kbps"
 msgid "Medium, 145-185 kbps"
 msgstr "Mitjana, 145-185 kbps"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Estàndard"
 
@@ -9026,8 +11104,18 @@ msgid "Medium"
 msgstr "Habitació mitjana"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "disponible"
+
+#: src/export/ExportMP3.cpp
 msgid "Average"
 msgstr "Mitjana"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Constant"
+msgstr "Guany constant"
 
 #: src/export/ExportMP3.cpp
 msgid "Joint Stereo"
@@ -9060,8 +11148,8 @@ msgid "Locate LAME"
 msgstr "Localitza LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "El Tenacity necessita el fitxer %s per a crear els MP3."
 
 #: src/export/ExportMP3.cpp
@@ -9089,14 +11177,34 @@ msgid "Where is %s?"
 msgstr "On és %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
-"Esteu enllaçant amb lame_enc.dll v%d.%d. Aquesta versió no és compatible amb "
-"el Tenacity %d.%d.%d.\n"
+"Esteu enllaçant amb lame_enc.dll v%d.%d. Aquesta versió no és compatible amb el Tenacity %d.%d.%d.\n"
 "Baixeu l’última versió de la biblioteca «LAME per al Tenacity»."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Fitxers de projecte AUP3"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -9128,8 +11236,18 @@ msgid "Exporting selected audio with %s preset"
 msgstr "S'està exportant l'àudio seleccionat amb el valor predefinit %s"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio with %s preset"
+msgstr "S'està exportant l'àudio seleccionat amb el valor predefinit %s"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting selected audio with VBR quality %s"
+msgstr "S'està exportant l'àudio seleccionat amb qualitat VBR de %s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio with VBR quality %s"
 msgstr "S'està exportant l'àudio seleccionat amb qualitat VBR de %s"
 
 #: src/export/ExportMP3.cpp
@@ -9180,6 +11298,12 @@ msgstr "Exporta múltiples fitxers"
 #: src/export/ExportMultiple.cpp
 msgid "Cannot Export Multiple"
 msgstr "No es pot fer una exportació múltiple"
+
+#: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
@@ -9328,12 +11452,41 @@ msgid "Unable to export - rate or quality problem"
 msgstr "No es pot establir la qualitat de presentació del QuickTime"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "No es pot carregar el fitxer dels valors predefinits."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "No es pot carregar el fitxer dels valors predefinits."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "No es pot carregar el fitxer dels valors predefinits."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "No es pot carregar el fitxer dels valors predefinits."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "No es pot carregar el fitxer dels valors predefinits."
 
 #: src/export/ExportOGG.cpp
 msgid "Exporting the selected audio as Ogg Vorbis"
 msgstr "S'està exportant l'àudio seleccionat com a Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Exporting the audio as Ogg Vorbis"
+msgstr "S'està exportant l'àudio seleccionat com a Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -9352,8 +11505,28 @@ msgid "Other uncompressed files"
 msgstr "Altres fitxers no comprimits"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "S'ha produït un error en importar"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -9381,11 +11554,11 @@ msgid "All supported files"
 msgstr "Tots els fitxers|*|Tots els fitxers admesos|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "«%s» \n"
@@ -9394,11 +11567,11 @@ msgstr ""
 "editar-lo en fer clic a Fitxer > Importa > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "«%s» \n"
 "no és un fitxer d’àudio. \n"
@@ -9409,19 +11582,18 @@ msgid "Select stream(s) to import"
 msgstr "Seleccioneu el(s) flux(es) de dades a importar"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
-msgstr ""
-"Aquesta versió del Tenacity no s’ha compilat amb la compatibilitat per a %s."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
+msgstr "Aquesta versió del Tenacity no s’ha compilat amb la compatibilitat per a %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "«%s» és una pista de CD d'àudio. \n"
 "Audacity no pot obrir directament els CD d'àudio.\n"
@@ -9430,10 +11602,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "«%s» és un fitxer de llista de reproducció.\n"
@@ -9442,10 +11614,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer WMA (Windows Media Audio). \n"
@@ -9454,10 +11626,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer AAC (Advanced Audio Coding). \n"
@@ -9466,12 +11638,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer d'àudio xifrat. \n"
@@ -9482,10 +11654,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer RealPlayer media. \n"
@@ -9494,12 +11666,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "«%s» és un fitxer basat en notes, i no un fitxer d'àudio.\n"
 "Audacity no pot obrir aquest tipus de fitxer.\n"
@@ -9508,10 +11680,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -9524,10 +11696,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer d'àudio Wavpack. \n"
@@ -9536,10 +11708,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer d'àudio Dolby Digital. \n"
@@ -9548,10 +11720,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer d'àudio Ogg Speex. \n"
@@ -9560,10 +11732,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer de vídeo. \n"
@@ -9579,7 +11751,27 @@ msgstr "S'ha trobat el mòdul «%s»."
 #: src/import/Import.cpp
 #, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, proves"
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -9588,6 +11780,11 @@ msgstr ""
 "Els importadors que suposadament haurien d’admetre aquests fitxers són:\n"
 "%s,\n"
 "però cap d’ells no ha entès el format del fitxer."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Fitxers de projecte AUP3"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -9602,8 +11799,57 @@ msgid "Import Project"
 msgstr "Importa els valors predefinits"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Error intern informat pel procés d'alineament."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Freqüència incorrecta"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -9611,16 +11857,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "No s'ha pogut trobar la carpeta de dades del projecte: «%s»"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Començament del projecte"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Freqüència incorrecta"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Freqüència incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -9650,24 +11954,6 @@ msgstr "Índex[%02x] Còdec[%s], Idioma[%s], Taxa de bits[%s], Canals[%d], Durad
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Fitxers FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Fitxers compatibles amb GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importador de GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Índex[%02x] Còdec[%s], Idioma[%s], Taxa de bits[%s], Canals[%d], Durada[%d]"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Error de GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -9707,6 +11993,16 @@ msgid "Import MIDI"
 msgstr "Importa MIDI"
 
 #: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s: Filename too short."
+msgstr "No s'ha pogut obrir el fitxer %s."
+
+#: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s: Incorrect filetype."
+msgstr "No s'ha pogut obrir el fitxer %s."
+
+#: src/import/ImportMIDI.cpp
 #, c-format
 msgid "Could not open file %s."
 msgstr "No s'ha pogut obrir el fitxer %s."
@@ -9714,6 +12010,14 @@ msgstr "No s'ha pogut obrir el fitxer %s."
 #: src/import/ImportMP3.cpp
 msgid "MP3 files"
 msgstr "Fitxers MP3"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
@@ -9749,8 +12053,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF i altres tipus de fitxers no comprimits"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) PCM de 32 bits amb coma flotant"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "PCM de 16 bits"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -9761,12 +12159,56 @@ msgid "Signed 24 bit PCM"
 msgstr "PCM de 24 bits"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "PCM de 24 bits"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "PCM de 16 bits"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "Coma flotant de 32 bits"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "Coma flotant de 32 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) PCM de 32 bits amb coma flotant"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bits"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -9777,12 +12219,20 @@ msgid "24 bit DWVW"
 msgstr "24 bits"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "PCM de 16 bits"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "PCM de 16 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -9879,6 +12329,10 @@ msgid "Start offset:"
 msgstr "Desplaçament inicial:"
 
 #: src/import/ImportRaw.cpp
+msgid "bytes"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
 msgid "Amount to import:"
 msgstr "Quantitat a importar:"
 
@@ -9890,6 +12344,10 @@ msgstr "Freqüència de mostreig:"
 #: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
 msgid "&Import"
 msgstr "&Importa"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -9911,12 +12369,18 @@ msgstr "%s dreta"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
 msgid_plural "%s %d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "start"
+msgstr "Començament"
 
 #: src/menus/ClipMenus.cpp
 msgid "end"
@@ -9930,6 +12394,7 @@ msgstr "acabament"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -9948,9 +12413,23 @@ msgid_plural "%d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp
+msgid "Time shifted clips to the right"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Time shifted clips to the left"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Desplaçament temporal"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "clip not moved"
+msgstr "No s'ha desat l'script."
 
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
@@ -10082,7 +12561,8 @@ msgstr "Retalla l'àudio de les pistes seleccionades des de %.2f segons fins a %
 msgid "Trim Audio"
 msgstr "Retalla l'àudio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Divideix"
 
@@ -10203,32 +12683,8 @@ msgid "Delete Key&2"
 msgstr "Tecla de supressió &2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "&Mesclador"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "A&justa el volum de reproducció..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "A&puja el volum de reproducció"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "A&baixa el volum de reproducció"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Aj&usta el volum d'enregistrament..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Apuja el v&olum d'enregistrament"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Abaixa el vo&lum d'enregistrament"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -10255,6 +12711,13 @@ msgid "&Full Screen (on/off)"
 msgstr "&Pantalla completa (activada/desactivada)"
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Exporta l'àudio seleccionat"
 
@@ -10266,6 +12729,16 @@ msgstr "etiquetes.txt"
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
 msgstr "No hi ha cap pista d'etiqueta per exportar."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Please select only one Note Track at a time."
+msgstr "Només es pot mesurar una pista cada vegada."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Please select a Note Track."
+msgstr "Seleccioneu una pista d'àudio."
 
 #: src/menus/FileMenus.cpp
 msgid "Export MIDI As:"
@@ -10303,6 +12776,11 @@ msgstr "Importa etiquetes"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Seleccioneu un fitxer MIDI"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Tots els fitxers|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -10383,6 +12861,11 @@ msgid "&Labels..."
 msgstr "&Etiquetes..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Exporta el MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Dades en c&ru..."
 
@@ -10399,6 +12882,10 @@ msgstr "Im&primeix..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Surt"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -10431,6 +12918,10 @@ msgid "Nothing to do"
 msgstr "No hi ha res a desfer"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Tan&ca la pista amb focus"
 
@@ -10441,6 +12932,10 @@ msgstr "No es pot obrir el fitxer de projecte"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Començament de l'enregistrament:"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -10459,12 +12954,17 @@ msgid "&Getting Started"
 msgstr "&Com començar"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manual del Tenacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Gestiona"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&Ajuda ràpida..."
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -10482,11 +12982,8 @@ msgstr "Informació del dispositiu &MIDI…"
 msgid "Show &Log..."
 msgstr "Mostra el &registre…"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Quant al Tenacity…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "S’ha afegit l’etiqueta"
 
@@ -10624,18 +13121,43 @@ msgstr "Àudio eti&quetat"
 msgid "&Cut"
 msgstr "Re&talla"
 
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Cut"
+msgstr "Còpia de l'etiqueta"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Delete"
+msgstr "Text de l'etiqueta"
+
 #. i18n-hint: (verb) A special way to cut out a piece of audio
 #: src/menus/LabelMenus.cpp
 msgid "&Split Cut"
 msgstr "Di&videix i retalla"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Cut"
+msgstr "Divideix i retalla"
+
+#: src/menus/LabelMenus.cpp
 msgid "Sp&lit Delete"
 msgstr "Divideix i &elimina"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Delete"
+msgstr "Divideix i elimina"
+
+#: src/menus/LabelMenus.cpp
 msgid "Silence &Audio"
 msgstr "Silencia l'&àudio"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Silence"
+msgstr "Silenci"
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
@@ -10651,6 +13173,16 @@ msgstr "Còpia de l'etiqueta"
 msgid "Spli&t"
 msgstr "Di&videix"
 
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split"
+msgstr "Edita l'etiqueta"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Join"
+msgstr "Etiquetes"
+
 #: src/menus/NavigationMenus.cpp
 msgid "Move Backward Through Active Windows"
 msgstr "Mou cap enrere a través de les finestres actives"
@@ -10658,6 +13190,10 @@ msgstr "Mou cap enrere a través de les finestres actives"
 #: src/menus/NavigationMenus.cpp
 msgid "Move Forward Through Active Windows"
 msgstr "Mou cap endavant a través de les finestres actives"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -10717,6 +13253,11 @@ msgid "&Repeat %s"
 msgstr "Repeteix %s"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy, c-format
+msgid "Plug-in %d to %d"
+msgstr "Compatibilitat amb el connector"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "&Genera"
 
@@ -10753,6 +13294,10 @@ msgid "Repeat Last Tool"
 msgstr "Repeteix la darrera eina"
 
 #: src/menus/PluginMenus.cpp
+msgid "&Macros..."
+msgstr "&Macros…"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
 msgstr "&Aplica la macro"
 
@@ -10784,6 +13329,11 @@ msgstr "Detecta els abandonaments ascendents"
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
 msgstr "Script"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Select Time..."
+msgstr "Selecciona..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Select Frequencies..."
@@ -10828,6 +13378,12 @@ msgstr "Estableix l'etiqueta..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Estableix el projecte..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Script"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -10886,6 +13442,11 @@ msgstr "&Selecciona"
 #: src/menus/SelectMenus.cpp
 msgid "&None"
 msgstr "&Cap"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select None"
+msgstr "Selecció"
 
 #: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
 msgid "&Tracks"
@@ -10962,6 +13523,16 @@ msgstr "Es&pectral"
 #: src/menus/SelectMenus.cpp
 msgid "To&ggle Spectral Selection"
 msgstr "Co&mmuta la selecció espectral"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Next &Higher Peak Frequency"
+msgstr "Freqüència alta"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Next &Lower Peak Frequency"
+msgstr "Freqüència baixa"
 
 #: src/menus/SelectMenus.cpp
 msgid "Cursor to Stored &Cursor Position"
@@ -11084,6 +13655,11 @@ msgid "Cursor to Project End"
 msgstr "Cursor a l'acabament del projecte"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Cursor"
+msgstr "Posiciona el &cursor"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor &Left"
 msgstr "Cursor es&querre"
 
@@ -11091,9 +13667,30 @@ msgstr "Cursor es&querre"
 msgid "Cursor &Right"
 msgstr "Cursor d&ret"
 
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor Sh&ort Jump Left"
+msgstr "Cursor es&querre"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor Shor&t Jump Right"
+msgstr "Cursor d&ret"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor Long J&ump Left"
+msgstr "Cursor es&querre"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor Long Ju&mp Right"
+msgstr "Cursor d&ret"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Desplaçamen&t"
@@ -11148,6 +13745,17 @@ msgstr "S'han mesclat i renderitzat %d pistes dins d'una pista estèreo nova"
 msgid "Mixed and rendered %d tracks into one new mono track"
 msgstr "S'han mesclat i renderitzat %d pistes dins d'una pista mono nova"
 
+#. i18n-hint: One or more audio tracks have been panned
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Panned audio track(s)"
+msgstr "S'ha canviat freqüència de mostreig de la pista/es"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan Track"
+msgstr "Pista"
+
 #: src/menus/TrackMenus.cpp
 msgid "Start to &Zero"
 msgstr "Comença al &zero"
@@ -11167,6 +13775,122 @@ msgstr "Acaba al cu&rsor o al començament de la selecció"
 #: src/menus/TrackMenus.cpp
 msgid "End to Selection En&d"
 msgstr "Acaba a l'acabament &de la selecció"
+
+#. i18n-hint: In this and similar messages describing editing actions,
+#. the starting or ending points of tracks are re-"aligned" to other
+#. times, and the time selection may be "moved" too.  The first
+#. noun -- "start" in this example -- is the object of a verb (not of
+#. an implied preposition "from").
+#: src/menus/TrackMenus.cpp
+msgid "Aligned/Moved start to zero"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to zero"
+msgstr "Comença al &zero"
+
+#. i18n-hint: This and similar messages give shorter descriptions of
+#. the aligning and moving editing actions
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move Start"
+msgstr "Amplitud inicial"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align Start"
+msgstr "Començament de la selecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to cursor/selection start"
+msgstr "Comença al &cursor o al començament de la selecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to cursor/selection start"
+msgstr "Comença al &cursor o al començament de la selecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to selection end"
+msgstr "Comença a l'acabament de la s&elecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to selection end"
+msgstr "Comença a l'acabament de la s&elecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to cursor/selection start"
+msgstr "Acaba al cu&rsor o al començament de la selecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to cursor/selection start"
+msgstr "Acaba al cu&rsor o al començament de la selecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move End"
+msgstr "&Alinea l'acabament a l'acabament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align End"
+msgstr "&Alinea l'acabament a l'acabament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to selection end"
+msgstr "Acaba a l'acabament &de la selecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to selection end"
+msgstr "Acaba a l'acabament &de la selecció"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to end"
+msgstr "&Alinea l'acabament a l'acabament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to end"
+msgstr "&Alinea l'acabament a l'acabament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move End to End"
+msgstr "&Alinea l'acabament a l'acabament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align End to End"
+msgstr "&Alinea l'acabament a l'acabament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved together"
+msgstr "Alinea conjun&tament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned together"
+msgstr "Alinea conjun&tament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move Together"
+msgstr "Alinea conjun&tament"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align Together"
+msgstr "Alinea conjun&tament"
 
 #: src/menus/TrackMenus.cpp
 msgid "Synchronize MIDI with Audio"
@@ -11201,20 +13925,21 @@ msgid "Created new label track"
 msgstr "S'ha creat una pista d'etiquetes nova"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
-msgstr ""
-"Aquesta versió del Tenacity només permet tenir una pista de temps a cada "
-"finestra de projecte."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr "Aquesta versió del Tenacity només permet tenir una pista de temps a cada finestra de projecte."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "S'ha creat una pista de temps nova"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Freqüència de mostreig nova (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "El valor que heu introduït no és vàlid"
 
@@ -11296,6 +14021,11 @@ msgstr "Pista de &temps"
 #: src/menus/TrackMenus.cpp
 msgid "Mi&x"
 msgstr "Mesc&la"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mix Stereo Down to &Mono"
+msgstr "Divideix d'estèreo a mo&no"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mi&x and Render"
@@ -11394,12 +14124,57 @@ msgid "By &Name"
 msgstr "Per &nom"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "Pistes de bloqueig de sincronització"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Track"
 msgstr "Pis&ta"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Change P&an on Focused Track..."
+msgstr "Tan&ca la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan &Left on Focused Track"
+msgstr "Tan&ca la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan &Right on Focused Track"
+msgstr "Tan&ca la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Change Gai&n on Focused Track..."
+msgstr "Tan&ca la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Increase Gain on Focused Track"
+msgstr "Tan&ca la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Decrease Gain on Focused Track"
+msgstr "Tan&ca la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Op&en Menu on Focused Track..."
+msgstr "S&ilencia/Dessilencia la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
 msgid "M&ute/Unmute Focused Track"
 msgstr "S&ilencia/Dessilencia la pista amb focus"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Solo/Unsolo Focused Track"
+msgstr "Tan&ca la pista amb focus"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Close Focused Track"
@@ -11431,13 +14206,70 @@ msgstr "Reproduint"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Enregistrament"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track"
+msgstr "Pista d'etiquetes"
+
+#: src/menus/TransportMenus.cpp
+msgid "no label track at or below focused track"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no labels in label track"
+msgstr "S'ha creat una pista d'etiquetes nova"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Please select in a mono track."
+msgstr "Seleccioneu una pista d'àudio."
+
+#: src/menus/TransportMenus.cpp
 msgid "Please select in a stereo track or two mono tracks."
 msgstr "Seleccioneu una pista d'àudio."
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy, c-format
+msgid "Please select at least %d channels."
+msgstr "Seleccioneu una pista d'àudio."
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Please select a time within a clip."
+msgstr "Seleccioneu una acció"
+
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Tra&nsport"
+msgstr "&Opcions de transport"
 
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
@@ -11482,6 +14314,10 @@ msgid "&Timer Record..."
 msgstr "Enregistrament &temporitzat..."
 
 #: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "&Fragment de reproducció"
 
@@ -11522,8 +14358,9 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "Reprodueix &mentre s'enregistra (activat/desactivat)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Ajustament a&utomàtic del nivell d'enregistrament (activat/desactivat)"
+#, fuzzy
+msgid "T&ransport"
+msgstr "Traductors"
 
 #. i18n-hint: (verb) Start playing audio
 #: src/menus/TransportMenus.cpp
@@ -11575,6 +14412,32 @@ msgstr "Reprod&ueix la vista prèvia del retall"
 msgid "&Play-at-Speed"
 msgstr "Re&produeix a velocitat"
 
+#. i18n-hint: 'Normal Play-at-Speed' doesn't loop or cut preview.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Normal Pl&ay-at-Speed"
+msgstr "Reprodueix a velocitat"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play-at-Speed"
+msgstr "Re&produeix a velocitat"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview-at-Speed"
+msgstr "Reprod&ueix la vista prèvia del retall"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Ad&just Playback Speed..."
+msgstr "A&justa el volum de reproducció..."
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Increase Playback Speed"
+msgstr "&Redueix la velocitat de reproducció"
+
 #: src/menus/TransportMenus.cpp
 msgid "&Decrease Playback Speed"
 msgstr "&Redueix la velocitat de reproducció"
@@ -11590,6 +14453,13 @@ msgstr "Mou el focus a la s&egüent i selecciona-la"
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Visualitza"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "Eina de &zoom"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
@@ -11659,6 +14529,11 @@ msgstr "Menú &extres (activat/desactivat)"
 msgid "Track &Name (on/off)"
 msgstr "Menú &extres (activat/desactivat)"
 
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Show Clipping (on/off)"
+msgstr "Escapçament suau"
+
 #: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
 msgid "Show Effects Rack"
 msgstr "Mostra el tauler d'efectes"
@@ -11703,7 +14578,8 @@ msgid "Preferences for Application"
 msgstr "Preferències: "
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Actualitza el Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -11750,7 +14626,8 @@ msgstr "&Amfitrió:"
 msgid "Using:"
 msgstr "Mitjançant:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Reproducció"
 
@@ -11770,7 +14647,8 @@ msgstr "Ca&nals:"
 msgid "Latency"
 msgstr "Latència"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "mil·lisegons"
 
@@ -11799,7 +14677,8 @@ msgid "2 (Stereo)"
 msgstr "2 (estèreo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Directoris"
 
@@ -11812,8 +14691,22 @@ msgid "Default directories"
 msgstr "Directoris"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Navega..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -11873,6 +14766,11 @@ msgstr "Trieu una ubicació per desar-hi els fitxers"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "No existeix el directori %s. Voleu crear-lo?"
 
@@ -11886,9 +14784,9 @@ msgid "Directory %s is not writable"
 msgstr "No es pot escriure al directori %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
-msgstr ""
-"Els canvis en el directori temporal tindran efecte en reiniciar el Tenacity"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr "Els canvis en el directori temporal tindran efecte en reiniciar el Tenacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -11920,9 +14818,16 @@ msgstr "Agrupats pel tipus"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr "LV&2"
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -11937,6 +14842,12 @@ msgstr "N&yquist"
 #: src/prefs/EffectsPrefs.cpp
 msgid "&Vamp"
 msgstr "Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -11959,11 +14870,13 @@ msgid "Plugin Options"
 msgstr "Opcions del connector"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Comprova si hi ha connectors actualitzats quan s’iniciï el Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Torna a escanejar els efectes la següent vegada que Audacity s'iniciï"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -12034,12 +14947,7 @@ msgstr "Filtres no utilitzats:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"Hi ha caràcters d’espai en blanc (espais, salts de línia, tabuladors o "
-"retorns de carro) en un dels elements. Aquests caràcters podrien trencar la "
-"cerca per patrons. Llevat que sapigueu exactament què esteu fent, és "
-"recomanable que elimineu aquests espais en blanc. Voleu que el Tenacity "
-"netegi els espais?"
+msgstr "Hi ha caràcters d’espai en blanc (espais, salts de línia, tabuladors o retorns de carro) en un dels elements. Aquests caràcters podrien trencar la cerca per patrons. Llevat que sapigueu exactament què esteu fent, és recomanable que elimineu aquests espais en blanc. Voleu que el Tenacity netegi els espais?"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -12100,6 +15008,11 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (marge PCM de mostres de 24 bits)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Ubicació"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
 msgstr "D'Internet"
 
@@ -12124,12 +15037,37 @@ msgid "Meter dB &range:"
 msgstr "Ma&rge de dB del vúmetre:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Show e&xtra menus"
 msgstr "Mostra els menús e&xtres"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "&Fes 'bip' quan es completi una acció de llarga durada"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -12139,9 +15077,28 @@ msgstr "Habilita els consells a la línia de temps"
 msgid "Show Scrub Ruler"
 msgstr "Mostra el regle de rastreig"
 
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Importació / exportació"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Preferències: "
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Mix down to Stereo or Mono"
+msgstr "Quan es mescla reduint a &estèreo en l'exportació"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Use Advanced Mixing Options"
@@ -12150,6 +15107,10 @@ msgstr "Opcions de mescla avançades"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Estàndard"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -12175,6 +15136,14 @@ msgstr "Ignora els silencis als principis i als finals"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Anomena i exporta les etiquetes:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -12259,7 +15228,15 @@ msgid "&Defaults"
 msgstr "Valors per &defecte"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Seleccioneu un fitxer XML amb les dreceres de teclat del Tenacity…"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -12268,8 +15245,21 @@ msgstr "S'ha produït un error en importar les dreceres de teclat"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "S'han llegit %d dreceres de teclat\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -12290,6 +15280,15 @@ msgstr "No podeu assignar una clau a aquesta entrada"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "Heu de seleccionar una vinculació abans d'assignar una drecera"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -12360,12 +15359,17 @@ msgid "Dow&nload"
 msgstr "Bai&xa"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity ha detectat automàticament les biblioteques FFmpeg vàlides.\n"
 "Encara voleu localitzar-les manualment?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -12395,8 +15399,16 @@ msgid "Using: PortMidi"
 msgstr "Mitjançant: PortMidi"
 
 #: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "La latència del sintetitzador MIDI ha de ser un nombre enter"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
 
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
@@ -12408,27 +15420,25 @@ msgid "Preferences for Module"
 msgstr "Preferències del mòdul"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
-"Aquests mòduls són experimentals. Activeu-los només si us heu llegit el "
-"manual\n"
+"Aquests mòduls són experimentals. Activeu-los només si us heu llegit el manual\n"
 "del Tenacity i sabeu el que esteu fent."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
-msgstr ""
-"  «Pregunta-m’ho» significa que el Tenacity us preguntarà si voleu carregar "
-"el mòdul cada vegada que engegui."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr "  «Pregunta-m’ho» significa que el Tenacity us preguntarà si voleu carregar el mòdul cada vegada que engegui."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr ""
-"  «Fallit» significa que el Tenacity creu que el mòdul està trencat i no "
-"l’executarà."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr "  «Fallit» significa que el Tenacity creu que el mòdul està trencat i no l’executarà."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -12436,10 +15446,9 @@ msgid "  'New' means no choice has been made yet."
 msgstr "«Nou» significa que encara no s'ha fet cap tria."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
-msgstr ""
-"Els canvis en aquests paràmetres només tindran efecte quan el Tenacity s’"
-"iniciï de nou."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "Els canvis en aquests paràmetres només tindran efecte quan el Tenacity s’iniciï de nou."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -12456,6 +15465,10 @@ msgstr "No s'ha trobat cap mòdul"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Mòdul"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr "Ctrl"
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -12497,7 +15510,10 @@ msgstr "Arrossegament amb el botó principal"
 msgid "Set Selection Range"
 msgstr "Estableix l’interval de la selecció"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Maj+clic esquerre"
 
@@ -12566,8 +15582,17 @@ msgid "Zoom default"
 msgstr "Ampliació per defecte"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip left/right or between tracks"
+msgstr "Mou el clip amunt o avall entre pistes"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Shift-Left-Drag"
 msgstr "Maj+Arrossegament esquerre"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
@@ -12576,6 +15601,15 @@ msgstr "-Arrossegament esquerre"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Mou el clip amunt o avall entre pistes"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Arrossegament esquerre"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -12646,6 +15680,11 @@ msgstr "Amplia i redueix l’ona"
 msgid "-Shift-Wheel-Rotate"
 msgstr "-Maj+Roda del ratolí"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Vertical Scale Waveform (dB) range"
+msgstr "Ma&rge de dB del vúmetre:"
+
 #: src/prefs/PlaybackPrefs.cpp
 msgid "Preferences for Playback"
 msgstr "Preferències: "
@@ -12684,11 +15723,20 @@ msgid "Lo&ng period:"
 msgstr "Període &llarg:"
 
 #: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "Always scrub un&pinned"
 msgstr "Rastreja sem&pre sense enclavar"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferències del Tenacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -12702,6 +15750,11 @@ msgstr "Preferències: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferències de la qualitat"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -12766,6 +15819,11 @@ msgid "Use &hardware to play other tracks"
 msgstr "Utilitza el &maquinari per reproduir les altres pistes"
 
 #: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "&Software playthrough of input"
+msgstr "Reprodueix &mentre s'enregistra (activat/desactivat)"
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Enregistra a una pista nova"
 
@@ -12817,41 +15875,38 @@ msgid "System T&ime"
 msgstr "Hora del s&istema"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Ajustament automàtic del nivell d'enregistrament"
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Preferències: "
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Habilita l'ajustament automàtic del nivell d'enregistrament."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Valor màxim a aconseguir:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Entre:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Temps d'anàlisi:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "mil·lisegons (temps d'una anàlisi)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Nombre d'anàlisis consecutives:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 significa sense acabament"
+msgid "Pre-ro&ll:"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "&Fosa de transició:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Period"
+msgstr "Període de la trama d'àudio"
 
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -12945,12 +16000,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Freqüència mà&x. (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "&Guany (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "Inte&rval (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -12971,6 +16034,10 @@ msgstr "8 - banda més ampla"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - per defecte"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -13070,13 +16137,14 @@ msgid "Info"
 msgstr "Informació"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -13155,6 +16223,11 @@ msgid "Enable cut &lines"
 msgstr "Habilita les &línies del retall"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Enable &dragging selection edges"
+msgstr "Habilita l'arrossegament de la selecció"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Editing a clip can &move other clips"
 msgstr "L'edició d'un clip pot &moure altres clips"
 
@@ -13167,8 +16240,17 @@ msgid "&Type to create a label"
 msgstr "&Teclegeu per crear una etiqueta"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Enable scrolling left of &zero"
 msgstr "Habilita el desplaçament esquerre del &zero"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Advanced &vertical zooming"
+msgstr "Ajusts avançats"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Solo &Button:"
@@ -13250,7 +16332,8 @@ msgstr "Mostres"
 msgid "4 Pixels per Sample"
 msgstr "4 píxels per mostra"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom màx."
 
@@ -13259,8 +16342,29 @@ msgid "Preferences for Tracks"
 msgstr "Preferències de les pistes"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "&Mostra el nom de la pista d'àudio com una superposició"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Capçal de reproducció/enregistrament"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -13324,6 +16428,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "Quan es mescla reduint a &estèreo en l'exportació"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "Quan es mescla reduint a &mono en l'exportació"
 
@@ -13348,16 +16456,24 @@ msgid "Stopped"
 msgstr "Aturat"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Vés al començament"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Vés a l'acabament"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Selecciona fins al començament"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Selecciona fins a l'acabament"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -13371,20 +16487,17 @@ msgstr "Enregistra una pista nova"
 msgid "Append Record"
 msgstr "Annexa un enregistrament"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Selecciona fins a l'acabament"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Selecciona fins al començament"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "En pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s: %s"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -13464,11 +16577,17 @@ msgstr "Silencia l'àudio de la selecció"
 msgid "Sync-Lock Tracks"
 msgstr "Pistes de bloqueig de sincronització"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Augmenta el zoom"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Disminueix el zoom"
 
@@ -13535,43 +16654,6 @@ msgstr "Barra d'eines del vúmetre d'&enregistrament"
 msgid "&Playback Meter Toolbar"
 msgstr "Barra d'eines del vúmetre de &reproducció"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volum d'enregistrament"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volum de reproducció"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volum d'enregistrament: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volum d'enregistrament (no disponible; utilitzeu el mesclador del sistema.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volum de reproducció: %s (emulat)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volum de reproducció: %s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volum de reproducció (no disponible; utilitzeu el mesclador del sistema.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra d'eines del &mesclador"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Recerca"
@@ -13587,6 +16669,7 @@ msgstr "Rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Atura el rastreig"
@@ -13594,6 +16677,7 @@ msgstr "Atura el rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Comença el rastreig"
@@ -13601,6 +16685,7 @@ msgstr "Comença el rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Atura la recerca"
@@ -13608,6 +16693,7 @@ msgstr "Atura la recerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Comença la recerca"
@@ -13662,7 +16748,9 @@ msgstr "Ajusta a la mostra"
 msgid "Length"
 msgstr "Durada"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centre"
 
@@ -13670,6 +16758,21 @@ msgstr "Centre"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "Ajusta els clics/seleccions a %s"
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
+
+#. i18n-hint: each string is replaced by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated)
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Selection %s. %s won't change."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a time range of audio
@@ -13711,8 +16814,8 @@ msgstr "Barra d'eines dels &dispositius"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra d’eines %s del Tenacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -13739,7 +16842,8 @@ msgstr "Eina de desplaçament en el temps"
 msgid "Zoom Tool"
 msgstr "Eina de zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Eina de dibuix"
 
@@ -13797,6 +16901,11 @@ msgstr "Reprodueix a la velocitat seleccionada"
 msgid "Playback Speed"
 msgstr "Velocitat de reproducció"
 
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "Reprodueix a velocitat"
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
 #: src/toolbars/TranscriptionToolBar.cpp
@@ -13811,11 +16920,13 @@ msgstr "Arrossegueu un o més límits d'etiqueta."
 msgid "Drag label boundary."
 msgstr "Arrossega un límit d'etiqueta."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "S'ha modificat l'etiqueta"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Edita l'etiqueta"
 
@@ -13870,31 +16981,42 @@ msgstr "S’han editat les etiquetes"
 msgid "New label"
 msgstr "Etiqueta nova"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Apuja-ho una &octava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Baixa-ho una octa&va"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Feu clic per augmentar el zoom verticalment. Maj+Clic per reduir el zoom. Arrossegueu per especificar el zoom d'un fragment."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clic dret per al menú."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Restableix el zoom"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Maj+clic esquerre"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Amplia el zoom\tClic esquerre/Arrossegament esquerre"
 
@@ -13936,7 +17058,8 @@ msgstr "Combina"
 msgid "Expanded Cut Line"
 msgstr "S'ha expandit la línia del retall"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expandeix"
 
@@ -13959,6 +17082,11 @@ msgstr "Mostres desplaçades"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Edita la mostra"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -13985,6 +17113,11 @@ msgid "S&pectrogram Settings..."
 msgstr "Ajusts de l'es&pectrograma..."
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Canvia el format"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Freqüència incorrecta"
 
@@ -14000,7 +17133,8 @@ msgstr "S'està &processant: "
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "S'ha canviat «%s» a %s"
@@ -14012,6 +17146,54 @@ msgstr "Canvia el format"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Fr&eqüència"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -14031,7 +17213,8 @@ msgstr "Canvia la freqüència"
 msgid "Set Rate"
 msgstr "Estableix la freqüència"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Diverses"
 
@@ -14050,6 +17233,11 @@ msgstr "D&ivideix la pista estèreo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Divideix d'estèreo a mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -14120,19 +17308,22 @@ msgid "Right, %dHz"
 msgstr "Dret, %d Hz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% esquerre"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% dret"
@@ -14145,6 +17336,25 @@ msgstr "Feu clic i arrossegueu per ajustar, doble clic per restablir"
 msgid "Click and drag to rearrange sub-views"
 msgstr "Feu clic i arrossegueu per moure una pista en el temps"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Feu clic i arrossegueu per moure una pista en el temps"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Augmenta el zoom"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Augmenta el zoom"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
 msgstr "Mitja ona"
@@ -14156,6 +17366,11 @@ msgstr "For&ma d'ona"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Color de l'&ona"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Instrument musical"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -14229,9 +17444,8 @@ msgstr "&Interpolació logarítmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Feu clic i arrossegueu per moure una pista en el temps"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -14267,6 +17481,11 @@ msgid "Name Change"
 msgstr "Canvi de nom"
 
 #: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Click and drag to warp playback time"
+msgstr "Feu clic i arrossegueu per moure una pista en el temps"
+
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Click and drag to edit the amplitude envelope"
 msgstr "Feu clic i arrossegueu per a modificar l'envolupant d'amplitud"
 
@@ -14278,6 +17497,7 @@ msgstr "S'ha ajustat l'envolupant."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Rastreja"
@@ -14289,9 +17509,15 @@ msgstr "Recerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Regle de rastreig"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Playing at Speed"
+msgstr "Reprodueix a velocitat"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Seek"
@@ -14360,6 +17586,11 @@ msgstr "Feu clic i arrossegueu per establir l'amplada de banda de la freqüènci
 msgid "Click and drag to select audio"
 msgstr "Feu clic i arrossegueu per seleccionar l'àudio"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Feu clic i arrossegueu per moure una pista en el temps"
@@ -14367,6 +17598,21 @@ msgstr "Feu clic i arrossegueu per moure una pista en el temps"
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Could not shift between tracks"
 msgstr "Mou el clip amunt o avall entre pistes"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Moved clips to another track"
+msgstr "Mou el focus a l'ú&ltima següent"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy, c-format
+msgid "Time shifted tracks/clips right %.02f seconds"
+msgstr "S'han silenciat les pistes seleccionades durant %.2f segons a partir de la posició %.2f"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy, c-format
+msgid "Time shifted tracks/clips left %.02f seconds"
+msgstr "S'han silenciat les pistes seleccionades durant %.2f segons a partir de la posició %.2f"
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Collapse"
@@ -14400,9 +17646,26 @@ msgstr "Ctrl-Clic"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "%s per seleccionar o desseleccionar la pista."
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track."
 msgstr "%s per seleccionar o desseleccionar la pista."
+
+#. i18n-hint: will substitute name of track for %s
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' up"
+msgstr "S'ha importat «%s»"
+
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' down"
+msgstr "Mou el criteri a&vall"
 
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Move Track"
@@ -14483,9 +17746,19 @@ msgstr "Buit"
 msgid "Backwards"
 msgstr "Cap enrere"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Cap endavant"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -14574,6 +17847,11 @@ msgid "Horizontal"
 msgstr "Horitzontal"
 
 #: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "Divideix &verticalment"
+
+#: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr "S'està monitorant "
 
@@ -14610,6 +17888,29 @@ msgstr "Seleccioneu una acció"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 segons"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + mostres"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 dies 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -14625,11 +17926,35 @@ msgstr "0100 dies 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + centèsimes"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 fotogrames|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + mil·lisegons"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 fotogrames|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -14651,6 +17976,7 @@ msgstr "0100 h 060 m 060 s+># mostres"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "mostres"
@@ -14812,6 +18138,44 @@ msgstr "01000,01000 fotogrames|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000>0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000>01000 kHz|0.001"
+msgstr "0100000>0100 Hz"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in octaves
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "octaves"
+msgstr "fins a l'octava"
+
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "100>01000 octaves|1.442695041"
+msgstr "10>01000 dècades|0.434294482"
+
 #. i18n-hint: an octave is a doubling of frequency
 #: src/widgets/NumericTextCtrl.cpp
 msgid "thousandths of octaves"
@@ -14862,6 +18226,11 @@ msgstr "(utilitzeu el menú contextual per canviar el format)"
 msgid "centiseconds"
 msgstr "centisegons"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Temps transcorregut:"
@@ -14904,6 +18273,11 @@ msgstr "Confirmació del tancament"
 msgid "Unable to write files to directory: %s."
 msgstr "No es pot llegir el fitxer dels valors predefinits."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -14920,6 +18294,10 @@ msgstr "Preferències: "
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "No tornis a mostrar aquesta advertència"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -15003,18 +18381,57 @@ msgstr "No s'ha pogut obrir el fitxer"
 msgid "Spectral edit multi tool"
 msgstr "Eina d'edició múltiple de l'espectre"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "S'està filtrant..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Publicat sota els termes de la versió 2 de la llicència pública general GNU"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aSeleccioneu les freqüències."
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy, lisp-format
+msgid "Error.~%"
+msgstr "Error"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, fuzzy
+msgid "Spectral edit parametric EQ"
+msgstr "Eina d'edició múltiple de l'espectre"
 
 #: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
 msgid "Gain (dB)"
@@ -15035,6 +18452,61 @@ msgstr "~aLa freqüència alta està sense definir."
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "~aLa freqüència del centre ha de ser superior a 0 Hz."
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Spectral edit shelves"
+msgstr "Eina d'edició múltiple de l'espectre"
+
+#: plug-ins/StudioFadeOut.ny
+#, fuzzy
+msgid "Studio Fade Out"
+msgstr "Fosa de tancament"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Applying Fade..."
+msgstr "S’està aplicant…"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "&Estableix-ho com a per defecte"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Publicat sota els termes de la versió 2 de la llicència pública general GNU"
+
+#: plug-ins/StudioFadeOut.ny
+#, fuzzy, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr "La selecció ha de tenir més de %d mostres."
+
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
 msgstr "Fosa ajustable"
@@ -15050,6 +18522,20 @@ msgstr "Fosa cap amunt"
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Down"
 msgstr "Fosa cap avall"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "S-Curve Up"
+msgstr "Nom de la corba"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "S-Curve Down"
+msgstr "Mou avall"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
@@ -15070,6 +18556,15 @@ msgstr "Començament (o acabament)"
 #: plug-ins/adjustable-fade.ny
 msgid "End (or start)"
 msgstr "Acabament (o començament)"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "None Selected"
+msgstr " seleccionat"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Linear In"
@@ -15095,6 +18590,58 @@ msgstr "Entrada logarítmica"
 msgid "Logarithmic Out"
 msgstr "Sortida logarítmica"
 
+#: plug-ins/adjustable-fade.ny
+msgid "Rounded In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Rounded Out"
+msgstr "Fosa de tancament"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Cosine In"
+msgstr "Cosinus"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Cosine Out"
+msgstr "Cosinus"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "S-Curve In"
+msgstr "Nom de la corba"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "S-Curve Out"
+msgstr "La corba ja existeix"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy, lisp-format
+msgid "Error~%~%"
+msgstr "Error: "
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr "El guany de freqüència no pot ser negatiu"
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Cercador de pulsacions"
@@ -15103,6 +18650,42 @@ msgstr "Cercador de pulsacions"
 msgid "Finding beats..."
 msgstr "S'estan cercant pulsacions..."
 
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Threshold Percentage"
+msgstr "Controls dels llindars"
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Clip Fix"
+msgstr "Escapçament dels pics"
+
+#: plug-ins/clipfix.ny
+msgid "Reconstructing clips..."
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr "Publicat sota els termes de la versió 2 de la llicència pública general GNU"
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Llindar %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Fosa de transició de clips"
@@ -15110,6 +18693,16 @@ msgstr "Fosa de transició de clips"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "S'està realitzant la fosa de transició..."
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
 
 #: plug-ins/crossfadeclips.ny
 #, lisp-format
@@ -15174,6 +18767,28 @@ msgid "Delay type"
 msgstr "Tipus de retard"
 
 #: plug-ins/delay.ny
+msgid "Regular"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "&Reducció de soroll (dB):"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay time (seconds)"
+msgstr "Temps de retard (segons):"
+
+#: plug-ins/delay.ny
 msgid "Pitch change effect"
 msgstr "Efecte de canvi d'altura"
 
@@ -15193,6 +18808,14 @@ msgstr "Canvi d'altura per eco (semitons)"
 msgid "Number of echoes"
 msgstr "Nombre d'ecos"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Repeteix el darrer efecte"
@@ -15204,6 +18827,10 @@ msgstr "Equalització"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "Fitxers MP3"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -15218,6 +18845,12 @@ msgstr "Confirmació de la sobreescriptura"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Error.~%No es pot obrir el fitxer"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Error (podria ser que el fitxer no s'hagués escrit): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
@@ -15226,6 +18859,10 @@ msgstr "Error (podria ser que el fitxer no s'hagués escrit): %s"
 #: plug-ins/equalabel.ny
 msgid "Regular Interval Labels"
 msgstr "Etiquetes d'intervals regulars"
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -15313,6 +18950,11 @@ msgstr "&Detalls"
 msgid "Warnings only"
 msgstr "Advertències"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -15322,6 +18964,17 @@ msgstr "Etiqueta nova"
 msgid "point labels"
 msgstr "S'han editat les etiquetes"
 
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
 msgstr "Filtre passaalt"
@@ -15330,7 +18983,12 @@ msgstr "Filtre passaalt"
 msgid "Performing High-Pass Filter..."
 msgstr "S'està realitzant el filtre passaalt..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Freqüència (Hz)"
 
@@ -15338,18 +18996,42 @@ msgstr "Freqüència (Hz)"
 msgid "Roll-off (dB per octave)"
 msgstr "Atenuació (dB per octava)"
 
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
+
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "La freqüència ha de ser com a mínim de 0,1 Hz."
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Etiquetes"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Publicat sota els termes de la versió 2 de la llicència pública general GNU"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -15392,8 +19074,37 @@ msgid "Point after sound"
 msgstr "Estèreo unificat"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "Estèreo unificat"
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "S'està cercant el silenci..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "S'està cercant el silenci..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -15405,6 +19116,11 @@ msgstr "La selecció ha de tenir més de %d mostres."
 #, lisp-format
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "No s'ha trobat cap silenci. Proveu de reduir el nivell~%i la durada del silenci."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -15426,6 +19142,17 @@ msgstr "Límit suau"
 msgid "Hard Limit"
 msgstr "Límit fort"
 
+#. i18n-hint: clipping of wave peaks and troughs, not division of a track into clips
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Soft Clip"
+msgstr "Escapçament suau"
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Hard Clip"
+msgstr "Escapçament fort"
+
 #: plug-ins/limiter.ny
 msgid ""
 "Input Gain (dB)\n"
@@ -15442,6 +19169,19 @@ msgstr ""
 "Guany de l'entrada (dB)\n"
 "canal dret"
 
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Limit to (dB)"
+msgstr "Esquerre (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
+
 #: plug-ins/lowpass.ny
 msgid "Low-Pass Filter"
 msgstr "Filtre passabaix"
@@ -15457,6 +19197,10 @@ msgstr "Tipus de soroll:"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Selecció"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -15494,6 +19238,44 @@ msgstr "Temps d'atac/caiguda"
 msgid "Decay (ms)"
 msgstr "Temps d'atac/caiguda"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "La selecció ha de tenir més de %d mostres."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Filtre eliminabanda"
@@ -15509,6 +19291,14 @@ msgstr "Steve Daulton i Bill Wharrie"
 #: plug-ins/notch.ny
 msgid "Q (higher value reduces width)"
 msgstr "Q (els valors més elevats redueixen l'amplada)"
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -15531,7 +19321,8 @@ msgstr "Fitxers MP3"
 msgid "HTML file"
 msgstr "Fitxers MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Anomena els fitxers:"
 
@@ -15548,9 +19339,24 @@ msgid "Disallow"
 msgstr "Inhabilitat"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Inhabilitat"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "No s'ha pogut suprimir %s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -15561,8 +19367,47 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Seleccioneu un fitxer"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Filtres no utilitzats:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Seleccioneu un fitxer"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Generating pluck sound..."
+msgstr "S'està generant el tambor Risset..."
+
+#: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
@@ -15571,6 +19416,10 @@ msgstr "Tipus de fosa de tancament"
 #: plug-ins/pluck.ny
 msgid "Abrupt"
 msgstr "Abrupte"
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -15601,6 +19450,19 @@ msgid "1 - 20 beats/measure"
 msgstr "1 - 20 pulsacions/mesura"
 
 #: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Swing amount"
+msgstr "Quantitat de distorsió"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr "+/− 1"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Nombre de barres"
 
@@ -15613,8 +19475,27 @@ msgid "Rhythm track duration"
 msgstr "Durada de la pista de ritme"
 
 #: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Used if 'Number of bars' = 0"
+msgstr "Nombre de barres"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Start time offset"
+msgstr "Desplaçament inicial:"
+
+#: plug-ins/rhythmtrack.ny
 msgid "Silence before first beat"
 msgstr "Silencia abans de la primera pulsació"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Beat sound"
+msgstr "Cercador de pulsacions"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Ping (short)"
@@ -15624,6 +19505,48 @@ msgstr "Ping (curt)"
 msgid "Ping (long)"
 msgstr "Ping (llarg)"
 
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Resonant Noise"
+msgstr "Ressonància"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Noise Click"
+msgstr "Nivell de soroll"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Drip (short)"
+msgstr "Ping (curt)"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Drip (long)"
+msgstr "Ping (llarg)"
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
 msgstr "Tambor Risset"
@@ -15631,6 +19554,10 @@ msgstr "Tambor Risset"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "S'està generant el tambor Risset..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -15689,6 +19616,11 @@ msgid "Sample Count"
 msgstr "Nombre de mostres"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Time Indexed"
+msgstr "Línia del temps"
+
+#: plug-ins/sample-data-export.ny
 msgid "Include header information"
 msgstr "Inclou la informació de l'encapçalament"
 
@@ -15730,6 +19662,11 @@ msgstr "Mostra els missatges"
 msgid "Errors Only"
 msgstr "Només els errors"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -15747,8 +19684,38 @@ msgstr "~aS'han escrit les dades a:~%~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a linear, ~a dB."
 msgstr "~a lineal, ~a dB."
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr "Esquerre: ~a lineal, ~a dB | Dret: ~a lineal, &nbsp;&nbsp;~a dB."
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -15767,6 +19734,24 @@ msgstr "Anàlisi de dades d'àudio:"
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr "<b>Freqüència de mostreig:</b> &nbsp;&nbsp;~a Hz."
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr "<b>Freqüència de mostreig:</b> &nbsp;&nbsp;~a Hz."
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr "<b>Freqüència de mostreig:</b> &nbsp;&nbsp;~a Hz."
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
 msgstr "<b>Freqüència de mostreig:</b> &nbsp;&nbsp;~a Hz."
 
 #: plug-ins/sample-data-export.ny
@@ -15848,17 +19833,79 @@ msgstr "Una columna per canal.~%"
 msgid "One row per channel.~%"
 msgstr "Una fila per canal.~%"
 
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Error (podria ser que el fitxer no s'hagués escrit): %s"
+
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
 msgstr "Importació de dades de mostres"
+
+#: plug-ins/sample-data-import.ny
+#, fuzzy
+msgid "Reading and rendering samples..."
+msgstr "S'estan mesclant i renderitzant les pistes"
 
 #: plug-ins/sample-data-import.ny
 msgid "Select file"
 msgstr "Seleccioneu un fitxer"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, fuzzy
+msgid "Throw Error"
+msgstr "Error de LOF"
+
+#: plug-ins/sample-data-import.ny
 msgid "Read as Zero"
 msgstr "Llegeix com a zero"
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -15868,6 +19915,11 @@ msgstr "Error.~%No es pot obrir el fitxer"
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Supressió espectral"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Tremolo"
@@ -15886,6 +19938,11 @@ msgid "Inverse Sawtooth"
 msgstr "Dent de serra invers"
 
 #: plug-ins/tremolo.ny
+#, fuzzy
+msgid "Starting phase (degrees)"
+msgstr "Fase d'inici LFO en graus"
+
+#: plug-ins/tremolo.ny
 msgid "Wet level (percent)"
 msgstr "Nivell d'humitat (percentual)"
 
@@ -15896,6 +19953,10 @@ msgstr "Reducció de veus i aïllament"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "S'està aplicant l'acció..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -15946,12 +20007,83 @@ msgid "High Cut for Vocals (Hz)"
 msgstr "Retall alt per a les veus (Hz)"
 
 #: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "This plug-in works only with stereo tracks."
 msgstr "Aquest complement només funciona amb pistes estèreo."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "S'està processant Vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr "Edgar-RFT"
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -15994,6 +20126,217 @@ msgstr "Freqüència del tren de polsos (Hz)"
 msgid "Error.~%Stereo track required."
 msgstr "Error.~%Es requereix la pista estèreo."
 
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Actualitza el Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Omet"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Instal·la l’actualització"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Registre de canvis"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Llegiu-ne més al GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "S’ha produït un error en comprovar si hi ha actualitzacions"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "No s’ha pogut connectar al servidor d’actualitzacions del Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Les dades d’actualització eren malmeses."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "S’ha produït un error en baixar l’actualització."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "No s’ha pogut obrir l’enllaç de baixada del Tenacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "El Tenacity %s és disponible."
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Enregistrament"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Id. de consignació:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Biblioteca d'interfície gràfica multiplataforma"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importació a través de GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "S’ha aturat l’ajustament automàtic del nivell d’enregistrament. No és possible optimitzar-lo més. Encara és massa alt."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "L’ajustament automàtic del nivell d’enregistrament ha abaixat el volum a %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "S’ha aturat l’ajustament automàtic del nivell d’enregistrament. No és possible optimitzar-lo més. Encara és massa baix."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "L’ajustament automàtic del nivell d’enregistrament ha apujat el volum a %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "S’ha aturat l’ajustament automàtic del nivell d’enregistrament. S’ha excedit el nombre total d’anàlisis sense trobar un volum acceptable. Encara és massa alt."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "S’ha aturat l’ajustament automàtic del nivell d’enregistrament. S’ha excedit el nombre total d’anàlisis sense trobar un volum acceptable. Encara és massa baix."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "S’ha aturat l’ajustament automàtic del nivell d’enregistrament. %.2f sembla un volum acceptable."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "No es pot obrir el fitxer de gèneres.\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Mescladors disponibles:\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "%s - %s\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Simula errors d'enregistrament\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volum de reproducció\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Volum d'enregistrament\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Volum d'enregistrament\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Volum de reproducció: %s (emulat)\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Volum de reproducció: %s (emulat)\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Data i hora d'acabament"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Fitxers compatibles amb GStreamer"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importador de GStreamer"
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Índex[%02x] Còdec[%s], Idioma[%s], Taxa de bits[%s], Canals[%d], Durada[%d]"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Error de GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "&Mesclador"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "A&puja el volum de reproducció"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "A&baixa el volum de reproducció"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Aj&usta el volum d'enregistrament..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Apuja el v&olum d'enregistrament"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Abaixa el vo&lum d'enregistrament"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manual del Tenacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Quant al Tenacity…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Ajustament a&utomàtic del nivell d'enregistrament (activat/desactivat)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Ajustament automàtic del nivell d'enregistrament"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Habilita l'ajustament automàtic del nivell d'enregistrament."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Valor màxim a aconseguir:"
+
+#~ msgid "Within:"
+#~ msgstr "Entre:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Temps d'anàlisi:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "mil·lisegons (temps d'una anàlisi)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Nombre d'anàlisis consecutives:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 significa sense acabament"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volum d'enregistrament"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volum de reproducció"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volum d'enregistrament: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volum d'enregistrament (no disponible; utilitzeu el mesclador del sistema.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volum de reproducció: %s (emulat)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volum de reproducció: %s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volum de reproducció (no disponible; utilitzeu el mesclador del sistema.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra d'eines del &mesclador"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Feu clic i arrossegueu per moure una pista en el temps"
+
 #~ msgid "Program build date:"
 #~ msgstr "Data de muntatge del programa:"
 
@@ -16027,18 +20370,11 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgid "Unknown error"
 #~ msgstr "Error desconegut"
 
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "No es pot llegir el fitxer dels valors predefinits."
-
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
 #~ msgstr "El %s és un programa lliure escrit per un equip de %s de tot el món. El %s és %s per al Windows, el macOS i el Linux (a més d’altres sistemes similars al Unix)."
 
 #~ msgid "volunteers"
 #~ msgstr "voluntaris"
-
-#~ msgid "available"
-#~ msgstr "disponible"
 
 #~ msgid "If you find a bug or have a suggestion for us, please write, in English, to our %s. For help, view the tips and tricks on our %s or visit our %s."
 #~ msgstr "Si trobeu un error o teniu un suggeriment per a nosaltres, escriviu-ne, en anglès, al %s. Per a obtenir ajuda, vegeu els consells i trucs al %s o visiteu el %s."
@@ -16111,10 +20447,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgstr "&Baixa"
 
 #, fuzzy
-#~ msgid "Error.n"
-#~ msgstr "Error"
-
-#, fuzzy
 #~ msgid "Failed to copy tags"
 #~ msgstr "No s'ha pogut suprimir %s"
 
@@ -16164,9 +20496,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgid ""
 #~ "Export recording to %s\n"
 #~ "/%s/%s.%s"
-#~ msgstr "Exporta l'enregistrament"
-
-#~ msgid "Export recording"
 #~ msgstr "Exporta l'enregistrament"
 
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
@@ -16290,10 +20619,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgid "Import complete. Running an on-demand waveform calculation. %2.0f%% complete."
 #~ msgstr "S'ha completat la importació. S'està executant el càlcul sol·licitat sobre l'ona resultant.  Completat un %2.0f%% del total."
 
-#, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Compressió:"
-
 #~ msgid "&Use legacy (version 3) syntax."
 #~ msgstr "&Utilitzeu la sintaxi antiga (versió 3)."
 
@@ -16319,9 +20644,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 
 #~ msgid "Make a &copy of the files before editing (safer)"
 #~ msgstr "Fes una &còpia dels fitxers abans d'editar-los (més segur)"
-
-#~ msgid "Read the files &directly from the original (faster)"
-#~ msgstr "Llegeix els fitxers &directament de l'original (més ràpid)"
 
 #~ msgid "Don't &warn again and always use my choice above"
 #~ msgstr "No m'a&visis més i utilitza sempre aquesta elecció"
@@ -16517,10 +20839,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgstr "%d corbes s'han exportat a %s"
 
 #, fuzzy
-#~ msgid "%d kpbs"
-#~ msgstr "%d kbps"
-
-#, fuzzy
 #~ msgid ""
 #~ "\".\n"
 #~ "Nothing is imported."
@@ -16689,9 +21007,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgid "&Use custom mix"
 #~ msgstr "&Utilitza el mesclador personalitzat"
 
-#~ msgid "Vocal Remover"
-#~ msgstr "Eliminador de veu"
-
 #~ msgid "Remove vocals or view Help"
 #~ msgstr "Elimina les veus o mostra l'ajuda"
 
@@ -16748,195 +21063,3 @@ msgstr "Error.~%Es requereix la pista estèreo."
 
 #~ msgid "[Project %02i] Audacity "
 #~ msgstr "[Projecte %02i] Tenacity "
-
-#: src/ProjectFileIO.cpp
-msgid ""
-"This project was created with a newer version of Audacity.\n"
-"\n"
-"You will need to upgrade to open it."
-msgstr ""
-"El projecte s’ha creat amb una versió més recent del Tenacity.\n"
-"\n"
-"Haureu d’actualitzar el programa per a obrir-lo."
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Projecte %02i] "
-
-#: plug-ins/vocoder.ny
-msgid "Edgar-RFT"
-msgstr "Edgar-RFT"
-
-#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
-msgid "Projects cannot be saved to FAT drives."
-msgstr "No és possible desar projectes a les unitats FAT."
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/prefs/EffectsPrefs.cpp
-msgid "LV&2"
-msgstr "LV&2"
-
-#: src/export/ExportMP3.cpp
-msgid "65-105 kbps"
-msgstr "65-105 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "95-135 kbps"
-msgstr "95-135 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "110-150 kbps"
-msgstr "110-150 kb/s"
-
-#: plug-ins/rhythmtrack.ny
-msgid "+/- 1"
-msgstr "+/− 1"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "High Playback Latency: %g\n"
-msgstr "Latència de reproducció alta: %g\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Low Playback Latency: %g\n"
-msgstr "Latència de reproducció baixa: %g\n"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "60 ms"
-msgstr "60 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "40 ms"
-msgstr "40 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "20 ms"
-msgstr "20 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10 ms"
-msgstr "10 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "5 ms"
-msgstr "5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "2.5 ms"
-msgstr "2,5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "9"
-msgstr "9"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "7"
-msgstr "7"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "6"
-msgstr "6"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "5"
-msgstr "5"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "4"
-msgstr "4"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "3"
-msgstr "3"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "1"
-msgstr "1"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "0"
-msgstr "0"
-
-#: src/menus/PluginMenus.cpp
-msgid "&Macros..."
-msgstr "&Macros…"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "No playback device found for '%s'.\n"
-msgstr "No s’ha trobat cap dispositiu de reproducció per a «%s».\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "No recording device found for '%s'.\n"
-msgstr "No s’ha trobat cap dispositiu d’enregistrament per a «%s».\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Default playback device number: %d\n"
-msgstr "Nombre de dispositiu de reproducció per defecte: %d\n"
-
-#: src/FileNames.cpp
-msgid "Dynamically Linked Libraries"
-msgstr "Biblioteques enllaçades dinàmicament"
-
-#: src/effects/Repeat.cpp
-#, c-format
-msgid "New selection length: %s"
-msgstr "Durada de selecció nova: %s"
-
-#: src/effects/Repeat.cpp
-#, c-format
-msgid "Current selection length: %s"
-msgstr "Durada de selecció actual: %s"
-
-#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
-msgstr "[Projecte %02i] Tenacity «%s»"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid ""
-"Failed to update the project file.\n"
-"The following command failed:\n"
-"\n"
-"%s"
-msgstr ""
-"No s’ha pogut actualitzar el fitxer del projecte.\n"
-"Ha fallat l’ordre següent:\n"
-"\n"
-"%s"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Ctrl"
-msgstr "Ctrl"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"

--- a/locale/ca@valencia.po
+++ b/locale/ca@valencia.po
@@ -9,53 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-27 11:11+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
-"Language-Team: Valencian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/ca@valencia/>\n"
+"Language-Team: Valencian <https://hosted.weblate.org/projects/tenacity/tenacity/ca@valencia/>\n"
 "Language: ca@valencia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Ix d'Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Canal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "S'ha produït un error en descodificar el fitxer"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Error carregant metadades"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Barra d'eines %s d'Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Gravació"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -65,6 +28,24 @@ msgstr "No s'ha pogut determinar"
 #, c-format
 msgid "%s bytes"
 msgstr "bytes"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -186,8 +167,14 @@ msgstr "&Para\tF6"
 msgid "&About"
 msgstr "&Quant a"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Elements programables"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Eixida"
 
@@ -203,7 +190,12 @@ msgstr "Scripts de Nyquist (*.ny)|*.ny|scripts de Lisp (*.lsp)|*.lsp|Tots els fi
 msgid "Script was not saved."
 msgstr "No s'ha guardat l'script."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Atenció"
 
@@ -224,11 +216,17 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galeria d'icones de Tango (icones de la barra d'eines)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 per Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 per Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Mòdul extern d'Audacity que proporciona un IDE senzill per als efectes d'escriptura."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -251,7 +249,8 @@ msgstr "Sense títol"
 msgid "Nyquist Effect Workbench - "
 msgstr "Banc de treball d'efectes de Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nou"
 
@@ -291,7 +290,8 @@ msgstr "Copia"
 msgid "Copy to clipboard"
 msgstr "Copia al porta-retalls"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Retalla"
 
@@ -299,7 +299,8 @@ msgstr "Retalla"
 msgid "Cut to clipboard"
 msgstr "Retalla i pega al porta-retalls"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Apega"
 
@@ -324,7 +325,8 @@ msgstr "Selecciona-ho tot"
 msgid "Select all text"
 msgstr "Selecciona tot el text"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Desfés"
 
@@ -332,7 +334,8 @@ msgstr "Desfés"
 msgid "Undo last change"
 msgstr "Desfés l'últim canvi"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Refés"
 
@@ -389,7 +392,8 @@ msgid "Go to next S-expr"
 msgstr "Ves a l'expressió simbòlica següent"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Inici"
 
@@ -397,7 +401,8 @@ msgstr "Inici"
 msgid "Start script"
 msgstr "Inicia l'script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Para"
 
@@ -412,7 +417,8 @@ msgid "About %s"
 msgstr "Quant a"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "D'acord"
 
@@ -420,11 +426,13 @@ msgstr "D'acord"
 msgid "Build Information"
 msgstr "Informació de compilació"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Habilitat"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Inhabilitat"
 
@@ -434,8 +442,9 @@ msgid "The Build"
 msgstr "Versió de proves"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Identificador de publicació:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versió: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -445,22 +454,28 @@ msgstr "Tipus de compilació:"
 msgid "Compiler:"
 msgstr "Compilador:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefix d'instal·lació: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Carpeta de configuració: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Carpeta de configuració: "
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Compatibilitat amb formats de fitxers"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Biblioteca d'interfície gràfica multiplataforma"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -474,7 +489,6 @@ msgstr "Conversió de la freqüència de mostreig"
 msgid "MP3 Importing"
 msgstr "Importació d'MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importació i exportació Ogg Vorbis"
@@ -483,7 +497,6 @@ msgstr "Importació i exportació Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Compatibilitat amb les etiquetes ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importació i exportació  FLAC"
@@ -501,14 +514,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importació i exportació FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importa mitjançant GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Característiques"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Compatibilitat dels connectors"
 
@@ -523,6 +528,10 @@ msgstr "Compatibilitat dels canvis de to i de tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Compatibilitat dels canvis de to extrem i de temps"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Característiques"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -636,6 +645,15 @@ msgstr "desenvolupador web"
 msgid "%s, graphics"
 msgstr "gràfics"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -645,6 +663,10 @@ msgstr "Audacity és el programari lliure, de codi obert i multiplataforma per a
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Crèdits"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -695,6 +717,7 @@ msgstr "Lloc web i gràfics"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "traducció al català@valencià: Empar Montoro"
@@ -712,6 +735,22 @@ msgstr "Agraïments especials:"
 #, c-format
 msgid "%s website: "
 msgstr "Lloc web d'Audacity: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Col·laboradors"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -734,6 +773,7 @@ msgstr "Línia de temps"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Feu clic i arrossegueu per a començar la cerca"
@@ -741,6 +781,7 @@ msgstr "Feu clic i arrossegueu per a començar la cerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Feu clic i arrossegueu per a començar el rastreig"
@@ -748,6 +789,7 @@ msgstr "Feu clic i arrossegueu per a començar el rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Feu clic i moveu per a rastrejar. Feu clic i arrossegueu per a buscar."
@@ -755,6 +797,7 @@ msgstr "Feu clic i moveu per a rastrejar. Feu clic i arrossegueu per a buscar."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Moveu per a buscar"
@@ -762,6 +805,7 @@ msgstr "Moveu per a buscar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Moveu per a rastrejar"
@@ -818,6 +862,21 @@ msgstr ""
 "No es pot bloquejar la zona\n"
 "més enllà del final del projecte."
 
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Error"
+msgstr "Error"
+
 #: src/AudacityApp.cpp
 #, c-format
 msgid "Failed to remove %s"
@@ -838,7 +897,8 @@ msgstr ""
 "Aquesta pregunta només es fa una vegada, després d'un «Instal·la» on heu demanat restablir les preferències."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Restableix les preferències d'Audacity"
 
 #: src/AudacityApp.cpp
@@ -851,6 +911,10 @@ msgstr ""
 "No s'ha trobat %s.\n"
 "\n"
 "S'ha eliminat de la llista de fitxers recents."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -875,7 +939,7 @@ msgstr "&Obri..."
 msgid "Open &Recent..."
 msgstr "Obri un fitxer &recent..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "Qu&ant a Audacity..."
@@ -889,9 +953,10 @@ msgid "&File"
 msgstr "&Fitxer"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity no troba cap lloc per a guardar els fitxers temporals.\n"
@@ -899,20 +964,23 @@ msgstr ""
 "Indiqueu un directori adient en les preferències."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity no troba cap lloc per a guardar els fitxers temporals.\n"
 "Indiqueu un directori adient en les preferències."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity es tancarà tot seguit. Reinicieu-lo per a poder utilitzar el nou directori temporal."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -921,15 +989,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity no ha pogut bloquejar la carpeta de fitxers temporals\n"
 "Pot ser que alguna altra còpia d'Audacity estiga utilitzant aquesta carpeta.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "De segur que voleu iniciar lAudacity?"
 
 #: src/AudacityApp.cpp
@@ -937,24 +1007,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "S'ha produït un error en bloquejar la carpeta de fitxers temporals"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "El sistema ha detectat que hi ha una altra còpia d'Audacity en funcionament.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Utilitzeu les ordres «Nou» o «Obri» del procés actual d'Audacity\n"
 "per a obrir diversos projectes de manera simultània.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity ja es troba en funcionament"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Fitxers de projecte de l'Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -974,7 +1092,8 @@ msgstr "executa l'autodiagnòstic"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "mostra la versió d'Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -984,9 +1103,10 @@ msgid "audio or project file name"
 msgstr "nom de fitxer d'àudio o de projecte"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -999,24 +1119,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Fitxers de projecte de l'Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Missatge"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Personalització de DarkAudacity"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Ajuda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Ix d'Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Registre d'Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1028,9 +1172,14 @@ msgstr "&Guarda..."
 msgid "Cl&ear"
 msgstr "Net&eja"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Tanca"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1079,7 +1228,8 @@ msgid "Error Initializing Midi"
 msgstr "S'ha produït un error en inicialitzar MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Registre d'Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1094,37 +1244,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "No hi ha prou memòria."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. No és possible optimitzar-lo més. Encara és massa alt."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "L'ajustament automàtic del nivell de gravació ha abaixat el volum a %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. No és possible optimitzar-lo més. Encara és massa baix."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "L'ajustament automàtic del nivell de gravació ha apujat el volum a %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. S'ha excedit el nombre total d'anàlisis sense trobar un volum acceptable. Encara és massa alt."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. S'ha excedit el nombre total d'anàlisis sense trobar un volum acceptable. Encara és massa baix."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. %.2f sembla un volum acceptable."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1238,43 +1357,6 @@ msgstr "No s'ha trobat cap dispositiu de reproducció per a «%s».\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "No es poden comprovar les freqüències de mostreig mútues sense els dos dispositius.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "S'ha rebut %d en obrir els dispositius\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "No s'ha pogut obrir Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Mescladors disponibles:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Fonts de gravació disponibles:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volums de reproducció disponibles:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Volum de gravació és emulat\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "El volum de gravació és natiu\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "El volum de reproducció és emulat\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "El volum de reproducció és natiu\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1317,8 +1399,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Recuperació automàtica de fallades"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1330,12 +1413,14 @@ msgid "Recoverable &projects"
 msgstr "Projectes recuperables"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Selecciona"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nom"
 
@@ -1346,6 +1431,10 @@ msgstr "S'ha seleccionat"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "No s'ha seleccionat res"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1421,6 +1510,11 @@ msgstr "Efecte"
 msgid "Menu Command (With Parameters)"
 msgstr "Ordre de menú (amb paràmetres)"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
 msgstr "Ordre de menú (sense paràmetres)"
@@ -1489,6 +1583,12 @@ msgstr "Gestiona les macros"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Seleccioneu la macro"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "Aplica la macro"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
@@ -1560,7 +1660,8 @@ msgstr "Re&staura"
 msgid "I&mport..."
 msgstr "I&mporta..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xporta..."
 
@@ -1601,7 +1702,8 @@ msgstr "Mou am&unt"
 msgid "Move &Down"
 msgstr "Mou a&vall"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Guarda"
 
@@ -1684,7 +1786,8 @@ msgid "Run"
 msgstr "Executa"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Tanca"
 
@@ -1831,9 +1934,13 @@ msgid "Benchmark completed successfully.\n"
 msgstr "La prova de rendiment s'ha completat correctament.\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Data i hora d'acabament"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Versió final"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1939,10 +2046,24 @@ msgstr "Projecte actual"
 msgid "Checkpointing %s"
 msgstr "S'està important %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "No s'ha pogut escriure al fitxer: %s\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity no ha pogut escriure el fitxer %s.\n"
+"Potser el disc està ple o no s'hi pot escriure."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1963,6 +2084,10 @@ msgid ""
 msgstr ""
 "No s'ha pogut registrar:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -2060,6 +2185,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Copia els noms en el porta-retalls"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Fitxers desapareguts"
 
@@ -2068,10 +2198,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Si ho feu, el vostre projecte no es guardarà al disc. És això el que voleu?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2085,27 +2216,84 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Comprovació de dependències"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Cap"
 
 #: src/Dither.cpp
+msgid "Rectangle"
+msgstr ""
+
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Triangle"
+msgstr ""
+
+#: src/Dither.cpp
 msgid "Shaped"
 msgstr "Perfilat"
+
+#: src/FFT.cpp
+#, fuzzy
+msgid "Rectangular"
+msgstr "Normal"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
 msgid "Welch"
 msgstr "Benvinguts!"
 
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "La compatibilitat amb FFmpeg no ha estat compilada"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2126,8 +2314,8 @@ msgid "Locate FFmpeg"
 msgstr "Troba FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity necessita el fitxer «%s» per a importar i exportar àudio mitjançant FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2140,7 +2328,8 @@ msgstr "Ubicació de «%s»:"
 msgid "To find '%s', click here -->"
 msgstr "Per trobar «%s», feu clic ací --> "
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Navega..."
 
@@ -2166,8 +2355,9 @@ msgid "FFmpeg not found"
 msgstr "No s'ha trobat FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2187,25 +2377,34 @@ msgstr "No tornes a mostrar aquesta advertència"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "No s'han trobat biblioteques FFmpeg compatibles."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity no ha pogut obrir un fitxer en %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity no ha pogut llegir d'un fitxer en %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity ha escrit amb èxit un fitxer en %s però ha fallat en el canvi de nom a %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2242,7 +2441,9 @@ msgstr "&No copies cap àudio"
 msgid "As&k"
 msgstr "Pre&gunta-m'ho"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Tots els fitxers|*"
 
@@ -2251,6 +2452,11 @@ msgstr "Tots els fitxers|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "S'estan guardant els fitxers de dades del projecte"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Biblioteques"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -2263,6 +2469,10 @@ msgstr "Anomena els fitxers:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Fitxers MP3"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2304,6 +2514,14 @@ msgstr "Autocorrelació d'arrel cúbica"
 msgid "Enhanced Autocorrelation"
 msgstr "Autocorrelació millorada"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Espectre"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2320,9 +2538,35 @@ msgstr "Freqüència lineal"
 msgid "Log frequency"
 msgstr "Freqüència de registre"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "Si"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Desplaçament"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "Apropa"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2333,6 +2577,11 @@ msgstr "Horitzontal"
 #, fuzzy
 msgid "Zoom Horizontal"
 msgstr "Horitzontal"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cursor:"
+msgstr "&Cursor a"
 
 #: src/FreqWindow.cpp
 msgid "Peak:"
@@ -2379,6 +2628,23 @@ msgstr "S'ha seleccionat un fragment de so massa llarg. Només s'analitzaran els
 msgid "Not enough data selected."
 msgstr "No s'han seleccionat prou dades."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f segons (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f s (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2401,7 +2667,8 @@ msgstr "espectre.txt"
 msgid "Export Spectral Data As:"
 msgstr "Anomena i exporta les dades d'espectre:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "No s'ha pogut escriure al fitxer: %s"
@@ -2579,6 +2846,11 @@ msgstr "Descarta"
 msgid "&Compact"
 msgstr "&Ordre"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2586,19 +2858,19 @@ msgid "&History..."
 msgstr "&Historial..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Error intern en %s en %s línia %d.\n"
 "Informeu l'equip d'Audacity en https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Error intern en %s línia %d.\n"
 "Informeu l'equip d'Audacity en https://forum.audacityteam.org/."
@@ -2617,7 +2889,9 @@ msgid "Track"
 msgstr "Pista"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -2677,7 +2951,8 @@ msgstr "Introduïu el nom de la pista"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Pista de l'etiqueta"
 
@@ -2688,11 +2963,13 @@ msgstr "No es poden llegir una o més etiquetes guardades."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "És la primera vegada que s'inicia l'Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Trieu l'idioma que utilitzarà Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2702,7 +2979,8 @@ msgstr "Trieu l'idioma que utilitzarà Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "La llengua que heu triat, %s (%s), no coincideix amb la llengua del sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirma"
 
@@ -2720,13 +2998,19 @@ msgstr ""
 "El fitxer antic s'ha guardat amb el nom «%s»"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "S'està obrint el projecte Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke d'Audacity%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Navega..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2772,19 +3056,23 @@ msgid "Mixing and rendering tracks"
 msgstr "S'estan mesclant i renderitzant les pistes"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Taula de mescles d'Audacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Guany"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocitat"
 
@@ -2793,28 +3081,43 @@ msgid "Musical Instrument"
 msgstr "Instrument musical"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balanç"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Silenci"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Mesurador del nivell de senyal"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "S'ha mogut el regulador de guany"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "S'ha mogut el regulador de guany"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "S'ha mogut el botó lliscant de la panoramització"
 
@@ -2845,9 +3148,9 @@ msgstr ""
 "No s'hi carregarà."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2880,12 +3183,20 @@ msgstr ""
 "\n"
 "Utilitzeu sols mòduls de fonts fiables"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Sí"
 
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
+#, fuzzy
+msgid "No"
+msgstr "Cap"
+
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Carregador del mòdul d'Audacity"
 
 #: src/ModuleManager.cpp
@@ -3126,7 +3437,8 @@ msgstr "&Selecciona-ho tot"
 msgid "C&lear All"
 msgstr "&Neteja-ho tot"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Habilita"
 
@@ -3200,6 +3512,21 @@ msgstr ""
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Per aplicar el filtre, cal que totes les pistes seleccionades tinguen la mateixa freqüència de mostreig."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "So gravat"
@@ -3218,10 +3545,11 @@ msgid "Dropouts"
 msgstr "Pèrdues"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3261,11 +3589,11 @@ msgid "Inspecting project file data"
 msgstr "S'estan inspeccionant les dades del fitxer del projecte"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3307,11 +3635,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Advertència - Falten fitxers referenciats per àlies"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "La comprovació del projecte de la carpeta «%s»\n"
@@ -3336,12 +3664,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Advertència - Falten fitxers de resums d'àlies"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3399,7 +3727,8 @@ msgstr "Advertència - Fitxers de bloc orfes"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progrés"
 
@@ -3424,6 +3753,11 @@ msgstr "Advertència: Hi ha hagut problemes durant la recuperació automàtica"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<Sense títol>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projecte"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3464,11 +3798,98 @@ msgid ""
 msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"No s'ha pogut registrar:\n"
+"%s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "S'està guardant un projecte d'Audacity"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "No s'ha pogut inicialitzar el flux de dades MP3"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3482,12 +3903,35 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Fitxer de blocs orfe: «%s»"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "No s'ha pogut establir l'estat del flux per a pausar-lo."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "No s'ha pogut trobar el còdec"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"No s'ha pogut registrar:\n"
+"%s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3498,9 +3942,9 @@ msgid "Error Writing to File"
 msgstr "S'ha produït un error en escriure en el fitxer"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3511,6 +3955,19 @@ msgstr ""
 msgid "Compacting project"
 msgstr "S'estan guardant els &projectes"
 
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Velocitat"
+
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
@@ -3518,10 +3975,10 @@ msgstr "(Recuperat)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Aquest fitxer es va guardar amb Audacity %s. \n"
 "Esteu utilitzant Audacity %s. Per obrir aquest fitxer heu d'actualitzar el programa a una versió més recent."
@@ -3529,6 +3986,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "No es pot obrir el fitxer de projecte"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3543,6 +4004,10 @@ msgid "Unable to parse project information."
 msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "S'estan guardant els &projectes"
 
@@ -3551,12 +4016,35 @@ msgid "Error Saving Project"
 msgstr "S'ha produït un error en guardar el projecte"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "S'estan guardant els projectes &buits"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3564,8 +4052,24 @@ msgstr ""
 "Es poden recuperar de manera automàtica els projectes següents :"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Alguns projectes no es van guardar correctament l'última vegada que s'utilitzà Audacity.\n"
+"Es poden recuperar de manera automàtica els projectes següents :"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "S'ha recuperat el projecte"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Directori per a fitxers temporals"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3594,6 +4098,17 @@ msgstr "Advertència - Projecte buit"
 msgid "Insufficient Disk Space"
 msgstr "Espai de disc"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3613,8 +4128,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sAnomena i guarda el projecte «%s»..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "«Guarda el projecte» és per a un projecte d'Audacity, no per a un fitxer d'àudio.\n"
@@ -3690,11 +4206,12 @@ msgid "Error Opening Project"
 msgstr "Error en obrir el projecte"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Esteu intentant obrir un fitxer de còpia de seguretat que es va crear automàticament. \n"
 "En fer açò es podria produir una pèrdua de dades important. \n"
@@ -3727,6 +4244,12 @@ msgid "Error Opening File or Project"
 msgstr "S'ha produït un error en obrir el fitxer o el projecte"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "S'ha recuperat el projecte"
 
@@ -3752,12 +4275,33 @@ msgid "Error Importing"
 msgstr "S'ha produït un error en importar"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Defineix el projecte"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "No es pot obrir el fitxer de projecte"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Ordre"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3768,8 +4312,8 @@ msgid "Automatic database backup failed."
 msgstr "S'ha activat l'acció de guardar automàticament:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Us donem la benvinguda a l'Audacity versió %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3849,6 +4393,21 @@ msgstr "Barra de desplaçament horitzontal"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Barra de desplaçament vertical"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -3969,7 +4528,8 @@ msgstr "Totes les preferències"
 msgid "SelectionBar"
 msgstr "Barra de selecció"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Selecció espectral"
 
@@ -3977,42 +4537,56 @@ msgstr "Selecció espectral"
 msgid "Timer"
 msgstr "Temps:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Eines"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "Traducció al català@valencià: Empar Montoro"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mesclador"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Mesurador"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Mesurador de reproducció"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Mesurador de gravació"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Edita"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Dispositiu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Reproduix-a-velocitat"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Rastreja"
 
@@ -4027,7 +4601,10 @@ msgstr "Regle"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Pistes"
 
@@ -4137,7 +4714,8 @@ msgid "Activation level (dB):"
 msgstr "Nivell d'activació (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Us donem la benvinguda a l'Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4264,10 +4842,25 @@ msgstr "S'ha produït un error en guardar els fitxers d'etiquetes"
 msgid "Unsuitable"
 msgstr "Mòdul inapropiat"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Directori per a fitxers temporals"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity no ha pogut escriure al fitxer:\n"
@@ -4285,9 +4878,9 @@ msgid ""
 msgstr "S'ha escrit el tema en: %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4296,9 +4889,9 @@ msgstr ""
 "per a escriure-hi."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity no ha pogut introduir les imatges en el fitxer:\n"
@@ -4315,9 +4908,9 @@ msgstr ""
 " %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4327,9 +4920,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4338,8 +4931,9 @@ msgstr ""
 "Potser té un format PNG incorrecte?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity no ha pogut carregar el tema per defecte.\n"
@@ -4377,9 +4971,9 @@ msgstr ""
 "són presents. Voleu sobreescriure'ls?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity no ha pogut guardar el fitxer:\n"
@@ -4418,7 +5012,11 @@ msgstr "Personalitzat"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Durada"
 
@@ -4429,7 +5027,8 @@ msgid "Time Track"
 msgstr "Pista de temps"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Gravació programada d'Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4501,7 +5100,8 @@ msgstr "Projecte actual"
 msgid "Recording start:"
 msgstr "Inici de la gravació:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Duració:"
 
@@ -4522,7 +5122,8 @@ msgid "Action after Timer Recording:"
 msgstr "Acció posterior a la gravació temporitzada:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Progrés de gravació temporitzada d'Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4619,6 +5220,7 @@ msgstr "099 dies 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data i hora d'inici"
@@ -4663,7 +5265,8 @@ msgstr "Voleu activar l'&exportació automàtica?"
 msgid "Export Project As:"
 msgstr "Anomena i exporta el projecte:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcions"
 
@@ -4676,7 +5279,8 @@ msgid "Do nothing"
 msgstr "No faces res"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Ix d'Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4700,7 +5304,8 @@ msgid "Scheduled to stop at:"
 msgstr "S'ha programat parar en:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Gravació temporitzada d'Audacity - S'està esperant per a començar"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4726,7 +5331,8 @@ msgid "Recording Exported:"
 msgstr "S'ha exportat la gravació:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Gravació temporitzada d'Audacity - S'està esperant"
 
 #: src/TrackInfo.cpp
@@ -4852,6 +5458,10 @@ msgstr "Mou la pista cap amunt"
 msgid "Move Track Down"
 msgstr "Mou la pista cap avall"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4918,6 +5528,20 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "S'està aplicant %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Ordre per lots"
@@ -4932,16 +5556,33 @@ msgstr "%s no és un paràmetre acceptat per %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Valor no vàlid per al paràmetre «%s»: hauria de ser %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Ordre"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repeteix %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -5040,17 +5681,33 @@ msgstr "Menús"
 msgid "Preferences"
 msgstr "Preferències"
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Defineix clip"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Envolupants"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiquetes"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Quadres"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5059,6 +5716,12 @@ msgstr "Informe"
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Tipus:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Projecte actual"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -5084,9 +5747,17 @@ msgstr "Comentaris"
 msgid "Command:"
 msgstr "Ordre:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Proporciona ajuda sobre una ordre."
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -5116,17 +5787,26 @@ msgstr "Exporta a un fitxers."
 msgid "Builtin Commands"
 msgstr "Ordres predefinides"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "L'equip d'Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Proporciona ordres predefinides a Audacity"
 
 #: src/commands/LoadCommands.cpp
 msgid "Unknown built-in command name"
 msgstr "Nom d'ordre integrada desconegut"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -5168,11 +5848,22 @@ msgstr "Guarda un projecte."
 msgid "Saves a copy of current project."
 msgstr "Guarda un projecte."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Obtín la preferència"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nom:"
 
@@ -5220,7 +5911,8 @@ msgstr "Pantalla completa"
 msgid "Toolbars"
 msgstr "Barres d'eines"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efectes"
 
@@ -5360,7 +6052,8 @@ msgstr "Defineix"
 msgid "Add"
 msgstr "Afig"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Suprimeix"
 
@@ -5371,6 +6064,11 @@ msgstr "Primera pista:"
 #: src/commands/SelectCommand.cpp
 msgid "Track Count:"
 msgstr "Recompte de pistes:"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Mode:"
+msgstr "Mode:"
 
 #: src/commands/SelectCommand.h
 msgid "Selects a time range."
@@ -5392,9 +6090,29 @@ msgstr "Selecciona l'àudio."
 msgid "Set Clip"
 msgstr "Defineix clip"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp
 msgid "At:"
 msgstr "A:"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
 
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
@@ -5421,7 +6139,8 @@ msgid "Edited Envelope"
 msgstr "Defineix l'envolupant"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Envolupant"
 
@@ -5464,6 +6183,14 @@ msgstr "Freqüència:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Canvia la mida:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5513,7 +6240,10 @@ msgstr "Panoramitza:"
 msgid "Set Track Visuals"
 msgstr "Estableix els aspectes visuals de la pista"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineal"
 
@@ -5538,6 +6268,11 @@ msgid "Scale:"
 msgstr "Ajusta la mida:"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "Vzoom part superior:"
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
 msgstr "Vzoom part superior:"
 
@@ -5552,6 +6287,12 @@ msgstr "Utilitza les preferències espectrals"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Selecció espectral"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5586,6 +6327,10 @@ msgid "Allo&w clipping"
 msgstr "Permet l'escapçament"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Redueix el volum d'una o més pistes tan prompte com el volum de la pista marcada com a «control» arriba a un determinat nivell"
 
@@ -5603,12 +6348,18 @@ msgstr "Heu seleccionat una pista sense àudio. AutoDuck només pot processar pi
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck necessita una pista de control situada sota la pista o pistes seleccionades."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Quantitat de «Duck»:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segons"
 
@@ -5632,7 +6383,8 @@ msgstr "Duració de la fosa final interior:"
 msgid "Inner &fade up length:"
 msgstr "Longitud de la fosa inicial interior:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Llindar:"
 
@@ -5759,6 +6511,10 @@ msgid "from (Hz)"
 msgstr "des de (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "fins a (Hz)"
 
@@ -5766,17 +6522,23 @@ msgstr "fins a (Hz)"
 msgid "t&o"
 msgstr "fins a"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Canvi percentual:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Canvi percentual"
 
 #: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
 msgid "&Use high quality stretching (slow)"
 msgstr "Utilitza l'estirament d'alta qualitat (lent)"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -5788,7 +6550,9 @@ msgstr "8"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "no aplicable"
 
@@ -5816,6 +6580,7 @@ msgstr "RPM de vinil estàndard:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Des de RPM"
@@ -5828,6 +6593,7 @@ msgstr "des de"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Fins a RPM"
@@ -5963,8 +6729,19 @@ msgid "Max Spike Width"
 msgstr "Amplària màxima dels pics"
 
 #: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Comprimeix:"
+
+#: src/effects/Compressor.cpp
 msgid "Compresses the dynamic range of audio"
 msgstr "Comprimeix l'interval dinàmic d'àudio"
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -5974,6 +6751,20 @@ msgstr "%.2f segons"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f segons"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f segons"
 
 #: src/effects/Compressor.cpp
@@ -6091,7 +6882,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analitzador de contrast, per a mesurar diferències de volum RMS entre dues seccions d'àudio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Final"
 
@@ -6151,9 +6943,32 @@ msgstr "&Diferència:"
 msgid "&Help"
 msgstr "&Ajuda"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "indeterminada"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6207,6 +7022,12 @@ msgstr "Diferència actual"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "S'ha mesurat el nivell del so principal"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6276,9 +7097,20 @@ msgstr "Barem d'èxit 1.4.7 de WCAG 2.0: Fallit"
 msgid "Data gathered"
 msgstr "Dades recollides"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Anàlisi del contrast (conformitat amb WCAG 2)"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Alt contrast"
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -6535,6 +7367,12 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "Genera tons duals multifreqüència (DTMF) com els que produeixen els telèfons de tecles"
 
 #: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Seqüència DTMF:"
 
@@ -6542,7 +7380,9 @@ msgstr "Seqüència DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitud (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Duració:"
 
@@ -6563,6 +7403,12 @@ msgstr "%.1f segons"
 msgid "Tone duration:"
 msgstr "Duració dels tons:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
+
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Duració dels silencis:"
@@ -6581,7 +7427,8 @@ msgstr "Eco"
 msgid "Repeats the selected audio again and again"
 msgstr "Repeteix l'àudio seleccionat una vegada i una altra"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "El valor sol·licitat supera la capacitat de la memòria."
 
@@ -6605,7 +7452,8 @@ msgstr "Valors predefinits"
 msgid "Export Effect Parameters"
 msgstr "Paràmetres d'&edició"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "No s'ha pogut obrir el fitxer: «%s»"
@@ -6629,6 +7477,12 @@ msgstr "Paràmetres d'&edició"
 msgid "%s: is not a valid presets file.\n"
 msgstr "«%s» no és un camí de fitxer vàlid.\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "S'està preparant la  previsualització"
@@ -6636,6 +7490,15 @@ msgstr "S'està preparant la  previsualització"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Previsualització"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Error Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -6918,6 +7781,11 @@ msgstr "Para la re&producció"
 msgid "Play"
 msgstr "Reprodueix"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
@@ -7003,12 +7871,35 @@ msgid "Effect Unavailable"
 msgstr "L'efecte no està disponible"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Màx. dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Mín. dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
 
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
@@ -7089,8 +7980,16 @@ msgid "D&efault"
 msgstr "Valors per d&efecte"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &multiprocés"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7335,7 +8234,8 @@ msgid "Builtin Effects"
 msgstr "Efectes predefinits"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Proporciona efectes predefinits a Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7345,6 +8245,14 @@ msgstr "Nom de l'efecte predefinit desconegut"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normalitza la sonoritat a"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Sets the loudness of one or more tracks"
@@ -7374,8 +8282,20 @@ msgid "Loudness LUFS"
 msgstr "Sonoritat LUFS"
 
 #: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Normalitza els canals estèreos de forma independent"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -7423,8 +8343,37 @@ msgid "Second greatest"
 msgstr "Segona pista"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "4 (per defecte)"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "4 (per defecte)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -7519,8 +8468,9 @@ msgid "Step 1"
 msgstr "Pas 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Seleccioneu uns quants segons de so on només hi hagi soroll, de manera que l'Audacity\n"
@@ -7572,13 +8522,63 @@ msgstr "Tipus de &finestra"
 msgid "Window si&ze:"
 msgstr "Mi&da de la finestra"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (per defecte)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Pass$os per finestra"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7694,12 +8694,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Normalitza els canals estèreos de forma independent"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Estira"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch és sols per a un estirament de temps extrem o per a l'efecte «immobilitat»"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Factor s'estirament:"
@@ -7749,6 +8755,10 @@ msgstr ""
 "\n"
 "Augmenteu la selecció d'àudio com a mínim a %.1f segons,\n"
 "o reduïu la «Resolució de temps» a menys de %.1f segons."
+
+#: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
@@ -7975,6 +8985,11 @@ msgstr "Inverteix l'àudio seleccionat"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Temps SBSMS / Estirament de to"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8131,6 +9146,11 @@ msgstr "Utilitza els valors per defecte"
 msgid "Restore Defaults"
 msgstr "Restableix els valors per defecte"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8218,6 +9238,10 @@ msgid "Square, no alias"
 msgstr "Quadrada, sense àlies"
 
 #: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr "To"
 
@@ -8285,6 +9309,10 @@ msgstr "Detecta el silenci"
 msgid "Tr&uncate to:"
 msgstr "Trunca en:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Comprimeix en :"
@@ -8298,7 +9326,8 @@ msgid "VST Effects"
 msgstr "Efectes VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Afegeix la capacitat d'utilitzar efectes VST amb Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8310,7 +9339,8 @@ msgstr "S'està comprovant Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "S'estan registrant %d de %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "No s'ha pogut carregar la biblioteca"
 
@@ -8322,15 +9352,25 @@ msgstr "Opcions de l'efecte VST"
 msgid "Buffer Size"
 msgstr "Mida de la memòria intermèdia"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Mida de la &memòria intermèdia (de 8 a 1048576 mostres):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Compensació de la latència"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Activa la &compensació"
 
@@ -8356,7 +9396,18 @@ msgid "Save VST Preset As:"
 msgstr "Guarda el valor predefinit VST com a:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Exporta els valors predefinits d'Audio Unit"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Exporta els valors predefinits d'Audio Unit"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Fitxers de projecte de l'Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8383,7 +9434,8 @@ msgstr "S'ha produït un error en carregar els valors VST predefinits"
 msgid "Unable to load presets file."
 msgstr "No s'han pogut carrega els fitxers predefinits."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Paràmetres de l'efecte"
 
@@ -8399,6 +9451,16 @@ msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Aquest fitxer de paràmetres es va guardar des de %s. Voleu continuar?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8430,7 +9492,8 @@ msgid "Audio Unit Effects"
 msgstr "Efectes d'Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Proporciona suport per a utilitzar els efectes d'Audio Unit en Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8446,8 +9509,16 @@ msgid "Audio Unit Effect Options"
 msgstr "Opcions dels efectes d'Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Interfície d'usuari"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -8503,6 +9574,14 @@ msgid "Unable to store preset in config file"
 msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not import \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "No s'ha pogut trobar la carpeta de dades del projecte:«%s»"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Export Audio Unit Preset As %s:"
 msgstr "Exporta els valors predefinits d'Audio Unit"
@@ -8510,6 +9589,14 @@ msgstr "Exporta els valors predefinits d'Audio Unit"
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Standard Audio Unit preset file"
 msgstr "Exporta els valors predefinits d'Audio Unit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not export \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "No s'ha pogut trobar la carpeta de dades del projecte:«%s»"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Export Audio Unit Presets"
@@ -8529,6 +9616,11 @@ msgid "Failed to retrieve preset content"
 msgstr "No es pot obtenir la descripció del flux de dades"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Conversió de la freqüència de mostreig"
 
@@ -8539,6 +9631,21 @@ msgstr ""
 "No s'ha pogut registrar:\n"
 "%s"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "No es pot obtenir la descripció del flux de dades"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "No es pot obtenir la descripció del flux de dades"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
+
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
 #: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
@@ -8547,6 +9654,7 @@ msgstr "Àudio Unit "
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efectes LADSPA"
@@ -8556,16 +9664,23 @@ msgid "Provides LADSPA Effects"
 msgstr "Proporciona efectes LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity ja no utilitza vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Opcions dels efectes LADSPA"
 
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s en:"
@@ -8573,6 +9688,14 @@ msgstr "%s en:"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Eixida de l'efecte"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Efectes LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8582,6 +9705,10 @@ msgstr "Paràmetres dels efectes LV2"
 #, c-format
 msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Mida de la &memòria intermèdia (de 8 a 1048576 mostres):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -8605,12 +9732,19 @@ msgstr "%d corbes s'han exportat a %s\n"
 msgid "Generator"
 msgstr "Generador"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efectes LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Proporciona suport per a utilitzar els efectes LV2 en Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8618,7 +9752,8 @@ msgid "Nyquist Effects"
 msgstr "Efectes Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Proporciona suport per a utilitzar els efectes Nyquist en Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8633,6 +9768,12 @@ msgstr "Procés de treball Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Capçalera del connector Nyquist mal formada"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -8839,7 +9980,8 @@ msgstr "Seleccioneu un fitxer"
 msgid "Save file as"
 msgstr "Anomena i guarda el fitxer"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "Sense títol"
 
@@ -8848,7 +9990,8 @@ msgid "Vamp Effects"
 msgstr "Efectes Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Proporciona suport per a utilitzar els efectes Vamp en Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -8870,6 +10013,12 @@ msgstr "Paràmetres del connector"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9036,9 +10185,18 @@ msgstr ""
 "Voleu continuar?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "No s'ha trobat el fitxer «%s»."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "No s'han pogut carrega els fitxers predefinits."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -9085,6 +10243,14 @@ msgid ""
 msgstr ""
 "FFmpeg no ha pogut trobar el còdec d'àudio 0x%x.\n"
 "És probable que aquest còdec no estiga suportat en la compilació de FFmpeg que utilitzeu."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -9150,7 +10316,8 @@ msgstr "S'està exportant l'àudio com a %s"
 msgid "Invalid sample rate"
 msgstr "Freqüència de mostreig no vàlida"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Torna a mostrejar"
 
@@ -9180,6 +10347,14 @@ msgstr "Hauríeu de tornar a mostrejar-ho a algun dels valors que es mostren a c
 msgid "Sample Rates"
 msgstr "Freqüències de mostreig"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Taxa de bits:"
@@ -9187,6 +10362,49 @@ msgstr "Taxa de bits:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualitat (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f segons"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -9201,6 +10419,10 @@ msgid "Constrained"
 msgstr "Constant"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Àudio..."
 
@@ -9209,8 +10431,44 @@ msgid "Low Delay"
 msgstr "Retard"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Pistes mitjanes"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -9281,8 +10539,17 @@ msgid "Replace preset '%s'?"
 msgstr "Voleu reemplaçar el valor predefinit «%s»?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Do"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principal"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9390,6 +10657,10 @@ msgstr "Idioma:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Acumulador de bits"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9523,6 +10794,11 @@ msgstr ""
 "0 -per defecte\n"
 "mín. - 1\n"
 "màx. - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Utilitza LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9793,8 +11069,23 @@ msgid "145-185 kbps"
 msgstr "Mitjana, 145-185 kbps"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "Estàndard, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "Mitjana, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
 msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
+msgstr "Mitjana, 145-185 kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -9817,7 +11108,17 @@ msgstr "Estàndard, 170-210 kbps"
 msgid "Medium, 145-185 kbps"
 msgstr "Mitjana, 145-185 kbps"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Estàndard"
 
@@ -9826,8 +11127,18 @@ msgid "Medium"
 msgstr "Habitació mitjana"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "Variable"
+
+#: src/export/ExportMP3.cpp
 msgid "Average"
 msgstr "Mitjana"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Constant"
+msgstr "Guany constant"
 
 #: src/export/ExportMP3.cpp
 msgid "Joint Stereo"
@@ -9860,8 +11171,8 @@ msgid "Locate LAME"
 msgstr "Localitza LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity necessita trobar el fitxer %s per a poder crear fitxers MP3."
 
 #: src/export/ExportMP3.cpp
@@ -9889,13 +11200,34 @@ msgid "Where is %s?"
 msgstr "On és %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Esteu enllaçant a lame_enc.dll v%d.%d. Aquesta versió no és compatible amb Audacity %d.%d.%d.\n"
 "Descarregueu l'última versió de «LAME per a Audacity»."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "S'estan guardant els fitxers de dades del projecte"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -10171,6 +11503,10 @@ msgid "Exporting the audio as Ogg Vorbis"
 msgstr "S'està exportant l'àudio com a Ogg Vorbis"
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
 msgstr "WAV (Microsoft) PCM de 32 bits amb signe"
 
@@ -10187,9 +11523,10 @@ msgid "Other uncompressed files"
 msgstr "Altres fitxers no comprimits"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Heu intentat exportar un fitxer WAV o AIFF superior a 4GB.\n"
 "Audacity no pot fer això, s'ha abandonat l'exportació."
@@ -10199,8 +11536,9 @@ msgid "Error Exporting"
 msgstr "S'ha produït un error en exportar"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "L'exportació del fitxer WAV s'ha interromput perquè Audacity no pot exportar fitxers\n"
@@ -10240,11 +11578,11 @@ msgid "All supported files"
 msgstr "Tots els fitxers|*|Tots els fitxers compatibles|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 " «%s»\n"
@@ -10253,11 +11591,11 @@ msgstr ""
 "editar-lo en fer clic a Fitxer > Importa > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 " «%s»\n"
 "és un fitxer MIDI, i no un fitxer d'àudio. \n"
@@ -10269,18 +11607,18 @@ msgid "Select stream(s) to import"
 msgstr "Seleccioneu els fluxos de dades per a importar"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Aquesta versió d'Audacity no s'ha compilat amb el suport %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "«%s» és una pista d'un CD d'àudio.\n"
 "Audacity no pot obrir directament aquest tipus de recurs.\n"
@@ -10289,10 +11627,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "«%s» és una llista de reproducció.\n"
@@ -10301,10 +11639,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer de tipus Windows Media Audio. \n"
@@ -10313,10 +11651,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer de tipus Advanced Audio Coding. \n"
@@ -10325,12 +11663,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "«%s»  és un fitxer de so encriptat.\n"
@@ -10341,10 +11679,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer de tipus RealPlayer. \n"
@@ -10353,12 +11691,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "«%s» és un fitxer basat en notes, i no un fitxer d'àudio.\n"
 "Audacity no pot obrir fitxers d'aquest tipus.\n"
@@ -10367,10 +11705,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10383,10 +11721,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer d'àudio de tipus Wavpack. \n"
@@ -10395,10 +11733,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer d'àudio de tipus Dolby Digital. \n"
@@ -10407,10 +11745,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer de tipus Ogg Speex. \n"
@@ -10419,10 +11757,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "«%s» és un fitxer de vídeo.\n"
@@ -10436,20 +11774,31 @@ msgstr "No s'ha trobat el fitxer «%s»."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity no reconeix el tipus de fitxer «%s».\n"
 "Instal·leu FFmpeg. Per a fitxers no comprimits, també podeu provar amb Fitxer > Importa > Dades sense processar."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "comprovador"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10458,6 +11807,11 @@ msgstr ""
 "Els importadors que suposadament haurien d'admetre aquests fitxers són: \n"
 "%s,\n"
 "però cap d'ells ha entés aquest format del fitxer."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "S'estan guardant els fitxers de dades del projecte"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10472,8 +11826,57 @@ msgid "Import Project"
 msgstr "Importa els valors predefinits"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Error intern reportat pel procés d'alineament."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Freqüència de mostreig no vàlida"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10481,16 +11884,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "No s'ha pogut trobar la carpeta de dades del projecte:«%s»"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Començament del projecte"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Freqüència de mostreig no vàlida"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Freqüència de mostreig no vàlida"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10520,40 +11981,6 @@ msgstr "Índex[%02x] Còdec[%s], Idioma[%s], Taxa de bits[%s], Canals[%d], Durac
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Fitxers FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Fitxers compatibles GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "No s'ha pogut afegir el descodificador al canal"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importador de GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "No s'ha pogut establir l'estat del flux per a pausar-lo."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Índex[%02x] Còdec[%s], Idioma[%s], Taxa de bits[%s], Canals[%d], Duració[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "El fitxer no conté cap flux d'àudio."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "No s'ha pogut importar el fitxer, ha fallat el canvi d'estat."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Error GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10611,6 +12038,14 @@ msgstr "No s'ha pogut obrir el fitxer %s."
 msgid "MP3 files"
 msgstr "Fitxers MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Fitxers Ogg Vorbis"
@@ -10645,8 +12080,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF i altres tipus de fitxers no comprimits"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) PCM de 32 bits amb signe"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16 bits PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -10657,12 +12186,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24 bits PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24 bits PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16 bits PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "Flotant de 32 bits"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "Flotant de 32 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) PCM de 32 bits amb signe"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bits"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -10673,12 +12246,20 @@ msgid "24 bit DWVW"
 msgstr "24 bits"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16 bits PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16 bits PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -10775,6 +12356,11 @@ msgid "Start offset:"
 msgstr "Desplaçament inicial:"
 
 #: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "bytes"
+msgstr "bytes"
+
+#: src/import/ImportRaw.cpp
 msgid "Amount to import:"
 msgstr "Quantitat a importar:"
 
@@ -10786,6 +12372,10 @@ msgstr "Freqüència de mostreig:"
 #: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
 msgid "&Import"
 msgstr "&Importa"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -10807,6 +12397,7 @@ msgstr "%s dreta"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -10830,6 +12421,7 @@ msgstr "final"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -10856,7 +12448,8 @@ msgstr "Clips amb el temps canviat a la dreta"
 msgid "Time shifted clips to the left"
 msgstr "Clips amb el temps canviat a l'esquerra"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Canvi del temps"
 
@@ -10994,7 +12587,8 @@ msgstr "Retalla l'àudio de les pistes seleccionades des de %.2f segons fins a %
 msgid "Trim Audio"
 msgstr "Retalla l'àudio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Divideix"
 
@@ -11115,32 +12709,8 @@ msgid "Delete Key&2"
 msgstr "Tecla de supressió &2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mes&clador"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "A&justa el volum de la reproducció..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Augmenta el volum de la reproducció"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Abaixa el volum de la reproducció"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "A&justa el volum de gravació..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "A&ugmenta el volum de gravació"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "&Abaixa el volum de gravació"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -11234,6 +12804,11 @@ msgid "Select a MIDI file"
 msgstr "Seleccioneu un fitxer MIDI"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Tots els fitxers|*"
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI files"
 msgstr "Fitxers MP3"
 
@@ -11312,6 +12887,11 @@ msgid "&Labels..."
 msgstr "&Etiquetes..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Exporta MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Dades sense p&rocessar..."
 
@@ -11328,6 +12908,10 @@ msgstr "Im&primeix..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Ix"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -11396,12 +12980,17 @@ msgid "&Getting Started"
 msgstr "&Primers passos"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manual d'Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Gestiona"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "Ajuda &ràpida..."
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -11419,11 +13008,8 @@ msgstr "Informació sobre el dispositiu &MIDI..."
 msgid "Show &Log..."
 msgstr "Mostra el &registre..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Qu&ant a Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "S'ha afegit l'etiqueta"
 
@@ -11625,6 +13211,10 @@ msgid "Move Forward Through Active Windows"
 msgstr "Mou cap avant a través de les finestres actives"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Mou cap en&rere des de la barra d'eines fins a les pistes"
 
@@ -11721,6 +13311,11 @@ msgstr "&Eines"
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Tool"
 msgstr "Repeteix l'últim efecte"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Macros..."
+msgstr "&Etiquetes..."
 
 #: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
@@ -12075,6 +13670,11 @@ msgid "Cursor to Project End"
 msgstr "Cursor al final del projecte"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Cursor"
+msgstr "&Cursor a"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor &Left"
 msgstr "Cursor a l'es&querra"
 
@@ -12101,6 +13701,7 @@ msgstr "S&alt llarg del cursor a la dreta"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Desplaçamen&t"
@@ -12312,18 +13913,21 @@ msgid "Created new label track"
 msgstr "S'ha creat una pista d'etiquetes nova"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Aquesta versió d'Audacity sols permet una sola pista per cada finestra del projecte."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "S'ha creat una pista de temps nova"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nova freqüència de mostreig (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "El valor que heu escrit no és vàlid"
 
@@ -12580,7 +14184,9 @@ msgstr "S'està reproduint"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Gravació"
 
@@ -12637,6 +14243,13 @@ msgstr "Seleccioneu com a mínim %d canals."
 #: src/menus/TransportMenus.cpp
 msgid "Please select a time within a clip."
 msgstr "Seleccioneu un moment en un clip."
+
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Tra&nsport"
+msgstr "&Opcions de transport"
 
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
@@ -12725,8 +14338,9 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "Reprodueix &mentre es grava (activat/desactivat)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Ajustament a&utomàtic del nivell de gravació (activat/desactivat)"
+#, fuzzy
+msgid "T&ransport"
+msgstr "Traducció al català@valencià: Empar Montoro"
 
 #. i18n-hint: (verb) Start playing audio
 #: src/menus/TransportMenus.cpp
@@ -12814,6 +14428,13 @@ msgstr "Mou a l'etiqueta següe&nt"
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Visualitza"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "Eina de &zoom"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
@@ -12932,7 +14553,7 @@ msgstr "Preferències de qualitat"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Ix d'Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -12979,7 +14600,8 @@ msgstr "&Amfitrió:"
 msgid "Using:"
 msgstr "S'està utilitzant:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Reproducció"
 
@@ -12999,7 +14621,8 @@ msgstr "Ca&nals:"
 msgid "Latency"
 msgstr "Latència"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "mil·lisegons"
 
@@ -13020,11 +14643,17 @@ msgid "No devices found"
 msgstr "No s'ha trobat cap dispositiu"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Canal (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "2 (Stereo)"
 msgstr "2 (Estèreo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Directoris"
 
@@ -13037,8 +14666,22 @@ msgid "Default directories"
 msgstr "Directoris"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Navega..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -13116,7 +14759,8 @@ msgid "Directory %s is not writable"
 msgstr "No es pot escriure al directori %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Els canvis en el directori temporal tindran efecte en reiniciar l'Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13147,6 +14791,40 @@ msgstr "S'ha agrupat per editor"
 msgid "Grouped by Type"
 msgstr "S'ha agrupat per tipus"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Error Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Habilita els efectes"
@@ -13168,11 +14846,13 @@ msgid "Plugin Options"
 msgstr "Opcions del connector"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Comprova si hi ha actualitzacions quan comence Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Torna a escanejar els connectors la propera vegada que s'inicie Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13304,6 +14984,11 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (marge PCM de mostres de 24 bits)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Veu I"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
 msgstr "D'Internet"
 
@@ -13348,13 +15033,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Con&serva les etiquetes si la selecció s'ajusta a una etiqueta"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Com&bina l'aparença del sistema i d'Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Utilitza sobretot distribucions d'esquerra a dreta amb llenguatges RTL"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13513,7 +15203,15 @@ msgid "&Defaults"
 msgstr "Valors per &defecte"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Seleccioneu un fitxer XML amb les dreceres de teclat d'Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13522,8 +15220,21 @@ msgstr "S'ha produït un error en importar les dreceres del teclat"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "S'han carregat %d dreceres de teclat\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -13544,6 +15255,15 @@ msgstr "No podeu assignar una tecla a aquesta entrada"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "He de seleccionar una vinculació abans d'assignar una drecera"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -13613,12 +15333,17 @@ msgid "Dow&nload"
 msgstr "Desca&rrega"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity ha detectat biblioteques FFmeg vàlides de forma automàtica.\n"
 "Encara voleu localitzar-les de forma manual?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -13655,6 +15380,10 @@ msgstr "Latència del sintonitzador MIDI (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "La latència del sintetitzador MIDI ha de ser un nombre enter"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -13665,8 +15394,9 @@ msgid "Preferences for Module"
 msgstr "Preferències del mòdul"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Hi ha mòduls experimentals. Habiliteu-los sols si heu llegit el manual d'Audacity\n"
@@ -13674,12 +15404,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "«Pregunta-m'ho» significa que Audacity us preguntarà si voleu carregar el mòdul cada vegada que s'inicie."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "«Ha fallat» significa que Audacity pensa que el mòdul està fet malbé i l'executarà."
 
 #. i18n-hint preserve the leading spaces
@@ -13688,7 +15420,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "«Nou» significa que encara no s'ha triat."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Els canvis en el directori temporal tindran efecte en reiniciar l'Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -13706,6 +15439,10 @@ msgstr "No s'ha trobat cap mòdul"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Mòdul"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -13747,7 +15484,10 @@ msgstr "Arrossegament amb el botó esquerre"
 msgid "Set Selection Range"
 msgstr "Estableix el rang de selecció"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Maj+clic esquerre"
 
@@ -13834,6 +15574,15 @@ msgstr "-Arrossegament amb el botó esquerre"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Mou el clip amunt o avall entre pistes"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Arrossegament amb el botó esquerre"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -13958,7 +15707,8 @@ msgid "Always scrub un&pinned"
 msgstr "Rastreja sem&pre sense fixar"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferències d'Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -13972,6 +15722,11 @@ msgstr "Preferències: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferències de qualitat"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14091,45 +15846,31 @@ msgid "System T&ime"
 msgstr "&Hora del sistema"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Ajustament automàtic del nivell de gravació"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Habilita l'ajustament automàtic del nivell de gravació."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Valor màxim a aconseguir:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "En:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Temps d'anàlisi:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "mil·lisegons (temps d'una anàlisi)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Nombre d'anàlisis consecutives:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 significa infinits"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Gravació Punch and Roll"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "&Fosa de transició:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14228,6 +15969,10 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Freqüència Ma&x. (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "&Guany (dB):"
 
@@ -14258,6 +16003,10 @@ msgstr "8 - banda més ampla"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - per defecte"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -14357,13 +16106,14 @@ msgid "Info"
 msgstr "Informació"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14420,6 +16170,11 @@ msgstr "Comportaments de les pistes"
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Preferences for TracksBehaviors"
 msgstr "Preferències dels ComportamentsdePistes"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "M"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -14542,7 +16297,8 @@ msgstr "M"
 msgid "4 Pixels per Sample"
 msgstr "4 píxels per mostra"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Ampliació màx."
 
@@ -14664,16 +16420,24 @@ msgid "Stopped"
 msgstr "S'ha parat"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Ves a l'inici"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Ves al final"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Selecciona fins a l'inici"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Selecciona fins al final"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -14687,20 +16451,17 @@ msgstr "Grava una pista nova"
 msgid "Append Record"
 msgstr "Annexa una gravació"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Selecciona fins al final"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Selecciona fins a l'inici"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "En pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s en:"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -14780,11 +16541,17 @@ msgstr "Silencia la selecció d'àudio"
 msgid "Sync-Lock Tracks"
 msgstr "Bloqueja la sincronització de les pistes"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Apropa"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Allunya"
 
@@ -14851,43 +16618,6 @@ msgstr "Barra d'eines del mesurador de g&ravació"
 msgid "&Playback Meter Toolbar"
 msgstr "Barra d'eines del mesurador de re&producció"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volum de gravació"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volum de reproducció"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volum de gravació: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volum de gravació (no disponible; utilitzeu el mesclador del sistema.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volum de reproducció: %s (emulat)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volum de reproducció: %s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volum de reproducció (no disponible; utilitzeu el mesclador del sistema.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra d'eines del me&sclador"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Busca"
@@ -14903,6 +16633,7 @@ msgstr "Rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Para el rastreig"
@@ -14910,6 +16641,7 @@ msgstr "Para el rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Comença el rastreig"
@@ -14917,6 +16649,7 @@ msgstr "Comença el rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Para el rastreig"
@@ -14924,6 +16657,7 @@ msgstr "Para el rastreig"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Comença el rastreig"
@@ -14978,7 +16712,9 @@ msgstr "Ajusta a"
 msgid "Length"
 msgstr "Duració"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centre"
 
@@ -15042,8 +16778,8 @@ msgstr "Barra d'eines del &dispositiu"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra d'eines %s d'Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15070,7 +16806,8 @@ msgstr "Eina de desplaçament en el temps"
 msgid "Zoom Tool"
 msgstr "Eina de zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Eina de dibuix"
 
@@ -15146,11 +16883,13 @@ msgstr "Arrossegueu un o més límits de l'etiqueta."
 msgid "Drag label boundary."
 msgstr "Arrossegueu el límit de l'etiqueta."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "S'ha modificat l'etiqueta"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Edita l'etiqueta"
 
@@ -15205,31 +16944,42 @@ msgstr "S'han editat les etiquetes"
 msgid "New label"
 msgstr "Etiqueta nova"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Apuja-ho una octava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Abaixa-ho una octava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Feu clic per a ampliar verticalment, Maj+clic per a allunyar. Arrossegueu per a ampliar una determinada zona."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Feu clic al botó dret per a accedir al menú."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Restableix el zoom"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Maj+clic esquerre"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Apropa\tclic esquerre/Arrossegament esquerre"
 
@@ -15271,7 +17021,8 @@ msgstr "Fusiona"
 msgid "Expanded Cut Line"
 msgstr "S'ha expandit la línia de tall"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expandeix"
 
@@ -15294,6 +17045,11 @@ msgstr "S'han mogut les mostres"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Edita la mostra"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15320,6 +17076,11 @@ msgid "S&pectrogram Settings..."
 msgstr "Configuració de l'espectrograma..."
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Canvi de format"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Freqüència de mostreig no vàlida"
 
@@ -15335,7 +17096,8 @@ msgstr "S'està processant: %s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "S'ha canviat «%s» a %s"
@@ -15347,6 +17109,54 @@ msgstr "Canvi de format"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Fr&eqüència"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15366,7 +17176,8 @@ msgstr "Canvi de freqüència"
 msgid "Set Rate"
 msgstr "Estableix la freqüència"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Diverses"
 
@@ -15385,6 +17196,10 @@ msgstr "Div&ideix la pista estèreo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Divideix la pista estèreo a mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -15440,6 +17255,11 @@ msgid "Stereo, %dHz"
 msgstr "Estèreo, %d Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Estèreo, %d Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Esquerre, %d Hz"
@@ -15450,19 +17270,22 @@ msgid "Right, %dHz"
 msgstr "Dret, %dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% esquerra"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% dreta"
@@ -15475,6 +17298,25 @@ msgstr "Feu clic i arrossegueu per a ajustar , doble clic per a reiniciar"
 msgid "Click and drag to rearrange sub-views"
 msgstr "Feu clic i arrossegueu per a moure una pista en el temps"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Feu clic i arrossegueu per a moure una pista en el temps"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Apropa"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Apropa"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
 msgstr "Mitja ona"
@@ -15486,6 +17328,11 @@ msgstr "Forma d'o&na"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Color de l'&ona"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Instrument musical"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -15559,9 +17406,8 @@ msgstr "&Interpolació logarítmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Feu clic i arrossegueu per a moure una pista en el temps"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15612,6 +17458,7 @@ msgstr "S'ha ajustat l'envolupant."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Ra&streja"
@@ -15623,6 +17470,7 @@ msgstr "Està buscant"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Regle de rastreig"
@@ -15857,9 +17705,19 @@ msgstr "Buit"
 msgid "Backwards"
 msgstr "Cap arrere"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Cap a avant"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -15948,6 +17806,11 @@ msgid "Horizontal"
 msgstr "Horitzontal"
 
 #: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "Divideix &verticalment"
+
+#: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr "Monitoratge "
 
@@ -15984,6 +17847,29 @@ msgstr "Seleccioneu una acció"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 segons"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + mostres"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "099h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -15999,11 +17885,35 @@ msgstr "0100 dies 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + centèsimes"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "099h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + mil·lisegons"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "099h 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16025,6 +17935,7 @@ msgstr "0100 h 060 m 060 s+># mostres"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "mostres"
@@ -16186,6 +18097,15 @@ msgstr "01000,01000 quadres|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000<0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -16193,6 +18113,17 @@ msgstr "0100000<0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0,001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in octaves
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "octaves"
+msgstr "fins a l'octava"
 
 #. i18n-hint: Format string for displaying log of frequency in octaves.
 #. * Change the decimal points for your locale. Don't change the numbers.
@@ -16252,6 +18183,11 @@ msgstr "(utilitzeu el menú contextual per a canviar el format)"
 msgid "centiseconds"
 msgstr "centisegons"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Temps transcorregut:"
@@ -16294,6 +18230,11 @@ msgstr "Confirmeu el tancament"
 msgid "Unable to write files to directory: %s."
 msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -16310,6 +18251,10 @@ msgstr "Preferències dels directoris"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "No mostres més aquest advertiment"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -16393,15 +18338,27 @@ msgstr "No s'ha pogut obrir el fitxer"
 msgid "Spectral edit multi tool"
 msgstr "Eina múltiple d'edició especial"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "S'està filtrant..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Publicat sota els termes de la versió 2 de la llicència pública general GNU"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~a seleccioneu freqüències."
@@ -16427,6 +18384,12 @@ msgstr ""
 "~aAls paràmetres del filtre no es pot aplicar.~%~\n"
 "                      Intenteu incrementa el límit inferor de la freqüència~%~\n"
 "                      o reduïu el filtre «Amplària»."
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy, lisp-format
+msgid "Error.~%"
+msgstr "Error"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 msgid "Spectral edit parametric EQ"
@@ -16484,6 +18447,25 @@ msgstr "Fosa d'eixida d'estudi"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "S'està aplicant la fosa..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "&Estableix com a predeterminat"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Publicat sota els termes de la versió 2 de la llicència pública general GNU"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16595,6 +18577,11 @@ msgid "S-Curve Out"
 msgstr "Eixida corba S"
 
 #: plug-ins/adjustable-fade.ny
+#, fuzzy, lisp-format
+msgid "Error~%~%"
+msgstr "Error: "
+
+#: plug-ins/adjustable-fade.ny
 #, lisp-format
 msgid "~aPercentage values cannot be negative."
 msgstr "~aEls valors percentuals no poden ser negatius."
@@ -16622,6 +18609,11 @@ msgstr "Cercador de pulsacions"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "S'estan buscant les pulsacions..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Registre d'Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -16776,6 +18768,10 @@ msgid "Allow duration to change"
 msgstr "Permet canviar la duració"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Repeteix l'últim efecte"
 
@@ -16786,6 +18782,10 @@ msgstr "Equalització"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "Fitxers MP3"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -16799,6 +18799,12 @@ msgstr "Confirma la sobreescriptura"
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Error.~%No s'ha pogut obrir el fitxer"
+
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Error.~%~s no pot ser escrit.~%"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
@@ -16932,13 +18938,38 @@ msgstr "Filtre passaalt"
 msgid "Performing High-Pass Filter..."
 msgstr "S'està aplicant el filtre passaalt..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Freqüència (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Atenuació (dB per octava)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -16959,10 +18990,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Uneix l'etiqueta"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Publicat sota els termes de la versió 2 de la llicència pública general GNU"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17005,12 +19032,37 @@ msgid "Point after sound"
 msgstr "Estèreo unificat"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "~aDuració de la zona = ~a segons."
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "~aDuració de la zona = ~a segons."
 
 #: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "S'està buscant el silenci..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "S'està buscant el silenci..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -17022,6 +19074,11 @@ msgstr "La selecció ha de ser més llarga que %d mostres."
 #, lisp-format
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "No s'ha trobat cap so. Proveu a reduir el nivell~% i a reduir al mínim la duració del silenci."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -17097,6 +19154,10 @@ msgid "Select Function"
 msgstr "Selecció"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
 msgstr "Temps d'anàlisi:"
 
@@ -17131,6 +19192,44 @@ msgstr "Temps d'atac/esmortiment"
 #: plug-ins/noisegate.ny
 msgid "Decay (ms)"
 msgstr "Temps d'atac/esmortiment"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "La selecció ha de ser més llarga que %d mostres."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
 
 #: plug-ins/notch.ny
 msgid "Notch Filter"
@@ -17180,7 +19279,8 @@ msgstr "Fitxers MP3"
 msgid "HTML file"
 msgstr "Fitxers MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Anomena els fitxers:"
 
@@ -17195,6 +19295,16 @@ msgstr "Permet l'escapçament"
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Disallow"
 msgstr "No està permés"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "No està permés"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
@@ -17225,9 +19335,22 @@ msgid "Unsupported file type:"
 msgstr "Filtres no utilitzats:"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Seleccioneu un fitxer de connectors"
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%No file selected."
 msgstr "Error.~%~s ja està instal·lat.~%"
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
@@ -17236,6 +19359,10 @@ msgstr "S'està generant un so pluck..."
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Valors MIDI per a les notes Do: 36, 48, 60 [do mitjà], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
@@ -17250,6 +19377,10 @@ msgid "Abrupt"
 msgstr "Abrupta"
 
 #: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Duration (60s max)"
 msgstr "Duració (60s max.)"
 
@@ -17260,6 +19391,10 @@ msgstr "Pista de ritme"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "S'està generant el ritme..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -17276,6 +19411,10 @@ msgstr "1 - 20 pulsacions per mesura"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Quantitat d'oscil·lació"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -17346,6 +19485,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "To MIDI de pulsació forta"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "To MIDI de pulsació feble"
 
@@ -17364,6 +19507,10 @@ msgstr "Tambor Risset"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "S'està generant el tambor Risset..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -17544,6 +19691,12 @@ msgstr "Anàlisi de dades d'àudio:"
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr "<b>Freqüència de mostreig:</b> &nbsp;&nbsp;~a Hz."
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
 msgstr "<b>Freqüència de mostreig:</b> &nbsp;&nbsp;~a Hz."
 
 #. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
@@ -17727,6 +19880,11 @@ msgstr "Error.~%No s'ha pogut obrir el fitxer"
 msgid "Spectral Delete"
 msgstr "Selecció espectral"
 
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
 #: plug-ins/tremolo.ny
 msgid "Tremolo"
 msgstr "Trèmolo"
@@ -17758,6 +19916,10 @@ msgstr "Reducció de veus i aïllament"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "S'està aplicant l'acció..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -17900,8 +20062,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Aquest connector només funciona amb pistes estèreo."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "S'està processant Vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -17944,6 +20114,208 @@ msgstr "Freqüència de les agulles del radar (Hz)"
 msgid "Error.~%Stereo track required."
 msgstr "Error.~%Es requereix la pista estèreo."
 
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Ix d'Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Canal"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "S'ha produït un error en descodificar el fitxer"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Error carregant metadades"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Barra d'eines %s d'Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Gravació"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Identificador de publicació:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Biblioteca d'interfície gràfica multiplataforma"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importa mitjançant GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. No és possible optimitzar-lo més. Encara és massa alt."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "L'ajustament automàtic del nivell de gravació ha abaixat el volum a %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. No és possible optimitzar-lo més. Encara és massa baix."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "L'ajustament automàtic del nivell de gravació ha apujat el volum a %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. S'ha excedit el nombre total d'anàlisis sense trobar un volum acceptable. Encara és massa alt."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. S'ha excedit el nombre total d'anàlisis sense trobar un volum acceptable. Encara és massa baix."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "S'ha parat l'ajustament automàtic del nivell de gravació. %.2f sembla un volum acceptable."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "S'ha rebut %d en obrir els dispositius\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "No s'ha pogut obrir Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Mescladors disponibles:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Fonts de gravació disponibles:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volums de reproducció disponibles:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Volum de gravació és emulat\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "El volum de gravació és natiu\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "El volum de reproducció és emulat\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "El volum de reproducció és natiu\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Data i hora d'acabament"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Fitxers compatibles GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "No s'ha pogut afegir el descodificador al canal"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importador de GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "No s'ha pogut establir l'estat del flux per a pausar-lo."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Índex[%02x] Còdec[%s], Idioma[%s], Taxa de bits[%s], Canals[%d], Duració[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "El fitxer no conté cap flux d'àudio."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "No s'ha pogut importar el fitxer, ha fallat el canvi d'estat."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Error GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mes&clador"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "A&justa el volum de la reproducció..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Augmenta el volum de la reproducció"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Abaixa el volum de la reproducció"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "A&justa el volum de gravació..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "A&ugmenta el volum de gravació"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "&Abaixa el volum de gravació"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manual d'Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Qu&ant a Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Ajustament a&utomàtic del nivell de gravació (activat/desactivat)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Ajustament automàtic del nivell de gravació"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Habilita l'ajustament automàtic del nivell de gravació."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Valor màxim a aconseguir:"
+
+#~ msgid "Within:"
+#~ msgstr "En:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Temps d'anàlisi:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "mil·lisegons (temps d'una anàlisi)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Nombre d'anàlisis consecutives:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 significa infinits"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volum de gravació"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volum de reproducció"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volum de gravació: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volum de gravació (no disponible; utilitzeu el mesclador del sistema.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volum de reproducció: %s (emulat)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volum de reproducció: %s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volum de reproducció (no disponible; utilitzeu el mesclador del sistema.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra d'eines del me&sclador"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Feu clic i arrossegueu per a moure una pista en el temps"
+
 #~ msgid "Program build date:"
 #~ msgstr "Data de compilació del programa: "
 
@@ -17963,16 +20335,8 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgstr "Desconegut"
 
 #, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "No s'ha pogut llegir el fitxer dels valors predefinits."
-
-#, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
 #~ msgstr "Audacity és un programa lliure escrit per un equip mundial de [[https://www.audacityteam.org/about/credits|voluntaris]]. Audacity és [[https://www.audacityteam.org/download|available]] per a Windows, Mac, i GNU/Linux (i altres sistemes Unix-like systems)."
-
-#, fuzzy
-#~ msgid "available"
-#~ msgstr "Variable"
 
 #, fuzzy
 #~ msgid "If you find a bug or have a suggestion for us, please write, in English, to our %s. For help, view the tips and tricks on our %s or visit our %s."
@@ -18034,10 +20398,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 
 #~ msgid "&Download"
 #~ msgstr "&Descarrega"
-
-#, fuzzy
-#~ msgid "Error.n"
-#~ msgstr "Error"
 
 #, fuzzy
 #~ msgid "Failed to copy tags"
@@ -18272,10 +20632,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 
 #~ msgid "Import complete. Running an on-demand waveform calculation. %2.0f%% complete."
 #~ msgstr "S'ha completat la importació. S'està executant el càlcul sol·licitat de la forma d'ona. S'ha completat %2.0f%%."
-
-#, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Comprimeix:"
 
 #~ msgid "Waiting for waveform to finish computing..."
 #~ msgstr "S'està esperant la forma d'ona per a acabar el càlcul..."
@@ -18590,10 +20946,6 @@ msgstr "Error.~%Es requereix la pista estèreo."
 #~ msgstr ""
 #~ "Cadena comodí no vàlida en el «camí de control».\n"
 #~ "En el seu lloc, utilitzeu una cadena buida."
-
-#, fuzzy
-#~ msgid "%d kpbs"
-#~ msgstr "%d kbps"
 
 #, fuzzy
 #~ msgid ""

--- a/locale/co.po
+++ b/locale/co.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Corsican <https://hosted.weblate.org/projects/tenacity/tenacity/co/>\n"
@@ -18,72 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Rinnovà Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Tralascià"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Installà u rinnovu"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Lista di i cambiamenti"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Sapene di più nant’à GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Sbagliu à u cuntrollu di a nova versione"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Impussibule di cunnettassi à u servitore di e nove versioni d’Audacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "I dati di u rinnovu sò alterati."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Sbagliu à u scaricamentu di u rinnovu."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Ùn si pò micca apre u liame di scaricamentu d’Audacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s hè dispunibule !"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Arregistramentu"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -237,7 +171,8 @@ msgid "Script"
 msgstr "Scenariu"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Esciuta"
 
@@ -253,7 +188,12 @@ msgstr "Scenarii Nyquist (*.ny)|*.ny|Scenarii Lisp (*.lsp)|*.lsp|Tutti schedarii
 msgid "Script was not saved."
 msgstr "U scenariu ùn hè statu micca arregistratu."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Avertimentu"
 
@@ -266,15 +206,25 @@ msgid "Find dialog"
 msgstr "Circà un dialogu"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango Icon Gallery (icone di a barra d’attrezzi)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 da Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 da Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Modulu esternu à Audacity chì pruvede un IDE simplice per a scrittura d’effetti."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -297,7 +247,8 @@ msgstr "Senza titulu"
 msgid "Nyquist Effect Workbench - "
 msgstr "Attellu di travagliu d’effettu Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Novu"
 
@@ -337,7 +288,8 @@ msgstr "Cupià"
 msgid "Copy to clipboard"
 msgstr "Cupià ver di u preme’papei"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Taglià"
 
@@ -345,7 +297,8 @@ msgstr "Taglià"
 msgid "Cut to clipboard"
 msgstr "Taglià ver di u preme’papei"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Incullà"
 
@@ -370,7 +323,8 @@ msgstr "Tuttu selezziunà"
 msgid "Select all text"
 msgstr "Selezziunà u testu sanu"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Disfà"
 
@@ -378,7 +332,8 @@ msgstr "Disfà"
 msgid "Undo last change"
 msgstr "Disfà l’ultimu cambiamentu"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Rifà"
 
@@ -435,7 +390,8 @@ msgid "Go to next S-expr"
 msgstr "Andà à l’Espr-S seguente"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Principià"
 
@@ -443,7 +399,8 @@ msgstr "Principià"
 msgid "Start script"
 msgstr "Principià u scenariu"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Piantà"
 
@@ -458,7 +415,8 @@ msgid "About %s"
 msgstr "Apprupositu di %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Vai"
 
@@ -466,11 +424,13 @@ msgstr "Vai"
 msgid "Build Information"
 msgstr "Infurmazione di custruzzione"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Attivatu"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Disattivatu"
 
@@ -480,8 +440,9 @@ msgid "The Build"
 msgstr "Custruzzione"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Identificazione di Commit :"
+#, fuzzy
+msgid "Version:"
+msgstr "Versione : %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -491,22 +452,28 @@ msgstr "Tipu di custruzzione :"
 msgid "Compiler:"
 msgstr "Cumpilatore :"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefissu d’installazione :"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Cartulare di preferenze :"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Cartulare di preferenze :"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Furmatu di schedariu accettatu"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Bibliuteca GUI multi piattaforma"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -520,7 +487,6 @@ msgstr "Cunversione di frequenza di campiunariu"
 msgid "MP3 Importing"
 msgstr "Impurtazione MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Impurtazione è espurtazione Ogg Vorbis"
@@ -529,7 +495,6 @@ msgstr "Impurtazione è espurtazione Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Impiegu d’etichetta ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Impurtazione è espurtazione FLAC"
@@ -547,14 +512,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Impurtazione è espurtazione FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Impurtazione via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Caratteristiche"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Sustegnu di modulu d’estensione"
 
@@ -569,6 +526,10 @@ msgstr "Permette u cambiu d’intunazione è di tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Permette u cambiu estremu d’intunazione è di tempo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Caratteristiche"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -687,6 +648,10 @@ msgstr "%s, grafichi"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (incurpurendu %s, %s, %s, %s è %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -696,6 +661,10 @@ msgstr "%s, u prugramma liberu, di tipu fonte aperta, chì funziuneghja nant’�
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Crediti"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -746,6 +715,7 @@ msgstr "Situ web è grafichi"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Traduzzione corsa da Patriccollu di Santa Maria è Sichè"
@@ -763,6 +733,22 @@ msgstr "Ringraziamenti particulari à :"
 #, c-format
 msgid "%s website: "
 msgstr "Situ web di %s : "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Cuntribuenti"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -785,6 +771,7 @@ msgstr "Linea tempurale"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Cliccà o trascinà per principià a ricerca"
@@ -792,6 +779,7 @@ msgstr "Cliccà o trascinà per principià a ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Cliccà o trascinà per principià a strufinera"
@@ -799,6 +787,7 @@ msgstr "Cliccà o trascinà per principià a strufinera"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Cliccà è move per strufinà. Cliccà è trascinà per ricercà."
@@ -806,6 +795,7 @@ msgstr "Cliccà è move per strufinà. Cliccà è trascinà per ricercà."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Move per ricercà"
@@ -813,6 +803,7 @@ msgstr "Move per ricercà"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Move per strufinà"
@@ -869,7 +860,17 @@ msgstr ""
 "Ùn si pò ammarchjunà a regione\n"
 "aldilà di a fine di u prughjettu."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Sbagliu"
 
@@ -893,7 +894,8 @@ msgstr ""
 "Ghjè una dumanda unica, dopu à un’installazione, quandu vò avete dumandatu chì e preferenze sianu rimesse d’origine."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Rimette d’origine e preferenze d’Audacity"
 
 #: src/AudacityApp.cpp
@@ -908,7 +910,8 @@ msgstr ""
 "Hè statu cacciatu da a lista di i schedarii recente."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Iniziu fiascu di a bibliuteca SQLite.  Audacity ùn pò micca cuntinuà."
 
 #: src/AudacityApp.cpp
@@ -934,7 +937,7 @@ msgstr "&Apre…"
 msgid "Open &Recent..."
 msgstr "Apre un schedariu &recente…"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Apprupositu d’Audacity…"
@@ -948,9 +951,10 @@ msgid "&File"
 msgstr "&Schedariu"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity ùn pò micca truvà un locu sicuru per piazzà i schedarii timpurarii.\n"
@@ -958,20 +962,23 @@ msgstr ""
 "Ci vole à scrive u nome di cartulare fattu apposta in u dialogu di e preferenze."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity ùn trova micca locu per piazzà i schedarii timpurarii.\n"
 "Ci vole à scrive u nome di cartulare fattu apposta in u dialogu di e preferenze."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity hà da compie avà. Ci vole à rilancià Audacity per impiegà u novu cartulare timpurariu."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -980,15 +987,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity ùn hà micca pussutu ammarchjunà u cartulare di i schedarii timpurarii.\n"
 "Stu cartulare pò esse impiegatu da un’altra copia d’Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Vulete lancià Audacity quantunque ?"
 
 #: src/AudacityApp.cpp
@@ -996,19 +1005,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Sbagliu durante u blucchime di u cartulare timpurariu"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "U sistema hà vistu chì ci hè un’altra copia d’Audacity in funzione.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Impiegate e cumande Novu o Apre in Audacity chì hè dighjà\n"
 "in funzione per apre parechji prughjetti à u listessu tempu.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity hè dighjà in funzione"
 
 #: src/AudacityApp.cpp
@@ -1024,7 +1036,8 @@ msgstr ""
 "di risorsa è un rilanciu hè forse richiestu."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Fiascu à l’avviu d’Audacity"
 
 #: src/AudacityApp.cpp
@@ -1064,8 +1077,9 @@ msgstr ""
 "di risorsa è un rilanciu hè forse richiestu."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1097,7 +1111,8 @@ msgstr "eseguisce i diagnostichi autumatichi"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "affisseghja a versione d’Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1107,9 +1122,10 @@ msgid "audio or project file name"
 msgstr "nome di schedariu audio o di prughjettu"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1122,16 +1138,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Schedarii di prughjettu Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Messaghju"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Sbagliu di cunfigurazione d’Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1141,7 +1159,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Quellu schedariu di cunfigurazione ùn pò micca esse accessu :\n"
 "\n"
@@ -1153,12 +1171,15 @@ msgstr ""
 "\n"
 "S’è vò sciglite d’« Esce da Audacity », u vostru prughjettu pò esse lasciatu in un statu micca arregistratu chì serà ricuperatu à a so prossima apertura."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Aiutu"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Esce da Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1166,7 +1187,8 @@ msgid "&Retry"
 msgstr "&Torna"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Ghjurnale d’Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1178,9 +1200,14 @@ msgstr "Arre&gistrà…"
 msgid "Cl&ear"
 msgstr "&Viutà"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Chjode"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1229,7 +1256,8 @@ msgid "Error Initializing Midi"
 msgstr "Sbagliu à l’Iniziu di u MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audio d’Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1244,37 +1272,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Mancanza di memoria !"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. Ùn hè statu micca pussibule di megliurà di più. Sempre troppu altu."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "L’accumudata autumatica di livellu d’arregistramentu hà diminuitu u vulume à %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. Ùn hè statu micca pussibule di megliurà di più. Sempre troppu bassu."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "L’accumudata autumatica di livellu d’arregistramentu hà cresciutu u vulume à %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. U numeru tutale d’analise hè statu toccu senza truvà un vulume accettevule. Sempre troppu altu."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. U numeru tutale d’analise hè statu toccu senza truvà un vulume accettevule. Sempre troppu bassu."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. %.2f pare un vulume accettevule."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1373,43 +1370,6 @@ msgstr "Alcunu apparechju di lettura trovu per « %s ».\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Impussibule di verificà e frequenze di campiunariu mutuale senza i dui apparechji.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Ricevutu %d durante l’apertura di l’apparechji\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Impussibule d’apre Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Mischiadori dispunibule :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Fonti d’arregistramentu dispunibule :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Vulumi di lettura dispunibule :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "U vulume d’arregistramentu hè simulatu\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "U vulume d’arregistramentu hè nativu\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "U vulume di lettura hè simulatu\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "U vulume di lettura hè nativu\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1452,8 +1412,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Ricuperazione autumatica di lampata"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1466,12 +1427,14 @@ msgid "Recoverable &projects"
 msgstr "&Prughjetti ricuperevule"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Selezziunà"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nome"
 
@@ -1558,6 +1521,11 @@ msgstr "Effettu"
 msgid "Menu Command (With Parameters)"
 msgstr "Listinu di cumanda (cù parametri)"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
 msgstr "Listinu di cumanda (senza parametri)"
@@ -1626,6 +1594,12 @@ msgstr "Urganizà e macro"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Selezziunà una macro"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Macro…"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
@@ -1697,7 +1671,8 @@ msgstr "Ris&turà"
 msgid "I&mport..."
 msgstr "I&mpurtà…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Espurtà…"
 
@@ -1738,7 +1713,8 @@ msgstr "Move in&sù"
 msgid "Move &Down"
 msgstr "Move in&ghjò"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Arregistrà"
 
@@ -1821,7 +1797,8 @@ msgid "Run"
 msgstr "Lancià"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Chjode"
 
@@ -1967,11 +1944,6 @@ msgid "No revision identifier was provided"
 msgstr "Alcuna identificazione di revisione ùn hè stata pruvista"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Data è ora di fine"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Versione di diagnosticu (livellu di diagnosticu %d)"
@@ -1980,6 +1952,10 @@ msgstr "Versione di diagnosticu (livellu di diagnosticu %d)"
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Versione di diffusione (livellu di diagnosticu %d)"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -2230,10 +2206,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "S’è voi cuntinuate, u vostru prughjettu ùn serà micca arregistratu nant’à u discu. Ghjè què chì voi vulete ?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2247,7 +2224,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Cuntrollu di dipendenza"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nisuna"
 
@@ -2255,7 +2235,7 @@ msgstr "Nisuna"
 msgid "Rectangle"
 msgstr "Rettangulu"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triangulu"
 
@@ -2266,6 +2246,38 @@ msgstr "Onda"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Rettangulare"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, nisunu"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Benvenuti !"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2287,9 +2299,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "L’accessu à FFmpeg ùn hè micca cumpilatu"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2311,8 +2324,8 @@ msgid "Locate FFmpeg"
 msgstr "Lucalizà FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity hà bisoniu di u schedariu « %s » per impurtà è espurtà l’audio via FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2325,7 +2338,8 @@ msgstr "Lucalizazione di « %s » :"
 msgid "To find '%s', click here -->"
 msgstr "Per truvà « %s », cliccà quì -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Navigà…"
 
@@ -2351,8 +2365,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg micca trovu"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2382,24 +2397,24 @@ msgid "Only libavformat.so"
 msgstr "Solu libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Fiascu d’Audacity per apre un schedariu in %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Fiascu d’Audacity per leghje un schedariu in %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity hà riesciutu à scrive un schedariu in %s ma hà fiascatu à rinuminallu cum’è %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2437,7 +2452,9 @@ msgstr "Ùn cupià &nisunu audio"
 msgid "As&k"
 msgstr "&Dumandà"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Tutti i schedarii"
 
@@ -2462,6 +2479,10 @@ msgstr "Schedarii di testu"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Schedarii XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2503,6 +2524,14 @@ msgstr "Autocorrelazione radica cubica"
 msgid "Enhanced Autocorrelation"
 msgstr "Autocorrelazione megliurata"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spettru"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2519,6 +2548,18 @@ msgstr "Frequenza lineare"
 msgid "Log frequency"
 msgstr "Frequenza lugaritmica"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "Si"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Sfilà"
@@ -2526,6 +2567,15 @@ msgstr "Sfilà"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Ingrandamentu"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2586,6 +2636,37 @@ msgstr "Troppu audio hè statu selezziunatu. Solu e prime %.1f seconde d’audio
 msgid "Not enough data selected."
 msgstr "Ùn bastanu micca i dati selezziunati."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "spettru.txt"
@@ -2594,7 +2675,8 @@ msgstr "spettru.txt"
 msgid "Export Spectral Data As:"
 msgstr "Espurtà i dati spettrale cum’è :"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Ùn si pò scrive ver di u schedariu : %s"
@@ -2786,19 +2868,19 @@ msgid "&History..."
 msgstr "&Cronolugia…"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Sbagliu internu in %s à %s linea %d.\n"
 "Ci vole à infurmà a squadra Audacity à https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Sbagliu internu à %s linea %d.\n"
 "Ci vole à infurmà a squadra Audacity à https://forum.audacityteam.org/."
@@ -2817,7 +2899,9 @@ msgid "Track"
 msgstr "Traccia"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etichetta"
 
@@ -2877,7 +2961,8 @@ msgstr "Scrivite u nome di a traccia"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Traccia d’etichetta"
 
@@ -2888,11 +2973,13 @@ msgstr "Un’etichetta arregistrata o più ùn pò micca esse letta."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Primu avviu d’Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Sceglie a lingua à impiegà cù Audacity :"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2902,7 +2989,8 @@ msgstr "Sceglie a lingua à impiegà cù Audacity :"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "A lingua chì voi avete scelta, %s (%s), ùn hè micca listessa chì quella di u sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Cunfirmà"
 
@@ -2920,12 +3008,13 @@ msgstr ""
 "U vechju schedariu hè statu arregistratu cù u nome « %s »"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Apertura d’un prughjettu Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke%s Audacity"
 
 #: src/LyricsWindow.cpp
@@ -2976,19 +3065,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mischju è restituzione di e traccie"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tavula di mischju %s d’Audacity"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Guadagnu"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocità"
 
@@ -2996,24 +3089,45 @@ msgstr "Velocità"
 msgid "Musical Instrument"
 msgstr "Strumentu di musica"
 
+#. i18n-hint: Title of the Pan slider, used to move the sound left or right
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Pan"
+msgstr "Panoramicu :"
+
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Mutu"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr " Resu solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Vu-metru di u signale"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Cursore di guadagnu dispiazzatu"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Cursore di velocità dispiazzatu"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Cursore di panoramicu dispiazzatu"
 
@@ -3048,9 +3162,9 @@ msgstr ""
 "Ùn serà micca caricatu."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3084,16 +3198,19 @@ msgstr ""
 "\n"
 "Impiegate solu moduli chì venenu da fonti sicure"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Iè"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Innò"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Caricadore di modulu d’Audacity"
 
 #: src/ModuleManager.cpp
@@ -3335,7 +3452,8 @@ msgstr "&Tuttu selezziunà"
 msgid "C&lear All"
 msgstr "S&quassà tuttu"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Attivà"
 
@@ -3415,9 +3533,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "E frequenze di campiunariu ùn currispondenu"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Ùn bastanu e traccie selezziunate per l’arregistramentu à sta\n"
@@ -3446,10 +3565,11 @@ msgid "Dropouts"
 msgstr "Perdite"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3489,11 +3609,11 @@ msgid "Inspecting project file data"
 msgstr "Inspezzione di i dati di u schedarii di prughjettu"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3536,11 +3656,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Avertimentu - Schedariu(i) assuciatu(i) assente(i)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "U cuntrollu di prughjettu di u cartulare « %s »\n"
@@ -3565,12 +3685,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Avertimentu - Schedariu(i) assuciatu(i) di riassuntu assente(i)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3628,7 +3748,8 @@ msgstr "Avertimentu - Schedariu(i) di bloccu urfanellu(i)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Prugressione"
 
@@ -3653,6 +3774,11 @@ msgstr "Avertimentu - Penseri cù a ricuperazione autumatica"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<senza titulu>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Prughjettu %02i] Audacity « %s »"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3722,12 +3848,14 @@ msgstr ""
 "(Impussibule di creacci i schedarii timpurarii richiesti)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Què ùn hè micca un schedariu di prughjettu Audacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3859,9 +3987,9 @@ msgid "Error Writing to File"
 msgstr "Sbagliu durante a scrittura di u schedariu"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3875,9 +4003,16 @@ msgstr "Cumpressione di u prughjettu"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Prughjettu %02i] Audacity « %s »"
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Velocità"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3886,10 +4021,10 @@ msgstr "(Ricuperatu)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Stu schedariu hè statu arregistratu da Audacity %s.\n"
 "Impiegate Audacity %s. Ci vuleria à cambià per una versione più recente per apre stu schedariu."
@@ -3961,8 +4096,9 @@ msgid "Backing up project"
 msgstr "Salvaguardia di u prughjettu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3971,8 +4107,9 @@ msgstr ""
 "Hè statu ricuperatu à l’ultima fotò istantanea."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4050,8 +4187,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%s Arregistrà u prughjettu « %s » cù u nome…"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "« Arregistrà u prughjettu » hè per un prughjettu Audacity, è micca un schedariu audio.\n"
@@ -4128,11 +4266,12 @@ msgid "Error Opening Project"
 msgstr "Sbagliu à l’apertura di prughjettu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Pruvate d’apre un schedariu di salvaguardia creatu autumaticamente.\n"
 "St’azzione pò creà una perdita tamanta di dati.\n"
@@ -4241,8 +4380,8 @@ msgid "Automatic database backup failed."
 msgstr "Fiascu di a salvaguardia autumatica di a basa di dati."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Benvenuti in Audacity versione %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4354,6 +4493,18 @@ msgstr "Alta qualità"
 msgid "Best Quality (Slowest)"
 msgstr "Qualità a più bella (u più pianu)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "DPCM 16 bit"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "DPCM 8 bit"
+
 #. i18n-hint: Audio data bit depth (precision): 32-bit floating point
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
@@ -4447,7 +4598,8 @@ msgstr "Tutte e preferenze"
 msgid "SelectionBar"
 msgstr "Barra di selezzione"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Selezzione spettrale"
 
@@ -4455,46 +4607,55 @@ msgstr "Selezzione spettrale"
 msgid "Timer"
 msgstr "Cronometru"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Attrezzi"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Trasportu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mischiu"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Cuntadore"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Cuntadore di lettura"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Cuntadore d’arregistramentu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Mudificà"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Apparechju"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Ripruduce à a vitezza"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Strufinà"
 
@@ -4509,7 +4670,10 @@ msgstr "Regula"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Traccie"
 
@@ -4619,7 +4783,8 @@ msgid "Activation level (dB):"
 msgstr "Livellu d’attivazione (dB) :"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Benvenuti in Audacity !"
 
 #: src/SplashDialog.cpp
@@ -4765,9 +4930,9 @@ msgstr ""
 "Cliccu nant’à u buttone d’aiutu per cunnosce minichichje nant’à i lettori adattati."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity ùn pò micca scrive u schedariu :\n"
@@ -4787,9 +4952,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4798,9 +4963,9 @@ msgstr ""
 "per scrivecci."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity ùn pò micca scrive fiure ver di u schedariu :\n"
@@ -4817,9 +4982,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4829,9 +4994,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4840,8 +5005,9 @@ msgstr ""
 "Forse un furmatu png gattivu ?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity ùn pò micca leghje u so temu predefinitu.\n"
@@ -4879,9 +5045,9 @@ msgstr ""
 "sò dighjà presente. Rimpiazzalli ?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity ùn pò micca arregistrà u schedariu :\n"
@@ -4920,7 +5086,11 @@ msgstr "Persunalizatu"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Durata"
 
@@ -4931,7 +5101,8 @@ msgid "Time Track"
 msgstr "Traccia di tempo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Arregistramentu prugrammatu d’Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5005,7 +5176,8 @@ msgstr "Prughjettu attuale"
 msgid "Recording start:"
 msgstr "Principiu d’arregistramentu :"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Durata :"
 
@@ -5026,7 +5198,8 @@ msgid "Action after Timer Recording:"
 msgstr "Azzione dopu l’arregistramentu prugrammatu :"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Prugressione di l’arregistramentu prugrammatu d’Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5122,6 +5295,7 @@ msgstr "099 ghjorni 024 o 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data è ora di principiu"
@@ -5166,7 +5340,8 @@ msgstr "Attivà l’&espurtazione autumatica ?"
 msgid "Export Project As:"
 msgstr "Espurtà u prughjettu cù u nome :"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Ozzioni"
 
@@ -5179,7 +5354,8 @@ msgid "Do nothing"
 msgstr "Ùn fà nunda"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Chjode Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5203,7 +5379,8 @@ msgid "Scheduled to stop at:"
 msgstr "Prugrammatu per piantà à :"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Arregistramentu prugrammatu d’Audacity - In attesa di principià"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5229,8 +5406,13 @@ msgid "Recording Exported:"
 msgstr "Arregistramentu espurtatu :"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Arregistramentu prugrammatu d’Audacity - In attesa"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5422,7 +5604,11 @@ msgid "Applying %s..."
 msgstr "Appiecazione di %s…"
 
 #. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%s: %s"
 msgstr "%s : %s"
@@ -5445,13 +5631,15 @@ msgstr "%s ùn hè micca un parametru accettatu da %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Valore inaccettevule per u parametru « %s » ; duveria esse %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Cumanda"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ripete %s"
@@ -5578,13 +5766,24 @@ msgstr "Pezzi"
 msgid "Envelopes"
 msgstr "Inviluppi"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etichette"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Scatule"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5594,7 +5793,8 @@ msgstr "Succintu"
 msgid "Type:"
 msgstr "Tipu :"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Furmatu :"
 
@@ -5621,6 +5821,10 @@ msgstr "Cummentu"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Cumanda :"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5658,12 +5862,17 @@ msgstr "Espurtà ver di un schedariu."
 msgid "Builtin Commands"
 msgstr "Cumande integrate"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "A squadra d’Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Pruvede cumande integrate à Audacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5726,7 +5935,10 @@ msgstr "Viota u cuntenutu di u ghjurnale."
 msgid "Get Preference"
 msgstr "Ottene e preferenze"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nome :"
 
@@ -5774,7 +5986,8 @@ msgstr "Screnu sanu"
 msgid "Toolbars"
 msgstr "Barre d’attrezzi"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effetti"
 
@@ -5914,7 +6127,8 @@ msgstr "Definite"
 msgid "Add"
 msgstr "Aghjunghje"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Caccià"
 
@@ -5999,7 +6213,8 @@ msgid "Edited Envelope"
 msgstr "Inviluppu mudificatu"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Inviluppu"
 
@@ -6099,7 +6314,10 @@ msgstr "Panoramicu :"
 msgid "Set Track Visuals"
 msgstr "Definisce l’aspetti di a traccia"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineare"
 
@@ -6212,7 +6430,9 @@ msgid "Duck &amount:"
 msgstr "Quantità di vulume :"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "seconde"
 
@@ -6236,7 +6456,8 @@ msgstr "Longhezza di scaghjatura interna di chjususa :"
 msgid "Inner &fade up length:"
 msgstr "Longhezza di scaghjatura interna d’apertura :"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Sogliu :"
 
@@ -6374,11 +6595,13 @@ msgstr "à (Hz)"
 msgid "t&o"
 msgstr "&à"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "&Percentuale di mudificazione :"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Percentuale di mudificazione"
 
@@ -6386,9 +6609,23 @@ msgstr "Percentuale di mudificazione"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Impiegà una stinzata di alta qualità (pianu)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "s/d"
 
@@ -6416,6 +6653,7 @@ msgstr "Vitezza g/m discu nurmale :"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Da g/m"
@@ -6428,6 +6666,7 @@ msgstr "&da"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Ver di g/m"
@@ -6570,6 +6809,12 @@ msgstr "Cumpressore"
 msgid "Compresses the dynamic range of audio"
 msgstr "Cumprime a stesa dinamica di l’audio"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6579,6 +6824,20 @@ msgstr "%.2f sec"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f sec"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6695,7 +6954,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analisa di cuntrastu, per misurà e sfarenze di vulume RMS trà duie selezzioni d’audio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Fine"
 
@@ -6755,6 +7015,18 @@ msgstr "S&farenza :"
 msgid "&Help"
 msgstr "Ai&utu"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "zeru"
@@ -6762,6 +7034,13 @@ msgstr "zeru"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "micca determinata"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6815,6 +7094,12 @@ msgstr "Sfarenza attuale"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Livellu di primu pianu misuratu"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f x"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -7168,7 +7453,9 @@ msgstr "&Sequenza DTMF :"
 msgid "&Amplitude (0-1):"
 msgstr "&Ampiitutine (0-1) :"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Durata :"
 
@@ -7181,12 +7468,29 @@ msgid "Duty cycle:"
 msgstr "Ciclu d’attività :"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f sec"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Durata di sonu :"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Durata di silenziu :"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7196,7 +7500,8 @@ msgstr "Ribombu"
 msgid "Repeats the selected audio again and again"
 msgstr "Ripete ab’eternu l’audio selezziunatu"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "U valore richiestu eccede a capacità di a memoria."
 
@@ -7220,7 +7525,8 @@ msgstr "Prerigature"
 msgid "Export Effect Parameters"
 msgstr "Espurtà i parametri di l’effettu"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Ùn si pò micca apre u schedariu : « %s »"
@@ -7257,6 +7563,15 @@ msgstr "Preparazione di a previsualizazione"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Previsualizazione"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Sbagliu Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7539,6 +7854,11 @@ msgstr "Piantà a &lettura"
 msgid "Play"
 msgstr "Lettura"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinu"
@@ -7584,6 +7904,10 @@ msgid "Low rolloff for speech"
 msgstr "Chjucu slatamentu per i discorsi"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefonu"
 
@@ -7620,12 +7944,41 @@ msgid "Effect Unavailable"
 msgstr "Effettu micca dispunibule"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "dB massimu"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "dB minimu"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7700,8 +8053,16 @@ msgid "D&efault"
 msgstr "Pr&edefinitu"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SS&E multi-tacche"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7946,7 +8307,8 @@ msgid "Builtin Effects"
 msgstr "Effetti integrati"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Pruvede effetti integrati à Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7956,6 +8318,10 @@ msgstr "Nome scunnisciutu d’effettu integratu"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "intensità percepità"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7987,6 +8353,14 @@ msgstr "&Nurmalizà"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Sunurità LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -8056,7 +8430,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (predefinitu)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, nisunu"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, nisunu"
 
 #: src/effects/NoiseReduction.cpp
@@ -8156,8 +8539,9 @@ msgid "Step 1"
 msgstr "Tappa 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Selezziunà poche seconde di trostu per ch’Audacity ampareghji ciò ch’ellu\n"
@@ -8209,13 +8593,62 @@ msgstr "Tipi di &finestra :"
 msgid "Window si&ze:"
 msgstr "&Dimensione di a finestra :"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (predefinitu)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Ta&ppe à a finestra :"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8331,12 +8764,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&urmalizà canali stereo indipendentemente"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Stinzà"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Impiegà Paulstretch solu per una stinzata tempurale estrema o per un effettu di « stasi »"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Fattore di &stinzata :"
@@ -8618,6 +9057,11 @@ msgstr "Arritrosa l’audio selezziunatu"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Tempu SBSMS / Stinzata d’intunazione"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8773,6 +9217,11 @@ msgstr "Impiegà e predefinizioni"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Risturà e predefinizioni"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8932,6 +9381,10 @@ msgstr "Abbentà u silenziu"
 msgid "Tr&uncate to:"
 msgstr "Tr&oncà à :"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "C&umprime à :"
@@ -8945,7 +9398,8 @@ msgid "VST Effects"
 msgstr "Effetti VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Aghjunghje a pussbilità d’impiegà l’effetti VST in Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8957,7 +9411,8 @@ msgstr "Analisa di l’interpretadore Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Inscrizzione %d di %d : %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Impussibule di caricà a bibliuteca"
 
@@ -8977,7 +9432,8 @@ msgstr "A dimensione di u stampone cuntrolleghja u numeru di campioni mandati à
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Dimensione di u &stampone (da 8 à 1048576 campioni) :"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Cumpensazione di tempu d’attesa"
 
@@ -8985,7 +9441,8 @@ msgstr "Cumpensazione di tempu d’attesa"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Durante i so trattamenti, certi effetti VST devenu indusgiulà l’audio restituitu à Audacity. Quandu stu cumportu ùn hè micca cumpensatu, viderete chì chjuchi silenzii sò stati frametti in l’audio. Attivà st’ozzione per permette sta cumpensazione, ma forse ùn funziunerà micca per tutti l’effetti VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Attivà a &cumpensazione"
 
@@ -9019,7 +9476,8 @@ msgid "Standard VST program file"
 msgstr "Schedariu classicu di prugramma VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Schedariu Audacity di prerigatura VST"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9046,7 +9504,8 @@ msgstr "Sbagliu di caricamentu di e prerigature VST"
 msgid "Unable to load presets file."
 msgstr "Impussibule di caricà u schedariu di prerigature."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Preferenze d’effettu"
 
@@ -9062,6 +9521,16 @@ msgstr "Impussibule di leghje u schedariu di presets."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Stu schedariu di parametru hè statu arregistratu da %s. Cuntinuà ?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -9093,7 +9562,8 @@ msgid "Audio Unit Effects"
 msgstr "Effetti « Audio Unit »"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Pruvede l’effetti « Audio Unit » à Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9109,7 +9579,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Ozzioni d’effettu « Audio Unit »"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Durante i so trattamenti, certi effetti « Audio Unit » devenu indusgiulà l’audio restituitu à Audacity. Quandu stu cumportu ùn hè micca cumpensatu, viderete chì chjuchi silenzii sò stati frametti in l’audio. Attivà st’ozzione per permette sta cumpensazione, ma forse ùn funziunerà micca per tutti l’effetti « Audio Unit »."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9253,6 +9724,7 @@ msgstr "Protocollu Audio Unit"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Effetti LADSPA"
@@ -9262,7 +9734,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Pruvede l’effetti LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity ùn impiega più vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9270,12 +9743,15 @@ msgid "LADSPA Effect Options"
 msgstr "Ozzioni d’effettu LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Durante i so trattamenti, certi effetti LADSPA devenu indusgiulà l’audio restituitu à Audacity. Quandu stu cumportu ùn hè micca cumpensatu, viderete chì chjuchi silenzii sò stati frametti in l’audio. Attivà st’ozzione per permette sta cumpensazione, ma forse ùn funziunerà micca per tutti l’effetti LADSPA."
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s :"
@@ -9283,6 +9759,14 @@ msgstr "%s :"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Esciuta d’effettu"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Effetti LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9294,7 +9778,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Dimensione di u stam&pone (da 8 à %d) campioni :"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Durante i so trattamenti, certi effetti LV2 devenu indusgiulà l’audio restituitu à Audacity. Quandu stu cumportu ùn hè micca cumpensatu, viderete chì chjuchi silenzii sò stati frametti in l’audio. Attivà st’ozzione per permette sta cumpensazione, ma forse ùn funziunerà micca per tutti l’effetti LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9319,12 +9804,19 @@ msgstr "%s richiede l’ozzione %s micca accettata\n"
 msgid "Generator"
 msgstr "Generatore"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Effetti LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Permette à Audacity d’impiegà l’effetti LV2"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9332,7 +9824,8 @@ msgid "Nyquist Effects"
 msgstr "Effetti Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Permette à Audacity d’impiegà l’effetti Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9560,7 +10053,8 @@ msgstr "Selezziunà un schedariu"
 msgid "Save file as"
 msgstr "Arregistrà u schedariu cù u nome"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "senza titulu"
 
@@ -9569,7 +10063,8 @@ msgid "Vamp Effects"
 msgstr "Effetti Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Permette à Audacity d’impiegà l’effetti Vamp"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9591,6 +10086,12 @@ msgstr "Preferenze di l’estensione"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Prugramma"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9891,7 +10392,8 @@ msgstr "Espurtazione di l’audio cum’è %s"
 msgid "Invalid sample rate"
 msgstr "Frequenza di campiunariu inaccettevule"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Campiunà torna"
 
@@ -9921,6 +10423,14 @@ msgstr "Pudete campiunà torna à una di e frequenze quaghjò."
 msgid "Sample Rates"
 msgstr "Frequenze di campiunariu"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Scolu binariu :"
@@ -9928,6 +10438,48 @@ msgstr "Scolu binariu :"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualità (kbps) :"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f sec"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9938,8 +10490,41 @@ msgid "Constrained"
 msgstr "Custrettu"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Audio"
+msgstr "&Audio…"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Chjucu cumportu"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -10026,8 +10611,17 @@ msgid "Replace preset '%s'?"
 msgstr "Rimpiazzà a prerigatura « %s » ?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Do"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principale"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10135,6 +10729,10 @@ msgstr "Lingua :"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Dipositu bit"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10268,6 +10866,11 @@ msgstr ""
 "0 - predefinizioni\n"
 "min - 1\n"
 "mas - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Impiegà LPC (cudificazione predittiva lineare)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10448,6 +11051,16 @@ msgid "Failed to find the codec"
 msgstr "Impussibule di truvà u cudecu"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "DWVW 16 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "DWVW 24 bit"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (u più rapidu)"
 
@@ -10516,6 +11129,42 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (a più bella qualità)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Estremu, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "Classicu, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "Medianu, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "Medianu, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (i più chjuchi schedarii)"
 
@@ -10545,7 +11194,8 @@ msgstr "Scemu"
 msgid "Extreme"
 msgstr "Estremu"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Classicu"
 
@@ -10570,6 +11220,11 @@ msgid "Joint Stereo"
 msgstr "Canali stereo ghjunti"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Creà stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Modu di scolu binariu :"
 
@@ -10592,8 +11247,8 @@ msgid "Locate LAME"
 msgstr "Lucalizà LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity hà bisoniu di u schedariu %s per creà MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10621,10 +11276,10 @@ msgid "Where is %s?"
 msgstr "Induve si trova %s ?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Avete da ligà ver di lame_enc.dll v%d.%d. Sta versione ùn hè micca cunciliabile cù Audacity %d.%d.%d.\n"
 "Ci vole à scaricà l’ultima versione di « LAME for Audacity »."
@@ -10929,6 +11584,14 @@ msgstr "Espurtazione di l’audio selezziunatu cum’è Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Espurtazione di l’audio cum’è Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Intestatura :"
@@ -10942,9 +11605,10 @@ msgid "Other uncompressed files"
 msgstr "Altri schedarii micca cumpressi"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Avete pruvatu d’espurtà un schedariu WAV o AIFF chì seria superiore à 4GB.\n"
 "Audacity ùn pò micca fà què, è l’espurtazione hè stata abbandunata."
@@ -10954,8 +11618,9 @@ msgid "Error Exporting"
 msgstr "Sbagliu à l’espurtazione"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "U vostru schedariu WAV espurtatu hè statu truncatu perchè Audacity ùn pò\n"
@@ -10995,11 +11660,11 @@ msgid "All supported files"
 msgstr "Tutti i schedarii accettati"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "« %s »\n"
@@ -11008,11 +11673,11 @@ msgstr ""
 "pudete mudificallu da u listinu Schedariu > Impurtà > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "« %s »\n"
 "ùn hè micca un schedariu audio. \n"
@@ -11023,18 +11688,18 @@ msgid "Select stream(s) to import"
 msgstr "Selezziunà u(i) flussu(i) à impurtà"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Sta versione d’Audacity ùn permette micca l’adopru di %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "« %s » hè una traccia di CD audio. \n"
 "Audacity ùn pò micca apre direttamente di CD audio. \n"
@@ -11043,10 +11708,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "« %s » hè un schedariu di lista di lettura. \n"
@@ -11055,10 +11720,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu Windows Media Audio. \n"
@@ -11067,10 +11732,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu Advanced Audio Coding.\n"
@@ -11079,12 +11744,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu audio cifratu. \n"
@@ -11095,10 +11760,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu multimedia RealPlayer. \n"
@@ -11107,12 +11772,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "« %s » hè un schedariu di note, è micca un schedariu audio. \n"
 "Audacity ùn pò micca apre stu tipu di schedariu. \n"
@@ -11121,10 +11786,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11137,10 +11802,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu audio Wavpack. \n"
@@ -11149,10 +11814,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu audio Dolby Digital. \n"
@@ -11161,10 +11826,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu audio Ogg Speex. \n"
@@ -11173,10 +11838,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "« %s » hè un schedariu video. \n"
@@ -11190,9 +11855,9 @@ msgstr "Schedariu « %s » micca trovu."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11208,11 +11873,16 @@ msgstr ""
 "Pruvate d’installà FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, esperimentadore"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11242,12 +11912,13 @@ msgid "Import Project"
 msgstr "Impurtà u prughjettu"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Stu prughjettu hè statu arregistratu da Audacity versione 1.0 o più vechja. U furmatu hà cambiatu è sta versione d’Audacity ùn pò impurtà u prughjettu.\n"
 "\n"
@@ -11297,7 +11968,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Ùn si pò micca truvà u cartulare di dati di prughjettu : « %s »"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "E traccie MIDI chì si trovanu in u schedariu di prughjettu sò state ignurate perchè sta versione d’Audacity ùn e accetteghja micca."
 
 #: src/import/ImportAUP.cpp
@@ -11402,40 +12074,6 @@ msgstr "Indice[%02x] Cudecu[%s], Linguaghju[%s], Scolu binariu[%s], Canali[%d], 
 msgid "FLAC files"
 msgstr "Schedarii FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Schedarii cunciliabile cù GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Impussibule d’aghjunghje u discudificatore à u cundottu"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Impurtadore GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Impussibule di definisce u statu di pausa per u flussu."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indice[%02d], Tipu[%s], Canali[%d], Frequenza[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "U schedariu ùn cuntene alcunu flussu audio."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Impussibule d’impurtà u schedariu, u cambiamentu di statu ùn hà riesciutu."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Sbagliu GStreamer : %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Lista di i schedarii in furmatu di testu"
@@ -11537,14 +12175,50 @@ msgstr "Sbagliu di logica interna"
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, è altri schedarii micca cumpressi"
 
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/import/ImportPCM.cpp
 msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (cudecu audio FLAC senza perdita)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (Furmatu di cuntenente OGG)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "PVF (Portable Voice Format)"
@@ -11553,6 +12227,46 @@ msgstr "PVF (Furmatu di voce purtavule)"
 #: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (senza intestatura)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11583,6 +12297,34 @@ msgid "64 bit float"
 msgstr "64 bit virgula mobile"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "DWVW 12 bit"
 
@@ -11595,12 +12337,20 @@ msgid "24 bit DWVW"
 msgstr "DWVW 24 bit"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "DPCM 16 bit"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "DPCM 8 bit"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11649,6 +12399,19 @@ msgstr "Impurtà dati grossi (raw)"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Nisunu endianness"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Medianu"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -11723,6 +12486,7 @@ msgstr "%s à diritta"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11746,6 +12510,7 @@ msgstr "Fine"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11772,7 +12537,8 @@ msgstr "Pezzi spustati tempuralmente à diritta"
 msgid "Time shifted clips to the left"
 msgstr "Pezzi spustati tempuralmente à manca"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Spustamentu tempurale"
 
@@ -11910,7 +12676,8 @@ msgstr "Ammuzzà e traccie audio selezziunate da %.2f seconde à %.2f seconde"
 msgid "Trim Audio"
 msgstr "Amuzzatura audio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Sparte"
 
@@ -12033,34 +12800,6 @@ msgstr "Tastu di squassatura&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "Est&ra"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "M&ischiera"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "A&dattà u vulume di lettura…"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "A&ummentà u vulume di lettura"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "D&iminuisce u vulume di lettura"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Ada&ttà u vulume d’arregistramentu…"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Au&mmentà u vulume d’arregistramentu"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Dimi&nuisce u vulume d’arregistramentu"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12328,8 +13067,9 @@ msgid "&Getting Started"
 msgstr "&Cumu principià"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manuale d’Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manuale…"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12355,11 +13095,8 @@ msgstr "Infurmazioni nant’à l’apparechji &MIDI…"
 msgid "Show &Log..."
 msgstr "Affissà u &ghjurnale di messaghji…"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Apprupositu d’Audacity…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etichetta aghjunta"
 
@@ -13049,6 +13786,7 @@ msgstr "Saltu lon&gu di cursore à diritta"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Ricercà"
@@ -13260,18 +13998,21 @@ msgid "Created new label track"
 msgstr "Nova traccia d’etichetta creata"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Sta versione d’Audacity permette solu una traccia di tempo per ogni finestra di prughjettu."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Nova traccia di tempo creata"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nova frequenza di campiunariu (Hz) :"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "U valore scrittu ùn hè micca accettevule"
 
@@ -13528,7 +14269,9 @@ msgstr "Lettura"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Arregistramentu"
 
@@ -13677,10 +14420,6 @@ msgstr "&Soprarregistramentu (iè/no)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Lettura audio da u &prugramma (iè/no)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Acc&umudata autumatica di livellu d’arregistramentu (iè/no)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13896,7 +14635,7 @@ msgstr "Preferenze per a qualità"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Rinnovà Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13943,7 +14682,8 @@ msgstr "&Ospite :"
 msgid "Using:"
 msgstr "Impiegatu :"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Lettura"
 
@@ -13963,7 +14703,8 @@ msgstr "&Canali :"
 msgid "Latency"
 msgstr "Tempu d’attesa"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milliseconde"
 
@@ -13983,8 +14724,19 @@ msgstr "Nisuna interfaccia audio"
 msgid "No devices found"
 msgstr "Nisunu apparechju trovu"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Canale (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 Canali (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Cartulari"
 
@@ -14092,7 +14844,8 @@ msgid "Directory %s is not writable"
 msgstr "Ùn si pò scrive in u cartulare %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "I cambiamenti di u cartulare timpurariu seranu effettivi dopu un rilanciu d’Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14123,6 +14876,40 @@ msgstr "Adunitu da editore"
 msgid "Grouped by Type"
 msgstr "Adunitu da tipu"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Sbagliu Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Attivà l’effetti"
@@ -14144,11 +14931,13 @@ msgid "Plugin Options"
 msgstr "Ozzioni di modulu d’estensione"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Cuntrollà e nove versioni di i moduli d’estensione à u lanciu d’Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Torna à analizà i moduli d’estensione à u prossimu lanciu d’Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14328,7 +15117,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Cunservà l’&etichette s’è a selezzione s’azzicca à un’etichetta"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "&Fusione di i temi di u sistema è quelli d’Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14506,7 +15296,8 @@ msgstr ""
 "   *   « %s » (perchè l’accurtatoghju « %s » hè impiegatu da « %s »)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Selezziunà un schedariu XML chì cuntene l’accurtatoghji di tastera d’Audacity…"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14638,8 +15429,9 @@ msgid "Dow&nload"
 msgstr "&Scaricà"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity hà autumaticamente abbentatu bibliuteche FFmpeg accettevule.\n"
@@ -14698,8 +15490,9 @@ msgid "Preferences for Module"
 msgstr "Preferenze per i moduli"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Quelli moduli sò esperimentale. Attivateli solu s’è vò avete lettu\n"
@@ -14707,12 +15500,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  « Dumandà » indicheghja chì Audacity vi dumanderà s’è vò vulete caricà u modulu ogni volta ch’ellu si lancia."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  « Fiascu » vole si dì chì Audacity pensa chì u modulu hè rottu è ùn l’eseguiscerà micca."
 
 #. i18n-hint preserve the leading spaces
@@ -14721,7 +15516,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  « Fiascu » indicheghja chì alcuna scelta ùn hè ancu fatta."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "I cambiamenti di ste preferenze seranu solu effettivi dopu un rilanciu d’Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14739,6 +15535,10 @@ msgstr "Alcunu modulu trovu"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modulu"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14780,7 +15580,10 @@ msgstr "Trascinà à manca"
 msgid "Set Selection Range"
 msgstr "Definisce una stesa di selezzione"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Maiusc + cliccu à manca"
 
@@ -14868,6 +15671,15 @@ msgstr "-trascinà à manca"
 msgid "Move clip up/down between tracks"
 msgstr "Dispiazzà i pezzi insù/inghjò trà e traccie"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-trascinà à manca"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14896,6 +15708,11 @@ msgstr "Cambià parechji campioni"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Cambià UN solu campionu"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Attrezzi multiple"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14987,7 +15804,8 @@ msgid "Always scrub un&pinned"
 msgstr "&Strufinera sempre micca spirlata"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferenze d’Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -15001,6 +15819,11 @@ msgstr "Preferenze :"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferenze per a qualità"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -15043,6 +15866,14 @@ msgstr "Cunverti&dore di frequenza di campiunariu :"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "A&llisciata :"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -15110,39 +15941,6 @@ msgstr "&Data di u sistema"
 #: src/prefs/RecordingPrefs.cpp
 msgid "System T&ime"
 msgstr "&Ora di u sistema"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Accumudata autumatica di livellu d’arregistramentu"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Attivà l’accumudata autumatica di livellu d’arregistramentu."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Obbiettivu di piccu :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Dentru :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Durata d’analisa :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milliseconde (durata di un’analisa)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Numeru d’analise cunsecutive :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 vole dì senza fine"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
@@ -15304,6 +16102,10 @@ msgid "1024 - default"
 msgstr "1024 - predefinita"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - striscia a più stretta"
 
@@ -15401,13 +16203,14 @@ msgid "Info"
 msgstr "Infurmazione"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15590,7 +16393,8 @@ msgstr "Campioni"
 msgid "4 Pixels per Sample"
 msgstr "4 pixel à u campione"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Ingrandamentu massimu"
 
@@ -15712,16 +16516,24 @@ msgid "Stopped"
 msgstr "Piantatu"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Andà à u principiu"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Andà à a fine"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Selezzione fin’à u principiu"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Selezzione fin’à a fine"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15735,20 +16547,17 @@ msgstr "Arregistrà una nova traccia"
 msgid "Append Record"
 msgstr "Accudà l’arregistramentu"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Selezzione fin’à a fine"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Selezzione fin’à u principiu"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s in pausa."
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s :"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15828,11 +16637,17 @@ msgstr "Ammutulisce a selezzione audio"
 msgid "Sync-Lock Tracks"
 msgstr "Traccie sincrunizate è ammarchjunate"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Ingrandamentu"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Riduzzione"
 
@@ -15899,43 +16714,6 @@ msgstr "Barra d’attrezzi di misura d’&arregistramentu"
 msgid "&Playback Meter Toolbar"
 msgstr "Barra d’attrezzi di misura di &lettura"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Vulume d’arregistramentu"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Vulume di lettura"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Vulume d’arregistramentu: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Vulume d’arregistramentu (micca dispunibule ; impiegà u mischiadore sistema.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Vulume di lettura : %.2f (simulatu)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Vulume di lettura :%.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Vulume di lettura (micca dispunibule ; impiegà u mischiadore sistema.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra d’attrezzi di m&ischiera"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Circà"
@@ -15951,6 +16729,7 @@ msgstr "Strufinera"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Piantà a strufinera"
@@ -15958,6 +16737,7 @@ msgstr "Piantà a strufinera"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Principià a strufinera"
@@ -15965,6 +16745,7 @@ msgstr "Principià a strufinera"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Piantà a ricerca"
@@ -15972,6 +16753,7 @@ msgstr "Piantà a ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Principià a ricerca"
@@ -16026,7 +16808,9 @@ msgstr "Azziccassi"
 msgid "Length"
 msgstr "Durata"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centru"
 
@@ -16090,8 +16874,8 @@ msgstr "Barra d’attrezzi temp&urale"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra d’attrezzi %s d’Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -16118,7 +16902,8 @@ msgstr "Attrezzu di sculiscera tempurale"
 msgid "Zoom Tool"
 msgstr "Attrezzu d’ingrandamentu"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Attrezzu di disegnu"
 
@@ -16194,11 +16979,13 @@ msgstr "Trascinà una o parechje cunfine di l’etichetta."
 msgid "Drag label boundary."
 msgstr "Trascinà una cunfina di l’etichetta."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Etichetta mudificata"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Mudificà l’etichetta"
 
@@ -16253,31 +17040,42 @@ msgstr "Etichette mudificate"
 msgid "New label"
 msgstr "Nova etichetta"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "&Ottava superiore"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Otta&va inferiore"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Cliccu per ingrandà verticalmente. Maiusc + cliccu per riduce. Trascinà per specificà una regione d’ingrandamentu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Cliccu dirittu per u listinu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Reinizià l’ingrandamentu"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Maiusc + cliccu dirittu"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Cliccu à manca/trascinà à manca"
 
@@ -16319,7 +17117,8 @@ msgstr "Unione"
 msgid "Expanded Cut Line"
 msgstr "Allargà a linea di tagliata"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Allargà"
 
@@ -16342,6 +17141,11 @@ msgstr "Campioni dispiazzati"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Mudificà u campione"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16387,7 +17191,8 @@ msgstr "Trattamentu...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "« %s » cambiatu in %s"
@@ -16399,6 +17204,54 @@ msgstr "Cambiamentu di furmatu"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Fr&equenza"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16418,7 +17271,8 @@ msgstr "Cambiamentu di frequenza"
 msgid "Set Rate"
 msgstr "Definisce a frequenza di campiunariu"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Multi-vista"
 
@@ -16437,6 +17291,10 @@ msgstr "S&parte una traccia stereo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Sparte una stereo in mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16487,6 +17345,16 @@ msgid "Split to Mono"
 msgstr "Sparte in mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Manca, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Manca, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Manca, %dHz"
@@ -16496,14 +17364,23 @@ msgstr "Manca, %dHz"
 msgid "Right, %dHz"
 msgstr "Diritta, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% à manca"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% à diritta"
@@ -16621,9 +17498,8 @@ msgstr "&Interpolazione lugaritmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Cliccà è fà trascinà per dispiazzà tempuralmente una traccia"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16674,6 +17550,7 @@ msgstr "Inviluppu adattatu."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Strufinà"
@@ -16685,6 +17562,7 @@ msgstr "Ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Re&gula di strufinera"
@@ -16919,9 +17797,19 @@ msgstr "Viotu"
 msgid "Backwards"
 msgstr "In daretu"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "In avanti"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -17134,6 +18022,7 @@ msgstr "0100 o 060 m 060 s+># campioni"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "campioni"
@@ -17295,6 +18184,15 @@ msgstr "01000,01000 fiure|75"
 msgid "010,01000>0100 Hz"
 msgstr "010.01000<0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -17302,6 +18200,10 @@ msgstr "010.01000<0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0.001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -17367,6 +18269,11 @@ msgstr "(Impiegà u listinu cuntestuale per cambià di furmatu.)"
 msgid "centiseconds"
 msgstr "centesimi di seconda"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Tempu scorsu :"
@@ -17408,6 +18315,11 @@ msgstr "Cunfirmà a chjusura"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Impussibule di leghje a prerigatura in « %s »"
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -17512,15 +18424,27 @@ msgstr "Ùn si pò micca analizà u XML"
 msgid "Spectral edit multi tool"
 msgstr "Attrezzi multiple di mudificazione spettrale"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtratura…"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Pruvistu sottu à i termi di a licenza GNU General Public License versione 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aCi vole à selezziunà e frequenze."
@@ -17547,7 +18471,8 @@ msgstr ""
 "                      Pruvate d’aummentà a cunfine bassa di frequenza~%~\n"
 "                      o di riduce u filtru « Larghezza »."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Sbagliu.~%"
@@ -17608,6 +18533,25 @@ msgstr "Scaghjatura di chjusura di u Studio"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Appiecazione di a scaghjatura…"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Pre&ferenze predefinite"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Pruvistu sottu à i termi di a licenza GNU General Public License versione 2 o più recente."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17751,6 +18695,11 @@ msgstr "Circatore di palpitu"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Ricerca di palpiti…"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Ghjurnale d’Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18075,13 +19024,38 @@ msgstr "Filtru passa-altu"
 msgid "Performing High-Pass Filter..."
 msgstr "Appiecazione di u filtru passa-altu…"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequenza (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Slatamentu (dB à l’ottava)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -18102,10 +19076,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Etichetta Soni"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Pruvistu sottu à i termi di a licenza GNU General Public License versione 2 o più recente."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18405,7 +19375,8 @@ msgstr "Schedariu Lisp"
 msgid "HTML file"
 msgstr "Schedariu HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Schedariu di testu"
 
@@ -18470,12 +19441,20 @@ msgid "Error.~%No file selected."
 msgstr "Sbagliu.~%Nisunu schedariu selezziunatu."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Ingenerà un sonu pluck…"
 
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Valori MIDI per e note Do (C) :36, 48, 60 [Do centrale], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
@@ -18506,6 +19485,10 @@ msgid "Generating Rhythm..."
 msgstr "Generazione di ritimu…"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 palpiti/minutu"
 
@@ -18520,6 +19503,10 @@ msgstr "1 - 20 palpiti/misura"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Quantità di swing"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18590,6 +19577,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Intunazione MIDI di u palpitu forte"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Intunazione MIDI di u palpitu debule"
 
@@ -18608,6 +19599,10 @@ msgstr "Tamburu Risset"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Generazione d’un tamburu Risset…"
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18710,6 +19705,11 @@ msgstr "Affissà i messaghji"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Solu i sbaglii"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -19010,6 +20010,10 @@ msgid "Applying Action..."
 msgstr "Appiecazione di l’azzione…"
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "Caccià e voci : ver di mono"
 
@@ -19150,8 +20154,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "U modulu d’estensione funziuneghja solu cù traccie stereo."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Trattamentu Vocoder…"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -19193,6 +20205,232 @@ msgstr "Frequenza di l’achi di u radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Sbagliu.~%Traccia stereo richiesta."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Rinnovà Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Tralascià"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Installà u rinnovu"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Lista di i cambiamenti"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Sapene di più nant’à GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Sbagliu à u cuntrollu di a nova versione"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Impussibule di cunnettassi à u servitore di e nove versioni d’Audacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "I dati di u rinnovu sò alterati."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Sbagliu à u scaricamentu di u rinnovu."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Ùn si pò micca apre u liame di scaricamentu d’Audacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s hè dispunibule !"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Arregistramentu"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Identificazione di Commit :"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Bibliuteca GUI multi piattaforma"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Impurtazione via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. Ùn hè statu micca pussibule di megliurà di più. Sempre troppu altu."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "L’accumudata autumatica di livellu d’arregistramentu hà diminuitu u vulume à %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. Ùn hè statu micca pussibule di megliurà di più. Sempre troppu bassu."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "L’accumudata autumatica di livellu d’arregistramentu hà cresciutu u vulume à %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. U numeru tutale d’analise hè statu toccu senza truvà un vulume accettevule. Sempre troppu altu."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. U numeru tutale d’analise hè statu toccu senza truvà un vulume accettevule. Sempre troppu bassu."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Fermata di l’accumudata autumatica di livellu d’arregistramentu. %.2f pare un vulume accettevule."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Ricevutu %d durante l’apertura di l’apparechji\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Impussibule d’apre Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Mischiadori dispunibule :\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Fonti d’arregistramentu dispunibule :\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Vulumi di lettura dispunibule :\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "U vulume d’arregistramentu hè simulatu\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "U vulume d’arregistramentu hè nativu\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "U vulume di lettura hè simulatu\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "U vulume di lettura hè nativu\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Data è ora di fine"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Schedarii cunciliabile cù GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Impussibule d’aghjunghje u discudificatore à u cundottu"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Impurtadore GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Impussibule di definisce u statu di pausa per u flussu."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indice[%02d], Tipu[%s], Canali[%d], Frequenza[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "U schedariu ùn cuntene alcunu flussu audio."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Impussibule d’impurtà u schedariu, u cambiamentu di statu ùn hà riesciutu."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Sbagliu GStreamer : %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "M&ischiera"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "A&dattà u vulume di lettura…"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "A&ummentà u vulume di lettura"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "D&iminuisce u vulume di lettura"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Ada&ttà u vulume d’arregistramentu…"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Au&mmentà u vulume d’arregistramentu"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Dimi&nuisce u vulume d’arregistramentu"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manuale d’Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Apprupositu d’Audacity…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Acc&umudata autumatica di livellu d’arregistramentu (iè/no)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Accumudata autumatica di livellu d’arregistramentu"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Attivà l’accumudata autumatica di livellu d’arregistramentu."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Obbiettivu di piccu :"
+
+#~ msgid "Within:"
+#~ msgstr "Dentru :"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Durata d’analisa :"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milliseconde (durata di un’analisa)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Numeru d’analise cunsecutive :"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 vole dì senza fine"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Vulume d’arregistramentu"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Vulume di lettura"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Vulume d’arregistramentu: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Vulume d’arregistramentu (micca dispunibule ; impiegà u mischiadore sistema.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Vulume di lettura : %.2f (simulatu)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Vulume di lettura :%.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Vulume di lettura (micca dispunibule ; impiegà u mischiadore sistema.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra d’attrezzi di m&ischiera"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Cliccà è fà trascinà per dispiazzà tempuralmente una traccia"
 
 #~ msgid "Program build date:"
 #~ msgstr "Data di custruzzione di u prugramma :"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/tenacity/tenacity/cs/>\n"
@@ -17,47 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Aktualizovat Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Přeskočit"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Kanál"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Chyba při dekódování souboru"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Chyba při nahrávání popisných dat"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s panel nástrojů"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Nahrávání"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Nepodařilo se zjistit"
@@ -66,6 +25,24 @@ msgstr "Nepodařilo se zjistit"
 #, c-format
 msgid "%s bytes"
 msgstr "%s bytů"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -192,7 +169,8 @@ msgid "Script"
 msgstr "Skript"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Výstup"
 
@@ -208,7 +186,12 @@ msgstr "Skripty Nyquist (*.ny)|*.ny|Skripty Lisp (*.lsp)|*.lsp|Všechny soubory|
 msgid "Script was not saved."
 msgstr "Skript nebyl uložen."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Varování "
 
@@ -221,15 +204,25 @@ msgid "Find dialog"
 msgstr "Dialog hledání"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galerie ikon Tango (ikony v nástrojovém pruhu)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 od Lelanda Lucia"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 od Lelanda Lucia"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Vnější modul Audacity, který poskytuje jednoduché IDE pro zápis efektů."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -252,7 +245,8 @@ msgstr "Bez názvu"
 msgid "Nyquist Effect Workbench - "
 msgstr "Pracovní stůl efektů Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nový"
 
@@ -292,7 +286,8 @@ msgstr "Kopírovat"
 msgid "Copy to clipboard"
 msgstr "Kopírovat do schránky"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Vyjmout"
 
@@ -300,7 +295,8 @@ msgstr "Vyjmout"
 msgid "Cut to clipboard"
 msgstr "Vyjmout a vložit do schránky"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Vložit"
 
@@ -325,7 +321,8 @@ msgstr "Vybrat vše"
 msgid "Select all text"
 msgstr "Vybrat všechen text"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Zpět"
 
@@ -333,7 +330,8 @@ msgstr "Zpět"
 msgid "Undo last change"
 msgstr "Zpět poslední změnu"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Znovu"
 
@@ -390,7 +388,8 @@ msgid "Go to next S-expr"
 msgstr "Jít na další S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Začátek"
 
@@ -398,7 +397,8 @@ msgstr "Začátek"
 msgid "Start script"
 msgstr "Spustit skript"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Zastavit"
 
@@ -412,15 +412,23 @@ msgstr "Zastavit skript"
 msgid "About %s"
 msgstr "O programu %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informace o sestavení"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Zakázáno"
 
@@ -430,8 +438,9 @@ msgid "The Build"
 msgstr "Sestavení pro ladění"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "ID zápisu (commit):"
+#, fuzzy
+msgid "Version:"
+msgstr "Verze"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -441,22 +450,28 @@ msgstr "Typ sestavení:"
 msgid "Compiler:"
 msgstr "Překladač:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Předpona instalace:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Složka s nastavením:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Složka s nastavením:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Podporovaný typ formátu"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Knihovna rozhraní pro více systémů"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -470,7 +485,6 @@ msgstr "Převod vzorkovacího kmitočtu"
 msgid "MP3 Importing"
 msgstr "Nahrávání MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Nahrávání a ukládání do Ogg Vorbis "
@@ -479,7 +493,6 @@ msgstr "Nahrávání a ukládání do Ogg Vorbis "
 msgid "ID3 tag support"
 msgstr "Podpora značek ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Nahrávání a ukládání do FLAC"
@@ -497,14 +510,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Nahrávání/ukládání FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Nahrát přes GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Funkce"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Podpora přídavných modulů"
 
@@ -519,6 +524,10 @@ msgstr "Podpora změny výšky tónu a tempa"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Podpora změny krajní výšky tónu a tempa"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Funkce"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -637,6 +646,10 @@ msgstr "%s, grafika"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (zahrnující %s, %s, %s, %s a %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -646,6 +659,10 @@ msgstr "%s je program zadarmo, s otevřeným zdrojovým kódem, pro více opera�
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Zásluhy"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -696,6 +713,7 @@ msgstr "Stránky a grafika"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Český překlad: Aleš Tošovský, Dominik Joe Pantůček, Vladimír Krupka (Audacity 1.x), Pavel Fric (Audacity 2.x)"
@@ -713,6 +731,22 @@ msgstr "Zvláštní poděkování:"
 #, c-format
 msgid "%s website: "
 msgstr "Stránky %s: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Přispěvatelé"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -735,6 +769,7 @@ msgstr "Časová osa"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klepněte nebo táhněte pro započetí přehrávání normální rychlostí s přeskakováním"
@@ -742,6 +777,7 @@ msgstr "Klepněte nebo táhněte pro započetí přehrávání normální rychlo
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klepněte nebo táhněte pro započetí přehrávání proměnlivou rychlostí"
@@ -749,6 +785,7 @@ msgstr "Klepněte nebo táhněte pro započetí přehrávání proměnlivou rych
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Klepněte a pohybujte pro přehrávání proměnlivou rychlostí. Klepněte a táhněte pro přehrávání normální rychlostí s přeskakováním."
@@ -756,6 +793,7 @@ msgstr "Klepněte a pohybujte pro přehrávání proměnlivou rychlostí. Klepn�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Pohybovat pro přehrávání normální rychlostí s přeskakováním"
@@ -763,6 +801,7 @@ msgstr "Pohybovat pro přehrávání normální rychlostí s přeskakováním"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Pohybovat pro přehrávání proměnlivou rychlostí"
@@ -819,7 +858,17 @@ msgstr ""
 "Nelze uzamknout oblast za koncem\n"
 "projektu."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Chyba"
 
@@ -843,7 +892,8 @@ msgstr ""
 "Toto je jednorázová otázka pokládaná po instalaci, kde jste dotazováni na obnovení výchozího nastavení."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Nastavit znovu nastavení Audacity"
 
 #: src/AudacityApp.cpp
@@ -858,7 +908,8 @@ msgstr ""
 "Byl odstraněno ze seznamu posledních souborů. "
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Knihovnu SQLite se nepodařilo inicializovat. Audacity nemůže pokračovat."
 
 #: src/AudacityApp.cpp
@@ -884,7 +935,7 @@ msgstr "&Otevřít..."
 msgid "Open &Recent..."
 msgstr "Otevřít &Nedávné..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&O programu Audacity..."
@@ -898,9 +949,10 @@ msgid "&File"
 msgstr "&Soubor"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity se nepodařilo najít místo pro uložení dočasných souborů.\n"
@@ -908,20 +960,23 @@ msgstr ""
 "Zadejte, prosím, příslušnou složku v dialogu Nastavení."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity se nepodařilo najít místo pro uložení dočasných souborů.\n"
 "Zadejte, prosím, příslušnou složku v dialogu Nastavení."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Ukončení Audacity. Spusťte, prosím, Audacity znovu, aby se použil nový dočasný adresář."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -930,15 +985,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity se nepodařilo zamknout adresář dočasných souborů\n"
 ".Tato složka může být používána jinou kopií Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Chcete znovu spustit Audacity?"
 
 #: src/AudacityApp.cpp
@@ -946,19 +1003,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Chyba při zamykání dočasné složky"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Systém zjistil, že je spuštěna další kopie Audacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Použijte položku Nový nebo Otevřít v právě běžícím Audacity\n"
 "k otevření více projektů současně.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity je již spuštěno"
 
 #: src/AudacityApp.cpp
@@ -974,7 +1034,8 @@ msgstr ""
 "a může být vyžadován restart."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity se nepodařilo spustit"
 
 #: src/AudacityApp.cpp
@@ -1014,8 +1075,9 @@ msgstr ""
 "a může být vyžadován restart."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1047,7 +1109,8 @@ msgstr "Spustit vlastní diagnostiku"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Zobrazit verzi Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1057,9 +1120,10 @@ msgid "audio or project file name"
 msgstr "Název souboru se zvukem nebo s projektem"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1072,16 +1136,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Projektové soubory Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Zpráva"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Chyba v nastavení Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1091,7 +1157,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Nelze získat přístup k následujícímu nastavovacímu souboru: \n"
 "\n"
@@ -1103,12 +1169,15 @@ msgstr ""
 "\n"
 "Pokud se rozhodnete „Ukončit Audacity“, může být váš projekt ponechán v neuloženém stavu, který bude obnoven při příštím otevření."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Nápověda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Ukončit Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1116,7 +1185,8 @@ msgid "&Retry"
 msgstr "&Zkusit znovu"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Zápis Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1128,9 +1198,14 @@ msgstr "&Uložit..."
 msgid "Cl&ear"
 msgstr "Sm&azat"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Zavřít"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1179,7 +1254,8 @@ msgid "Error Initializing Midi"
 msgstr "Chyba při inicializaci MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Zvuk Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1194,37 +1270,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Nedostatek paměti!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automatizované upravení úrovně nahrávání zastaveno. Nebylo možno ji více vyladit. Stále je příliš vysoká."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automatizované upravení úrovně nahrávání snížilo hlasitost na %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatizované upravení úrovně nahrávání zastaveno. Nebylo možno ji více vyladit. Stále je ještě nízká."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automatizované upravení úrovně nahrávání snížilo hlasitost na %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automatizované upravení úrovně nahrávání zastaveno. Celkový počet rozborů byl překročen bez nalezení přijatelného objemu. Stále je příliš vysoká."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automatizované upravení úrovně nahrávání zastaveno. Celkový počet rozborů byl překročen bez nalezení přijatelného objemu. Stále je příliš nízká."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatizované upravení úrovně nahrávání zastaveno. %.2f se zdá jako přijatelná hlasitost."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1323,43 +1368,6 @@ msgstr "Nenalezeno žádné přehrávací zařízení pro '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Bez obou zařízení nelze prověřit vzájemné vzorkovací kmitočty.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Při otevírání zařízení přijato %d\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Nelze otevřít směšovač přípojek\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Dostupné směšovače:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Dostupné zdroje nahrávání:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Dostupné hlasitosti přehrávání:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Hlasitost nahrávání je napodobena\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Hlasitost nahrávání je původní\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Hlasitost přehrávání je napodobena\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Hlasitost přehrávání je původní\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1402,8 +1410,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatické obnovení po chybě"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1416,12 +1425,14 @@ msgid "Recoverable &projects"
 msgstr "Obnovitelné &projekty"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Vybrat"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Název"
 
@@ -1507,6 +1518,11 @@ msgstr "Efekt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Příkaz v nabídce (s parametry)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1652,7 +1668,8 @@ msgstr "&Obnovit"
 msgid "I&mport..."
 msgstr "&Nahrát..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Uložit jako..."
 
@@ -1693,7 +1710,8 @@ msgstr "Posunout &nahoru"
 msgid "Move &Down"
 msgstr "Posunout &dolů"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Uložit"
 
@@ -1776,7 +1794,8 @@ msgid "Run"
 msgstr "Spustit"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Zavřít"
 
@@ -1920,11 +1939,6 @@ msgstr "Srovnávací zkouška byla úspěšně dokončena.\n"
 #: src/BuildInfo.h
 msgid "No revision identifier was provided"
 msgstr "Nebyl poskytnut žádný identifikátor změny"
-
-#: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Datum a čas konce"
 
 #: src/BuildInfo.h
 #, c-format
@@ -2177,6 +2191,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopírovat názvy do schránky"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Chybí"
 
@@ -2185,10 +2204,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Pokud budete pokračovat, nebude váš projekt uložen na disk. Opravdu to tak chcete?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2202,7 +2222,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Zkontrolovat závislost"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Žádná"
 
@@ -2210,7 +2233,7 @@ msgstr "Žádná"
 msgid "Rectangle"
 msgstr "Obdélník"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trojúhelník"
 
@@ -2221,6 +2244,38 @@ msgstr "Tvarované"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Obdélník"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, žádný"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Vítejte!"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2242,9 +2297,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Podpora FFmpegu není zkompilována v"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2266,8 +2322,8 @@ msgid "Locate FFmpeg"
 msgstr "Vyhledat FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity potřebuje soubor '% s' k nahrání a uložení zvuku přes FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2280,7 +2336,8 @@ msgstr "Umístění '% s':"
 msgid "To find '%s', click here -->"
 msgstr "Chcete-li najít '% s', klepněte zde →"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Procházet ..."
 
@@ -2306,8 +2363,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg nebyl nalezen"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2337,24 +2395,24 @@ msgid "Only libavformat.so"
 msgstr "Jen libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity se nepodařilo otevřít soubor v %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity se nepodařilo přečíst soubor v %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity se úspěšně podařilo zapsat soubor v %s, ale nepodařilo se jej přejmenovat na %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2392,7 +2450,9 @@ msgstr "&Nekopírovat žádný zvuk"
 msgid "As&k"
 msgstr "&Ptát se"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Všechny soubory"
 
@@ -2417,6 +2477,10 @@ msgstr "Textové soubory"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Soubory XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2481,6 +2545,18 @@ msgstr "Lineární"
 msgid "Log frequency"
 msgstr "Logaritmická"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "H"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Projíždět"
@@ -2488,6 +2564,15 @@ msgstr "Projíždět"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Zvětšení"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2548,6 +2633,23 @@ msgstr "Bylo vybráno příliš mnoho zvuku. Bude rozebráno jen prvních %.1f s
 msgid "Not enough data selected."
 msgstr "Není vybrán dostatek údajů."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f s (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f s (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2570,7 +2672,8 @@ msgstr "spektrum.txt"
 msgid "Export Spectral Data As:"
 msgstr "Uložit spektrální data jako:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Nelze zapisovat do souboru: %s"
@@ -2760,19 +2863,19 @@ msgid "&History..."
 msgstr "&Historie"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Vnitřní chyba v %s na %s řádek %d.\n"
 "Dejte, prosím, vědět týmu Audacity na https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Vnitřní chyba v %s řádek %d.\n"
 "Dejte, prosím, vědět týmu Audacity na https://forum.audacityteam.org/."
@@ -2791,7 +2894,9 @@ msgid "Track"
 msgstr "Stopa"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Štítek"
 
@@ -2851,7 +2956,8 @@ msgstr "Vložte název stopy"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Popisová stopa"
 
@@ -2862,11 +2968,13 @@ msgstr "Jeden nebo více uložených štítků se nepodařilo přečíst."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "První spuštění Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Vyberte jazyk, který se v Audacity bude používat:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2876,7 +2984,8 @@ msgstr "Vyberte jazyk, který se v Audacity bude používat:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Vámi vybraný jazyk, %s (%s), se neshoduje s jazykem systému, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Potvrdit"
 
@@ -2894,8 +3003,19 @@ msgstr ""
 "Starý soubor byl uložen jako '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Otevírání projektu Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Zvláštní poděkování:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "&Procházet..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2941,19 +3061,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Spojit (smíchat) stopy"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Směšovač Audacity %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Zesílení"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Síla tónu"
 
@@ -2962,17 +3086,23 @@ msgid "Musical Instrument"
 msgstr "Hudební nástroj"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Vyvážení"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Ztlumit"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Sólo"
 
@@ -2980,15 +3110,18 @@ msgstr "Sólo"
 msgid "Signal Level Meter"
 msgstr "Měřič úrovně signálu"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Ovládání hlasitosti posunuto"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Posuvník rychlosti přesunut"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Ovládání vyvážení (panorama) posunuto"
 
@@ -3023,9 +3156,9 @@ msgstr ""
 "Nebude nahrán."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3059,16 +3192,19 @@ msgstr ""
 "\n"
 "Používejte pouze moduly z důvěryhodných zdrojů"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Ano"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ne"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Nahrávač modulů Audacity"
 
 #: src/ModuleManager.cpp
@@ -3094,8 +3230,113 @@ msgstr "Notová stopa"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "B"
 msgstr "H"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3206,7 +3447,8 @@ msgstr "&Vybrat vše"
 msgid "C&lear All"
 msgstr "V&yprázdnit vše"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Povolit"
 
@@ -3286,9 +3528,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Neodpovídající vzorkovací kmitočty"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Pro nahrávání při tomto vzorkovacím kmitočtu je vybráno příliš málo stop.\n"
@@ -3316,10 +3559,11 @@ msgid "Dropouts"
 msgstr "Výpadky"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3359,11 +3603,11 @@ msgid "Inspecting project file data"
 msgstr "Kontrola dat souboru projektu"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3406,11 +3650,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Varování - Chybějící přiřazený soubor(y)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Kontrola projektu \"%s\" složka \n"
@@ -3435,12 +3679,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Varování - Chybějící přiřazený souhrnný soubor(y)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3499,7 +3743,8 @@ msgstr "Varování - osiřelý blok souboru(ů)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Postup"
 
@@ -3524,6 +3769,11 @@ msgstr "Varování: Problémy při automatickém zotavení"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<bez názvu>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3580,13 +3830,22 @@ msgstr ""
 "\n"
 "%s"
 
+#. i18n-hint: An error message.
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Toto není soubor s projektem Audacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3596,6 +3855,67 @@ msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Nelze inicializovat soubor s projektem"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nelze inicializovat soubor s projektem"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nelze inicializovat soubor s projektem"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nelze inicializovat soubor s projektem"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nelze inicializovat soubor s projektem"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nelze inicializovat soubor s projektem"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nelze inicializovat soubor s projektem"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Nelze inicializovat soubor s projektem"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3650,9 +3970,9 @@ msgid "Error Writing to File"
 msgstr "Chyba při zapisování do souboru"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3666,9 +3986,16 @@ msgstr "Sceluje se projekt"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekt %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Síla tónu"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3677,10 +4004,10 @@ msgstr "(Obnoveno)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Tento soubor byl uložen Audacity %s.\n"
 "Používáte Audacity %s. Pro otevření tohoto souboru bude třeba, abyste program povýšil na novější verzi."
@@ -3752,8 +4079,9 @@ msgid "Backing up project"
 msgstr "Zálohování projektu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3762,8 +4090,9 @@ msgstr ""
 "Byl obnoven ve stavu pořízení posledního snímku."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3843,8 +4172,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sUložit projekt %s\" jako..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "Uložit projekt je určeno pro uložení projektu Audacity, ne pro\n"
@@ -3922,11 +4252,12 @@ msgid "Error Opening Project"
 msgstr "Chyba při otevírání projektu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Pokoušíte se otevřít automaticky vytvořený zajišťovací soubor se zálohou.\n"
 "To může vést až k vážné ztrátě dat.\n"
@@ -4034,8 +4365,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatické zálohování databáze selhalo."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Vítejte v Audacity verze %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4252,7 +4583,8 @@ msgstr "Všechna nastavení"
 msgid "SelectionBar"
 msgstr "Panel výběru (zobrazení času)"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Výběr spektra"
 
@@ -4260,46 +4592,55 @@ msgstr "Výběr spektra"
 msgid "Timer"
 msgstr "Časovač"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Nástroje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Pohyb"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Směšovač"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Měřič"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Hladina přehrávání"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Hladina nahrávání"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Úpravy"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Zařízení"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Přehrát nastavenou rychlostí"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Přehrávat proměnlivou rychlostí"
 
@@ -4314,7 +4655,10 @@ msgstr "Pravítko"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Stopy"
 
@@ -4424,7 +4768,8 @@ msgid "Activation level (dB):"
 msgstr "Úroveň spuštění (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Vítejte v Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4571,9 +4916,9 @@ msgstr ""
 "Rady, jak uvolnit místo, zobrazíte klepnutím na tlačítko nápovědy."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity se nepodařilo zapsat soubor:\n"
@@ -4593,9 +4938,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4604,9 +4949,9 @@ msgstr ""
 "pro čtení."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity se nepodařilo zapsat obrázky do souboru:\n"
@@ -4623,9 +4968,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4635,9 +4980,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4646,8 +4991,9 @@ msgstr ""
 "Pravděpodobně špatný formát PNG?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity se nepodařilo přečíst vlastní výchozí téma.\n"
@@ -4685,9 +5031,9 @@ msgstr ""
 "již byly přítomny. Přepsat?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity se nepodařilo uložit soubor:\n"
@@ -4726,7 +5072,11 @@ msgstr "Vlastní"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Doba trvání"
 
@@ -4737,7 +5087,8 @@ msgid "Time Track"
 msgstr "Doba trvání stopy"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Časované nahrávání Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4811,7 +5162,8 @@ msgstr "Nynější projekt"
 msgid "Recording start:"
 msgstr "Začátek nahrávání:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Doba trvání:"
 
@@ -4832,7 +5184,8 @@ msgid "Action after Timer Recording:"
 msgstr "Činnost po časovaném nahrávání:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Postup časovaného nahrávání Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4913,6 +5266,12 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Časované nahrávání"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 dní 024 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -4923,6 +5282,7 @@ msgstr "099 dní 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Datum a čas začátku"
@@ -4967,7 +5327,8 @@ msgstr "Povolit &automatické ukládání v jiném formátu?"
 msgid "Export Project As:"
 msgstr "Uložit projekt v jiném formátu jako:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Volby"
 
@@ -4980,7 +5341,8 @@ msgid "Do nothing"
 msgstr "Nedělat nic"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Ukončit Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5004,7 +5366,8 @@ msgid "Scheduled to stop at:"
 msgstr "Naplánované zastavení v:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Časované nahrávání Audacity - Čeká se na začátek"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5030,7 +5393,8 @@ msgid "Recording Exported:"
 msgstr "Nahrávání uloženo v jiném formátu:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Časované nahrávání Audacity - Čeká se"
 
 #: src/TrackInfo.cpp
@@ -5226,6 +5590,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Používá se %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "SELHÁNÍ"
@@ -5244,13 +5618,15 @@ msgstr "%s není parametr přijatý %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Neplatná hodnota pro parametr '%s': má být %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Příkaz"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Zopakovat %s"
@@ -5303,6 +5679,11 @@ msgstr "Provede ukázkovou činnost."
 #: src/commands/DragCommand.cpp
 msgid "Drag"
 msgstr "Táhnout"
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Panel"
+msgstr "Oblast stopy"
 
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
@@ -5373,13 +5754,24 @@ msgstr "Klipy"
 msgid "Envelopes"
 msgstr "Obálky"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Štítky"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Okénka"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5389,7 +5781,8 @@ msgstr "Krátký"
 msgid "Type:"
 msgstr "Typ:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formát:"
 
@@ -5416,6 +5809,10 @@ msgstr "Poznámka"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Příkaz:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5453,17 +5850,26 @@ msgstr "Uloží v jiném formátu do souboru."
 msgid "Builtin Commands"
 msgstr "Vestavěné příkazy"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tým Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Poskytuje Audacity vestavěné příkazy"
 
 #: src/commands/LoadCommands.cpp
 msgid "Unknown built-in command name"
 msgstr "Neznámý název vestavěného příkazu"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -5517,7 +5923,10 @@ msgstr "Vyprázdní obsah zápisu."
 msgid "Get Preference"
 msgstr "Získat nastavení"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Název:"
 
@@ -5565,7 +5974,8 @@ msgstr "Na celou obrazovku"
 msgid "Toolbars"
 msgstr "Nástrojové panely"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efekty"
 
@@ -5705,7 +6115,8 @@ msgstr "Nastavit"
 msgid "Add"
 msgstr "Přidat"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Odstranit"
 
@@ -5790,7 +6201,8 @@ msgid "Edited Envelope"
 msgstr "Nastavit obálku"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Obálka"
 
@@ -5833,6 +6245,14 @@ msgstr "Kmitočet:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Změnit velikost:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5882,7 +6302,10 @@ msgstr "Vyvážení:"
 msgid "Set Track Visuals"
 msgstr "Nastavit podobu stopy"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineární"
 
@@ -5925,6 +6348,12 @@ msgstr "Použít nastavení spektra"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Výběr spektra"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5980,12 +6409,18 @@ msgstr "Je vybrána stopa, která neobsahuje zvuková data. Automatické zeslabe
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Automatické zeslabení vyžaduje řídící stopu, která musí být umístěna pod vybranou stopou (stopami)."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "&Míra zeslabení:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekund"
 
@@ -6009,7 +6444,8 @@ msgstr "Délka vnitřního postupného &ztišení:"
 msgid "Inner &fade up length:"
 msgstr "Délka vnitřního postupného &zesílení:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Prahová hodnota:"
 
@@ -6147,11 +6583,13 @@ msgstr "do (Hz)"
 msgid "t&o"
 msgstr "d&o"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "&Změna v procentech:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Změna vyjádřená v procentech"
 
@@ -6163,9 +6601,19 @@ msgstr "&Použít vysoce jakostní protažení (pomalé)"
 msgid "33⅓"
 msgstr "33 ⅓"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "nedostupné"
 
@@ -6193,6 +6641,7 @@ msgstr "Otáček gramofonové desky za minutu:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Z otáček za minutu"
@@ -6205,6 +6654,7 @@ msgstr "&od"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Na otáčky za minutu"
@@ -6347,6 +6797,12 @@ msgstr "Kompresor"
 msgid "Compresses the dynamic range of audio"
 msgstr "Zkomprimuje dynamický rozsah zvuku"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6356,6 +6812,20 @@ msgstr "%.2f sek."
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f sek."
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6472,7 +6942,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analyzátor kontrastu pro měření rozdílů v hlasitosti RMS mezi dvěma vybranými oblastmi jedné stopy."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Konec"
 
@@ -6537,6 +7008,12 @@ msgstr "&Nápověda"
 #, c-format
 msgid "RMS = %s."
 msgstr "Efektivní hodnota = %s."
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "zero"
@@ -6606,6 +7083,12 @@ msgstr "Nynější rozdíl"
 msgid "Measured foreground level"
 msgstr "Změřená úroveň popředí"
 
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB efektivní hodnota"
+
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
 msgstr "Žádné popředí nebylo změřeno"
@@ -6673,6 +7156,12 @@ msgstr "Success-Kriterien 1.4.7 od WCAG 2.0: Neúspěch"
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
 msgstr "Data přečtena"
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
@@ -6952,7 +7441,9 @@ msgstr "&Sekvence DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Rozkmit (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Doba trvání:"
 
@@ -6965,18 +7456,41 @@ msgid "Duty cycle:"
 msgstr "Provádění úloh:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f sek."
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Doba trvání tónu:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Doba trvání ticha:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
+
+#: src/effects/Echo.cpp
+#, fuzzy
+msgid "Echo"
+msgstr "Ozvěna..."
+
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Opakuje vybraný zvuk znovu a znovu"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Požadovaná hodnota překračuje možnosti paměti"
 
@@ -7000,7 +7514,8 @@ msgstr "Přednastavení"
 msgid "Export Effect Parameters"
 msgstr "Vyvést parametry efektu"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Nelze otevřít soubor: \"%s\""
@@ -7037,6 +7552,15 @@ msgstr "Připravuje se náhled"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Náhled"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Chyba v Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7319,6 +7843,11 @@ msgstr "Zastavit &přehrávání"
 msgid "Play"
 msgstr "Přehrát"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Kosinová"
@@ -7364,6 +7893,10 @@ msgid "Low rolloff for speech"
 msgstr "Tiché drčení pro řeč"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefon"
 
@@ -7398,6 +7931,43 @@ msgstr "Vzorkovací kmitočet stopy je pro tento efekt příliš nízký."
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Efekt není dostupný"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7472,8 +8042,16 @@ msgid "D&efault"
 msgstr "&Výchozí"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &závitový"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7718,7 +8296,8 @@ msgid "Builtin Effects"
 msgstr "Vestavěné efekty"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Poskytuje Audacity vestavěné efekty"
 
 #: src/effects/LoadEffects.cpp
@@ -7728,6 +8307,10 @@ msgstr "Neznámý název vestavěného efektu"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Pozorovaná hlasitost"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7759,6 +8342,14 @@ msgstr "&Normalizovat"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Hlasitost LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7828,7 +8419,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (výchozí)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, žádný"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, žádný"
 
 #: src/effects/NoiseReduction.cpp
@@ -7928,8 +8528,9 @@ msgid "Step 1"
 msgstr "Krok 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Vyberte několik sekund samotného šumu, aby Audacity věděla,\n"
@@ -7979,13 +8580,62 @@ msgstr "&Typy &okna:"
 msgid "Window si&ze:"
 msgstr "&Velikost okna:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (výchozí)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Kroků na okno:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8111,6 +8761,7 @@ msgstr "Program Paulstretch je jen na mimořádné protažení času nebo zpomal
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Faktor &protažení:"
@@ -8553,6 +9204,11 @@ msgstr "Použít výchozí nastavení"
 msgid "Restore Defaults"
 msgstr "Obnovit výchozí nastavení"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8711,6 +9367,10 @@ msgstr "Zjistit ticho"
 msgid "Tr&uncate to:"
 msgstr "&Zkrátit na:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "&Komprimovat na:"
@@ -8724,7 +9384,8 @@ msgid "VST Effects"
 msgstr "Efekty VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Přidá schopnost použít efekty VST v Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8736,7 +9397,8 @@ msgstr "Prohledává se shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Zaznamenání %d z %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Nepodařilo se nahrát knihovnu"
 
@@ -8756,7 +9418,8 @@ msgstr "Velikost vyrovnávací paměti řídí počet vzorků poslaných efektu 
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Velikost vyrovnávací paměti (8 až 1048576 vzorků):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Vyrovnávání prodlevy"
 
@@ -8764,7 +9427,8 @@ msgstr "Vyrovnávání prodlevy"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Jako část jejich zpracování některé efekty VST musí zpozdit vrácení zvuku do Audacity. Pokud toto zpoždění nebude vyrovnáno, povšimnete si vloženímalých tich do zvuku. Povolení této volby toto vyrovnání poskytne, nemusí však pracovat pro všechny efekty VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Povolit &vyrovnávání"
 
@@ -8798,7 +9462,8 @@ msgid "Standard VST program file"
 msgstr "Standardní soubor programu VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Soubor Audacity s přednastavením VST"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8825,7 +9490,8 @@ msgstr "Chyba při nahrávání přednastavení VST"
 msgid "Unable to load presets file."
 msgstr "Nelze nahrát soubor s přednastaveními."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Nastavení efektu"
 
@@ -8841,6 +9507,12 @@ msgstr "Nelze přečíst soubor s přednastaveními."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Tento parametrický soubor byl uložen z %s. Pokračovat?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -8876,7 +9548,8 @@ msgid "Audio Unit Effects"
 msgstr "Efekty Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Poskytuje Audacity podporu pro efekty Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8892,7 +9565,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Volby pro efekty Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Jako část jejich zpracování některé efekty Audio Unit musí zpozdit vrácení zvuku do Audacity. Pokud toto zpoždění nebude vyrovnáno, povšimnete si vloženímalých tich do zvuku. Povolení této volby toto vyrovnání poskytne, nemusí však pracovat pro všechny efekty Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9028,8 +9702,16 @@ msgstr "Nepodařilo se vytvořit seznam vlastností pro přednastavení"
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "Nepodařilo se nastavit informace o třídě pro \"%s\" přednastavení"
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efekty LADSPA"
@@ -9039,7 +9721,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Poskytuje efekty LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity nadále nepoužívá vst-most"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9047,12 +9730,30 @@ msgid "LADSPA Effect Options"
 msgstr "Volby pro efekty LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Jako část jejich zpracování některé efekty LADSPA musí zpozdit vrácení zvuku do Audacity. Pokud toto zpoždění nebude vyrovnáno, povšimnete si vloženímalých tich do zvuku. Povolení této volby toto vyrovnání poskytne, nemusí však pracovat pro všechny efekty LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s v:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Výstup efektu"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Efekty LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9064,7 +9765,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Velikost vyrovnávací paměti (8 až %d) vzorků:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Jako část jejich zpracování některé efekty LV2 musí zpozdit vrácení zvuku do Audacity. Pokud toto zpoždění nebude vyrovnáno, povšimnete si vloženímalých tich do zvuku. Povolení této volby toto vyrovnání poskytne, nemusí však pracovat pro všechny efekty LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9089,12 +9791,19 @@ msgstr "%s vyžaduje nepodporovanou volbu %s\n"
 msgid "Generator"
 msgstr "Tvůrce"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efekty LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Poskytuje Audacity podporu pro efekty LV2"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9102,7 +9811,8 @@ msgid "Nyquist Effects"
 msgstr "Efekty Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Poskytuje Audacity podporu pro efekty Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9117,6 +9827,12 @@ msgstr "Pracovník Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Vadná hlavička přídavného modulu Nyquist"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -9322,7 +10038,8 @@ msgstr "Vybrat soubor"
 msgid "Save file as"
 msgstr "Uložit soubor jako"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "Bez názvu"
 
@@ -9331,7 +10048,8 @@ msgid "Vamp Effects"
 msgstr "Efekty Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Poskytuje Audacity podporu pro efekty Vamp"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9349,6 +10067,17 @@ msgstr "Promiňte, ale přídavný modul Vamp nelze inicializovat."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Nastavení přídavného modulu"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9507,6 +10236,10 @@ msgid "Command Output"
 msgstr "Výstup příkazu"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "Vybral jste název souboru bez přípony. Jste si jistý?"
 
@@ -9645,7 +10378,8 @@ msgstr "Zvuk se ukládá jako %s"
 msgid "Invalid sample rate"
 msgstr "Neplatný vzorkovací kmitočet"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Převzorkovat"
 
@@ -9673,7 +10407,8 @@ msgstr "Vzorkovací kmitočty"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kb/s"
@@ -9693,12 +10428,52 @@ msgid "%.2f kbps"
 msgstr "%.2f kb/s"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Na"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Constrained"
 msgstr "Omezeno"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -9711,6 +10486,27 @@ msgstr "Nepatrné zpoždění"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9795,6 +10591,11 @@ msgstr "Přednastavení '%s' neexistuje."
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "Nahradit přednastavení '%s'?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "D-S"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
@@ -9910,6 +10711,10 @@ msgstr "Jazyk:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Byte Reservoir"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10046,6 +10851,11 @@ msgstr ""
 "max - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LTP (komprese zvuku)"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -10076,6 +10886,10 @@ msgstr ""
 "max - 32 (s LPC) nebo 4 (bez LPC)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal prediction order\n"
 "Optional\n"
@@ -10088,6 +10902,10 @@ msgstr ""
 "-1 - standardní\n"
 "min - 0\n"
 "max - 32 (s LPC) nebo 4 (bez LPC)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10104,6 +10922,10 @@ msgstr ""
 "max - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal partition order\n"
 "Optional\n"
@@ -10116,6 +10938,10 @@ msgstr ""
 "-1 - standardní\n"
 "min - 0\n"
 "max - 8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
 
 #. i18n-hint:  Abbreviates "Linear Predictive Coding",
 #. but this text needs to be kept very short
@@ -10206,6 +11032,16 @@ msgstr "Nepodařilo se uhádnout formát"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to find the codec"
 msgstr "Nepodařilo se najít kodek"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16 bitů DWVW"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "24 bitů DWVW"
 
 #: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
@@ -10337,7 +11173,8 @@ msgstr "Skvělý"
 msgid "Extreme"
 msgstr "Mimořádný"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standardní"
 
@@ -10362,6 +11199,11 @@ msgid "Joint Stereo"
 msgstr "Společné stereo"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Vytvořit stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Režim datového toku:"
 
@@ -10384,8 +11226,8 @@ msgid "Locate LAME"
 msgstr "Hledat LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "K vytvoření formátu MP3 Audacity potřebuje soubor %s ."
 
 #: src/export/ExportMP3.cpp
@@ -10413,10 +11255,10 @@ msgid "Where is %s?"
 msgstr "Kde je %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Chcete nastavit lame_enc.dll v%d.%d. Tato verze ale není slučitelná s Audacity %d.%d.%d.\n"
 "Stáhněte, prosím, poslední verzi knihovny LAME pro Audacity."
@@ -10722,6 +11564,15 @@ msgstr "Vybraná zvuková data se ukládají jako Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Zvuk se ukládá jako Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft) 16 bitů PCM"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Hlavička:"
@@ -10735,9 +11586,10 @@ msgid "Other uncompressed files"
 msgstr "Jiné nekomprimované soubory"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Pokusil jste se uložit soubor WAV nebo AIFF, který by byl větší než 4GB.\n"
 "Audacity toto nedokáže, od uložení bylo upuštěno."
@@ -10747,8 +11599,9 @@ msgid "Error Exporting"
 msgstr "Chyba při ukládání"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Uložený soubor WAV byl zkrácen, protože Audacity neumí uložit soubory WAV\n"
@@ -10788,11 +11641,11 @@ msgid "All supported files"
 msgstr "Všechny podporované soubory"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10801,11 +11654,11 @@ msgstr ""
 "klepnutím na Soubor → Nahrát → MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "ne zvukový soubor.\n"
@@ -10816,18 +11669,18 @@ msgid "Select stream(s) to import"
 msgstr "Vyberte proud(y) k nahrání"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Tato verze Audacity nebyla sestavena s podporou %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvuková stopa CD. \n"
 "Audacity tyto stopy nedokáže  přímo otevřít. \n"
@@ -10836,10 +11689,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\"  je seznam souborů k přehrávání (seznam skladeb).\n"
@@ -10848,10 +11701,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvukový soubor Windows Media. \n"
@@ -10860,10 +11713,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je soubor AAC (Advanced Audio Coding). \n"
@@ -10872,12 +11725,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zakódovaný zvukový soubor, pravděpodobně z internetového obchodu s hudbou. \n"
@@ -10887,10 +11740,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je soubor pro RealPlayer. \n"
@@ -10899,12 +11752,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" je soubor obsahující noty, nikoliv zvuková data. \n"
 "Audacity tento typ souboru neumí otevřít. \n"
@@ -10913,10 +11766,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10929,10 +11782,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvukový soubor Wavpack. \n"
@@ -10941,10 +11794,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvukový soubor Dolby Digital. \n"
@@ -10953,10 +11806,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvukový soubor Ogg Speex. \n"
@@ -10965,10 +11818,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je video soubor. \n"
@@ -10982,9 +11835,9 @@ msgstr "Soubor \"%s\" nalezen."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11000,11 +11853,16 @@ msgstr ""
 "Zkuste nainstalovat FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, zkoušeč"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11034,12 +11892,13 @@ msgid "Import Project"
 msgstr "Zavést projekt"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Tento projekt byl uložen Audacity verze 1.0 nebo starší. Formát se\n"
 "změnil a tato verze Audacity projekt nedokáže zavést.\n"
@@ -11090,7 +11949,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Nepodařilo se najít složku s daty projektu: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "V souboru projektu byly nalezeny stopy MIDI, ale toto sestavení Audacitynezahrnuje podporu MIDI, proto se stopa obejde."
 
 #: src/import/ImportAUP.cpp
@@ -11195,40 +12055,6 @@ msgstr "Index[%02x] Kodek[%s], Jazyk[%s], Datový tok[%s], Kanály[%d], Doba trv
 msgid "FLAC files"
 msgstr "Soubory FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "S GStreamer kompatibilní soubory"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Do komunikačního spojení nelze přidat dekodér"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Zavaděč GStreameru"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Nelze nastavit stav proudu na pozastaveno."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index [%02d], Typ [%s], Kanály [%d], Vzorkovací kmitočet [%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Soubor neobsahuje žádné zvukové proudy."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Nelze nahrát soubor. Nepodařila se změna stavu."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Chyba Gstreameru: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Seznam souborů ve formátu prostého textu"
@@ -11331,6 +12157,14 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, a další nekomprimované typy"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "CAF (Apple Core Audio File)"
 msgstr "CAF (Apple Core zvukový soubor)"
 
@@ -11340,12 +12174,81 @@ msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (FLAC bezztrátový zvukový kodek)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG kontejnerový formát)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (bez hlavičky)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAVEX (Microsoft)"
+msgstr "WAV (Microsoft) 16 bitů PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11376,6 +12279,26 @@ msgid "64 bit float"
 msgstr "64 bitů pohyblivá řádová čárka"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "32kbs G721 ADPCM"
 msgstr "32 kB/s G721 ADPCM"
 
@@ -11396,12 +12319,20 @@ msgid "24 bit DWVW"
 msgstr "24 bitů DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16 bitů DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8 bitů DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11536,6 +12467,7 @@ msgstr "%s vpravo"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11560,6 +12492,7 @@ msgstr "Konec"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11588,7 +12521,8 @@ msgstr "Časově posunuté klipy doprava"
 msgid "Time shifted clips to the left"
 msgstr "Časově posunuté klipy doleva"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Časový posun"
 
@@ -11726,7 +12660,8 @@ msgstr "Oříznout vybrané zvukové stopy od %.2f sekund %.2f sekund"
 msgid "Trim Audio"
 msgstr "Oříznout zvuk"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Rozdělit"
 
@@ -11849,34 +12784,6 @@ msgstr "Klávesa pro mazání Delete &2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "&Navíc"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "S&měšovač"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Přizpůs&obit hlasitost přehrávání..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Zvýšit hlasitost přehrávání"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Snížit hlasitost přehrávání"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "&Přizpůsobit hlasitost nahrávání..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Z&výšit hlasitost nahrávání"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "S&nížit hlasitost nahrávání"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12052,6 +12959,11 @@ msgid "&Labels..."
 msgstr "&Štítky..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Uložit jako &MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Původní data..."
 
@@ -12140,8 +13052,9 @@ msgid "&Getting Started"
 msgstr "P&rvní kroky"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Příručka k Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Příručka..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12167,11 +13080,8 @@ msgstr "Informace o zařízení &MIDI..."
 msgid "Show &Log..."
 msgstr "Zobrazit &zápis..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&O programu Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Štítek přidán"
 
@@ -12419,6 +13329,11 @@ msgstr "Přepínat mezi v&ybranými stopami"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Bez kategorie"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Nový..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12857,6 +13772,7 @@ msgstr "Dlouhý sk&ok ukazatelem doprava"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Hledat"
@@ -13068,18 +13984,21 @@ msgid "Created new label track"
 msgstr "Vytvořena nová popisová stopa"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Tato verze Audacity umožňuje pouze jednorázovou stopu pro každé okno projektu."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Vytvořena nová časová stopa"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nový vzorkovací kmitočet (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Vložená hodnota je neplatná"
 
@@ -13336,7 +14255,9 @@ msgstr "Přehrává se"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Nahrávání"
 
@@ -13485,10 +14406,6 @@ msgstr "Při nahrávání hrají &jiné stopy (zapnout/vypnout)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Nahrávku současně &přehrávat (zapnuto/vypnuto)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomatické přizpůsobení úrovně nahrávání zvuku (zapnuto/vypnuto)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13704,7 +14621,7 @@ msgstr "Nastavení kvality"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Ukončit Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13751,7 +14668,8 @@ msgstr "&Hostitelský počítač:"
 msgid "Using:"
 msgstr "Používá:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Přehrávání"
 
@@ -13771,7 +14689,8 @@ msgstr "&Kanály:"
 msgid "Latency"
 msgstr "Prodleva"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisekund"
 
@@ -13791,8 +14710,19 @@ msgstr "Žádná zvuková zařízení"
 msgid "No devices found"
 msgstr "Nenalezena žádná zařízení"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 kanál (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 kanály (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Adresáře"
 
@@ -13900,7 +14830,8 @@ msgid "Directory %s is not writable"
 msgstr "Do adresáře %s nelze zapisovat"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Změna dočasného adresáře se projeví až po opětovném spuštění Audacity."
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13931,6 +14862,40 @@ msgstr "Seskupeno podle vydavatele"
 msgid "Grouped by Type"
 msgstr "Seskupeno podle typu"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Chyba v Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Povolit efekty"
@@ -13952,11 +14917,13 @@ msgid "Plugin Options"
 msgstr "Volby pro přídavné moduly"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Při spuštění Audacity se podívat po aktualizovaných přídavných modulech"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Prohledat znovu přídavné moduly při příštím spuštění Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14136,13 +15103,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "&Zachovat štítky, když výběr zapadne k štítku"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Smísit systémový vzhled a vzhled Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Použít většinou rozvržení zleva doprava v jazycích RTL"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -14310,7 +15282,8 @@ msgstr ""
 "   *   \"%s\"  (protože klávesová zkratka '%s' je používána \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Zvolte XML soubor obsahující klávesové zkratky pro Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14442,8 +15415,9 @@ msgid "Dow&nload"
 msgstr "&Stahování"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity nalezla vhodné knihovny FFmpeg automaticky.\n"
@@ -14502,8 +15476,9 @@ msgid "Preferences for Module"
 msgstr "Nastavení modulu"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Tyto jsou pokusné moduly. Povolte je jen tehdy, pokud jste si přečetli příručku k Audacity,\n"
@@ -14511,12 +15486,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  Ptát se znamená, že Audacity se zeptá, zda chcete modul nahrát, pokaždé když je program spuštěn."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  Nepodařilo se, znamená, že Audacity si myslí, že modul je poškozen, a nespustí jej."
 
 #. i18n-hint preserve the leading spaces
@@ -14525,7 +15502,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  Nový znamená, že ještě nebyla učiněna žádná volba."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Změna těchto nastavení se projeví až po opětovném spuštění Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14543,6 +15521,10 @@ msgstr "Nebyly nalezeny žádné moduly"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modul"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14584,7 +15566,10 @@ msgstr "Klepnutí levým tlačítkem myši+tažení"
 msgid "Set Selection Range"
 msgstr "Nastavit rozsah výběru"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift+levé tlačítko myši"
 
@@ -14672,6 +15657,15 @@ msgstr "-Klepnutí levým tlačítkem myši+tažení"
 msgid "Move clip up/down between tracks"
 msgstr "Přesunout klip nahoru nebo dolů mezi stopami"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Klepnutí levým tlačítkem myši+tažení"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14700,6 +15694,11 @@ msgstr "Posunout několik vzorků"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Posunout jen JEDEN vzorek"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Víceúčelový nástroj"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14791,7 +15790,8 @@ msgid "Always scrub un&pinned"
 msgstr "Vždy přehrávat proměnlivou rychlostí &odšpendlené"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Nastavení Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14805,6 +15805,11 @@ msgstr "Nastavení:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Nastavení kvality"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14924,39 +15929,6 @@ msgid "System T&ime"
 msgstr "Systémový č&as"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatické přizpůsobení nahrávací úrovně zvuku"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Povolit automatické přizpůsobení nahrávací úrovně zvuku."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Nejvyšší hodnota cíle:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "V průběhu:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Čas rozboru:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisekund (čas rozboru)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Počet probíhajících rozborů:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 (nekonečný)"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Úrovní zvuku řízené nahrávání"
 
@@ -14968,10 +15940,20 @@ msgstr "Zaváděcí část &pásky:"
 msgid "Cross&fade:"
 msgstr "Pro&línání:"
 
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
 #. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Bark"
 msgstr "Štěknutí"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15106,6 +16088,10 @@ msgid "1024 - default"
 msgstr "1024 - výchozí"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - nejužší pásmo"
 
@@ -15203,13 +16189,14 @@ msgid "Info"
 msgstr "Informace"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15392,7 +16379,8 @@ msgstr "Vzorky"
 msgid "4 Pixels per Sample"
 msgstr "4 pixely na vzorek"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Největší zvětšení"
 
@@ -15514,16 +16502,24 @@ msgid "Stopped"
 msgstr "Zastaveno"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pozastavit"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Přeskočit na začátek"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Přeskočit na konec"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pozastavit"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Výběr po začátek"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Vybrat po konec"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15537,20 +16533,17 @@ msgstr "Nahrát novou stopu"
 msgid "Append Record"
 msgstr "Připojit nahrávání"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Vybrat po konec"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Výběr po začátek"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s Pozastaveno."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15630,11 +16623,17 @@ msgstr "Přeměnit vybraný zvuk na ticho"
 msgid "Sync-Lock Tracks"
 msgstr "Při zpracování (přesun, vložení) držet synchronně"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Přiblížit"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Oddálit"
 
@@ -15701,43 +16700,6 @@ msgstr "Měřicí panel hladiny &nahrávání"
 msgid "&Playback Meter Toolbar"
 msgstr "Měřicí panel hladiny &přehrávání"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Hlasitost nahrávání"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Hlasitost přehrávání"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Nahrávací hlasitost: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Nahrávací hlasitost (není dostupná; použijte systémový směšovač)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Hlasitost přehrávání: %.2f (napodobená)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Hlasitost přehrávání: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Hlasitost přehrávání (není dostupná; použijte systémový směšovač)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Panel směš&ování"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Přehrávat normální rychlostí s přeskakováním"
@@ -15753,6 +16715,7 @@ msgstr "Přehrávání proměnlivou rychlostí"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Zastavit přehrávání proměnlivou rychlostí"
@@ -15760,6 +16723,7 @@ msgstr "Zastavit přehrávání proměnlivou rychlostí"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Spustit přehrávání proměnlivou rychlostí"
@@ -15767,6 +16731,7 @@ msgstr "Spustit přehrávání proměnlivou rychlostí"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Zastavit přehrávání normální rychlostí s přeskakováním"
@@ -15774,6 +16739,7 @@ msgstr "Zastavit přehrávání normální rychlostí s přeskakováním"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Spustit přehrávání normální rychlostí s přeskakováním"
@@ -15828,7 +16794,9 @@ msgstr "Přichytávat"
 msgid "Length"
 msgstr "Délka"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Střed"
 
@@ -15892,8 +16860,8 @@ msgstr "Panel č&asu"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %s panel nástrojů"
 
 #: src/toolbars/ToolBar.cpp
@@ -15920,7 +16888,8 @@ msgstr "Nástroj pro časový posun"
 msgid "Zoom Tool"
 msgstr "Nástroj lupa"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Nástroj pro kreslení"
 
@@ -15996,11 +16965,13 @@ msgstr "Přesunout jednu nebo více hranic oblastí."
 msgid "Drag label boundary."
 msgstr "Přesunout hranice oblastí."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Změněný štítek"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Upravit štítek"
 
@@ -16055,31 +17026,42 @@ msgstr "Upravené štítky"
 msgid "New label"
 msgstr "Nový štítek"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "O &oktávu výš"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "O ok&távu níž"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klepněte pro svislé přiblížení. Shift+klepnutí pro oddálení. Táhněte pro přiblížení oblasti."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Klepnutí pravým tlačítkem myši pro vyvolání nabídky."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Obnovit výchozí zvětšení"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift+klepnutí pravým tlačítkem myši"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Klepnutí levým tlačítkem myši/tažení"
 
@@ -16121,7 +17103,8 @@ msgstr "Spojit"
 msgid "Expanded Cut Line"
 msgstr "Rozšířená čára střihu"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Rozšířit"
 
@@ -16144,6 +17127,11 @@ msgstr "Přesunuté vzorky"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Upravit vzorek"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16189,7 +17177,8 @@ msgstr "Zpracovává se... %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Změněno '%s' na %s"
@@ -16201,6 +17190,54 @@ msgstr "Změnit formát"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Kmitočet"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16220,7 +17257,8 @@ msgstr "Změna vzorkovacího kmitočtu"
 msgid "Set Rate"
 msgstr "Nastavit vzorkovací kmitočet"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Vícepohled"
 
@@ -16239,6 +17277,10 @@ msgstr "&Rozdělit stereo stopu"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Rozdělit stereo na &monofonní stopy"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16308,14 +17350,23 @@ msgstr "Levý, %d Hz"
 msgid "Right, %dHz"
 msgstr "Pravý, %d Hz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%+.1f dB"
+msgstr "%.2f dB efektivní hodnota"
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% vlevo"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% vpravo"
@@ -16433,9 +17484,8 @@ msgstr "Logaritmická &interpolace"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klepněte a táhněte pro přesunutí zvukové stopy na časové ose"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16486,6 +17536,7 @@ msgstr "Upravená obalová křivka."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Přehrávat proměnlivou rychlostí"
@@ -16497,6 +17548,7 @@ msgstr "Přehrávání normální rychlostí s přeskakováním"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Pravítko pro přehrávání proměnlivou rychlostí"
@@ -16680,11 +17732,23 @@ msgstr "Stisknout"
 msgid "Button"
 msgstr "Tlačítko"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
 #. i18n-hint: One-letter abbreviation for Right, in the Pan slider
 #. i18n-hint: One-letter abbreviation for Right, in VU Meter
 #: src/widgets/ASlider.cpp src/widgets/Meter.cpp
 msgid "R"
 msgstr "P"
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
@@ -16719,9 +17783,19 @@ msgstr "Prázdný"
 msgid "Backwards"
 msgstr "Vzad"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Vpřed"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16850,6 +17924,29 @@ msgstr "Vyberte, prosím, činnost"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 sekund"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + vzorky"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 dnů 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -16865,11 +17962,35 @@ msgstr "0100 dnů 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh: mm: ss + setiny"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 snímků|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + millisekundy"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 snímků|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16891,6 +18012,7 @@ msgstr "0100 h 060 m 060 s+># vzorků"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "vzorky"
@@ -17056,6 +18178,20 @@ msgstr "010,01000 > 0100 Hz"
 msgid "centihertz"
 msgstr "Centihertz"
 
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000>01000 kHz|0.001"
+msgstr "010,01000 > 0100 Hz"
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hertz"
 msgstr "Hertz"
@@ -17124,6 +18260,11 @@ msgstr "(Pomocí související nabídky změnit formát.)"
 msgid "centiseconds"
 msgstr "Centisekundy"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Uplynulý čas:"
@@ -17166,6 +18307,11 @@ msgstr "Potvrdit zavření"
 msgid "Unable to write files to directory: %s."
 msgstr "Nelze přečíst přednastavení z \"%s\""
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17182,6 +18328,10 @@ msgstr "Nastavení adresářů"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Nezobrazovat toto varování znovu"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17232,6 +18382,11 @@ msgid "Value must not be greater than %s"
 msgstr "Hodnota nesmí být větší než %s"
 
 #: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Dialog"
+msgstr "Dialog souboru"
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Vybrat adresář"
 
@@ -17261,15 +18416,27 @@ msgstr "Nepodařilo se zpracovat XML"
 msgid "Spectral edit multi tool"
 msgstr "Zpracování spektra - vícefunkční nástroj"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtruje se..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Vydáno za podmínek GNU General Public License verze 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aVyberte, prosím, kmitočty."
@@ -17296,7 +18463,8 @@ msgstr ""
 "                      Zkuste zvýšit spodní kmitočtovou hranici~%~\n"
 "                      nebo zmenšete \"šířku\" filtru."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Chyba.~%"
@@ -17357,6 +18525,25 @@ msgstr "Studio postupné zeslabení signálu (do ztracena, Fade Out)"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Používá se prolínání..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Nastavit vý&chozí"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Vydáno za podmínek GNU General Public License verze 2 nebo novější."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17500,6 +18687,11 @@ msgstr "Vyhledávač dob"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Hledají se doby..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Zápis Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17824,13 +19016,39 @@ msgstr "Filtr horního pásma"
 msgid "Performing High-Pass Filter..."
 msgstr "Provádí se filtrování horního pásma..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Dominic Mazzoni"
+msgstr "Odstranění šumu od Dominika Mazzoniho"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Kmitočet (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Třpytit se (dB na oktávu)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17851,10 +19069,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Označit zvuky"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Vydáno za podmínek GNU General Public License verze 2 nebo novější."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17915,6 +19129,12 @@ msgstr "Největší ticho na konci"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Zvuk ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -18094,6 +19314,12 @@ msgstr ""
 "Vrchol založen na prvních ~a sekundách ~a dB~%\n"
 "Navržené nastavení prahové hodnoty ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Vroubkový filtr"
@@ -18142,7 +19368,8 @@ msgstr "Soubor Lisp"
 msgid "HTML file"
 msgstr "Soubory HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Textový soubor"
 
@@ -18219,6 +19446,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Hodnoty MIDI pro noty C: 36, 48, 60 [jednočárkované C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Zabrnkat výšku tónu MIDI"
 
@@ -18265,6 +19496,10 @@ msgstr "1 - 20 úderů/měření"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Hodnota swingu"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18335,6 +19570,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Výška tónu MIDI silné doby"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Výška tónu MIDI slabé doby"
 
@@ -18353,6 +19592,10 @@ msgstr "Rissetův buben"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Vytváří se Rissetův buben..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18455,6 +19698,11 @@ msgstr "Ukázat zprávy"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Jen chyby"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18723,6 +19971,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Chyba.~%Vzorkovací kmitočet pod 100 Hz není podporován."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Používá se tremolo..."
 
@@ -18749,6 +20001,10 @@ msgstr "Umenšení zpěvu a izolace"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Používá se činnost..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18891,8 +20147,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Tento přídavný modul pracuje jen se stereo stopami."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Zpracovává se Vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18934,6 +20198,212 @@ msgstr "Kmitočet jehel radaru (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Chyba.~%Požadována stopa sterea."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Aktualizovat Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Přeskočit"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Kanál"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Chyba při dekódování souboru"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Chyba při nahrávání popisných dat"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s panel nástrojů"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Nahrávání"
+
+#~ msgid "Commit Id:"
+#~ msgstr "ID zápisu (commit):"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Knihovna rozhraní pro více systémů"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Nahrát přes GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automatizované upravení úrovně nahrávání zastaveno. Nebylo možno ji více vyladit. Stále je příliš vysoká."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automatizované upravení úrovně nahrávání snížilo hlasitost na %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatizované upravení úrovně nahrávání zastaveno. Nebylo možno ji více vyladit. Stále je ještě nízká."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automatizované upravení úrovně nahrávání snížilo hlasitost na %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automatizované upravení úrovně nahrávání zastaveno. Celkový počet rozborů byl překročen bez nalezení přijatelného objemu. Stále je příliš vysoká."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automatizované upravení úrovně nahrávání zastaveno. Celkový počet rozborů byl překročen bez nalezení přijatelného objemu. Stále je příliš nízká."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatizované upravení úrovně nahrávání zastaveno. %.2f se zdá jako přijatelná hlasitost."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Při otevírání zařízení přijato %d\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Nelze otevřít směšovač přípojek\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Dostupné směšovače:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Dostupné zdroje nahrávání:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Dostupné hlasitosti přehrávání:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Hlasitost nahrávání je napodobena\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Hlasitost nahrávání je původní\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Hlasitost přehrávání je napodobena\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Hlasitost přehrávání je původní\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Datum a čas konce"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "S GStreamer kompatibilní soubory"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Do komunikačního spojení nelze přidat dekodér"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Zavaděč GStreameru"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Nelze nastavit stav proudu na pozastaveno."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index [%02d], Typ [%s], Kanály [%d], Vzorkovací kmitočet [%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Soubor neobsahuje žádné zvukové proudy."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Nelze nahrát soubor. Nepodařila se změna stavu."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Chyba Gstreameru: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "S&měšovač"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Přizpůs&obit hlasitost přehrávání..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Zvýšit hlasitost přehrávání"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Snížit hlasitost přehrávání"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "&Přizpůsobit hlasitost nahrávání..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Z&výšit hlasitost nahrávání"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "S&nížit hlasitost nahrávání"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Příručka k Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&O programu Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomatické přizpůsobení úrovně nahrávání zvuku (zapnuto/vypnuto)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatické přizpůsobení nahrávací úrovně zvuku"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Povolit automatické přizpůsobení nahrávací úrovně zvuku."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Nejvyšší hodnota cíle:"
+
+#~ msgid "Within:"
+#~ msgstr "V průběhu:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Čas rozboru:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisekund (čas rozboru)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Počet probíhajících rozborů:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 (nekonečný)"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Hlasitost nahrávání"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Hlasitost přehrávání"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Nahrávací hlasitost: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Nahrávací hlasitost (není dostupná; použijte systémový směšovač)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Hlasitost přehrávání: %.2f (napodobená)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Hlasitost přehrávání: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Hlasitost přehrávání (není dostupná; použijte systémový směšovač)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Panel směš&ování"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klepněte a táhněte pro přesunutí zvukové stopy na časové ose"
 
 #~ msgid "Program build date:"
 #~ msgstr "Datum sestavení programu:"
@@ -19773,9 +21243,6 @@ msgstr "Chyba.~%Požadována stopa sterea."
 #~ msgid "AIFF (Apple) signed 16-bit PCM"
 #~ msgstr "AIFF (Apple) 16 bitů PCM"
 
-#~ msgid "WAV (Microsoft) signed 16-bit PCM"
-#~ msgstr "WAV (Microsoft) 16 bitů PCM"
-
 #~ msgid "WAV (Microsoft) signed 24-bit PCM"
 #~ msgstr "WAV (Microsoft) se znaménkem 24 bit PCM"
 
@@ -19891,9 +21358,6 @@ msgstr "Chyba.~%Požadována stopa sterea."
 
 #~ msgid "false"
 #~ msgstr "nepravdivý"
-
-#~ msgid "AudioUnit"
-#~ msgstr "Audio Unit"
 
 #~ msgid "Nyquist Effects Prompt"
 #~ msgstr "Výzva k zadání efektů Nyquist"
@@ -20217,9 +21681,6 @@ msgstr "Chyba.~%Požadována stopa sterea."
 #~ msgid "L-E"
 #~ msgstr "D-K"
 
-#~ msgid "L-C"
-#~ msgstr "D-S"
-
 #~ msgid "Show start time and end time"
 #~ msgstr "Ukázat čas začátku a čas konce"
 
@@ -20447,9 +21908,6 @@ msgstr "Chyba.~%Požadována stopa sterea."
 
 #~ msgid "Offset"
 #~ msgstr "Posun"
-
-#~ msgid "Version"
-#~ msgstr "Verze"
 
 #~ msgid "C&ategory:"
 #~ msgstr "&Skupina:"
@@ -21114,9 +22572,6 @@ msgstr "Chyba.~%Požadována stopa sterea."
 
 #~ msgid "Applied effect: %s delay = %f seconds, decay factor = %f"
 #~ msgstr "Použitý efekt: %s zpoždění = %f vteřin,  faktor doběhu (dozvuku) = %f"
-
-#~ msgid "Echo..."
-#~ msgstr "Ozvěna..."
 
 #~ msgid "Performing Echo"
 #~ msgstr "Provedení ozvěny"
@@ -21797,9 +23252,6 @@ msgstr "Chyba.~%Požadována stopa sterea."
 
 #~ msgid "Noise Threshold (Hiss/Hum/Ambient Noise)"
 #~ msgstr "Práh šumu (sykot/hukot/šum prostředí)"
-
-#~ msgid "Noise Removal by Dominic Mazzoni"
-#~ msgstr "Odstranění šumu od Dominika Mazzoniho"
 
 #~ msgid "by Nasca Octavian Paul"
 #~ msgstr "(Bass Boost) od Nasca Octaviana Paula"

--- a/locale/cy.po
+++ b/locale/cy.po
@@ -6,57 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-27 11:11+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
-"Language-Team: Welsh <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"cy/>\n"
+"Language-Team: Welsh <https://hosted.weblate.org/projects/tenacity/tenacity/cy/>\n"
 "Language: cy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0) ? 0 : (n==1) ? 1 : (n==2) ? 2 : "
-"(n==3) ? 3 :(n==6) ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=(n==0) ? 0 : (n==1) ? 1 : (n==2) ? 2 : (n==3) ? 3 :(n==6) ? 4 : 5;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
 "X-Poedit-Country: Cymru\n"
 "X-Poedit-Language: Cymraeg\n"
 "X-Poedit-SourceCharset: utf-8\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Rhedeiad Cyntaf Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Sianel"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Gwall wrth agor ffeil"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Gwall wrth agor ffeil"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Rhedeiad Cyntaf Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Recordio"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -67,9 +29,31 @@ msgstr "Methu penodi"
 msgid "%s bytes"
 msgstr "beit"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Yn chwyddo"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -80,12 +64,68 @@ msgid "2nd Experimental Command"
 msgstr "Diolchiadau arbennig:"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Gweithredu'r Effaith Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Gludo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Gludo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Gludo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Gludo"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Dewis"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -100,15 +140,47 @@ msgid "Split &Horizontally"
 msgstr "Stereo Llorweddol"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show S&cript"
+msgstr "Annog Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show &Output"
+msgstr "Mesurydd Allbwn"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "Erfyn"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Aros"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Annog Nyquist..."
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Mesurydd Allbwn"
 
@@ -116,7 +188,20 @@ msgstr "Mesurydd Allbwn"
 msgid "Load Nyquist script"
 msgstr "Annog Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Rhybudd"
 
@@ -125,20 +210,67 @@ msgid "Save Nyquist script"
 msgstr "Annog Nyquist..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Gweithredu'r Effaith Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "No matches found"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Gweithredu'r Effaith Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Newydd"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Annog Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
 msgstr "&Agor..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Open script"
+msgstr "Annog Nyquist..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
 msgid "Save"
@@ -164,7 +296,8 @@ msgstr "Copio"
 msgid "Copy to clipboard"
 msgstr "Torri i'r clipfwrdd"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Torri"
 
@@ -172,13 +305,19 @@ msgstr "Torri"
 msgid "Cut to clipboard"
 msgstr "Torri i'r clipfwrdd"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Gludo"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Paste from clipboard"
 msgstr "Gludo o'r clipfwrdd"
+
+#. i18n-hint verb; to empty or erase
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+msgid "Clear"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Clear selection"
@@ -192,7 +331,8 @@ msgstr "Dewis"
 msgid "Select all text"
 msgstr "Dewis"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Dadwneud"
 
@@ -200,19 +340,79 @@ msgstr "Dadwneud"
 msgid "Undo last change"
 msgstr "Newid Fformat"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&Ailwneud"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Newid Fformat"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Match"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to top S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Erfyn Blaenorol"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Symud Trac i Fynu"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Erfyn Nesaf"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Start"
+msgstr "Atred gychwyn:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Start script"
 msgstr "Annog Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Aros"
 
@@ -220,18 +420,139 @@ msgstr "Aros"
 msgid "Stop script"
 msgstr "Annog Nyquist..."
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Galluogwyd"
 
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Disabled"
+msgstr " (analluogwyd)"
+
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Yn Troi o Chwith"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr " ffenest"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "Gosodiadau'r Effaith"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Sample rate conversion"
 msgstr "Graddfa Samplo:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "Gwall wrth fewnforio"
+
+#: src/AboutDialog.cpp
+msgid "Ogg Vorbis Import and Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "FLAC import and export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "Ffurfweddu Alfforio MP3"
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export"
+msgstr "Gwall LOF"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "Ategion %i i %i"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "GPL License"
+msgstr ""
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -254,6 +575,18 @@ msgstr "Chwyddamlen"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Chwyddamlen"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Chwyddamlen"
 
@@ -261,6 +594,54 @@ msgstr "Chwyddamlen"
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer and support"
+msgstr "Chwyddamlen"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Chwyddamlen"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Chwyddamlen"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Chwyddamlen"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Chwyddamlen"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
 msgstr "Chwyddamlen"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
@@ -275,19 +656,60 @@ msgstr "Allbwn Nyquist: "
 msgid "%s, web developer"
 msgstr "Chwyddamlen"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Rhestr Clod"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "DarkTenacity Customisation"
 msgstr "Cyfuniad Bysyll"
 
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s Contributors"
+msgstr "Chwyddamlen"
+
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Tenacity Special thanks:"
 msgstr "Diolchiadau arbennig:"
+
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "Ffolderau"
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s includes code from the following projects:"
+msgstr ""
 
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
@@ -295,11 +717,24 @@ msgstr "Diolchiadau arbennig:"
 msgid "%s Team Members"
 msgstr "Hoffterau Audacity"
 
+#: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Contributors"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
+
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Cyfieithwyd y fersiwn Gymraeg gan f00."
@@ -318,6 +753,26 @@ msgstr "Diolchiadau arbennig:"
 msgid "%s website: "
 msgstr "Rhedeiad Cyntaf Audacity"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr ""
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Cliciwch a llusgwch i newid maint cymharol y traciau stereo."
@@ -328,9 +783,15 @@ msgstr "Cliciwch a llusgwch i newid maint cymharol y traciau stereo."
 msgid "Record/Play head"
 msgstr "Recordio"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Ategion 1 i %i"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Cliciwch a llusgwch i olygu'r samplau"
@@ -338,12 +799,57 @@ msgstr "Cliciwch a llusgwch i olygu'r samplau"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Clicio a llusgo i newid maint y trac."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Symud Trac i Fynu"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Symud Trac i Lawr"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Symud Trac i Fynu"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr " (analluogwyd)"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr " (analluogwyd)"
 
 #: src/AdornedRulerPanel.cpp
@@ -351,20 +857,81 @@ msgid "Timeline Options"
 msgstr "Ategion 1 i %i"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "Distewi'r dewisiad"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "Recordio"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Gwall"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy, c-format
+msgid "Failed to remove %s"
+msgstr "Methu penodi"
+
+#: src/AudacityApp.cpp
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Hoffterau Audacity"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -383,47 +950,156 @@ msgstr "&Agor..."
 
 #: src/AudacityApp.cpp
 #, fuzzy
+msgid "Open &Recent..."
+msgstr "&Agor..."
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
+#, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Ynglyn â Audacity..."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "&Preferences..."
+msgstr "Hoffterau Audacity"
 
 #: src/AudacityApp.cpp src/menus/FileMenus.cpp
 msgid "&File"
 msgstr "&Ffeil"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Methodd Audacity ganfod lle i storio ffeiliau dros dro.\n"
 "Dewisiwch ffolder addas yn yr ymgom hoffterau."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Methodd Audacity ganfod lle i storio ffeiliau dros dro.\n"
 "Dewisiwch ffolder addas yn yr ymgom hoffterau."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr ""
 "Mae Audacity am orffen nawr. Rhedwch Audacity eto i ddefnyddio'r\n"
 "ffolder dros dro newydd, os gwelwch yn dda."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+msgid ""
+"Running two copies of Tenacity simultaneously may cause\n"
+"data loss or cause your system to crash.\n"
+"\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Do you still want to start Tenacity?"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Gwall wrth agor ffeil"
+
+#: src/AudacityApp.cpp
+msgid "The system has detected that another copy of Tenacity is running.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Use the New or Open commands in the currently running Tenacity\n"
+"process to open multiple projects simultaneously.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Mae Audacity yn rhedeg yn barod"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Ffeiliau Cywaith Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
+
+#. i18n-hint: This displays a list of available options
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "this help message"
+msgstr "Galluogwyd"
+
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+msgid "run self diagnostics"
+msgstr ""
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Hoffterau Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -433,9 +1109,10 @@ msgid "audio or project file name"
 msgstr "Methu agor ffeil cywaith"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -448,26 +1125,84 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Ffeiliau Cywaith Audacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "Gosod Amrediad..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Sianel Dde"
 
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Help"
+msgstr "&Help"
+
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Rhedeiad Cyntaf Audacity"
+
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Rhedeiad Cyntaf Audacity"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/Tags.cpp
+#, fuzzy
+msgid "&Save..."
+msgstr "Cadwyd %s"
+
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Cau"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "Cadwyd %s"
 
 #: src/AudacityLogger.cpp
 #, c-format
 msgid "Couldn't save log to file: %s"
 msgstr "Methwyd ysgrifennu i'r ffeil: "
+
+#: src/AudioIO.cpp
+msgid "Could not find any audio devices.\n"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid ""
@@ -487,13 +1222,61 @@ msgid "Error Initializing Audio"
 msgstr "Gwall Wrth Baratoi'r Sain"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"Ni fyddwch yn gallu chwarae neu recordio sain.\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "Gwall Wrth Baratoi'r Sain"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Rhedeiad Cyntaf Audacity"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "Recordio\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Recordio\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Device info unavailable for: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -526,8 +1309,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Recordio\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Recordio\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Recordio\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Recordio\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -541,37 +1334,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Recordio\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Recordio\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Chwarae Nôl\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Methu penodi\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Recordio\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
 msgstr "Chwarae Nôl\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Recordio\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Mewnforwyd '%s'\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Recordio\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Chwarae Nôl\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Chwarae Nôl\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -579,14 +1375,47 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Recordio\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Recordio\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
 msgstr "Chwarae Nôl\n"
 
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
+msgstr "Chwarae Nôl\n"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Automatic Crash Recovery"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
+"\n"
+"After recovery, save the projects to ensure changes are written to disk."
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Recoverable &projects"
+msgstr ""
+
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Dewis"
+
+#. i18n-hint: (noun).  It's the name of the project to recover.
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Name"
+msgstr "Enwi..."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "&Discard Selected"
@@ -597,12 +1426,55 @@ msgid "&Recover Selected"
 msgstr "Dewis"
 
 #: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "Ni ddewiswyd digon o ddata."
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "Select Command"
+msgstr "Gweithred Orchymun"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Command"
+msgstr "Gweithred Orchymun"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Edit Parameters"
+msgstr "Gweithredu effaith: %s"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Use Preset"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/BatchCommandDialog.cpp
+msgid "&Parameters"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "Gweithred Orchymun"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -613,12 +1485,47 @@ msgid "Import Macro"
 msgstr "Mewnforio MIDI"
 
 #: src/BatchCommands.cpp
+#, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr ""
+
+#: src/BatchCommands.cpp
 msgid "Export Macro"
 msgstr "Allforio Niferus"
 
 #: src/BatchCommands.cpp
 msgid "Effect"
 msgstr "&Effeithio"
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (With Parameters)"
+msgstr ""
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (No Parameters)"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Your batch command of %s was not recognized."
+msgstr ""
+
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Applied Macro"
+msgstr "Gweithredwyd effaith : %s"
 
 #: src/BatchCommands.cpp
 msgid "Apply Macro"
@@ -635,39 +1542,216 @@ msgstr "Gweithredwyd effaith : %s"
 msgid "Apply '%s'"
 msgstr "Gweithredu'r Gweddydd"
 
+#: src/BatchCommands.cpp
+#, c-format
+msgid ""
+"Apply %s with parameter(s)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Test Mode"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Apply %s"
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Dewis"
 
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to project"
+msgstr "Gweithredu'r Gweddydd"
+
 #: src/BatchProcessDialog.cpp
 msgid "&Project"
 msgstr "Ca&dw Cywaith"
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to files..."
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/BatchProcessDialog.cpp
 msgid "&Files..."
 msgstr "&Ffeil"
+
+#. i18n-hint: The Expand button makes the dialog bigger, with more in it
+#: src/BatchProcessDialog.cpp
+msgid "&Expand"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "No macro selected"
 msgstr "Ni ddewiswyd digon o ddata."
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "Applying '%s' to current project"
+msgstr "Ca&dw Cywaith"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Please save and close the current project first."
+msgstr "Ca&dw Cywaith"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Select file(s) for batch processing..."
+msgstr "Dewisiad i'r Diwedd"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Applying..."
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "File"
+msgstr "&Ffeil"
+
+#: src/BatchProcessDialog.cpp
+msgid "&Cancel"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Remo&ve"
 msgstr "&Dileu Traciau"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "Enwi..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "Mewnforio"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "Allforio Nife&r..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Edit Steps"
+msgstr ""
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "Gweithred Orchymun"
 
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+msgid "Parameters"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp
+msgid "&Insert"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "&Edit..."
 msgstr "&Golygu"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp
+#, fuzzy
+msgid "De&lete"
+msgstr "Dileu"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "Move &Up"
+msgstr "Symud Trac i Fynu"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "Move &Down"
+msgstr "Symud Trac i Lawr"
+
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Cadwyd %s"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
+
+#. i18n-hint: This is the last item in a list.
+#: src/BatchProcessDialog.cpp
+msgid "- END -"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "%s changed"
+msgstr "Newid Fformat"
+
+#: src/BatchProcessDialog.cpp
+msgid "Do you want to save the changes?"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Enter name of new macro"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Name of new macro"
+msgstr "Nifer o weithiau i ailadrodd: "
+
+#: src/BatchProcessDialog.cpp
+msgid "Name must not be blank"
+msgstr ""
+
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Names may not contain '%c' and '%c'"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of a file.
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "Are you sure you want to delete %s?"
+msgstr " Ydych wir eisiau cadw'r ffeil fel \""
 
 #. i18n-hint: Benchmark means a software speed test
 #: src/Benchmark.cpp
@@ -675,11 +1759,38 @@ msgid "Benchmark"
 msgstr "&Rhedeg Meincnod..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Nifer o weithiau i ailadrodd: "
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Cau"
 
@@ -694,9 +1805,51 @@ msgid "Export Benchmark Data as:"
 msgstr "Allforio Data Sbectral Fel:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Preparing...\n"
+msgstr "Yn Normaleiddio..."
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 #, c-format
 msgid "Performing %d edits...\n"
 msgstr "Gweithredu Ailadrodd\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -704,8 +1857,94 @@ msgid "Paste: %lld\n"
 msgstr "Gludo\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Sianel Dde\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -716,9 +1955,58 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Rhaid dewis trac yn gyntaf."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Ni ddewiswyd digon o ddata."
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr "Rhaid dewis trac yn gyntaf."
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr "Rhaid dewis trac yn gyntaf."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -735,9 +2023,26 @@ msgid "Checkpointing project"
 msgstr "Crëwyd cywaith newydd"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "Crëwyd cywaith newydd"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Methwyd ysgrifennu i'r ffeil: \n"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -747,11 +2052,143 @@ msgid ""
 "%s"
 msgstr "Methwyd ysgrifennu i'r ffeil: "
 
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to release savepoint:\n"
+"\n"
+"%s"
+msgstr "Methwyd ysgrifennu i'r ffeil: "
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Removing Dependencies"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copying audio data into project..."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Project Depends on Other Audio Files"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Dependencies"
+msgstr "i Ddechrau y Dewisiad"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Audio File"
+msgstr "Trac Sain"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Disk Space"
+msgstr "Lle Rhydd:"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "Distewi'r dewisiad"
+
+#: src/Dependencies.cpp
+msgid "Cancel Save"
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Label"
+
+#: src/Dependencies.cpp
+msgid "Do Not Copy"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Whenever a project depends on other files:"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Ask me"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "Dewis ffeil MIDI..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Torri i'r clipfwrdd"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Missing"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Dependency Check"
+msgstr ""
+
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Dim"
 
@@ -759,7 +2196,7 @@ msgstr "Dim"
 msgid "Rectangle"
 msgstr "Petryal"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triongl"
 
@@ -771,6 +2208,167 @@ msgstr "Wedi shapio"
 msgid "Rectangular"
 msgstr "Petryalog"
 
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Gweithred"
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "To find '%s', click here -->"
+msgstr ""
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Browse..."
+msgstr "Dewis..."
+
+#: src/FFmpeg.cpp
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
+msgstr ""
+
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "Ble mae %s?"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "Peidio dangos y rhybydd yma eto"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr "Methu penodi"
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
+"Perhaps %s is not writable or the disk is full.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
 #: src/FileException.h
 msgid "File Error"
 msgstr "Gwall LOF"
@@ -781,7 +2379,29 @@ msgstr "Gwall LOF"
 msgid "Error (file may not have been written): %s"
 msgstr "Gwall (efallai na gadwyd y ffeil): %s"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy all audio into project (safest)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Pob ffeil (*)|*"
 
@@ -792,6 +2412,14 @@ msgid "AUP3 project files"
 msgstr "Ffeiliau Cywaith Audacity"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "Enwi ffeiliau:"
 
@@ -799,12 +2427,24 @@ msgstr "Enwi ffeiliau:"
 msgid "XML files"
 msgstr "Enwi ffeiliau:"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "Enwi ffeiliau:"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -831,6 +2471,14 @@ msgstr "Awto-gydberthynas Trydydd Isradd"
 msgid "Enhanced Autocorrelation"
 msgstr "Awto-gydberthynas Uwch"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Sbectrwm"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -847,9 +2495,34 @@ msgstr "Amledd Linellol"
 msgid "Log frequency"
 msgstr "Amledd log"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Chwyddo"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -866,12 +2539,33 @@ msgid "Cursor:"
 msgstr "Cyrchydd i'r Chwith"
 
 #: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Algorithm:"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Size:"
 msgstr "Maint"
+
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Export..."
+msgstr "Allforio Nife&r..."
 
 #: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "Gweithred"
+
+#: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Replot..."
@@ -890,6 +2584,37 @@ msgstr "Dewiswyd gormod o sain. Dim ond y %.1f eiliad o sain gaith ei ddadansodd
 msgid "Not enough data selected."
 msgstr "Ni ddewiswyd digon o ddata."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "sbectrwm.txt"
@@ -898,7 +2623,8 @@ msgstr "sbectrwm.txt"
 msgid "Export Spectral Data As:"
 msgstr "Allforio Data Sbectral Fel:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Methwyd ysgrifennu i'r ffeil: "
@@ -910,6 +2636,27 @@ msgstr "Amledd (Hz)\tLefel (dB)"
 #: src/FreqWindow.cpp
 msgid "Lag (seconds)\tFrequency (Hz)\tLevel"
 msgstr "Oedi (eiliadau)\tAmledd (Hz)\tLefel"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Plot Spectrum..."
+msgstr "Sbectrwm"
+
+#: src/HelpText.cpp
+msgid "Welcome!"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "Gweithredu'r Gweddydd"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording Audio"
+msgstr "Sain a Recordwyd"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
@@ -925,6 +2672,95 @@ msgstr "Recordio"
 #: src/HelpText.cpp
 msgid "Recording - Setting the Recording Level"
 msgstr "Recordio"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Allforio Niferus"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Yn Agor Cywaith Audacity"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -943,18 +2779,96 @@ msgid "Used Space"
 msgstr "Lle Rhydd:"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr " (analluogwyd)"
 
 #: src/HistoryWindow.cpp
+msgid "&Levels to discard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Discard"
+msgstr "Ca&dw Cywaith"
+
+#: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "Ca&dw Cywaith"
+
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Compact"
+msgstr "Ca&dw Cywaith"
+
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Hanes..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.h
+#, fuzzy
+msgid "Internal Error"
+msgstr "Gwall LOF"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "Newidwyd Label"
+
+#. i18n-hint: (noun).  A track contains waves, audio etc.
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Track"
+msgstr "Traciau"
+
+#. i18n-hint: (noun)
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#, fuzzy
+msgid "Label"
+msgstr "Labeli"
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Time"
+msgstr "Amser Ymosod:"
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Time"
+msgstr "Track Amser"
 
 #. i18n-hint: (noun) of a label
 #: src/LabelDialog.cpp src/toolbars/SpectralSelectionBar.cpp
@@ -966,6 +2880,14 @@ msgstr "Amledd log"
 msgid "High Frequency"
 msgstr "Amledd (Hz):"
 
+#: src/LabelDialog.cpp
+msgid "New..."
+msgstr ""
+
+#: src/LabelDialog.cpp
+msgid "Press F2 or double click to edit cell contents."
+msgstr ""
+
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Select a text file containing labels"
 msgstr "Dewisiwch ffeil testun yn cynnwys labeli..."
@@ -975,6 +2897,11 @@ msgstr "Dewisiwch ffeil testun yn cynnwys labeli..."
 msgid "Could not open file: %s"
 msgstr "Methwyd agor y ffeil: \"%s\""
 
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "No labels to export."
+msgstr "Nid oes labeli traciau i allforio."
+
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Export Labels As:"
 msgstr "Allforio Labeli Fel:"
@@ -983,15 +2910,52 @@ msgstr "Allforio Labeli Fel:"
 msgid "New Label Track"
 msgstr "Trac La&bel Newydd"
 
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Enter track name"
+msgstr "Newid enw trac i:"
+
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "Label Trac"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Rhedeiad Cyntaf Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Dewis Iaith ar gyfer Audacity:"
+
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+msgid "Confirm"
+msgstr ""
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "Methwyd ysgrifennu i'r ffeil: "
 
 #: src/Legacy.cpp
 #, c-format
@@ -1003,8 +2967,19 @@ msgstr ""
 "Mae'r hen ffeil wedi'i gadw fel '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Yn Agor Cywaith Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Diolchiadau arbennig:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Dewis..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1024,39 +2999,99 @@ msgstr "&Ailwneud %s"
 msgid "&Redo"
 msgstr "&Ailwneud"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr " (analluogwyd)"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
 msgstr "Cymysgu"
 
+#: src/Mix.cpp src/menus/TrackMenus.cpp
+msgid "Mix and Render"
+msgstr ""
+
+#: src/Mix.cpp
+msgid "Mixing and rendering tracks"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr ""
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Cynnydd"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Trem"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Mudo"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Unawd"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Symudwyd y llithrydd cynnydd"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Symudwyd y llithrydd cynnydd"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Symudwyd y llithrydd trem"
+
+#: src/MixerBoard.cpp
+msgid "&Mixer Board..."
+msgstr ""
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1066,13 +3101,73 @@ msgid ""
 "Error: %s"
 msgstr "Methu penodi"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Galluogwyd"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Dim"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Rhedeiad Cyntaf Audacity"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1082,13 +3177,133 @@ msgstr "Trac Nodau"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Ysgrifennu dros ffeiliau cyfredol"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to register:\n"
+"%s"
+msgstr "Methwyd ysgrifennu i'r ffeil: "
 
 #. i18n-hint A plug-in is an optional added program for a sound
 #. effect, or generator, or analyzer
@@ -1107,9 +3322,29 @@ msgstr[5] "Methu penodi\n"
 msgid "Enable new plug-ins"
 msgstr "Methu penodi"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Gweithredu'r Effaith Nyquist..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Methu penodi"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "Galluogwyd"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -1136,11 +3371,36 @@ msgstr "Galluogwyd"
 msgid "E&nabled"
 msgstr "Galluogwyd"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Galluogwyd"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Dewis"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "C&lear All"
+msgstr "Dewis"
+
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Galluogwyd"
 
@@ -1164,6 +3424,13 @@ msgid ""
 "%s"
 msgstr "Gweithredwyd effaith : %s"
 
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Effect or Command at %s failed to register:\n"
+"%s"
+msgstr ""
+
 #: src/Printing.cpp
 msgid "There was a problem printing."
 msgstr "Roedd anhawster wrth argraffu."
@@ -1171,6 +3438,19 @@ msgstr "Roedd anhawster wrth argraffu."
 #: src/Printing.cpp
 msgid "Print"
 msgstr "Argraffu"
+
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+#, c-format
+msgid "Actual Rate: %d"
+msgstr ""
 
 #: src/ProjectAudioManager.cpp src/effects/Effect.cpp
 msgid ""
@@ -1182,6 +3462,21 @@ msgstr "Gwall wrth agor y ddyfais sain. Gwiriwch osodiadau'r ddyfais allbwn a gr
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "I blotio'r sbectrwm, rhaid i bob trac dewisiedig fod o'r un graddfa samplo."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Sain a Recordwyd"
@@ -1190,11 +3485,187 @@ msgstr "Sain a Recordwyd"
 msgid "Record"
 msgstr "Recordio"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Methu agor ffeil cywaith"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no further changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Cynnydd"
+
+#: src/ProjectFSCK.cpp
+msgid "Cleaning up unused directories in project data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Ca&dw Cywaith"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1217,6 +3688,14 @@ msgid "Failed to restore connection"
 msgstr "Methu penodi"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to execute a project file command:\n"
+"\n"
+"%s"
+msgstr "Methu penodi"
+
+#: src/ProjectFileIO.cpp
 #, c-format
 msgid ""
 "Unable to prepare project file command:\n"
@@ -1225,11 +3704,96 @@ msgid ""
 msgstr "Methu penodi"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Methu penodi"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Methu penodi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Methu penodi"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1238,12 +3802,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Methu penodi"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Methu penodi"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Methu penodi"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Methu penodi"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1254,16 +3844,51 @@ msgid "Error Writing to File"
 msgstr "Methwyd ysgrifennu i'r ffeil: "
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write file %s.\n"
+"Perhaps disk is full or not writable.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Compacting project"
 msgstr "Crëwyd cywaith newydd"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Rhedeiad Cyntaf Tenacity"
+
+#. i18n-hint: E.g this is recovered audio that had been lost.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "(Recovered)"
+msgstr "Recordio"
+
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Methu agor ffeil cywaith"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -1278,12 +3903,99 @@ msgid "Unable to parse project information."
 msgstr "Methu penodi"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Ca&dw Cywaith"
+
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Gweithredu effaith: %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "Ca&dw Cywaith"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "i Ddechrau y Dewisiad"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "Ca&dw Cywaith"
+
+#: src/ProjectFileManager.cpp
+msgid "Insufficient Disk Space"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -1291,9 +4003,34 @@ msgid "Saved %s"
 msgstr "Cadwyd %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Cadw Cywaith &Fel..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -1301,9 +4038,21 @@ msgid "Overwrite Project Warning"
 msgstr "Ysgrifennu dros ffeiliau cyfredol"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Cadw Cywaith &Fel..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -1326,6 +4075,23 @@ msgstr "Dewis un neu fwy o ffeiliau sain..."
 msgid "%s is already open in another window."
 msgstr "Mae %s yn barod yn agored mewn ffenest arall."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Gwall wrth agor ffeil"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Gwall wrth agor ffeil"
@@ -1333,6 +4099,34 @@ msgstr "Gwall wrth agor ffeil"
 #: src/ProjectFileManager.cpp
 msgid "Error opening file"
 msgstr "Gwall wrth agor ffeil"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"File may be invalid or corrupted: \n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Gwall wrth agor ffeil"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Project was recovered"
+msgstr "i Ddechrau y Dewisiad"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Recover"
+msgstr "Recordio"
 
 #: src/ProjectFileManager.cpp
 #, c-format
@@ -1352,16 +4146,46 @@ msgid "Error Importing"
 msgstr "Gwall wrth fewnforio"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Ca&dw Cywaith"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Methu agor ffeil cywaith"
 
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "Ca&dw Cywaith"
+
 #: src/ProjectHistory.cpp
 msgid "Created new project"
 msgstr "Crëwyd cywaith newydd"
+
+#: src/ProjectHistory.cpp
+msgid "Automatic database backup failed."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "Welcome to Tenacity version %s"
+msgstr ""
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
 #: src/ProjectManager.cpp
@@ -1372,6 +4196,25 @@ msgstr "Cadw'r newidiadau?"
 #: src/ProjectManager.cpp
 msgid "Save project before closing?"
 msgstr "Cadw'r newidiadau cyn cau?"
+
+#: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "Disk space remaining for recording: %s"
+msgstr ""
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -1387,6 +4230,25 @@ msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
+#. i18n-hint: This is an experimental feature where the main panel in
+#. Audacity is put on a notebook tab, and this is the name on that tab.
+#. Other tabs in that notebook may have instruments, patch panels etc.
+#: src/ProjectWindow.cpp
+msgid "Main Mix"
+msgstr ""
+
 #: src/ProjectWindow.cpp
 msgid "Horizontal Scrollbar"
 msgstr "Stereo Llorweddol"
@@ -1394,6 +4256,26 @@ msgstr "Stereo Llorweddol"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Stereo Fertigol"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "Ansawdd"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -1403,9 +4285,104 @@ msgstr "Ansawdd"
 msgid "High Quality"
 msgstr "Ansawdd"
 
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+msgid "16-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+msgid "24-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "Dewis lleoliad i gadw'r ffeiliau allforio"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "Cadw'r newidiadau?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Dewis..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "Maint"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "Maint"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+msgid "White Bkgnd"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr " ffenest"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr " ffenest"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "Crëwyd cywaith newydd"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "Erfyn"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -1419,7 +4396,13 @@ msgstr "Pob ffeil (*)|*"
 msgid "All Preferences"
 msgstr "Hoffterau Audacity"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Erfyn Dewis"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Gosod Pwynt Dewisiad"
 
@@ -1427,20 +4410,224 @@ msgstr "Gosod Pwynt Dewisiad"
 msgid "Timer"
 msgstr "Track Amser"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Tools"
+msgstr "Erfyn"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/Screenshot.cpp
+msgid "Mixer"
+msgstr ""
+
+#. i18n-hint: Noun (the meter is used for playback or record level monitoring)
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter"
+msgstr "Mesurydd Mewnbwn"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Play Meter"
+msgstr "Chwarae Nôl"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Record Meter"
+msgstr "Recordio"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&Golygu"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device"
+msgstr "Mesurydd Mewnbwn"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play-at-Speed"
+msgstr "Chwarae Nôl"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "Erfyn"
+
+#: src/Screenshot.cpp src/TrackPanel.cpp
+#, fuzzy
+msgid "Track Panel"
+msgstr "Rhif Trac:"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Traciau"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "Trac Nodau"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "Trac Newydd"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "Chwarae Un Eiliad"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "Trac Nodau"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "Trac Nodau"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "Traciau"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "Dewis lleoliad i gadw'r ffeiliau allforio"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "Galluogwyd"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
+
+#: src/ShuttleGui.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Preview"
+msgstr "Erfyn Blaenorol"
+
+#: src/ShuttleGui.cpp
+msgid "Dry Previe&w"
+msgstr ""
 
 #: src/ShuttleGui.cpp
 msgid "&Settings"
 msgstr "Gosodiadau'r Effaith"
 
+#: src/ShuttleGui.cpp
+msgid "Debu&g"
+msgstr ""
+
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Nearest"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+msgid "Sound Activated Record"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "Chwyddiad (dB):"
+
+#: src/SplashDialog.cpp
+msgid "Welcome to Tenacity!"
+msgstr ""
+
+#: src/SplashDialog.cpp
+#, fuzzy
+msgid "Don't show this again at start up"
+msgstr "Peidio dangos y rhybydd yma eto"
+
 #: src/SqliteSampleBlock.cpp
 msgid "Connection to project file is null"
 msgstr "Methu agor ffeil cywaith"
+
+#: src/Tags.cpp
+msgid "Artist Name"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Track Title"
+msgstr "Enw Trac"
+
+#: src/Tags.cpp
+msgid "Album Title"
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Track Number"
@@ -1450,20 +4637,333 @@ msgstr "Rhif Trac:"
 msgid "Year"
 msgstr "Blwyddyn"
 
+#: src/Tags.cpp
+msgid "Genre"
+msgstr ""
+
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Sylwadau"
 
 #: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "Tonffurf (dB)"
+
+#: src/Tags.cpp
+msgid "&Add"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "&Remove"
+msgstr "&Dileu Traciau"
+
+#: src/Tags.cpp
+msgid "Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&Golygu"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "Pellhau"
+
+#: src/Tags.cpp
+msgid "Template"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "&Load..."
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "256 - rhagosodedig"
+
+#: src/Tags.cpp
 msgid "Don't show this when exporting audio"
 msgstr "Peidio dangos y rhybydd yma eto"
+
+#: src/Tags.cpp
+msgid "Edit Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to save genre file."
+msgstr "Methu penodi"
+
+#: src/Tags.cpp
+msgid "Reset Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Are you sure you want to reset the genre list to defaults?"
+msgstr " Ydych wir eisiau cadw'r ffeil fel \"\n"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to open genre file."
+msgstr "Methu penodi"
+
+#: src/Tags.cpp
+msgid "Load Metadata As:"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Gwall wrth agor ffeil"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Save Metadata As:"
+msgstr "Cadw Cywaith &Fel..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Gwall wrth agor ffeil"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "Galluogwyd"
 
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
+"  %s."
+msgstr "Methwyd ysgrifennu i'r ffeil: "
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
+"  %s\n"
+"for writing."
+msgstr "Methu agor y ffeil ar gyfer ysgrifennu"
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write images to file:\n"
+"  %s."
+msgstr "Methwyd ysgrifennu i'r ffeil: "
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not create directory:\n"
+"  %s"
+msgstr "Methwyd ysgrifennu i'r ffeil: \n"
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not save file:\n"
+"  %s"
+msgstr "Methwyd agor y ffeil: \"%s\""
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
+#. i18n-hint: Light meaning opposite of dark
+#: src/Theme.cpp
+#, fuzzy
+msgid "Light"
+msgstr "Dde"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Enw Trac"
+
+#. i18n-hint: This string is used to configure the controls which shows the recording
+#. * duration. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The string 'days' indicates that the first number in the control will be the number of days,
+#. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
+#. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
+#. * seconds.
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Duration"
+msgstr "Gweithred"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "Track Amser"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record"
+msgstr "Recordio"
+
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
+msgstr "Recordio"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "Gweithredu effaith: %s"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "Sianel Dde"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Error in Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "Gwall wrth fewnforio"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
 msgstr "Recordio"
 
 #: src/TimerRecordDialog.cpp
@@ -1474,8 +4974,32 @@ msgstr "Crëwyd cywaith newydd"
 msgid "Recording start:"
 msgstr "Recordio"
 
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "Gweithred"
+
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
+msgstr "Recordio"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Action after Timer Recording:"
+msgstr "Recordio"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Recordio"
 
 #: src/TimerRecordDialog.cpp
@@ -1495,6 +5019,14 @@ msgid ""
 msgstr "Recordio"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "Recordio"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
@@ -1502,9 +5034,76 @@ msgid ""
 "Recording exported: %s"
 msgstr "Recordio"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Recordio"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Recordio"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint a format string for days, hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: This string is used to configure the controls for times when the recording is
+#. * started and stopped. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
+#. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date and Time"
+msgstr "Amser Ymosod:"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "Amser Ymosod:"
+
+#: src/TimerRecordDialog.cpp
+msgid "End Date and Time"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "End Date"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
+msgstr "Methu penodi"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Project As:"
@@ -1515,10 +5114,20 @@ msgid "Select..."
 msgstr "Dewis"
 
 #: src/TimerRecordDialog.cpp
+msgid "Automatic Export"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable Automatic &Export?"
+msgstr "Golygu Sampl"
+
+#: src/TimerRecordDialog.cpp
 msgid "Export Project As:"
 msgstr "Allforio Labeli Fel:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Gosodiadau'r Effaith"
 
@@ -1527,8 +5136,25 @@ msgid "After Recording completes:"
 msgstr "Recordio"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Rhedeiad Cyntaf Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -1538,11 +5164,23 @@ msgstr "Sianel Dde"
 msgid "Scheduled to stop at:"
 msgstr "Dewisiad i'r Dechrau"
 
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr ""
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Recordio"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -1551,6 +5189,33 @@ msgstr "Recordio"
 #: src/TimerRecordDialog.cpp
 msgid "Recording Exported:"
 msgstr "Recordio"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
+msgstr "Recordio"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo,"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Enw Trac"
+
+#. i18n-hint: The %d is replaced by the number of the track.
+#. i18n-hint: compose a name identifying an unnamed track by number
+#: src/TrackPanelAx.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "Track %d"
+msgstr "Traciau"
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this track is muted. (The mute button is on.)
@@ -1569,6 +5234,29 @@ msgstr "Unawd"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Dewis"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Mute On"
+msgstr "Mudo"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Solo On"
+msgstr "Unawd"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "Erfyn Dewis"
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
@@ -1635,25 +5323,129 @@ msgstr "Symud Trac i Fynu"
 msgid "Move Track Down"
 msgstr "Symud Trac i Lawr"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
+#. i18n-hint: Voice key is an experimental/incomplete feature that
+#. is used to navigate in vocal recordings, to move forwards and
+#. backwards by words.  So 'key' is being used in the sense of an index.
+#. This error message means that you've selected too short
+#. a region of audio to be able to use this feature.
+#: src/VoiceKey.cpp
+msgid "Selection is too small to use voice key."
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Results\n"
+msgstr ""
+
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Complete"
+msgstr ""
+
 #: src/WaveClip.cpp
 msgid "Resampling failed."
 msgstr "Analluogwyd ailsamplo."
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to paste the selection"
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to expand the cut line"
+msgstr ""
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Gweithredu'r Gweddydd"
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Gweithred Orchymun"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "Gweithred Orchymun"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ailadrodd %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -1663,6 +5455,15 @@ msgstr "Sain a Recordwyd"
 msgid "Threshold:"
 msgstr "Trothwy:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "Crëwyd trac sain newydd"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Amser oedi (eiliadau):"
@@ -1671,9 +5472,17 @@ msgstr "Amser oedi (eiliadau):"
 msgid "Decay factor:"
 msgstr "Ffactor Gwanhau:"
 
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Drag"
 msgstr "Chiwth-Lusgo"
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+msgid "Panel"
+msgstr ""
 
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
@@ -1687,9 +5496,43 @@ msgstr "Traciau"
 msgid "Track 1"
 msgstr "Traciau"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr " ffenest"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Get Info"
+msgstr "Symud Trac i Lawr"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Commands"
@@ -1703,21 +5546,86 @@ msgstr "Pob ffeil (*)|*"
 msgid "Preferences"
 msgstr "Hoffterau Audacity"
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Erfyn Nesaf"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Chwyddamlen"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Labeli"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Mewnhidlo"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Newid Fformat"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "Symud Trac i Lawr"
 
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "Mewnhidlo"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Sylwadau"
+
+#: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command:"
+msgstr "Gweithred Orchymun"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -1736,12 +5644,43 @@ msgid "Number of Channels:"
 msgstr "Nifer o weithiau i ailadrodd: "
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Allforio Niferus"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Allforio Niferus"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Builtin Commands"
+msgstr "Gweithred Orchymun"
+
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Rhedeiad Cyntaf Audacity"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+msgid "Unknown built-in command name"
+msgstr ""
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "Galluogwyd"
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Open Project2"
@@ -1763,6 +5702,10 @@ msgstr "Label"
 msgid "Save Log"
 msgstr "Cadwyd %s"
 
+#: src/commands/OpenSaveCommands.cpp
+msgid "Clear Log"
+msgstr ""
+
 #: src/commands/OpenSaveCommands.h
 msgid "Opens a project."
 msgstr "Yn Agor Cywaith Audacity"
@@ -1775,17 +5718,50 @@ msgstr "Ca&dw Cywaith"
 msgid "Saves a copy of current project."
 msgstr "Ca&dw Cywaith"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Hoffterau Audacity"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Enwi..."
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "Hoffterau Audacity"
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "Tonffurf (dB)"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "Dewis"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Window"
@@ -1800,8 +5776,23 @@ msgid "Window Plus"
 msgstr " ffenest"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "Erfyn"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "&Effeithio"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Pob ffeil (*)|*"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -1840,9 +5831,40 @@ msgid "All Tracks Plus"
 msgstr "Track Amser"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
+#. i18n-hint:  This really means the color, not as in "white noise"
+#: src/commands/ScreenshotCommand.cpp
+msgctxt "color"
+msgid "White"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Methwyd ysgrifennu i'r ffeil: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "Dewis"
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -1864,6 +5886,11 @@ msgstr "i Ddechrau y Dewisiad"
 msgid "Selection Start"
 msgstr "i Ddechrau y Dewisiad"
 
+#: src/commands/SelectCommand.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Selection"
+msgstr "Erfyn Dewis"
+
 #: src/commands/SelectCommand.cpp
 msgid "Selection End"
 msgstr "i Ddiwedd y Dewisiad"
@@ -1873,8 +5900,21 @@ msgid "Start Time:"
 msgstr "Amser Ymosod:"
 
 #: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "End Time:"
+msgstr "Amser Ymosod:"
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Frequencies"
 msgstr "Amledd (Hz):"
+
+#: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
@@ -1886,6 +5926,16 @@ msgid "Set"
 msgstr "Dewis"
 
 #: src/commands/SelectCommand.cpp
+msgid "Add"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&Dileu Traciau"
+
+#: src/commands/SelectCommand.cpp
 msgid "First Track:"
 msgstr "Trac Nodau"
 
@@ -1893,8 +5943,17 @@ msgstr "Trac Nodau"
 msgid "Track Count:"
 msgstr "Ffont Label Trac"
 
+#: src/commands/SelectCommand.cpp
+msgid "Mode:"
+msgstr ""
+
 #: src/commands/SelectCommand.h
 msgid "Selects a time range."
+msgstr "Dewis ffeil MIDI..."
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
 msgstr "Dewis ffeil MIDI..."
 
 #: src/commands/SelectCommand.h
@@ -1909,13 +5968,46 @@ msgstr "Distewi"
 msgid "Set Clip"
 msgstr "Erfyn Nesaf"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Atred gychwyn:"
 
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
+
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
 msgstr "Chwyddamlen"
+
+#: src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Time:"
+msgstr "Track Amser"
 
 #: src/commands/SetEnvelopeCommand.cpp src/menus/EditMenus.cpp
 msgid "Delete"
@@ -1926,9 +6018,14 @@ msgid "Edited Envelope"
 msgstr "Chwyddamlen"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Chwyddamlen"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -1938,6 +6035,10 @@ msgstr "Di&leu"
 msgid "Label Index"
 msgstr "Golygu Label"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Dewis"
@@ -1945,6 +6046,10 @@ msgstr "Dewis"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Newidwyd Label"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -1958,9 +6063,26 @@ msgstr "Gosod Graddfa Samplo"
 msgid "Resize:"
 msgstr "Maint"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Dde"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "Ca&dw Cywaith"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -1975,6 +6097,10 @@ msgid "Set Track Status"
 msgstr "Enw Trac"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "Seibio"
 
@@ -1987,16 +6113,40 @@ msgid "Gain:"
 msgstr "Cynnydd"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Trac Nodau"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Llinellol"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Pellhau"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Track Amser"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Display:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -2018,16 +6168,36 @@ msgstr "Gosodiadau'r Effaith"
 msgid "Spectral Select"
 msgstr "Gosod Pwynt Dewisiad"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Trac Newydd"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Crëwyd trac sain newydd"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Chwyddo"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "Chwyddiad (dB):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "Chwyddiad (dB):"
 
 #: src/effects/Amplify.cpp
@@ -2039,16 +6209,85 @@ msgid "Allo&w clipping"
 msgstr "Caniatau Clipio"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Ffont Label Trac"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#. i18n-hint: Name of time display format that shows time in seconds
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "seconds"
+msgstr "Amser oedi (eiliadau):"
+
+#: src/effects/AutoDuck.cpp
+msgid "Ma&ximum pause:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Trothwy:"
+
+#: src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "Preview not available"
+msgstr " (analluogwyd)"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
 
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Lleihau'r Dewisiad i'r Chwith"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Trothwy:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -2057,6 +6296,33 @@ msgstr "Chwyddo (dB)"
 #: src/effects/BassTreble.cpp
 msgid "Ba&ss (dB):"
 msgstr "Chwyddo (dB)"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "Tonffurf (dB)"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Golygu Label"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Volume (dB):"
+msgstr "Tonffurf (dB)"
+
+#: src/effects/BassTreble.cpp
+msgid "Level"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -2067,13 +6333,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Newid Traw heb Newid Tempo"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Ansawdd"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Newid Traw heb Newid Tempo"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "Traw (EAC)"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -2107,17 +6395,54 @@ msgstr "Hanner tonau:"
 msgid "Frequency"
 msgstr "Amledd (Hz):"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "i"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Canran Newid:"
 
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "Canran Newid:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "cdda mun:eil:fframau 75 fye"
 
@@ -2137,11 +6462,42 @@ msgstr "Newid Cyflymder, yn effeithio Tempo a Traw"
 msgid "&Speed Multiplier:"
 msgstr "Allforio Niferus"
 
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
 msgctxt "change speed"
 msgid "&to"
 msgstr "i"
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "Selection Length"
+msgstr "i Ddiwedd y Dewisiad"
 
 #: src/effects/ChangeSpeed.cpp
 msgid "C&urrent Length:"
@@ -2150,6 +6506,12 @@ msgstr "Gosodiadau'r Effaith"
 #: src/effects/ChangeSpeed.cpp
 msgid "Current length of selection."
 msgstr "Tocio'r ffeil i'r dewisiad"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
@@ -2170,8 +6532,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "Newid Tempo heb Newid Traw"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "Ansawdd"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "Newid Tempo heb Newid Traw"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -2186,6 +6573,12 @@ msgstr "Hyd (eiliadau)"
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
 msgid "t&o"
 msgstr "i"
 
@@ -2193,6 +6586,108 @@ msgstr "i"
 #, c-format
 msgid "Length in seconds from %s, to"
 msgstr "Hyd (eiliadau)"
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Tynnu Cliciau..."
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, c-format
+msgid "Selection must be larger than %d samples."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "Trothwy:"
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Cywasgydd..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "Amser Ymosod: %.1f eiliad"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+msgid "&Noise Floor:"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "Clic-Chwith"
+
+#: src/effects/Compressor.cpp
+msgid "&Ratio:"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
+msgstr "Gweithred"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' where the
@@ -2202,16 +6697,48 @@ msgid "&Attack Time:"
 msgstr "Amser Ymosod:"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Amser Ymosod:"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Amser Ymosod: %.1f eiliad"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "Amser Ymosod: %.1f eiliad"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "Trothwy: %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -2224,39 +6751,440 @@ msgid "Release Time %.1f secs"
 msgstr "Amser Ymosod: %.1f eiliad"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Crëwyd trac sain newydd"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Crëwyd trac sain newydd"
+
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Crëwyd trac sain newydd"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
+#. i18n-hint noun
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "End"
+msgstr "Trem"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "Distewi'r dewisiad"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background end time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "Distewi'r dewisiad"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "Pellhau"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "Hoffterau Audacity"
+
+#: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Help"
+msgstr "&Help"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Methu penodi"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr "Crëwyd cywaith newydd"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Allforio Labeli Fel:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "Ailenwyd '%s' i '%s'"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "Ailadrodd"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "256 - rhagosodedig"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Ffont..."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Clipping"
+msgstr "Caniatau Clipio"
 
 #: src/effects/Distortion.cpp
 msgid "Soft Clipping"
 msgstr "Caniatau Clipio"
 
 #: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Cywasgydd Amrediad Ddeinamig"
+
+#: src/effects/Distortion.cpp
+msgid "Leveller"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Rectifier Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Caniatau Clipio"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
 msgstr "Trothwy:"
 
 #: src/effects/Distortion.cpp
+msgid "Parameter 1"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Parameter 2"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Number of repeats"
 msgstr "Nifer o weithiau i ailadrodd: "
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion"
+msgstr "Rhyngosodiad Sinc Chwim"
+
+#: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Rhyngosodiad Sinc Chwim"
 
 #: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Threshold controls"
+msgstr "Trothwy:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter controls"
 msgstr "Trothwy:"
 
 #: src/effects/Distortion.cpp
@@ -2264,8 +7192,25 @@ msgid "Clipping level"
 msgstr "Gweithredu'r Gweddydd"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Trothwy:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "Rhyngosodiad Sinc Chwim"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -2275,6 +7220,71 @@ msgstr "Mesurydd Allbwn"
 msgid "Repeat processing"
 msgstr "Ailadrodd %s"
 
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "Caniatau Clipio"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Chwarae Nôl"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Chwarae Nôl"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Amledd (Hz):"
@@ -2283,9 +7293,47 @@ msgstr "Amledd (Hz):"
 msgid "&Amplitude (0-1):"
 msgstr "Osgled (0-1)"
 
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "&Duration:"
+msgstr "Gweithred"
+
 #: src/effects/DtmfGen.cpp
 msgid "&Tone/silence ratio:"
 msgstr "Cynhyrchydd Tôn"
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Tone duration:"
+msgstr "Sianel Dde"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Silence duration:"
+msgstr "Cynhyrchydd Tôn"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -2294,6 +7342,11 @@ msgstr "Atsain"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -2304,6 +7357,10 @@ msgid "D&ecay factor:"
 msgstr "Ffactor Gwanhau:"
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "Enw'r ffeil gyntaf:"
 
@@ -2311,7 +7368,8 @@ msgstr "Enw'r ffeil gyntaf:"
 msgid "Export Effect Parameters"
 msgstr "Gweithredu effaith: %s"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Methwyd agor y ffeil: \"%s\""
@@ -2325,11 +7383,40 @@ msgstr "Gweithredu effaith: %s"
 msgid "Error writing to file: \"%s\""
 msgstr "Methwyd ysgrifennu i'r ffeil: "
 
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Import Effect Parameters"
+msgstr "Gweithredu effaith: %s"
+
 #. i18n-hint %s will be replaced by a file name
 #: src/effects/Effect.cpp
 #, c-format
 msgid "%s: is not a valid presets file.\n"
 msgstr "Methu penodi\n"
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Preparing preview"
+msgstr "Recordio"
+
+#: src/effects/Effect.cpp
+msgid "Previewing"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -2345,9 +7432,19 @@ msgstr "Gweithredwyd effaith : %s"
 msgid "Select Preset"
 msgstr "Dewis"
 
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "&Preset:"
+msgstr "Enw'r ffeil gyntaf:"
+
 #: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
 msgid "User Presets"
 msgstr "Gosodiadau'r Effaith"
+
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "256 - rhagosodedig"
 
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
@@ -2357,27 +7454,149 @@ msgstr "Gosodiadau'r Effaith"
 msgid "Factory Defaults"
 msgstr "256 - rhagosodedig"
 
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "Dewisiad i'r Diwedd"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
+
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
 msgstr "&Effeithio"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Apply"
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/effects/EffectUI.cpp
+msgid "Latency: 0"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Wedi Alinio"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Symud Trac i Fynu"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect up in the rack"
+msgstr "i Ddiwedd y Dewisiad"
+
+#: src/effects/EffectUI.cpp
 msgid "Move Down"
 msgstr "Symud Trac i Lawr"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect down in the rack"
+msgstr "i Ddiwedd y Dewisiad"
+
+#: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Remove effect from the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Name of the effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Latency: %4d"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Gweithred Orchymun"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "Hanes Dadwneud"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Chwarae Nôl"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
 #: src/effects/EffectUI.cpp
 msgid "Start &Playback"
 msgstr "Chwarae Nôl"
+
+#: src/effects/EffectUI.cpp
+msgid "Preview effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Preview effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Neidio i'r Dechrau"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Neidio i'r Dechrau"
 
 #: src/effects/EffectUI.cpp
 msgid "Skip forward"
@@ -2395,6 +7614,11 @@ msgstr "Galluogwyd"
 msgid "Save Preset..."
 msgstr "Cadw Cywaith &Fel..."
 
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "Dewis"
+
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
 msgstr "256 - rhagosodedig"
@@ -2407,15 +7631,49 @@ msgstr "Mewnforio"
 msgid "Export..."
 msgstr "Allforio Nife&r..."
 
+#: src/effects/EffectUI.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Options..."
+msgstr "Gosodiadau'r Effaith"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Mewnhidlo"
+
 #: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Enwi ffeiliau:"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Yn Troi o Chwith"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Gwall:"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Description: %s"
+msgstr "Erfyn Dewis"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr " Ydych wir eisiau cadw'r ffeil fel \""
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "Cadw Cywaith &Fel..."
 
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
@@ -2425,11 +7683,37 @@ msgstr "Enw'r ffeil gyntaf:"
 msgid "You must specify a name"
 msgstr "Rhaid dewis trac yn gyntaf."
 
+#: src/effects/EffectUI.cpp
+msgid ""
+"Preset already exists.\n"
+"\n"
+"Replace?"
+msgstr ""
+
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
 #: src/effects/EffectUI.cpp
 msgid "Stop &Playback"
 msgstr "Chwarae Nôl"
+
+#: src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Play"
+msgstr "Gweithredu'r Gweddydd"
+
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Yn Allhidlo"
+
+#: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Equalization"
@@ -2439,13 +7723,61 @@ msgstr "Hafalu"
 msgid "Filter Curve EQ"
 msgstr "Dewis"
 
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Chwyddo Bas..."
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "Chwyddo Bas..."
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "Golygu Label"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Golygu Label"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -2456,12 +7788,230 @@ msgid "Track sample rate is too low for this effect."
 msgstr "Traciau yn rhy hir i aildraethu'r dewisiad."
 
 #: src/effects/Equalization.cpp
+msgid "Effect Unavailable"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "Mewnhidlo"
+
+#: src/effects/Equalization.cpp
+msgid "Draw Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Erfyn Darlunio"
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Interpolation type"
 msgstr "Rhyngosodiad Sinc Chwim"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Amledd Linellol"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Amledd Linellol"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Gweithredu'r Gweddydd"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Dewis"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Dewis"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Gwrthdroi"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Processing: "
+msgstr "Trac Nodau"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&efault"
+msgstr "256 - rhagosodedig"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Rhedeg Meincnod..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Gweithredu effaith: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Gweithredu Hafalu"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Hanes Dadwneud"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Methu penodi"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Cyrchydd i'r Chwith"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Enwi..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Dileu"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Dewis..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "De&faults"
+msgstr "256 - rhagosodedig"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -2469,9 +8019,23 @@ msgid "Rename '%s' to..."
 msgstr "Ailenwyd '%s' i '%s'"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "Enwi..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "Ailenwyd '%s' i '%s'"
+
+#: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Newid Enw"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -2479,9 +8043,28 @@ msgid "Overwrite existing curve '%s'?"
 msgstr "Ysgrifennu dros ffeiliau cyfredol"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "Symud Trac i Lawr"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Methu allforio sain i %s"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Dileu"
+
+#: src/effects/Equalization.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Deletion"
+msgstr "Distewi'r dewisiad"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -2489,8 +8072,49 @@ msgid "Delete %d items?"
 msgstr "BysellDdileu"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Choose an EQ curve file"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Allforio &Labeli"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Methu allforio sain i %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Recordio"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "No curves exported"
+msgstr ""
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -2504,13 +8128,75 @@ msgstr "Allhidlo"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Cliciwch a llusgwch i ddewis y sain"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Cliciwch a llusgwch i ddewis y sain"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "Caniatau Clipio"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Caniatau Clipio"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "Trothwy: %d dB"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "Trothwy: %d dB"
+
+#: src/effects/Generator.cpp
+msgid "There is not enough room available to generate the audio"
+msgstr ""
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Gwrthdroi"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Gweithredu'r Effaith Nyquist..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normaleiddio"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -2521,29 +8207,171 @@ msgstr "Normaleiddio\n"
 msgid "Analyzing: %s"
 msgstr "&Dadansoddi"
 
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "Trac Nodau"
+
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normaleiddio"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
+
+#. i18n-hint: not a color, but "white noise" having a uniform spectrum
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "White"
+msgstr ""
+
+#. i18n-hint: not a color, but "pink noise" having a spectrum with more power
+#. in low frequencies
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Pink"
+msgstr ""
+
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "Noise"
+msgstr "Tynnu Sŵn"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "&Noise type:"
+msgstr "Tynnu Sŵn"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Median"
 msgstr "Big-endian"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Second greatest"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "256 - rhagosodedig"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "256 - rhagosodedig"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Tynnu Sŵn"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "I blotio'r sbectrwm, rhaid i bob trac dewisiedig fod o'r un graddfa samplo."
 
 #: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
 msgstr "Dewisiad i'r Dechrau"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Noise reduction (dB):"
+msgstr "Tonffurf (dB)"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
+msgstr "Tynnu Sŵn"
+
+#: src/effects/NoiseReduction.cpp
+msgid "&Sensitivity:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Sensitivity"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Attac&k time (secs):"
@@ -2561,9 +8389,34 @@ msgstr "Amser oedi (eiliadau):"
 msgid "Release time"
 msgstr "Ailadroddwyd %d o weithiau"
 
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Frequency smoothing (bands):"
+msgstr "Amledd LFO (Hz):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Dadansoddiad Amledd"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "Tonffurf (dB)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old Sensitivity"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 1"
 msgstr "Cam 1"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid ""
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
+"then click Get Noise Profile:"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Get Noise Profile"
@@ -2572,6 +8425,33 @@ msgstr "Nôl Proffil Sŵn"
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 2"
 msgstr "Cam 2"
+
+#: src/effects/NoiseReduction.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "Tynnu Sŵn"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "&Dileu Traciau"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Maint"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -2585,25 +8465,168 @@ msgstr " ffenest"
 msgid "Window si&ze:"
 msgstr " ffenest"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - rhagosodedig"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "256 - rhagosodedig"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Tynnu Sŵn"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to remove noise.\n"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise re&duction (dB):"
+msgstr "Tonffurf (dB)"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "&Sensitivity (dB):"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Fr&equency smoothing (Hz):"
+msgstr "Amledd LFO (Hz):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "Amser Ymosod: %.1f eiliad"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Amser Ymosod:"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "Gwaredu Trac"
 
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Normaleiddio"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Yn Tynnu Sŵn\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Yn Tynnu Sŵn\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Yn Tynnu Sŵn\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -2613,9 +8636,23 @@ msgstr "Osged Frig Newydd (dB):"
 msgid "Peak amplitude dB"
 msgstr "Osged Frig Newydd (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Ffactor Gwanhau:"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Ffactor Gwanhau:"
@@ -2624,33 +8661,135 @@ msgstr "Ffactor Gwanhau:"
 msgid "&Time Resolution (seconds):"
 msgstr "Amser oedi (eiliadau):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Gweddydd"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Rhannau:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Rhannau:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "Amledd LFO (Hz):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "Amledd LFO (Hz):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "Gwedd Gychwyn LFO (gradd):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "Gwedd Gychwyn LFO (gradd):"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Dyfnder:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "Adlif (%):"
 
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "&Output gain (dB):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Output gain (dB)"
+msgstr "Chwyddo (dB)"
+
+#: src/effects/Repair.cpp
+msgid "Repair"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Ailadrodd"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -2674,6 +8813,67 @@ msgstr "Hyd dewisiad newydd: "
 msgid "New selection length: %s"
 msgstr "Hyd dewisiad newydd: "
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Dileu Trac"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "Big-endian"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Troi o Chwith"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Maint"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Amser oedi (eiliadau):"
+
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
 msgstr "Adlif (%):"
@@ -2681,6 +8881,34 @@ msgstr "Adlif (%):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "Dyfnder (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Dyfnder (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Chwyddo (dB)"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Chwyddo (dB)"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Stereo,"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -2695,13 +8923,116 @@ msgstr "Troi o Chwith"
 msgid "Reverses the selected audio"
 msgstr "Lleoliad allforio:"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Gweithredu Hafalu"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "I blotio'r sbectrwm, rhaid i bob trac dewisiedig fod o'r un graddfa samplo."
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Mewnhidlo"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Alinio'r Diwedd â Diwedd y Dewisiad"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Gweithred"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Gweithred"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size:"
+msgstr " ffenest"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size"
+msgstr " ffenest"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -2718,6 +9049,32 @@ msgstr "Trothwy:"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
 msgstr "Llyfn wrth Sampl"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
+msgstr "Llyfn wrth Sampl"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Line Time:"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time"
+msgstr "Dewis ffeil MIDI..."
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Smooth Time:"
@@ -2739,15 +9096,28 @@ msgstr "256 - rhagosodedig"
 msgid "Restore Defaults"
 msgstr "256 - rhagosodedig"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Distewi"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "Hollti Trac Stereo"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -2765,6 +9135,43 @@ msgstr "Hollti Trac Stereo"
 msgid "Sliding Stretch"
 msgstr "Ffactor Gwanhau:"
 
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "Rhyngosodiad Sinc Chwim"
+
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
 msgstr "Sin"
@@ -2778,6 +9185,26 @@ msgid "Sawtooth"
 msgstr "Dant llif"
 
 #: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Tonffurf:"
 
@@ -2786,18 +9213,91 @@ msgid "&Frequency (Hz):"
 msgstr "Amledd LFO (Hz):"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Amledd LFO (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "Amledd LFO (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Osgled (0-1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Osgled (0-1)"
+
+#: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "Rhyngosodiad Sinc Chwim"
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Detected Silence"
+msgstr "Yn Cynhyrchu  Distawrwydd"
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Distewi"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Yn Cynhyrchu  Distawrwydd"
 
 #: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Cywasgydd..."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "&Effeithio"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Methwyd agor y rhaglengell amgodio MP3!"
 
@@ -2805,37 +9305,129 @@ msgstr "Methwyd agor y rhaglengell amgodio MP3!"
 msgid "VST Effect Options"
 msgstr "Gosodiadau'r Effaith"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Hyd dewisiad newydd: "
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Cyfuniad Bysyll"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "Cyfuniad Bysyll"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Cadw Cywaith &Fel..."
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Allforio Niferus"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Allforio Niferus"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Ffeiliau Cywaith Audacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "Gweithredu effaith: %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Cadw Cywaith &Fel..."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Dewis ffeil MIDI..."
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "Gweithredu effaith: %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Methu penodi"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Gosodiadau'r Effaith"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Methu penodi"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Methu penodi"
 
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "Wa-wa"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -2846,8 +9438,29 @@ msgid "Reso&nance:"
 msgstr "Cyseiniant:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Cyseiniant:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Atred Amledd Wa-wa  (%):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Atred Amledd Wa-wa  (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Gosodiadau'r Effaith"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -2862,16 +9475,47 @@ msgid "Audio Unit Effect Options"
 msgstr "Gosodiadau'r Effaith"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Rhyngwyneb"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Lleihau'r Dewisiad i'r Chwith"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr " ffenest"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "Cy&nhyrchu"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Allforio Niferus"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "Enw'r ffeil gyntaf:"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
@@ -2885,6 +9529,11 @@ msgstr "Methwyd agor y ffeil: \"%s\""
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Unable to read the preset from \"%s\""
+msgstr "Methu penodi"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to encode preset from \"%s\""
 msgstr "Methu penodi"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -2929,15 +9578,80 @@ msgstr "Allforio Niferus"
 msgid "Failed to set preset name"
 msgstr "Methu penodi"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to retrieve preset content"
+msgstr "Methu penodi"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Methu penodi"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Graddfa Samplo:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to write XML preset to \"%s\""
+msgstr "Methu penodi"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Methu penodi"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Methwyd ysgrifennu i'r ffeil: "
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Methu penodi"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Trac Sain"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "&Effeithio"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "&Effeithio"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Gosodiadau'r Effaith"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -2945,6 +9659,7 @@ msgstr "Gosodiadau'r Effaith"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "&Effeithio"
@@ -2953,13 +9668,59 @@ msgstr "&Effeithio"
 msgid "LV2 Effect Settings"
 msgstr "Gosodiadau'r Effaith"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "Cy&nhyrchu"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "&Effeithio"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Gweithredu'r Effaith Nyquist..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -2975,6 +9736,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Allbwn Nyquist: "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Wedi alinio â diwedd y dewisiad"
 
@@ -2987,8 +9766,37 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Mae'n ddrwg gen i, nid yw'n bosib cyflawni effeithiau pan fo traciau unigol y sianeli ddim yn cydweddu."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Allbwn Nyquist: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "Recordio"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -3025,6 +9833,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Ni ddychwelodd Nyquist unrhyw sain.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Ni grynhöwyd y fersiwn yma o Audacity â chynhaliaeth %s."
@@ -3033,14 +9845,45 @@ msgstr "Ni grynhöwyd y fersiwn yma o Audacity â chynhaliaeth %s."
 msgid "Could not open file"
 msgstr "Methwyd agor y ffeil: "
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Methwyd agor y ffeil: "
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Methu penodi\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Rhowch Orchymun Nyquist:"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "&Load"
+msgstr ""
 
 #. i18n-hint: Nyquist is the name of a programming language
 #: src/effects/nyquist/Nyquist.cpp
@@ -3051,6 +9894,21 @@ msgstr "Annog Nyquist..."
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Annog Nyquist..."
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Methwyd agor y ffeil: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -3071,17 +9929,72 @@ msgstr "Dewis ffeil MIDI..."
 msgid "Save file as"
 msgstr "Enwi ffeiliau:"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "&Effeithio"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "Mae'n ddrwg gen i, nid yw'n bosib cyflawni effeithiau pan fo traciau unigol y sianeli ddim yn cydweddu."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "Ategion 1 i %i"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Sbectrogramau"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Gosodiadau'r Effaith"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
 msgstr "Allforio Niferus"
 
+#: src/export/Export.cpp src/export/ExportMultiple.cpp src/menus/EditMenus.cpp
+msgid "Edit Metadata Tags"
+msgstr ""
+
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "Mewnforwyd '%s'"
+
+#: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -3089,8 +10002,23 @@ msgid "Are you sure you want to export the file as \"%s\"?\n"
 msgstr " Ydych wir eisiau cadw'r ffeil fel \"\n"
 
 #: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
 msgstr "Ni chanieteir enwau llwybr hirach na 256 nod."
+
+#: src/export/Export.cpp
+#, c-format
+msgid "A file named \"%s\" already exists. Replace?"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Your tracks will be mixed down and exported as one mono file."
@@ -3105,8 +10033,39 @@ msgid "Your tracks will be mixed down to one exported file according to the enco
 msgstr "Bydd eich traciau yn cael eu cymysgu i ddau sianel stereo yn y ffeil allforedig."
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Advanced Mixing Options"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/export/Export.cpp
 msgid "Format Options"
 msgstr "Gosodiadau'r Effaith"
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Channel: %2d"
+msgstr "Sianel"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Output Channels: %2d"
+msgstr "%d Sianel"
+
+#: src/export/Export.cpp
+msgid "Mixer Panel"
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -3115,10 +10074,43 @@ msgid ""
 "Error %s"
 msgstr "Methu penodi"
 
+#: src/export/ExportCL.cpp
+msgid "Show output"
+msgstr ""
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Gweithred Orchymun"
+
+#: src/export/ExportCL.cpp
+msgid "(external program)"
+msgstr ""
+
 #: src/export/ExportCL.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Cannot export audio to %s"
 msgstr "Methu allforio sain i %s"
+
+#: src/export/ExportCL.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export"
+msgstr "Allforio Nife&r..."
 
 #: src/export/ExportCL.cpp
 msgid "Exporting the selected audio using command-line encoder"
@@ -3128,14 +10120,184 @@ msgstr "Allforio'r sain ddewisiedig gan ddefnyddio'r amgodydd llinell orchymun"
 msgid "Exporting the audio using command-line encoder"
 msgstr "Allforio'r sain ddewisiedig gan ddefnyddio'r amgodydd llinell orchymun"
 
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "Gweithred Orchymun"
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Methu penodi"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Gwall LOF"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Exporting the audio as %s"
 msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Graddfa Samplo:"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample"
+msgstr "Symudwyd y Sampl"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "Graddfa Samplo:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -3145,9 +10307,59 @@ msgstr "Cyfradd Ddidau:"
 msgid "Quality (kbps):"
 msgstr "Ansawdd"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "&Agor..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Constrained"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -3158,8 +10370,44 @@ msgid "Low Delay"
 msgstr "Allhidlo"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Big-endian"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -3174,8 +10422,20 @@ msgid "Frame Duration:"
 msgstr "Gweithred"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Vbr Mode:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "Gweithredu'r Gweddydd"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
@@ -3186,21 +10446,497 @@ msgid "Current Codec:"
 msgstr "Crëwyd cywaith newydd"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "Gweithredu effaith: %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Ysgrifennu dros ffeiliau cyfredol"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Confirm Overwrite"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "Crëwyd trac sain newydd"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Nid yw'r ffolder %s yn bod. Ei greu?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "Ailenwyd '%s' i '%s'"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Ch"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Main"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "Gwall LOF"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "4-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "8-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "Enw'r ffeil gyntaf:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Enw'r ffeil gyntaf:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Allforio Labeli Fel:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Allforio Labeli Fel:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Crëwyd cywaith newydd"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Ategion 1 i %i"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Iaith:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Quality:"
+msgstr "Ansawdd"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Graddfa Samplo:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Pob ffeil (*)|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Cywasgydd..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Enwi..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Dewisiad i'r Diwedd"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Gosod Graddfa Samplo"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "Enw Trac"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "Ailenwyd '%s' i '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "No presets to export"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file to export presets into"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Methu penodi"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Methu penodi"
+
+#: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "0 (fastest)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "8 (best)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "Level:"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Bit depth:"
+msgstr "Cyfradd Ddidau:"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "FLAC Files"
+msgstr "Pob ffeil (*)|*"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Methwyd agor y ffeil: \"%s\""
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the selected audio as FLAC"
+msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the audio as FLAC"
 msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 
+#: src/export/ExportMP2.cpp
+#, fuzzy
+msgid "MP2 Files"
+msgstr "Enwi ffeiliau:"
+
+#: src/export/ExportMP2.cpp
+msgid "Cannot export MP2 with this sample rate and bit rate"
+msgstr ""
+
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
 msgstr "Methu agor y ffeil ar gyfer ysgrifennu"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 
 #: src/export/ExportMP2.cpp
 #, c-format
@@ -3208,13 +10944,148 @@ msgid "Exporting the audio at %ld kbps"
 msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 
 #: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "Big-endian"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr " (analluogwyd)"
+
+#: src/export/ExportMP3.cpp
+msgid "Average"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Constant"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "Troi i Stereo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Troi i Stereo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "Cyfradd Ddidau:"
 
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "Ansawdd"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "Sianel"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Gwaredu Trac"
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Tenacity needs the file %s to create MP3s."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr "Gweithred"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "To find %s, click here -->"
+msgstr ""
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+msgid "To get a free copy of LAME, click here -->"
+msgstr ""
 
 #. i18n-hint: It's asking for the location of a file, for
 #. * example, "Where is lame_enc.dll?" - you could translate
@@ -3223,6 +11094,43 @@ msgstr "Ansawdd"
 #, c-format
 msgid "Where is %s?"
 msgstr "Ble mae %s?"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Ffeiliau Cywaith Audacity"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "Enwi ffeiliau:"
 
 #: src/export/ExportMP3.cpp
 msgid "Could not open MP3 encoding library!"
@@ -3237,14 +11145,66 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "Nid yw'n lyfrgell amgodio MP3 dilys neu ni'i chynhelir!"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "Methu penodi"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Allforio Niferus"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
 msgstr "Allforio Niferus"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio with VBR quality %s"
+msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
@@ -3255,8 +11215,22 @@ msgid "Cannot Export Multiple"
 msgstr "Allforio Niferus"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Lleoliad allforio:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Create"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Options:"
@@ -3275,6 +11249,11 @@ msgid "First file name:"
 msgstr "Enw'r ffeil gyntaf:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Enw'r ffeil gyntaf:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "Enwi ffeiliau:"
 
@@ -3283,7 +11262,22 @@ msgid "Using Label/Track Name"
 msgstr "Yn Defnyddio Label/Enw Trac"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Yn Defnyddio Label/Enw Trac"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Rhagddodiad enw ffeil:"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "Rhagddodiad enw ffeil:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "Rhagddodiad enw ffeil:"
 
 #: src/export/ExportMultiple.cpp
@@ -3291,11 +11285,105 @@ msgid "Overwrite existing files"
 msgstr "Ysgrifennu dros ffeiliau cyfredol"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Choose a location to save the exported files"
 msgstr "Dewis lleoliad i gadw'r ffeiliau allforio"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
+msgstr "Methu penodi"
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Save As..."
+msgstr "Cadwyd %s"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis Files"
+msgstr "Nid yw'n ffeil Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Methu penodi"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Methu penodi"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Methu penodi"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Methu penodi"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
 msgstr "Methu penodi"
 
 #: src/export/ExportOGG.cpp
@@ -3310,17 +11398,69 @@ msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "Header:"
+msgstr ""
+
 #: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
 msgid "Encoding:"
 msgstr "Amgodiad:"
+
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "Dewisiwch unrhyw ffeil heb ei gywasgu..."
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Gwall wrth fewnforio"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
 msgstr "Methu allforio sain yn y fformat yma."
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "Allforio'r sain dewisiedig fel Ogg Vorbis"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -3328,8 +11468,184 @@ msgstr "Mewnforwyd '%s'"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Dewisiad i'r Diwedd"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Ni grynhöwyd y fersiwn yma o Audacity â chynhaliaeth %s."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Ffeiliau Cywaith Audacity"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -3344,13 +11660,123 @@ msgid "Import Project"
 msgstr "Allforio Labeli Fel:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Methwyd canfod ffolder data y cywaith: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "i Ddechrau y Dewisiad"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -3367,13 +11793,20 @@ msgstr "Methu penodi"
 msgid "Unable to read %lld samples from %s"
 msgstr "Methu penodi"
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Methu penodi"
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Methu penodi"
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "Pob ffeil (*)|*"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -3427,6 +11860,29 @@ msgstr "Methwyd agor y ffeil: "
 msgid "Could not open file %s."
 msgstr "Methwyd agor y ffeil: \"%s\""
 
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "Enwi ffeiliau:"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis files"
+msgstr "Nid yw'n ffeil Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
 msgstr "Gwall Darllen Cyfrwng"
@@ -3447,6 +11903,230 @@ msgstr "Pennawd didlif Vorbis annilys"
 msgid "Internal logic fault"
 msgstr "Nam rhesymeg fewnol"
 
+#: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 16 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 24 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "Mewnforwyd '%s'"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "Enwi ffeiliau:"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Methu penodi"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "Methu penodi"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Methu penodi"
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "Mewnforio Data Crai"
+
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
 msgstr "Mewnforio Data Crai"
@@ -3456,6 +12136,19 @@ msgstr "Mewnforio Data Crai"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Dim 'endianness'"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Big-endian"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -3476,6 +12169,15 @@ msgstr "2 Sianel (Stereo)"
 msgid "%d Channels"
 msgstr "%d Sianel"
 
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Sianel"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
@@ -3493,6 +12195,15 @@ msgstr "Faint i fewnforio:"
 #: src/import/ImportRaw.cpp
 msgid "Sample rate:"
 msgstr "Graddfa Samplo:"
+
+#: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Import"
+msgstr "Mewnforio"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -3514,12 +12225,23 @@ msgstr "dde"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
 msgid_plural "%s %d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "start"
+msgstr "Atred gychwyn:"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "end"
+msgstr "Trem"
 
 #. i18n-hint:
 #. First two %s are each replaced with the noun "start"
@@ -3529,6 +12251,7 @@ msgstr[1] ""
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -3547,9 +12270,37 @@ msgid_plural "%d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Wedi distewi'r traciau a ddewiswyd am %.2f eiliad ger %.2f"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the left"
+msgstr "Wedi distewi'r traciau a ddewiswyd am %.2f eiliad ger %.2f"
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Symud-Sain"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "i Ddechrau y Dewisiad"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -3568,12 +12319,37 @@ msgid "Select Next Clip"
 msgstr "Erfyn Nesaf"
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "Erfyn Blaenorol"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "Crëwyd cywaith newydd"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "Erfyn Nesaf"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "i Ddechrau y Dewisiad"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
 msgstr "Erfyn Symud Trac Sain"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Right"
 msgstr "Erfyn Symud Trac Sain"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasted text from the clipboard"
+msgstr "Gludo o'r clipfwrdd"
 
 #: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
 msgid "Pasted from the clipboard"
@@ -3597,12 +12373,40 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Wedi dileu %.2f eiliad ger t=%.2f"
 
 #: src/menus/EditMenus.cpp
+msgid "Pasting one type of track into another is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Copying stereo audio into a mono track is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
 msgid "Duplicated"
 msgstr "Dyblygwyd"
 
 #: src/menus/EditMenus.cpp
 msgid "Duplicate"
 msgstr "Dyblygu"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split-cut to the clipboard"
+msgstr "Torri i'r clipfwrdd"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Cut"
+msgstr "Golygu Label"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Split-deleted %.2f seconds at t=%.2f"
+msgstr "Wedi dileu %.2f eiliad ger t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Delete"
+msgstr "Gosod Pwynt Dewisiad"
 
 #: src/menus/EditMenus.cpp
 #, c-format
@@ -3620,9 +12424,47 @@ msgstr "Distewi"
 msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
 msgstr "Wedi distewi'r traciau a ddewiswyd am %.2f eiliad ger %.2f"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "Trac Sain"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Hollti"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split to new track"
+msgstr "Hollti Trac Stereo"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split New"
+msgstr "Hollti"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Joined %.2f seconds at t=%.2f"
+msgstr "Wedi dileu %.2f eiliad ger t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Wedi dileu %.2f eiliad ger t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Metadata Tags"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "&Edit"
@@ -3647,6 +12489,70 @@ msgstr "&Copio"
 msgid "&Paste"
 msgstr "&Gludo"
 
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Duplic&ate"
+msgstr "Dyblygu"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "&Dileu Traciau"
+
+#. i18n-hint: (verb) Do a special kind of cut
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Spl&it Cut"
+msgstr "Golygu Label"
+
+#. i18n-hint: (verb) Do a special kind of DELETE
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split D&elete"
+msgstr "Gosod Pwynt Dewisiad"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Tri&m Audio"
+msgstr "Trac Sain"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/EditMenus.cpp
+msgid "Sp&lit"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Ne&w"
+msgstr "Hollti"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+msgid "&Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "Yn Cynhyrchu  Distawrwydd"
+
+#: src/menus/EditMenus.cpp
+msgid "&Metadata..."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "Hoffterau Audacity"
+
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
 msgstr "BysellDdileu"
@@ -3656,28 +12562,8 @@ msgid "Delete Key&2"
 msgstr "BysellDdileu2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Chwarae Nôl"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Chwarae Nôl"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Chwarae Nôl"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Recordio"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Recordio"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Recordio"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -3698,6 +12584,17 @@ msgstr "Newid enw trac i:"
 #: src/menus/ExtraMenus.cpp
 msgid "Change Recording Cha&nnels..."
 msgstr "Newid Traw"
+
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -3721,12 +12618,28 @@ msgid "Please select a Note Track."
 msgstr "Crëwyd trac sain newydd"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "Allforio Nife&r..."
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "Dewis ffeil MIDI..."
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "Pob ffeil (*)|*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "Allforio Nife&r..."
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -3742,6 +12655,11 @@ msgid "Select a MIDI file"
 msgstr "Dewis ffeil MIDI..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Pob ffeil (*)|*"
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI files"
 msgstr "Dewis ffeil MIDI..."
 
@@ -3752,6 +12670,18 @@ msgstr "Pob ffeil (*)|*"
 #: src/menus/FileMenus.cpp
 msgid "&Dangerous Reset..."
 msgstr "Cadw Cywaith &Fel..."
+
+#. i18n-hint: This is the name of the menu item on Mac OS X only
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Open Recent"
+msgstr "Crëwyd cywaith newydd"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "Enwi ffeiliau:"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -3786,6 +12716,11 @@ msgid "&Export Audio..."
 msgstr "Allforio Nife&r..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Expo&rt Selected Audio..."
+msgstr "Lleoliad allforio:"
+
+#: src/menus/FileMenus.cpp
 msgid "Export &Labels..."
 msgstr "Allforio &Labeli"
 
@@ -3798,8 +12733,42 @@ msgid "Export MI&DI..."
 msgstr "Allforio Nife&r..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "Allforio Nife&r..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Labels..."
+msgstr "Labeli"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Allforio Nife&r..."
+
+#: src/menus/FileMenus.cpp
+msgid "&Raw Data..."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Pa&ge Setup..."
 msgstr "Gosodiad Tudalen..."
+
+#. i18n-hint: (verb) It's item on a menu.
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Print..."
+msgstr "Argraffu"
+
+#. i18n-hint: (verb) It's item on a menu.
+#: src/menus/FileMenus.cpp
+msgid "E&xit"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -3816,12 +12785,25 @@ msgid "Unable to save %s"
 msgstr "Methu penodi"
 
 #: src/menus/HelpMenus.cpp
+msgid "Do you have these problems?"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Fix"
 msgstr "Cymysgu"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "&Help"
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "Dim i'w ddadwneud"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -3836,11 +12818,29 @@ msgid "Recording stops and starts"
 msgstr "Recordio"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "&Help"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Getting Started"
+msgstr "i Ddechrau y Dewisiad"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Manual"
 msgstr "Rhedeiad Cyntaf Audacity"
 
 #: src/menus/HelpMenus.cpp
@@ -3848,16 +12848,141 @@ msgid "&Quick Help..."
 msgstr "&Help"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Ynglyn â Audacity..."
+msgid "&Manual..."
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "&Diagnostics"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Wedi ychwanegu label"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "Symud Trac i Fynu"
+
+#. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
+#. regions.
+#: src/menus/LabelMenus.cpp
+msgid "Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Cut Labeled Audio"
+msgstr "Sain a Recordwyd"
+
+#. i18n-hint: (verb) Audacity has just deleted the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Deleted labeled audio regions"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Delete Labeled Audio"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb) Audacity has just split cut the labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut on the labels
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Cut Labeled Audio"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb) Audacity has just done a special kind of DELETE on
+#. the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Deleted labeled audio regions"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb) Do a special kind of DELETE on labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Delete Labeled Audio"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silenced labeled audio regions"
+msgstr "Distewi'r dewisiad"
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
 msgid "Silence Labeled Audio"
+msgstr "Distewi'r dewisiad"
+
+#: src/menus/LabelMenus.cpp
+msgid "Copied labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Copy Labeled Audio"
+msgstr "Sain a Recordwyd"
+
+#. i18n-hint: (verb) past tense.  Audacity has just split the labeled
+#. audio (a point or a region)
+#: src/menus/LabelMenus.cpp
+msgid "Split labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Labeled Audio"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+msgid "Joined labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Join Labeled Audio"
+msgstr "Distewi'r dewisiad"
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+msgid "Detached labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detach Labeled Audio"
 msgstr "Distewi'r dewisiad"
 
 #: src/menus/LabelMenus.cpp
@@ -3877,8 +13002,22 @@ msgid "Add Label at &Playback Position"
 msgstr "Ychwanegu Label ger y Safle Chwarae"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "Symud Trac i Fynu"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Sain a Recordwyd"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "&Cut"
+msgstr ""
 
 #: src/menus/LabelMenus.cpp
 msgid "Label Cut"
@@ -3888,17 +13027,49 @@ msgstr "Golygu Label"
 msgid "Label Delete"
 msgstr "Dileu"
 
+#. i18n-hint: (verb) A special way to cut out a piece of audio
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Split Cut"
+msgstr "Golygu Label"
+
 #: src/menus/LabelMenus.cpp
 msgid "Label Split Cut"
 msgstr "Golygu Label"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Sp&lit Delete"
+msgstr "Gosod Pwynt Dewisiad"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Delete"
+msgstr "Dileu"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "Distewi'r dewisiad"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "Distewi"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Co&py"
+msgstr ""
 
 #: src/menus/LabelMenus.cpp
 msgid "Label Copy"
 msgstr "Label"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Spli&t"
+msgstr "Hollti"
 
 #: src/menus/LabelMenus.cpp
 msgid "Label Split"
@@ -3907,6 +13078,23 @@ msgstr "Golygu Label"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "Golygu Label"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "Symud Trac i Fynu"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -3929,6 +13117,16 @@ msgid "Move Focus to &Last Track"
 msgstr "Symud Trac i Fynu"
 
 #: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to P&revious and Select"
+msgstr "Symud Trac i Fynu"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to N&ext and Select"
+msgstr "Symud Trac i Fynu"
+
+#: src/menus/NavigationMenus.cpp
 msgid "&Toggle Focused Track"
 msgstr "Symud Trac i Fynu"
 
@@ -3937,8 +13135,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Symud Trac i Fynu"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "…"
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -3955,12 +13161,31 @@ msgid "&Generate"
 msgstr "Cy&nhyrchu"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Generator"
+msgstr "Ailadrodd %s"
+
+#: src/menus/PluginMenus.cpp
 msgid "Effe&ct"
 msgstr "&Effeithio"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "Ailadrodd %s"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&Dadansoddi"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "Ailadrodd %s"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -3969,6 +13194,10 @@ msgstr "Erfyn"
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Tool"
 msgstr "Ailadrodd %s"
+
+#: src/menus/PluginMenus.cpp
+msgid "&Macros..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
@@ -3994,6 +13223,10 @@ msgstr "&Rhedeg Meincnod..."
 msgid "Simulate Recording Errors"
 msgstr "Recordio"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -4014,6 +13247,16 @@ msgstr "Dewis"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "Enw Trac"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Distewi"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Trac Nodau"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -4039,9 +13282,20 @@ msgstr "Allforio &Labeli"
 msgid "Set Project..."
 msgstr "Cadw Cywaith &Fel..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Pob ffeil (*)|*"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "Trac Nodau"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "Symud Trac i Lawr"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -4067,21 +13321,96 @@ msgstr "Dewis..."
 msgid "Compare Audio..."
 msgstr "Cywasgydd..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "Dewis"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Gosod Pwynt Dewisiad"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Gweithred"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Gosod Pwynt Dewisiad"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "Dewis"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&None"
+msgstr "Dim"
+
 #: src/menus/SelectMenus.cpp
 msgid "Select None"
 msgstr "Erfyn Dewis"
+
+#: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Tracks"
+msgstr "Traciau"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "Traciau"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Erfyn Dewis"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Left at Playback Position"
+msgstr "Ychwanegu Label ger y Safle Chwarae"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Selection Left at Play Position"
 msgstr "Gosod Pwynt Dewisiad"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Right at Playback Position"
+msgstr "Ychwanegu Label ger y Safle Chwarae"
+
+#: src/menus/SelectMenus.cpp
 msgid "Set Selection Right at Play Position"
 msgstr "Gosod Pwynt Dewisiad"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "Dewisiad i'r Dechrau"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "Dewisiad i'r Dechrau"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "Enw Trac"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -4120,8 +13449,16 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Amledd Linellol"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Dewisiad i'r Dechrau"
+
+#: src/menus/SelectMenus.cpp
+msgid "Store Cursor Pos&ition"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -4134,6 +13471,18 @@ msgstr "Canfod Croesiadau Sero"
 #: src/menus/SelectMenus.cpp
 msgid "&Selection"
 msgstr "Erfyn Dewis"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Off"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Nearest"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection to &Start"
@@ -4212,6 +13561,11 @@ msgid "Cursor to Project Start"
 msgstr "i Ddechrau y Dewisiad"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Project E&nd"
+msgstr "i Ddechrau y Dewisiad"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor to Project End"
 msgstr "Crëwyd cywaith newydd"
 
@@ -4243,9 +13597,64 @@ msgstr "Cyrchydd i'r Chwith"
 msgid "Cursor Long Ju&mp Right"
 msgstr "Cyrchydd i'r Dde"
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "Erfyn"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
+
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
 msgstr "Erfyn"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr "Gwaredwyd Trac(iau) sain"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+msgid "Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr ""
 
 #. i18n-hint: One or more audio tracks have been panned
 #: src/menus/TrackMenus.cpp
@@ -4255,6 +13664,11 @@ msgstr "Gwaredwyd Trac(iau) sain"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Track"
 msgstr "Symud Trac"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Zero"
+msgstr "i Ddiwedd y Dewisiad"
 
 #: src/menus/TrackMenus.cpp
 msgid "Start to &Cursor/Selection Start"
@@ -4368,6 +13782,25 @@ msgid "Align Together"
 msgstr "Alinio Traciau at ei gilydd"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "Alinio'r Diwedd â Diwedd y Dewisiad"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted gain"
+msgstr "Addaswyd y chwyddamlen."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted Pan"
+msgstr "Addaswyd y chwyddamlen."
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
 msgstr "Crëwyd trac sain newydd"
 
@@ -4384,16 +13817,97 @@ msgid "Created new label track"
 msgstr "Crëwyd trac label newydd"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Wedi creu trac amser newydd"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Graddfa Samplo:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "The entered value is invalid"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Resampling track %d"
+msgstr "Analluogwyd ailsamplo."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resampled audio track(s)"
+msgstr "Gwaredwyd Trac(iau) sain"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "Gwaredu Trac"
 
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "Crëwyd trac sain newydd"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "Alinio'r Diwedd â Diwedd y Dewisiad"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by time"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Time"
+msgstr "Amser Ymosod:"
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by name"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Name"
+msgstr "Rhif Trac:"
+
+#: src/menus/TrackMenus.cpp
+msgid "Can't delete track with active audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&Newydd"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "Symud Trac"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Stereo Track"
+msgstr "Gwneud Trac Stereo"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Label Track"
@@ -4404,8 +13918,25 @@ msgid "&Time Track"
 msgstr "Track Amser"
 
 #: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Hollti Trac Stereo"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x and Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix and Render to Ne&w Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Resample..."
+msgstr "Enwi..."
 
 #: src/menus/TrackMenus.cpp
 msgid "Remo&ve Tracks"
@@ -4414,6 +13945,11 @@ msgstr "&Dileu Traciau"
 #: src/menus/TrackMenus.cpp
 msgid "M&ute/Unmute"
 msgstr "Symud Trac i Fynu"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "Track Amser"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
@@ -4426,6 +13962,10 @@ msgstr "Trac Nodau"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "Track Amser"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -4452,12 +13992,22 @@ msgid "Pan Center"
 msgstr "Canoli"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "Traciau"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
 msgstr "Alinio'r Diwedd â Diwedd y Dewisiad"
 
 #: src/menus/TrackMenus.cpp
 msgid "Align &Together"
 msgstr "Alinio Traciau at ei gilydd"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Move Selection with Tracks (on/off)"
+msgstr "i Ddiwedd y Dewisiad"
 
 #: src/menus/TrackMenus.cpp
 msgid "Move Sele&ction and Tracks"
@@ -4468,8 +14018,17 @@ msgid "S&ort Tracks"
 msgstr "Trac Nodau"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "By &Start Time"
+msgstr "Amser Ymosod:"
+
+#: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "Enwi..."
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -4541,7 +14100,9 @@ msgstr "Gweithredu'r Gweddydd"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Recordio"
 
@@ -4550,8 +14111,32 @@ msgid "no label track"
 msgstr "Crëwyd trac label newydd"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track at or below focused track"
+msgstr "Crëwyd trac label newydd"
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Crëwyd trac label newydd"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -4580,8 +14165,33 @@ msgstr "Gosodiadau'r Effaith"
 msgid "Pl&aying"
 msgstr "Gweithredu'r Gweddydd"
 
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "Chwarae Nôl"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Seibio"
+
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
+msgstr "Recordio"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
 msgstr "Recordio"
 
 #: src/menus/TransportMenus.cpp
@@ -4593,8 +14203,71 @@ msgid "Record &New Track"
 msgstr "&Dileu Traciau"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Recordio"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Recordio"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "Gosodiadau'r Effaith"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Recordio"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "Gosodiadau'r Effaith"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&ay"
+msgstr "Gweithredu'r Gweddydd"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -4629,6 +14302,10 @@ msgid "Play Before an&d After Selection End"
 msgstr "i Ddiwedd y Dewisiad"
 
 #: src/menus/TransportMenus.cpp
+msgid "Play C&ut Preview"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "&Play-at-Speed"
 msgstr "Chwarae Nôl"
 
@@ -4639,6 +14316,11 @@ msgstr "Chwarae Nôl"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play-at-Speed"
+msgstr "Chwarae Nôl"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview-at-Speed"
 msgstr "Chwarae Nôl"
 
 #: src/menus/TransportMenus.cpp
@@ -4704,6 +14386,20 @@ msgid "&Fit to Width"
 msgstr "&Ffitio yn y Ffenest"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&Ffitio yn y Ffenest"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Collapse All Tracks"
+msgstr "Track Amser"
+
+#: src/menus/ViewMenus.cpp
+msgid "E&xpand Collapsed Tracks"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "Sk&ip to"
 msgstr "Neidio i'r Diwedd"
 
@@ -4720,12 +14416,57 @@ msgid "Skip to Selection End"
 msgstr "i Ddiwedd y Dewisiad"
 
 #: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
 msgstr "Caniatau Clipio"
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "&Effeithio"
 
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr " ffenest"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Recordio"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -4733,7 +14474,7 @@ msgstr "Hoffterau Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Rhedeiad Cyntaf Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -4741,9 +14482,26 @@ msgstr "Rhedeiad Cyntaf Audacity"
 msgid "&Check for Updates"
 msgstr "Gwall wrth agor ffeil"
 
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+msgid "Batch"
+msgstr ""
+
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
 msgstr "Hoffterau Audacity"
+
+#: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Behaviors"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "Mesurydd Mewnbwn"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
@@ -4755,7 +14513,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Rhyngwyneb"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "Using:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Chwarae Nôl"
 
@@ -4772,6 +14540,16 @@ msgid "Cha&nnels:"
 msgstr "Sianel"
 
 #: src/prefs/DevicePrefs.cpp
+msgid "Latency"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "milliseconds"
+msgstr "Amser oedi (eiliadau):"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "&Buffer length:"
 msgstr "Hyd dewisiad newydd: "
 
@@ -4779,18 +14557,57 @@ msgstr "Hyd dewisiad newydd: "
 msgid "&Latency compensation:"
 msgstr "Cyfuniad Bysyll"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Gwaredwyd Trac(iau) sain"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Sianel (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 Sianel (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Ffolderau"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Hoffterau Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Ffolderau"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Dewis..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -4813,6 +14630,24 @@ msgid "Bro&wse..."
 msgstr "Dewis..."
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "&Macro output:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "Ffolder Dros Dro Newydd"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Gweithred"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
 msgstr "Dewis..."
 
@@ -4825,8 +14660,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Dewisiwch leoliad ar gyfer y ffolder dros dro"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "Gweithred Orchymun"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -4843,18 +14687,52 @@ msgid "Directory %s is not writable"
 msgstr "Nid oes posib ysgrifennu i'r ffolder %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Ni fydd newidiadau i'r ffolder dros dro yn cael effaith tan ailgychwyn Audacity"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Ffolder Dros Dro Newydd"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
 msgstr "Hoffterau Audacity"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Effect Name"
+msgstr "Gweithredu effaith: %s"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Publisher and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Type and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&Effeithio"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -4864,17 +14742,139 @@ msgstr "&Effeithio"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "&Effeithio"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Gosodiadau'r Effaith"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Ategion 1 i %i"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Rhyngosodiad Sinc Chwim"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Mewnforio"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Hoffterau Audacity"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Mime-types"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Allforio Labeli Fel:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Symud Trac i Fynu"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Symud Trac i Lawr"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Move f&ilter up"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Symudwyd '%s' %s"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Lleoliad allforio:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Lleoliad allforio:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Dewis"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr " Ydych wir eisiau cadw'r ffeil fel \""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Sianel Dde"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -4899,6 +14899,11 @@ msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (amrediad PCM samplau 8 did)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (amrediad PCM samplau 16 did)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
 msgstr "-96 dB (amrediad PCM samplau 16 did)"
 
@@ -4918,17 +14923,149 @@ msgstr "-120 dB (bras derfyn clyw dynol)"
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (amrediad PCM samplau 24 did)"
 
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Gweithred"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "Display"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Iaith:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Location of &Manual:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Tonffurf (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "Galluogwyd"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Ategion 1 i %i"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Erfyn"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "Allforio Labeli Fel:"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Hoffterau Audacity"
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
 msgstr "Hollti Trac Stereo"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Use Advanced Mixing Options"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Seconds"
+msgstr "Amser oedi (eiliadau):"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Beats"
 msgstr "Ailadrodd"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Allforio Labeli Fel:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -4940,19 +15077,95 @@ msgid "Preferences for KeyConfig"
 msgstr "Hoffterau Audacity"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Key Bindings"
+msgstr "Cyfuniad Bysyll"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "View by:"
 msgstr "G&weld"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Enwi..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "G&weld"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "G&weld"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "G&weld"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Bindings"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
 msgstr "Nodyn: Bydd pwyso Cmd+Q yn cau. Mae pob bysell arall yn ddilys."
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "&Import..."
+msgstr "Mewnforio"
+
+#: src/prefs/KeyConfigPrefs.cpp src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "&Defaults"
+msgstr "256 - rhagosodedig"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Dewisiwch ffeil XML yn cynnwys byrlwybrau bysellfwrdd Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -4961,8 +15174,21 @@ msgstr "Allforio Byrlwybrau Allweddell Fel:"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Wedi llwytho %d byrlwybr bysellfwrdd\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -4976,6 +15202,38 @@ msgstr "Allforio Byrlwybrau Allweddell Fel:"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Allforio Byrlwybrau Allweddell Fel:"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "Cyfuniad Bysyll"
@@ -4985,12 +15243,72 @@ msgid "Preferences for Library"
 msgstr "Hoffterau Audacity"
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "Fersiwn Rhaglengell MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "Fersiwn Rhaglengell MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "Gwall LOF"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "Enwi..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "Dewis ffeil MIDI..."
 
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "Hoffterau Audacity"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Rhyngwyneb"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -4998,13 +15316,77 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Rhyngwyneb"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "Hoffterau Audacity"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Ni fydd newidiadau i'r ffolder dros dro yn cael effaith tan ailgychwyn Audacity"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Ask"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -5046,13 +15428,26 @@ msgstr "Chiwth-Lusgo"
 msgid "Set Selection Range"
 msgstr "Gosod Amrediad Dewisiad"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-Clic-Chwith"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Extend Selection Range"
 msgstr "Estyn Amrediad y Dewisiad"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Alt-Chwith-Clic"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "Dewisiad i'r Diwedd"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
@@ -5071,6 +15466,10 @@ msgid "Zoom in on a Range"
 msgstr "Nesáu at Amrediad"
 
 #: src/prefs/MousePrefs.cpp
+msgid "same as right-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Right-Click"
 msgstr "Clic-dde"
 
@@ -5083,8 +15482,61 @@ msgid "Right-Drag"
 msgstr "Chwith-Lusgo"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "same as left-drag"
+msgstr "Fel yr erfyn dewis"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Chiwth-Lusgo"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom out on a Range"
+msgstr "Nesáu at Amrediad"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Clic-Chwith"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom default"
+msgstr "256 - rhagosodedig"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip left/right or between tracks"
+msgstr "Symud Trac i Fynu"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Left-Drag"
+msgstr "Chiwth-Lusgo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
 msgstr "Chiwth-Lusgo"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip up/down between tracks"
+msgstr "Symud Trac i Fynu"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Chiwth-Lusgo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -5136,6 +15588,11 @@ msgid "Scroll tracks up or down"
 msgstr "Sgrolio i fyny neu i lawr"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Wheel-Rotate"
+msgstr "Cylchdroi Olwyn"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Scroll waveform"
 msgstr "Tonffurf"
 
@@ -5160,12 +15617,59 @@ msgid "Preferences for Playback"
 msgstr "Hoffterau Audacity"
 
 #: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Effects Preview"
+msgstr "Gosodiadau'r Effaith"
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "&Length:"
 msgstr "Hyd dewisiad newydd: "
 
+#. i18n-hint: (noun) this is a preview of the cut
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Cut Preview"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Hoffterau Audacity"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -5176,8 +15680,18 @@ msgid "Preferences for Quality"
 msgstr "Hoffterau Audacity"
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Arall..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "Symudwyd y Sampl"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Rate:"
@@ -5187,13 +15701,73 @@ msgstr "Graddfa Samplo Rhagosodedig:"
 msgid "Default Sample &Format:"
 msgstr "Fformat Sampl Rhagosodedig:"
 
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Graddfa Samplo:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Con&verter:"
+msgstr "Graddfa Samplo:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Rhyngosodiad Sinc Ansawdd Uchel"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Conver&ter:"
+msgstr "Graddfa Samplo:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
 msgstr "Hoffterau Audacity"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Trac Newydd"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Recordio"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -5204,9 +15778,19 @@ msgstr "Tonffurf (dB)"
 msgid "Name newly recorded tracks"
 msgstr "Crëwyd trac sain stereo newydd"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Enw Trac"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Golygu Label"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -5216,11 +15800,67 @@ msgstr "Sain a Recordwyd"
 msgid "&Track Number"
 msgstr "Rhif Trac:"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "System &Date"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Hoffterau Audacity"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Trac Nodau"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "256 - rhagosodedig"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "256 - rhagosodedig"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "Llinellol"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -5232,10 +15872,43 @@ msgstr "Llinellol"
 msgid "Frequencies"
 msgstr "Amledd (Hz):"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Traw (EAC)"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be at least 0 Hz"
+msgstr "Amledd LFO (Hz):"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "Amledd LFO (Hz):"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -5254,6 +15927,10 @@ msgstr "Hoffterau Audacity"
 msgid "&Use Preferences"
 msgstr "Hoffterau Audacity"
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "Amledd LFO (Hz):"
@@ -5263,12 +15940,91 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Amledd Uchaf (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Chwyddo (dB)"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Chwyddo (dB)"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Algorithm"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "A&lgorithm:"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &size:"
+msgstr " ffenest"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "256 - rhagosodedig"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr " ffenest"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Ffactor Gwanhau:"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Gosod Pwynt Dewisiad"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "Osged Frig Newydd (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -5282,9 +16038,118 @@ msgstr "Gosod Pwynt Dewisiad"
 msgid "The maximum frequency must be an integer"
 msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
 
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum frequency must be an integer"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Rhaid i'r amledd uchaf for yn gyfanrif"
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/prefs/ThemePrefs.cpp src/prefs/ThemePrefs.h
+msgid "Theme"
+msgstr ""
+
 #: src/prefs/ThemePrefs.cpp
 msgid "Preferences for Theme"
 msgstr "Hoffterau Audacity"
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Info"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Save Files"
+msgstr "Enwi ffeiliau:"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Load Files"
+msgstr "Gweithredu Hafalu"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+msgid "Tracks Behaviors"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "Hoffterau Audacity"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "Symudwyd y Sampl"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -5304,8 +16169,33 @@ msgid "Enable &dragging selection edges"
 msgstr "Distewi'r dewisiad"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Gosodiadau'r Effaith"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Botymau"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -5318,6 +16208,14 @@ msgstr "Tonffurf"
 #: src/prefs/TracksPrefs.cpp
 msgid "Spectrogram"
 msgstr "Sbectrogramau"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
@@ -5332,10 +16230,52 @@ msgid "Zoom Default"
 msgstr "256 - rhagosodedig"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Seconds"
+msgstr "Amser oedi (eiliadau):"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "5ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "10ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "20ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "50ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "100ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "500ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "MilliSeconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Samples"
 msgstr "Symudwyd y Sampl"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Chwyddo"
 
@@ -5344,12 +16284,42 @@ msgid "Preferences for Tracks"
 msgstr "Hoffterau Audacity"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Recordio"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "Graddfa Samplo Rhagosodedig:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Fformat Sampl Rhagosodedig:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "Symudwyd y Sampl"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -5372,9 +16342,46 @@ msgstr "Enw'r ffeil gyntaf:"
 msgid "Preset 2:"
 msgstr "Enw'r ffeil gyntaf:"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "Rhybudd"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "Hoffterau Audacity"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "Ca&dw Cywaith"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "Ca&dw Cywaith"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "Hollti Trac Stereo"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "Hollti Trac Stereo"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -5397,16 +16404,24 @@ msgid "Stopped"
 msgstr "Aros"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Seibio"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Neidio i'r Dechrau"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Neidio i'r Diwedd"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Seibio"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Dewisiad i'r Dechrau"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Dewisiad i'r Diwedd"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -5420,20 +16435,24 @@ msgstr "Trac Newydd"
 msgid "Append Record"
 msgstr "Recordio"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Dewisiad i'r Diwedd"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Dewisiad i'r Dechrau"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Seibio"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Erfyn Dewis"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -5444,6 +16463,11 @@ msgstr "Chwarae Nôl"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Recordio"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "Trac Sain"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -5466,8 +16490,24 @@ msgid "Select Playback Device"
 msgstr "Chwarae Nôl"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Distewi"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Sianel Dde"
+
+#: src/toolbars/DeviceToolBar.cpp
+msgid "Device information is not available."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that manages devices
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "&Device Toolbar"
+msgstr "Erfyn"
 
 #: src/toolbars/EditToolBar.cpp
 msgid "Cut selection"
@@ -5485,11 +16525,22 @@ msgstr "Tocio tu allan i'r dewisiad"
 msgid "Silence audio selection"
 msgstr "Distewi'r dewisiad"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "Trac Nodau"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Nesáu"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Pellhau"
 
@@ -5501,6 +16552,22 @@ msgstr "Ffitio'r dewisiad i'r ffenest"
 msgid "Fit project to width"
 msgstr "Ffitio'r cywaith i'r ffenest"
 
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "&Effeithio"
+
+#. i18n-hint: Clicking this menu item shows the toolbar for editing
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "&Edit Toolbar"
+msgstr "Erfyn"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "Recordio"
+
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Meter"
 msgstr "Recordio"
@@ -5508,6 +16575,21 @@ msgstr "Recordio"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "Chwarae Nôl"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "Recordio"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+msgid "Meter-Play"
+msgstr ""
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Level"
@@ -5529,32 +16611,24 @@ msgstr "Recordio"
 msgid "&Playback Meter Toolbar"
 msgstr "Chwarae Nôl"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Recordio"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Chwarae Nôl"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Erfyn"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Recordio"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Chwarae Nôl"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Chwarae Nôl"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Annog Nyquist..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Annog Nyquist..."
@@ -5562,6 +16636,7 @@ msgstr "Annog Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Annog Nyquist..."
@@ -5569,9 +16644,24 @@ msgstr "Annog Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "i Ddiwedd y Dewisiad"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "i Ddiwedd y Dewisiad"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Erfyn"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -5582,6 +16672,14 @@ msgstr "Erfyn"
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "i Ddechrau y Dewisiad"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap-To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
+msgid "Audio Position"
+msgstr ""
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
@@ -5599,9 +16697,37 @@ msgstr "i Ddiwedd y Dewisiad"
 msgid "Length and Center of Selection"
 msgstr "Tocio'r ffeil i'r dewisiad"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Length"
+msgstr "Hyd dewisiad newydd: "
+
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Canoli"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -5609,6 +16735,13 @@ msgstr "Canoli"
 #, c-format
 msgid "Selection %s. %s won't change."
 msgstr "Dewis ffeil MIDI..."
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for selecting a time range of audio
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "&Selection Toolbar"
+msgstr "Erfyn Dewis"
 
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Center frequency and Width"
@@ -5622,11 +16755,20 @@ msgstr "Yn Chwyddo'r Amleddau Bas"
 msgid "Center Frequency"
 msgstr "Amledd Linellol"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spe&ctral Selection Toolbar"
 msgstr "Erfyn Dewis"
+
+#: src/toolbars/TimeToolBar.cpp
+#, fuzzy
+msgid "Time"
+msgstr "Track Amser"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for viewing actual time of the cursor
@@ -5636,13 +16778,18 @@ msgstr "Erfyn"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Rhedeiad Cyntaf Audacity"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Clicio a llusgo i newid maint y trac."
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Erfyn"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -5660,13 +16807,26 @@ msgstr "Erfyn Symud Trac Sain"
 msgid "Zoom Tool"
 msgstr "Erfyn Chwyddo"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Erfyn Darlunio"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Multi-Tool"
 msgstr "Aml-Erfynl"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "Erfyn Dewis"
+
+#. i18n-hint: Clicking this menu item shows a toolbar
+#. that has some tools in it
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools Toolbar"
+msgstr "Erfyn"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "&Selection Tool"
@@ -5700,17 +16860,42 @@ msgstr "Erfyn Blaenorol"
 msgid "&Next Tool"
 msgstr "Erfyn Nesaf"
 
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "Newid Cyflymder"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Playback Speed"
+msgstr "Chwarae Nôl"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "Chwarae Nôl"
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
 #: src/toolbars/TranscriptionToolBar.cpp
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "Chwarae Nôl"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Newidwyd Label"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Golygu Label"
 
@@ -5726,6 +16911,17 @@ msgstr "Ffont..."
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Label Track Font"
 msgstr "Ffont Label Trac"
+
+#. i18n-hint: (noun) The name of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+msgid "Face name"
+msgstr ""
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
+msgstr "Maint"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Cu&t Label text"
@@ -5748,34 +16944,50 @@ msgid "Deleted Label"
 msgstr "BysellDdileu"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Edited labels"
+msgstr "Newidwyd Label"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "New label"
 msgstr "Wedi ychwanegu label"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "I fynu Wythfed"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "I Lawr Wythfed"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Clico i chywddo yn fertigol,  Shift-Clic i bellhau, Llusgo i greu ardal chwyddo benodol."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clic-dde"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Pellhau"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-Clic-Chwith"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-Clic-Chwith"
 
@@ -5797,9 +17009,44 @@ msgstr "Trac Nodau"
 msgid "Stretch"
 msgstr "Ffactor Gwanhau:"
 
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "Caniatau Clipio"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Expand"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Removed Cut Line"
+msgstr "Gwaredu Trac"
+
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Click and drag to edit the samples"
 msgstr "Cliciwch a llusgwch i olygu'r samplau"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
@@ -5809,6 +17056,11 @@ msgstr "Symudwyd y Sampl"
 msgid "Sample Edit"
 msgstr "Golygu Sampl"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Nesáu at Bwynt"
@@ -5816,6 +17068,16 @@ msgstr "Nesáu at Bwynt"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Sbectrogramau"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -5834,9 +17096,15 @@ msgstr "Yn Newid Tempo"
 msgid "Processing...   0%%"
 msgstr "Trac Nodau"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   %i%%"
+msgstr "Trac Nodau"
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Newidwyd '%s' i %s"
@@ -5848,6 +17116,54 @@ msgstr "Newid Fformat"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Gosod Graddfa Samplo"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -5867,7 +17183,8 @@ msgstr "Newid Graddfa Sampl"
 msgid "Set Rate"
 msgstr "Gosod Graddfa Samplo"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Aml"
 
@@ -5886,6 +17203,11 @@ msgstr "Hollti Trac Stereo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Hollti Trac Stereo"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -5955,6 +17277,27 @@ msgstr "Chwith,"
 msgid "Right, %dHz"
 msgstr "Dde,"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "dde"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "Cliciwch a llusgwch i newid maint cymharol y traciau stereo."
@@ -5962,6 +17305,15 @@ msgstr "Cliciwch a llusgwch i newid maint cymharol y traciau stereo."
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "Cliciwch a llusgwch i symud y trac yn ôl neu ymlaen"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Cliciwch a llusgwch i symud y trac yn ôl neu ymlaen"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -5971,6 +17323,10 @@ msgstr "Nesáu"
 msgid "Zoom x2"
 msgstr "Chwyddo"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "Tonffurf"
@@ -5978,6 +17334,11 @@ msgstr "Tonffurf"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Tonffurf"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -6010,12 +17371,38 @@ msgid "Set Range"
 msgstr "Gosod Amrediad"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Display"
+msgstr "Erfyn Nesaf"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Rhyngosodiad Sinc Chwim"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "Llinellol"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Rhyngosodiad Sinc Chwim"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -6027,9 +17414,8 @@ msgstr "Rhyngosodiad Sinc Chwim"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Cliciwch a llusgwch i symud y trac yn ôl neu ymlaen"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -6080,6 +17466,21 @@ msgstr "Addaswyd y chwyddamlen."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Erfyn"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "i Ddiwedd y Dewisiad"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Erfyn"
@@ -6095,6 +17496,16 @@ msgstr "Symud Trac i Fynu"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Symud Trac i Lawr"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Annog Nyquist..."
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Neidio i'r Dechrau"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -6147,9 +17558,19 @@ msgstr "Cliciwch a llusgwch i ddewis y sain"
 msgid "Click and drag to select audio"
 msgstr "Cliciwch a llusgwch i ddewis y sain"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Cliciwch a llusgwch i symud y trac yn ôl neu ymlaen"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Could not shift between tracks"
+msgstr "Methwyd ysgrifennu i'r ffeil: \n"
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Moved clips to another track"
@@ -6164,6 +17585,10 @@ msgstr "Wedi distewi'r traciau a ddewiswyd am %.2f eiliad ger %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Wedi distewi'r traciau a ddewiswyd am %.2f eiliad ger %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -6190,6 +17615,12 @@ msgstr "Gweithred Orchymun"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Clic-Chwith"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Crëwyd trac sain newydd"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -6228,6 +17659,16 @@ msgstr "Chwith=Nesáu, Dde=Pellhau, Canol=Arferol"
 msgid "(disabled)"
 msgstr " (analluogwyd)"
 
+#: src/widgets/AButton.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Press"
+msgstr "Enw'r ffeil gyntaf:"
+
+#: src/widgets/AButton.cpp
+#, fuzzy
+msgid "Button"
+msgstr "Botymau"
+
 #. i18n-hint: One-letter abbreviation for Left, in the Pan slider
 #. i18n-hint: One-letter abbreviation for Left, in VU Meter
 #: src/widgets/ASlider.cpp src/widgets/Meter.cpp
@@ -6240,6 +17681,81 @@ msgstr "Ch"
 msgid "R"
 msgstr "Dd"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy
+msgid "Please choose an existing file."
+msgstr "Crëwyd trac sain newydd"
+
+#: src/widgets/FileDialog/mac/FileDialogPrivate.mm
+#, fuzzy
+msgid "File type:"
+msgstr "Allhidlo"
+
+#: src/widgets/FileHistory.cpp
+msgid "&Clear"
+msgstr ""
+
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
+#: src/widgets/Grid.cpp
+msgid "Empty"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Neidio i'r Dechrau"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Pob ffeil (*)|*"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click to Start Monitoring"
+msgstr "Neidio i'r Dechrau"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click for Monitoring"
+msgstr "Neidio i'r Dechrau"
+
 #: src/widgets/Meter.cpp
 msgid "Click to Start"
 msgstr "Neidio i'r Dechrau"
@@ -6247,6 +17763,16 @@ msgstr "Neidio i'r Dechrau"
 #: src/widgets/Meter.cpp
 msgid "Click"
 msgstr "Clic-Chwith"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Stop Monitoring"
+msgstr "Annog Nyquist..."
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Start Monitoring"
+msgstr "Annog Nyquist..."
 
 #: src/widgets/Meter.cpp
 msgid "Recording Meter Options"
@@ -6261,6 +17787,42 @@ msgid "Refresh Rate"
 msgstr "Gosod Graddfa Samplo"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter Style"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Type"
+msgstr "Mewnhidlo"
+
+#: src/widgets/Meter.cpp
+msgid "Orientation"
+msgstr ""
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+msgid "Automatic"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Horizontal"
 msgstr "Stereo Llorweddol"
 
@@ -6268,29 +17830,430 @@ msgstr "Stereo Llorweddol"
 msgid "Vertical"
 msgstr "Ffitio'n &Fertigol"
 
+#: src/widgets/Meter.cpp
+msgid " Monitoring "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Crëwyd trac sain newydd"
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + hundredths"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>0100 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + milliseconds"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>01000 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + samples"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+># samples"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "Symudwyd y Sampl"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames (lots of
+#. * frames) at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at PAL
+#. * TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
 msgid "octaves"
 msgstr "I Lawr Wythfed"
 
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "Hyd (eiliadau)"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Amser Ymosod: %.1f eiliad"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "Amser Ymosod: %.1f eiliad"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Cancel"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to cancel?"
 msgstr " Ydych wir eisiau cadw'r ffeil fel \""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Cancel"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to stop?"
 msgstr " Ydych wir eisiau cadw'r ffeil fel \""
 
 #: src/widgets/ProgressDialog.cpp
+msgid "Confirm Stop"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to close?"
 msgstr " Ydych wir eisiau cadw'r ffeil fel \""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Close"
+msgstr ""
 
 #. i18n-hint: %s is replaced with a directory path.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Methu penodi"
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -6307,10 +18270,63 @@ msgstr "Hoffterau Audacity"
 msgid "Don't show this warning again"
 msgstr "Peidio dangos y rhybydd yma eto"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Empty value"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Recordio"
+
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Nesáu at Amrediad"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Gwall LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Value not in range: %s to %s"
+msgstr "Cadw'r newidiadau?"
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be less than %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be greater than %s"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
@@ -6320,6 +18336,21 @@ msgstr "Crëwyd cywaith newydd"
 msgid "Directory Dialog"
 msgstr "Ffolderau"
 
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "Ffolderau"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "Gwall:"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Could not load file: \"%s\""
+msgstr "Methwyd agor y ffeil: \"%s\""
+
 #: src/xml/XMLFileReader.cpp
 msgid "Could not parse XML"
 msgstr "Methwyd agor y ffeil: "
@@ -6328,16 +18359,49 @@ msgstr "Methwyd agor y ffeil: "
 msgid "Spectral edit multi tool"
 msgstr "Gosod Pwynt Dewisiad"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Yn Normaleiddio..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Amledd (Hz):"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Gwall"
@@ -6352,8 +18416,34 @@ msgstr "Chwyddo (dB)"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Amledd Linellol"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -6366,6 +18456,32 @@ msgstr "Allhidlo"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Gweithredu'r Gweddydd"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -6388,12 +18504,32 @@ msgid "S-Curve Down"
 msgstr "Symud Trac i Lawr"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Start/End as"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
 msgstr "Cynnydd"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "i Ddiwedd y Dewisiad"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -6406,6 +18542,14 @@ msgstr "Llinellol"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Llinellol"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -6444,6 +18588,24 @@ msgstr "Symud Trac i Lawr"
 msgid "Error~%~%"
 msgstr "Gwall"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Ailadrodd"
@@ -6451,6 +18613,10 @@ msgstr "Ailadrodd"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Yn Cynhyrchu  Distawrwydd"
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Rhedeiad Cyntaf Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -6464,6 +18630,23 @@ msgstr "Cyrchydd i'r Dde"
 msgid "Reconstructing clips..."
 msgstr "Yn tynnu cliciau a popiau..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Trothwy: %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Trac Nodau"
@@ -6472,6 +18655,21 @@ msgstr "Trac Nodau"
 msgid "Crossfading..."
 msgstr "Trac Nodau"
 
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
 msgstr "Trac Nodau"
@@ -6479,6 +18677,18 @@ msgstr "Trac Nodau"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade type"
 msgstr "Allhidlo"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Gain"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 1"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 2"
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Custom Curve"
@@ -6491,6 +18701,19 @@ msgstr "Enw Trac"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade direction"
 msgstr "Mewnhidlo"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Delay"
@@ -6509,16 +18732,49 @@ msgid "Regular"
 msgstr "Petryalog"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Tonffurf (dB)"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Amser oedi (eiliadau):"
+
+#: plug-ins/delay.ny
+msgid "Pitch change effect"
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Pitch/Tempo"
 msgstr "Traw (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Pitch change per echo (semitones)"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "Nifer o weithiau i ailadrodd: "
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -6533,18 +18789,40 @@ msgid "XML file"
 msgstr "Enwi ffeiliau:"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "Recordio"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Gwall wrth agor ffeil"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Gwall (efallai na gadwyd y ffeil): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Gwall (efallai na gadwyd y ffeil): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -6575,18 +18853,67 @@ msgstr "Hyd (eiliadau)"
 msgid "Length of label region (seconds)"
 msgstr "Hyd (eiliadau)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Golygu Label"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "Cyfuniad Bysyll"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "Rhybudd"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -6596,6 +18923,17 @@ msgstr "Wedi ychwanegu label"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Mewnforio Labeli"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -6609,13 +18947,46 @@ msgstr "Gweithredu Hafalu"
 msgid "Dominic Mazzoni"
 msgstr "Tynnu Sŵn gan Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Amledd LFO (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Amledd LFO (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -6635,6 +19006,16 @@ msgid "Peak level"
 msgstr "Chwarae Nôl"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "Chwarae Nôl"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "Chwarae Nôl"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "Cynhyrchydd Tôn"
 
@@ -6647,8 +19028,64 @@ msgid "Label type"
 msgstr "Golygu Label"
 
 #: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Point after sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Yn Cynhyrchu  Distawrwydd"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Yn Cynhyrchu  Distawrwydd"
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
+#. i18n-hint: '~a' will be replaced by a time duration
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Error.~%Selection must be less than ~a."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -6676,8 +19113,29 @@ msgid "Hard Clip"
 msgstr "Caniatau Clipio"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Sianel Dde"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Tonffurf (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
 
 #: plug-ins/lowpass.ny
 msgid "Low-Pass Filter"
@@ -6696,7 +19154,24 @@ msgid "Select Function"
 msgstr "Amledd (Hz):"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Stereo Linking"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
+msgstr "Gwneud Trac Stereo"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
 msgstr "Gwneud Trac Stereo"
 
 #: plug-ins/noisegate.ny
@@ -6719,6 +19194,44 @@ msgstr "Amser Ymosod:"
 msgid "Decay (ms)"
 msgstr "Amser oedi (eiliadau):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Gweithredu'r Gweddydd"
@@ -6726,6 +19239,22 @@ msgstr "Gweithredu'r Gweddydd"
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "Gweithredu'r Gweddydd"
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -6748,7 +19277,8 @@ msgstr "Enwi ffeiliau:"
 msgid "HTML file"
 msgstr "Enwi ffeiliau:"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Enwi ffeiliau:"
 
@@ -6765,9 +19295,24 @@ msgid "Disallow"
 msgstr " (analluogwyd)"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr " (analluogwyd)"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Methu penodi"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -6778,16 +19323,62 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Dewis ffeil MIDI..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Lleoliad allforio:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Dewis ffeil MIDI..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Yn Cynhyrchu Tôn"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Allhidlo"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Duration (60s max)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm Track"
@@ -6798,8 +19389,40 @@ msgid "Generating Rhythm..."
 msgstr "Yn Cynhyrchu Tôn"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Nifer o weithiau i ailadrodd: "
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -6822,12 +19445,54 @@ msgid "Beat sound"
 msgstr "Ailadrodd"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Yn Tynnu Sŵn"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Clic-Chwith"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -6838,12 +19503,25 @@ msgid "Generating Risset Drum..."
 msgstr "Yn Cynhyrchu  Distawrwydd"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Amser oedi (eiliadau):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "Amledd Linellol"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Amledd LFO (Hz):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -6856,6 +19534,10 @@ msgstr "Golygu Sampl"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "&Dadansoddi"
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -6874,6 +19556,10 @@ msgid "HTML files"
 msgstr "Enwi ffeiliau:"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Golygu Sampl"
 
@@ -6882,8 +19568,34 @@ msgid "Time Indexed"
 msgstr "Golygu Label"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Methu penodi"
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "&Popeth"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -6898,6 +19610,11 @@ msgstr "Galluogwyd"
 msgid "Errors Only"
 msgstr "Gwall:"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -6910,6 +19627,46 @@ msgstr "Sianel Dde"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "Symudwyd y Sampl"
 
@@ -6917,6 +19674,43 @@ msgstr "Symudwyd y Sampl"
 #, lisp-format
 msgid "~a seconds."
 msgstr "Amser oedi (eiliadau):"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -6935,6 +19729,10 @@ msgid "Value (dB)"
 msgstr "Tonffurf (dB)"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Llinellol"
 
@@ -6951,6 +19749,14 @@ msgid "Right (dB)"
 msgstr "Dde,"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Llinellol"
 
@@ -6962,17 +19768,87 @@ msgstr "2 Sianel (Stereo)"
 msgid "1 channel (mono)"
 msgstr "1 Sianel (Mono)"
 
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Gwall (efallai na gadwyd y ffeil): %s"
+
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
 msgstr "Graddfa Samplo:"
+
+#: plug-ins/sample-data-import.ny
+msgid "Reading and rendering samples..."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Select file"
 msgstr "Dewis ffeil MIDI..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Gwall"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -6982,6 +19858,15 @@ msgstr "Gwall wrth agor ffeil"
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Gosod Pwynt Dewisiad"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -6999,9 +19884,21 @@ msgstr "Dant llif"
 msgid "Starting phase (degrees)"
 msgstr "Gwedd Gychwyn LFO (gradd):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Gweithredu'r Gweddydd"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -7043,6 +19940,98 @@ msgstr "&Dadansoddi"
 msgid "Strength"
 msgstr "i Ddiwedd y Dewisiad"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Processing Vocoder..."
+msgstr "Trac Nodau"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Output choice"
 msgstr "Mesurydd Allbwn"
@@ -7075,6 +20064,96 @@ msgstr "Amledd LFO (Hz):"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Amledd LFO (Hz):"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Rhedeiad Cyntaf Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Sianel"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Rhedeiad Cyntaf Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Recordio"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Methu penodi\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Recordio\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Chwarae Nôl\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Recordio\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Recordio\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Chwarae Nôl\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Chwarae Nôl\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Methu penodi"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Chwarae Nôl"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Chwarae Nôl"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Chwarae Nôl"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Recordio"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Recordio"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Recordio"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Ynglyn â Audacity..."
+
+#~ msgid "Recording Volume"
+#~ msgstr "Recordio"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Chwarae Nôl"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Recordio"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Chwarae Nôl"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Chwarae Nôl"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Cliciwch a llusgwch i symud y trac yn ôl neu ymlaen"
+
 #~ msgid "Program build date:"
 #~ msgstr "Dyddiad Adeiladu'r Rhaglen"
 
@@ -7085,10 +20164,6 @@ msgstr "Amledd LFO (Hz):"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "s"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Methu penodi"
 
 #, fuzzy
 #~ msgid "Audacity Support Data"
@@ -7104,10 +20179,6 @@ msgstr "Amledd LFO (Hz):"
 #, fuzzy
 #~ msgid "Error.n"
 #~ msgstr "Gwall"
-
-#, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "Dewisiwch unrhyw ffeil heb ei gywasgu..."
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -7151,10 +20222,6 @@ msgstr "Amledd LFO (Hz):"
 #~ "/%s/%s.%s"
 #~ msgstr "Recordio"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "Recordio"
-
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
 #~ msgstr "Nid yw cynnal Ogg Vorbis ar gael yn yr adeiladaeth yma o Audacity."
 
@@ -7182,10 +20249,6 @@ msgstr "Amledd LFO (Hz):"
 
 #~ msgid "Audacity was unable to convert an Audacity 1.0 project to the new project format."
 #~ msgstr "Methodd Audacity drosi'r cywaith Audacity 1.0 i'r fformat cywaith newydd."
-
-#, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Cywasgydd..."
 
 #, fuzzy
 #~ msgid ""
@@ -7261,10 +20324,6 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "Gwall wrth fewnforio"
 
 #, fuzzy
-#~ msgid "Click to unpin"
-#~ msgstr "Neidio i'r Dechrau"
-
-#, fuzzy
 #~ msgid "Click to pin"
 #~ msgstr "Neidio i'r Dechrau"
 
@@ -7324,10 +20383,6 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "Methwyd agor y ffeil: "
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "Dileu Trac"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "Yn tynnu cliciau a popiau..."
 
@@ -7360,10 +20415,6 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "."
 
 #, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Gweithredu'r Effaith Nyquist..."
-
-#, fuzzy
 #~ msgid "Unable to save MIDI device info"
 #~ msgstr "Methu penodi"
 
@@ -7376,24 +20427,8 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "Chwith"
 
 #, fuzzy
-#~ msgid "Right"
-#~ msgstr "Dde"
-
-#, fuzzy
 #~ msgid "&Select Chain"
 #~ msgstr "Dewis"
-
-#, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "Erfyn Dewis"
-
-#, fuzzy
-#~ msgid "&Tools"
-#~ msgstr "Erfyn"
-
-#, fuzzy
-#~ msgid "Transcri&ption"
-#~ msgstr "Erfyn Dewis"
 
 #~ msgid "Your tracks will be mixed down to a single mono channel in the exported file."
 #~ msgstr "Fydd eich traciau yn cael eu cymysgu i lawr i un sianel mono yn y ffeil a allforwyd."
@@ -7403,10 +20438,6 @@ msgstr "Amledd LFO (Hz):"
 #~ "Error opening sound device.\n"
 #~ "Try changing the audio host, recording device and the project sample rate."
 #~ msgstr "Gwall wrth agor y ddyfais sain. Gwiriwch osodiadau'r ddyfais allbwn a graddfa samplo y cywaith."
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "Recordio"
 
 #, fuzzy
 #~ msgid "Slider Playback"
@@ -7423,17 +20454,6 @@ msgstr "Amledd LFO (Hz):"
 #, fuzzy
 #~ msgid "High Frequency:"
 #~ msgstr "Amledd (Hz):"
-
-#~ msgid "Change track name to:"
-#~ msgstr "Newid enw trac i:"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "Erfyn"
-
-#, fuzzy
-#~ msgid "and"
-#~ msgstr "Trem"
 
 #, fuzzy
 #~ msgid "end to end"
@@ -7468,10 +20488,6 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "Canoli"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Dewisiad i'r Diwedd"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "i Ddiwedd y Dewisiad"
 
@@ -7498,24 +20514,12 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "Canran Newid:"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "Amser Ymosod:"
-
-#, fuzzy
 #~ msgid "Repeats"
 #~ msgstr "Ailadrodd"
 
 #, fuzzy
 #~ msgid "Sequence"
 #~ msgstr "Amledd (Hz):"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Osgled (0-1)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "Enwi..."
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -7558,10 +20562,6 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "Adlif (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Maint"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "Adlif (%):"
 
@@ -7576,10 +20576,6 @@ msgstr "Amledd LFO (Hz):"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Cynnydd"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Stereo,"
 
 #, fuzzy
 #~ msgid "RatePercentChangeStart"
@@ -7597,19 +20593,11 @@ msgstr "Amledd LFO (Hz):"
 #~ msgid "PitchPercentChangeEnd"
 #~ msgstr "Canran Newid:"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Yn Troi o Chwith"
-
 #~ msgid "Size"
 #~ msgstr "Maint"
 
 #~ msgid "Fit &Vertically"
 #~ msgstr "Ffitio'n &Fertigol"
-
-#, fuzzy
-#~ msgid "Co&mbined Meter Toolbar"
-#~ msgstr "Recordio"
 
 #, fuzzy
 #~ msgid "S&kip to Start"
@@ -7622,10 +20610,6 @@ msgstr "Amledd LFO (Hz):"
 #, fuzzy
 #~ msgid "Appen&d Record"
 #~ msgstr "Recordio"
-
-#, fuzzy
-#~ msgid "&Mono"
-#~ msgstr "Mono"
 
 #, fuzzy
 #~ msgid "&Left Channel"
@@ -7663,20 +20647,12 @@ msgstr "Amledd LFO (Hz):"
 #~ msgstr "Sianel Dde"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "Chwyddo (dB)"
-
-#, fuzzy
 #~ msgid "No wave tracks exist."
 #~ msgstr "Wedi dileu'r trac '%s.'"
 
 #, fuzzy
 #~ msgid "-Left-Click"
 #~ msgstr "Clic-Chwith"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "Alt-Chwith-Clic"
 
 #, fuzzy
 #~ msgid "Zoom in or out on Mouse Pointer"
@@ -7729,9 +20705,6 @@ msgstr "Amledd LFO (Hz):"
 #~ msgid "Plug-ins %i to %i"
 #~ msgstr "Ategion %i i %i"
 
-#~ msgid "MP3 Export Setup"
-#~ msgstr "Ffurfweddu Alfforio MP3"
-
 #~ msgid "Export format:"
 #~ msgstr "Fformat Allforio:"
 
@@ -7753,13 +20726,6 @@ msgstr "Amledd LFO (Hz):"
 
 #~ msgid "Using block size of %ld\n"
 #~ msgstr "Defnyddio maint bloc o %ld\n"
-
-#, fuzzy
-#~ msgid "Plot Spectrum"
-#~ msgstr "Sbectrwm"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "Rhyngosodiad Sinc Ansawdd Uchel"
 
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "Rhyngosodiad Sinc Chwim"
@@ -7795,9 +20761,6 @@ msgstr "Amledd LFO (Hz):"
 #~ msgid "Change Tempo..."
 #~ msgstr "Newid Tempo..."
 
-#~ msgid "Click Removal..."
-#~ msgstr "Tynnu Cliciau..."
-
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "Gweithredu Cywasgiad yr Amrediad Ddeinamig..."
 
@@ -7812,9 +20775,6 @@ msgstr "Amledd LFO (Hz):"
 
 #~ msgid "Equalization..."
 #~ msgstr "Hafalu..."
-
-#~ msgid "Performing Equalization"
-#~ msgstr "Gweithredu Hafalu"
 
 #~ msgid "Fading In"
 #~ msgstr "Yn Mewnhidlo"
@@ -7843,10 +20803,6 @@ msgstr "Amledd LFO (Hz):"
 
 #~ msgid "Applying Phaser"
 #~ msgstr "Gweithredu'r Gweddydd"
-
-#, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "Troi o Chwith"
 
 #~ msgid "Applied effect: Generate Silence, %.6lf seconds"
 #~ msgstr "Gweithredwyd effaith: Cynhyrchu Distawrwydd, %.6lf eiliad"
@@ -7878,20 +20834,9 @@ msgstr "Amledd LFO (Hz):"
 #~ msgid "Multi-Tool Mode: Ctrl-P for Mouse and Keyboard Preferences"
 #~ msgstr "Modd Aml-Erfyn: Ctrl-P ar gyfer Hoffterau Llygoden a Bysellfwrdd"
 
-#~ msgid "Input Meter"
-#~ msgstr "Mesurydd Mewnbwn"
-
 #, fuzzy
 #~ msgid "Change output device"
 #~ msgstr "Newid Cyflymder"
-
-#, fuzzy
-#~ msgid "Effect Refresh"
-#~ msgstr "Gosodiadau'r Effaith"
-
-#, fuzzy
-#~ msgid "Input Channels"
-#~ msgstr "%d Sianel"
 
 #, fuzzy
 #~ msgid "Select Input Channels"

--- a/locale/da.po
+++ b/locale/da.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/tenacity/tenacity/da/>\n"
@@ -22,42 +22,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Afslut Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Kanal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Fejl ved afkodning af fil"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Fejl ved indlæsning af metadata"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity-værktøjslinje: %s"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Optager"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Kan ikke fastslå"
@@ -67,9 +31,32 @@ msgstr "Kan ikke fastslå"
 msgid "%s bytes"
 msgstr "%s byte"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Forenklet"
+
+#: libraries/lib-strings/Languages.cpp
+#, fuzzy
+msgid "System"
+msgstr "Systemets &dato"
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -110,6 +97,11 @@ msgstr "&Ryd\tCtrl+L"
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "&Vælg alt\tCtrl+A"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Find...\tCtrl+F"
+msgstr "&Fortryd\tCtrl+Z"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Matching Paren\tF8"
@@ -172,8 +164,24 @@ msgid "&Go\tF5"
 msgstr "&Gå\tF5"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Stop\tF6"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&About"
 msgstr "&Om"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Scriptbare"
+
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Output"
+msgstr "Vis &output"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Load Nyquist script"
@@ -187,7 +195,12 @@ msgstr "Nyquist-script (*.ny)|*.ny|Lisp-script (*.lsp)|*.lsp|Alle filer|*"
 msgid "Script was not saved."
 msgstr "Script blev ikke gemt."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Advarsel"
 
@@ -196,15 +209,30 @@ msgid "Save Nyquist script"
 msgstr "Gem Nyquist-script"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find dialog"
+msgstr "Fildialog"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango-ikongalleri (værktøjsikoner)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 af Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 af Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Eksternt Audacity-modul der giver en simpel IDE til at skrive effekter."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -227,7 +255,8 @@ msgstr "Uden titel"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist-effekt-arbejdsbord - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Ny"
 
@@ -267,7 +296,8 @@ msgstr "Kopiér"
 msgid "Copy to clipboard"
 msgstr "Kopiér til udklipsholderen"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Klip"
 
@@ -275,7 +305,8 @@ msgstr "Klip"
 msgid "Cut to clipboard"
 msgstr "Klip til udklipsholderen"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Sæt ind"
 
@@ -300,7 +331,8 @@ msgstr "Vælg alt"
 msgid "Select all text"
 msgstr "Markér alt tekst"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Fortryd"
 
@@ -308,7 +340,8 @@ msgstr "Fortryd"
 msgid "Undo last change"
 msgstr "Fortryd sidste ændring"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Omgør"
 
@@ -317,8 +350,17 @@ msgid "Redo previous change"
 msgstr "Omgør forrige ændring"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "Find tekst"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
 msgstr "Find tekst"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Match"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Go to matching paren"
@@ -357,9 +399,26 @@ msgid "Go to next S-expr"
 msgstr "Gå til næste S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Begyndelse"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Start script"
+msgstr "Gem script"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Stop"
+msgstr "Stoppet"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Stop script"
+msgstr "Åbn script"
 
 #. i18n-hint: information about the program
 #: src/AboutDialog.cpp
@@ -367,25 +426,48 @@ msgstr "Begyndelse"
 msgid "About %s"
 msgstr "Om %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Byginformation"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Deaktiveret"
 
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Commit-id:"
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Komprimering:"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
 msgstr "Bygtype:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Compiler:"
+msgstr "Kompressor"
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
 
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
@@ -393,16 +475,18 @@ msgid "Installation Prefix:"
 msgstr "Installationens præfiks:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Indstillingsmappe:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Indstillingsmappe:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Understøttelse af filformater"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Grafisk brugerflade-bibliotek på tværs af platforme"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -416,7 +500,6 @@ msgstr "Konvertering af samplingshastighed"
 msgid "MP3 Importing"
 msgstr "Importerer MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Import og eksport af Ogg Vorbis"
@@ -425,7 +508,6 @@ msgstr "Import og eksport af Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Understøttelse af ID3-mærkat"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Import og eksport af FLAC"
@@ -443,14 +525,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg-import/-eksport"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Import gennem GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Funktionalitet"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Understøttelse af plugin"
 
@@ -465,6 +539,10 @@ msgstr "Understøttelse af tonehøjde- og temposkift"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Understøttelse af ekstrem tonehøjde- og temposkift"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Funktionalitet"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -556,6 +634,12 @@ msgstr "%s, komponist"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "%s, komponist"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, Nyquist-plugins"
@@ -577,6 +661,10 @@ msgstr "%s, grafik"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (med %s, %s, %s, %s og %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -586,6 +674,10 @@ msgstr "%s, det frie, open source, platformsuafhængige software til optagelse o
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Anerkendelse"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -620,6 +712,10 @@ msgid "%s Team Members"
 msgstr "%s-teammedlemmer"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Bidragydere"
 
@@ -632,6 +728,7 @@ msgstr "Websted og grafik"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Dansk oversættelse af Thomas Breinstrup og scootergrisen"
@@ -649,6 +746,22 @@ msgstr "Særlig tak til:"
 #, c-format
 msgid "%s website: "
 msgstr "%s-websted: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Bidragydere"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -671,6 +784,7 @@ msgstr "Tidslinje"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klik-og-træk for at starte søg"
@@ -678,6 +792,7 @@ msgstr "Klik-og-træk for at starte søg"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klik-og-træk for at starte skrub"
@@ -685,6 +800,7 @@ msgstr "Klik-og-træk for at starte skrub"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Klik-og-flyt for at skrubbe. Klik-og-træk for at søge."
@@ -692,6 +808,7 @@ msgstr "Klik-og-flyt for at skrubbe. Klik-og-træk for at søge."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Flyt for at søge"
@@ -699,6 +816,7 @@ msgstr "Flyt for at søge"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Flyt for at skrubbe"
@@ -755,7 +873,17 @@ msgstr ""
 "Kan ikke låse område udover\n"
 "slutningen af projektet."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Fejl"
 
@@ -779,7 +907,8 @@ msgstr ""
 "Dette er et engangsspørgsmål efter en 'installation', hvor du anmodede om at få præferencerne nulstillet."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Nulstil Audacity-præferencer"
 
 #: src/AudacityApp.cpp
@@ -792,6 +921,10 @@ msgstr ""
 "%s blev ikke fundet.\n"
 "\n"
 "Den er blevet fjernet fra listen over seneste filer."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -816,7 +949,7 @@ msgstr "&Åbn..."
 msgid "Open &Recent..."
 msgstr "Åbn &seneste..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Om Audacity..."
@@ -830,9 +963,10 @@ msgid "&File"
 msgstr "&Fil"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity kunne ikke finde et sikkert sted til at lagre midlertidige filer.\n"
@@ -840,20 +974,23 @@ msgstr ""
 "Indtast venligst en passende mappe i dialogen Præferencer."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity kunne ikke finde et sted til at lagre midlertidige filer.\n"
 "Indtast venligst en passende mappe i dialogen Præferencer."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity lukkes. Start venligst Audacity igen for at bruge den nye midlertidige mappe."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -862,15 +999,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity kunne ikke låse mappen til midlertidige filer.\n"
 "Denne mappe kan være i brug i en anden kopi af Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Vil du stadig starte Audacity?"
 
 #: src/AudacityApp.cpp
@@ -878,24 +1017,68 @@ msgid "Error Locking Temporary Folder"
 msgstr "Fejl ved låsning af midlertidig mappe"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Systemet her opdaget, at Audacity allerede kører.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Brug kommandoerne Nyt eller Åbn i den Audacity som køre, \n"
 "for at åbne flere projekter på samme tid.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity kører allerede"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Mislykket opstart af Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "An unrecoverable error has occurred during startup"
@@ -919,7 +1102,8 @@ msgstr "kør selvdiagnostik"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "vis Audacity version"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -929,9 +1113,10 @@ msgid "audio or project file name"
 msgstr "filnavn på lyd eller projekt"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -944,24 +1129,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity-projektfiler"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Meddelelse"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "DarkAudacity-tilpasning"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Hjælp"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Afslut Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity-log"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -973,9 +1182,14 @@ msgstr "&Gem..."
 msgid "Cl&ear"
 msgstr "R&yd"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Luk"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1024,7 +1238,8 @@ msgid "Error Initializing Midi"
 msgstr "Fejl ved opstart af MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity-lyd"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1039,37 +1254,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Ikke mere ledig hukommelse!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Den automatiske justering af indgangsniveauet standsede. Det var ikke muligt at optimere det yderligere. Det er stadig for højt."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Den automatiske justering af indgangsniveauet mindskede lydstyrken til %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Den automatiske justering af indgangsniveauet standsede. Det var ikke muligt at optimere det yderligere. Det er stadig for lavt."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Den automatiske justering af indgangsniveauet forøgede lydstyrken til %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Den automatiske justering af indgangsniveauet standsede. Det samlede antal analyser er overskredet, uden at en passende lydstyrke blev fundet. Den er stadig for høj."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Den automatiske justering af indgangsniveauet standsede. Det samlede antal analyser er overskredet, uden at en passende lydstyrke blev fundet. Den er stadig for lav."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Den automatiske justering af indgangsniveauet standsede. %.2f synes at være en passende lydstyrke."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1168,43 +1352,6 @@ msgstr "Ingen afspilningsenhed fundet for '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Kan ikke tjekke fælles samplingshastigheder uden begge enheder.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Modtog %d ved åbning af enheder\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Kan ikke åbne portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Tilgængelige mixere:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Tilgængelige kilder for optagelse:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Tilgængelige lydstyrker for afspilning:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Lydstyrke for optagelse er emuleret\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Lydstyrke for optagelse er systemets\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Lydstyrke for afspilning er emuleret\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Lydstyrke for afspilning er systemets\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1247,8 +1394,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatisk gendannelse efter nedbrud"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1263,12 +1411,14 @@ msgstr "Projekter, der kan gendannes"
 # scootergrisen: "Markering/Markér"
 # scootergrisen: har skrevet til malingslisten om det
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Markér"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Navn"
 
@@ -1279,6 +1429,10 @@ msgstr " Markeret"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Ingen markeret"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1353,6 +1507,11 @@ msgstr "Effekt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menukommando (med parametre)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1498,13 +1657,19 @@ msgstr "&Genskab"
 msgid "I&mport..."
 msgstr "&Importér..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Eksportér..."
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Rediger trin"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1534,7 +1699,8 @@ msgstr "Flyt &op"
 msgid "Move &Down"
 msgstr "Flyt &ned"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Gem"
 
@@ -1581,6 +1747,12 @@ msgstr "Navne må ikke indeholde \"%c\" og \"%c\""
 msgid "Are you sure you want to delete %s?"
 msgstr "Er du sikker på, at du vil slette %s?"
 
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Benchmark"
+msgstr "&Kør benchmark..."
+
 #: src/Benchmark.cpp
 msgid "Disk Block Size (KB):"
 msgstr "Diskblokstørrelse (KB):"
@@ -1612,9 +1784,17 @@ msgid "Run"
 msgstr "Kør"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Luk"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "&Kør benchmark..."
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1752,11 +1932,6 @@ msgid "No revision identifier was provided"
 msgstr "Der blev ikke angivet nogen revisionsidentifikator"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Slutdato og -tid"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Fejlfindingsbyg (fejlfindingsniveau %d)"
@@ -1865,10 +2040,24 @@ msgstr "Nuværende projekt"
 msgid "Checkpointing %s"
 msgstr "Importerer %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Kunne ikke skrive til filen: %s\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity kunne ikke skrive til filen %s.\n"
+"Måske er disken fuld eller der kan ikke skrives til den."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1889,6 +2078,10 @@ msgid ""
 msgstr ""
 "Kunne ikke registrere:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1986,6 +2179,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopiér navne til udklipsholderen"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Mangler"
 
@@ -1994,10 +2192,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Hvis du fortsætter, vil dit projekt ikke blive gemt på disken. Er dette, hvad du ønsker?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2010,7 +2209,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Afhængighedskontrol"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ingen"
 
@@ -2018,7 +2220,7 @@ msgstr "Ingen"
 msgid "Rectangle"
 msgstr "Rektangel"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trekant"
 
@@ -2029,6 +2231,38 @@ msgstr "Formet"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Rektangulær"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, ingen"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Velkommen!"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2050,9 +2284,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Understøttelse af FFmpeg er ikke lagt med ind"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2074,8 +2309,8 @@ msgid "Locate FFmpeg"
 msgstr "Find FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity skal bruge filen \"%s\" for at importere og eksportere lyd via FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2088,13 +2323,19 @@ msgstr "Placering af \"%s\":"
 msgid "To find '%s', click here -->"
 msgstr "Klik her for at finde \"%s\" -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Gennemse..."
 
 #: src/FFmpeg.cpp
 msgid "To get a free copy of FFmpeg, click here -->"
 msgstr "Klik her for at hente en gratis kopi af FFmpeg -->"
+
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
+msgstr ""
 
 #. i18n-hint: It's asking for the location of a file, for
 #. example, "Where is lame_enc.dll?" - you could translate
@@ -2109,8 +2350,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg blev ikke fundet"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2140,24 +2382,24 @@ msgid "Only libavformat.so"
 msgstr "Kun libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity kunne ikke åbne en fil i %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity kunne ikke læse fra en fil i %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity skrev en fil i %s, men kunne ikke omdøbe den til %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2194,7 +2436,9 @@ msgstr "Kopiér ikke lyde&n"
 msgid "As&k"
 msgstr "&Spørg"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Alle filer"
 
@@ -2219,6 +2463,10 @@ msgstr "Tekstfiler"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML-filer"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2260,6 +2508,14 @@ msgstr "Kubikrodsautokorrelation"
 msgid "Enhanced Autocorrelation"
 msgstr "Forbedret autokorrelation"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spektrum"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2276,9 +2532,34 @@ msgstr "Lineær frekvens"
 msgid "Log frequency"
 msgstr "Log hyppighed"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Rul"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoom ind"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2339,6 +2620,23 @@ msgstr "Der er markeret for meget lyd. Kun de første %.1f sekunders lyd vil bli
 msgid "Not enough data selected."
 msgstr "For få data markeret."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f sekund (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f sekund (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2361,7 +2659,8 @@ msgstr "spektrum.txt"
 msgid "Export Spectral Data As:"
 msgstr "Eksportér spektrumdata som:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Kunne ikke skrive til filen: %s"
@@ -2539,6 +2838,11 @@ msgstr "Forkast"
 msgid "&Compact"
 msgstr "&Kommando"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2546,19 +2850,19 @@ msgid "&History..."
 msgstr "&Historik..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internfejl i %s ved %s, linje %d.\n"
 "Informer venligst Audacity-teamet hos https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internfejl ved %s, linje %d.\n"
 "Informer venligst Audacity-teamet hos https://forum.audacityteam.org/."
@@ -2577,7 +2881,9 @@ msgid "Track"
 msgstr "Spor"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiket"
 
@@ -2637,7 +2943,8 @@ msgstr "Indtast navn på spor"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Etiketspor"
 
@@ -2648,11 +2955,13 @@ msgstr "En eller flere gemte etiketter kunne ikke læses."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Første kørsel af Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Vælg sprog i Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2662,7 +2971,8 @@ msgstr "Vælg sprog i Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Det sprog, som du har valgt, %s (%s), er ikke det samme som systemets sprog, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Bekræft"
 
@@ -2680,13 +2990,19 @@ msgstr ""
 "Den gamle fil er gemt som \"%s\""
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Åbner Audacity-projekt"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity-karaoke%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Gennemse..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2718,6 +3034,12 @@ msgstr ""
 msgid "Disallowed"
 msgstr "Ikke tilladt"
 
+#. i18n-hint: noun, means a track, made by mixing other tracks
+#: src/Mix.cpp
+#, fuzzy
+msgid "Mix"
+msgstr "Ret"
+
 #: src/Mix.cpp src/menus/TrackMenus.cpp
 msgid "Mix and Render"
 msgstr "Mix og render"
@@ -2727,19 +3049,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mixer alle renderer spor"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity-mixerpult%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Forstærkning"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Tonehastighed"
 
@@ -2748,23 +3074,44 @@ msgid "Musical Instrument"
 msgstr "Musikinstrument"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balance"
+
+#. i18n-hint: This is on a button that will silence this track.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Mute"
+msgstr " Mute"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr " Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Signalniveaumåler"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Ændrede på forstærkning"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Ændrede tonehastigheden"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Ændrede på balance"
 
@@ -2799,9 +3146,9 @@ msgstr ""
 "Det vil ikke blive indlæst."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2835,16 +3182,19 @@ msgstr ""
 "\n"
 "Brug kun moduler fra troværdige kilder"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Ja"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nej"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacity modulindlæser"
 
 #: src/ModuleManager.cpp
@@ -2867,6 +3217,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Nodespor"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2976,7 +3436,8 @@ msgstr "&Vælg alle"
 msgid "C&lear All"
 msgstr "&Fravælg alle"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Aktivér"
 
@@ -3055,9 +3516,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Uoverensstemmende samplingshastigheder"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Der er markeret for få spor til optagelse ved denne samplingshastighed.\n"
@@ -3085,10 +3547,11 @@ msgid "Dropouts"
 msgstr "Manglende lyd"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3128,11 +3591,11 @@ msgid "Inspecting project file data"
 msgstr "Undersøger projektfilens data"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3175,11 +3638,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Advarsel - manglende aliasfil(er)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Projektkontrollen af \"%s\"-mappen \n"
@@ -3204,12 +3667,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Advarsel - manglende alias-opsummeringsfil(er)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3267,7 +3730,8 @@ msgstr "Advarsel - herreløs(e) blokfil(er)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Forløb"
 
@@ -3292,6 +3756,11 @@ msgstr "Advarsel: der er problemer med automatisk gendannelse"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<uden titel>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3330,11 +3799,96 @@ msgid ""
 msgstr "Kan ikke læse fil med forudindstillinger."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Kunne ikke kode forudindstilling fra \"%s\""
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Gemmer et Audacity-projekt"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Kan ikke initiere MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kan ikke initiere MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kan ikke initiere MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kan ikke initiere MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kan ikke initiere MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kan ikke initiere MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kan ikke initiere MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Kan ikke initiere MP3-strøm"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3343,12 +3897,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Kan ikke initiere MP3-strøm"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Kan ikke sætte strømtilstand til pauset."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Kunne ikke finde codecet"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Kunne ikke kode forudindstilling fra \"%s\""
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3359,9 +3939,9 @@ msgid "Error Writing to File"
 msgstr "Fejl ved skrivning til filen"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3374,9 +3954,16 @@ msgstr "&Projekter gemmes"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekt %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tonehastighed"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3385,10 +3972,10 @@ msgstr "(gendannet)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Denne fil blev gemt i Audacity %s.\n"
 "Du bruger Audacity %s. Du skal måske opgradere til en nyere version for at kunne åbne filen."
@@ -3396,6 +3983,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Kan ikke åbne projektfilen"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3410,6 +4001,10 @@ msgid "Unable to parse project information."
 msgstr "Kan ikke læse fil med forudindstillinger."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Projekter gemmes"
 
@@ -3418,12 +4013,35 @@ msgid "Error Saving Project"
 msgstr "Fejl ved forsøg på at gemme projekt"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "&Tomme projekter gemmes"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3431,8 +4049,24 @@ msgstr ""
 "Heldigvis kan følgende projekter gendannes automatisk:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Nogle projekter blev ikke gemt korrekt, sidste gang Audacity kørte.\n"
+"Heldigvis kan følgende projekter gendannes automatisk:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Projektet blev gendannet"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Mappe til midlertidige filer"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3462,6 +4096,17 @@ msgstr "Advarsel - tomt projekt"
 msgid "Insufficient Disk Space"
 msgstr "Diskplads"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3481,8 +4126,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sGem projekt \"%s\" som..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Gem projekt' gælder et Audacity-projekt, ikke en lydfil.\n"
@@ -3559,11 +4205,12 @@ msgid "Error Opening Project"
 msgstr "Fejl ved åbning af projekt"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Du forsøger at åbne en automatisk oprettet sikkerhedskopifil.\n"
 "Det kan resultere i et alvorligt datatab.\n"
@@ -3596,6 +4243,12 @@ msgid "Error Opening File or Project"
 msgstr "Fejl ved åbning af fil eller projekt"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Projektet blev gendannet"
 
@@ -3621,12 +4274,33 @@ msgid "Error Importing"
 msgstr "Fejl ved import"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Sæt projekt"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Kan ikke åbne projektfilen"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Kommando"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3637,8 +4311,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatisk gem aktiveret:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Velkommen til Audacity version %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3750,6 +4424,23 @@ msgstr "Høj kvalitet"
 msgid "Best Quality (Slowest)"
 msgstr "Bedste kvalitet (langsomst)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16 bit PCM med fortegn"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24 bit PCM med fortegn"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
 #: src/SampleFormat.cpp
 msgid "Unknown format"
 msgstr "Ukendt format"
@@ -3838,7 +4529,8 @@ msgstr "Alle præferencer"
 msgid "SelectionBar"
 msgstr "Markeringslinje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektrummarkering"
 
@@ -3846,42 +4538,56 @@ msgstr "Spektrummarkering"
 msgid "Timer"
 msgstr "Tidsindstillet"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Værktøjer"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Betjening"
 
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Mixer"
+msgstr "Mixerpanel"
+
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Måler"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Afspilningsmåler"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Optagelsesmåler"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Redigering"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Enhed"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Afspilningshastighed"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Skrub"
 
@@ -3896,7 +4602,10 @@ msgstr "Lineal"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Spor"
 
@@ -4006,7 +4715,8 @@ msgid "Activation level (dB):"
 msgstr "Aktiveringsniveau (db):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Velkommen til Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4036,6 +4746,11 @@ msgstr "Spornummer"
 #: src/Tags.cpp
 msgid "Year"
 msgstr "År"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genre"
+msgstr "Genre"
 
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
@@ -4129,10 +4844,25 @@ msgstr "Fejl ved forsøg på at gemme mærkatfil"
 msgid "Unsuitable"
 msgstr "Modulet er ikke egnet"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Mappe til midlertidige filer"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity kunne ikke skrive til filen:\n"
@@ -4152,9 +4882,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4163,9 +4893,9 @@ msgstr ""
 "og skrive til den."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity kunne ikke skrive billeder til filen:\n"
@@ -4182,9 +4912,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4194,9 +4924,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4205,8 +4935,9 @@ msgstr ""
 "Måske et dårligt PNG-format?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity kunne ikke indlæse sit standardtema.\n"
@@ -4244,9 +4975,9 @@ msgstr ""
 "er allerede tilstede. Overskriv?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity kunne ikke gemme filen:\n"
@@ -4285,7 +5016,11 @@ msgstr "Tilpasset"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Varighed"
 
@@ -4296,7 +5031,8 @@ msgid "Time Track"
 msgstr "Tidsspor"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Tidsindstillet optagelse i Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4370,7 +5106,8 @@ msgstr "Nuværende projekt"
 msgid "Recording start:"
 msgstr "Optagelsens start:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Varighed:"
 
@@ -4391,7 +5128,8 @@ msgid "Action after Timer Recording:"
 msgstr "Handling efter tidsindstillet optagelse:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Forløb af tidsindstillet optagelse i Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4487,6 +5225,7 @@ msgstr "099 dage 024 t 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Startdato og -tid"
@@ -4531,7 +5270,8 @@ msgstr "Aktivér automatisk &eksport?"
 msgid "Export Project As:"
 msgstr "Eksportér projekt som:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Valgmuligheder"
 
@@ -4544,7 +5284,8 @@ msgid "Do nothing"
 msgstr "Gør intet"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Afslut Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4568,7 +5309,8 @@ msgid "Scheduled to stop at:"
 msgstr "Planlagt til at stoppe ved:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Tidsindstillet optagelse i Audacity - venter på at begynde"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4594,7 +5336,8 @@ msgid "Recording Exported:"
 msgstr "Optagelse eksporteret:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Tidsindstillet optagelse i Audacity - venter"
 
 #: src/TrackInfo.cpp
@@ -4720,6 +5463,10 @@ msgstr "Flyt spor op"
 msgid "Move Track Down"
 msgstr "Flyt spor ned"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4786,6 +5533,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Anvender %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "MISLYKKEDES"
@@ -4804,13 +5561,15 @@ msgstr "%s er ikke en parameter som accepteres af %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Ugyldig værdi for parameter '%s': skulle være %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Kommando"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Gentag %s"
@@ -4845,6 +5604,10 @@ msgid "Compares a range on two tracks."
 msgstr "Sammenligner et område på to spor."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Forsinkelsestid (sekunder):"
 
@@ -4860,6 +5623,11 @@ msgstr "Udfører demohandlingen."
 msgid "Drag"
 msgstr "Træk"
 
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Panel"
+msgstr "Sporpanel"
+
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
 msgstr "Program"
@@ -4871,6 +5639,11 @@ msgstr "Spor 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Spor 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -4924,7 +5697,8 @@ msgstr "Klip"
 msgid "Envelopes"
 msgstr "Niveauer"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiketter"
 
@@ -4932,9 +5706,30 @@ msgstr "Etiketter"
 msgid "Boxes"
 msgstr "Bokse"
 
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
 msgstr "Kort"
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Typer:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Nuværende format:"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -4960,9 +5755,17 @@ msgstr "Kommentarer"
 msgid "Command:"
 msgstr "Kommando:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Giver hjælp til en kommando."
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4992,12 +5795,17 @@ msgstr "Eksporterer til en fil."
 msgid "Builtin Commands"
 msgstr "Indbyggede kommandoer"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity-teamet"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Leverer indbyggede kommandoer til Audacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5048,11 +5856,22 @@ msgstr "Gemmer et projekt."
 msgid "Saves a copy of current project."
 msgstr "Gemmer et projekt."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Hent præference"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Navn:"
 
@@ -5100,7 +5919,8 @@ msgstr "Fuldskærm"
 msgid "Toolbars"
 msgstr "Værktøjslinjer"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effekter"
 
@@ -5240,7 +6060,8 @@ msgstr "Sæt"
 msgid "Add"
 msgstr "Tilføj"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Fjern"
 
@@ -5325,7 +6146,8 @@ msgid "Edited Envelope"
 msgstr "Sæt niveau"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Niveau"
 
@@ -5368,6 +6190,14 @@ msgstr "Hastighed:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Ændr størrelse:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5417,7 +6247,10 @@ msgstr "Balance:"
 msgid "Set Track Visuals"
 msgstr "Sæt sporets grafik"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineær"
 
@@ -5442,6 +6275,11 @@ msgid "Scale:"
 msgstr "Skala:"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "VZoom øverst:"
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
 msgstr "VZoom øverst:"
 
@@ -5456,6 +6294,12 @@ msgstr "Brug Spektrumpræferencer"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Spektrummarkering"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5511,12 +6355,18 @@ msgstr "Du har valgt et spor, som ikke rummer lyd. Automatisk dyk kan kun bearbe
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Automatisk dyk skal bruge et kontrolspor, som skal være placeret under de(t) markerede spor."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Dyk&mængde:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekunder"
 
@@ -5540,7 +6390,8 @@ msgstr "Længde på indre u&dtoning:"
 msgid "Inner &fade up length:"
 msgstr "Længde på indre o&ptoning:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Tærskel:"
 
@@ -5678,11 +6529,13 @@ msgstr "til (Hz)"
 msgid "t&o"
 msgstr "&til"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Ændring i &procent:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Ændring i procent"
 
@@ -5690,9 +6543,23 @@ msgstr "Ændring i procent"
 msgid "&Use high quality stretching (slow)"
 msgstr "Brug &højkvalitetsstrækning (langsom)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "-"
 
@@ -5720,6 +6587,7 @@ msgstr "Standard vinylplade o/min:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Fra o/min"
@@ -5732,6 +6600,7 @@ msgstr "&fra"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Til o/min"
@@ -5874,6 +6743,12 @@ msgstr "Kompressor"
 msgid "Compresses the dynamic range of audio"
 msgstr "Komprimér lydens dynamiske område"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -5883,6 +6758,20 @@ msgstr "%.2f sekunder"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f sekunder"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -5999,7 +6888,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Kontrastanalyse måler den gennemsnitlige forskel i lydstyrke mellem to lydmarkeringer."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Slutning"
 
@@ -6059,6 +6949,18 @@ msgstr "&Forskel:"
 msgid "&Help"
 msgstr "&Hjælp"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nul"
@@ -6066,6 +6968,13 @@ msgstr "nul"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "ubestemt"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6119,6 +7028,12 @@ msgstr "Nuværende forskel"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Målt niveau for forgrund"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f sekunder"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6260,6 +7175,14 @@ msgstr "Blød klip -12 dB, 80% make-up-forstærkning"
 msgid "Fuzz Box"
 msgstr "Fuzz-boks"
 
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
 #: src/effects/Distortion.cpp
 msgid "Light Crunch Overdrive"
 msgstr "Let crunch overdrive"
@@ -6325,6 +7248,16 @@ msgid "Upper Threshold"
 msgstr "Øvre tærskel"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Parametre"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Parametre"
+
+#: src/effects/Distortion.cpp
 msgid "Number of repeats"
 msgstr "Antal gentagelser"
 
@@ -6355,6 +7288,10 @@ msgstr "Parameter-styringer"
 #: src/effects/Distortion.cpp
 msgid "Clipping level"
 msgstr "Klipningsniveau"
+
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Make-up Gain"
@@ -6448,7 +7385,14 @@ msgstr ""
 msgid "DTMF &sequence:"
 msgstr "DTMF-&sekvens:"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
+#, fuzzy
+msgid "&Amplitude (0-1):"
+msgstr "&Ny spidspunktsamplitude (dB):"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Varighed:"
 
@@ -6461,12 +7405,29 @@ msgid "Duty cycle:"
 msgstr "Arbejdscyklus:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f sekunder"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Tonens varighed:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Stilhedens varighed:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -6476,7 +7437,8 @@ msgstr "Ekko"
 msgid "Repeats the selected audio again and again"
 msgstr "Gentager den markerede lyd, igen og igen"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Anmodet værdi overstiger hukommelseskapacitet."
 
@@ -6500,7 +7462,8 @@ msgstr "Forudindstillinger"
 msgid "Export Effect Parameters"
 msgstr "Eksportér effektparametre"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Kunne ikke åbne filen: \"%s\""
@@ -6537,6 +7500,15 @@ msgstr "Forbereder forhåndslytning"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Forhåndslytter"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist-fejl"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -6621,6 +7593,10 @@ msgstr "&Anvend"
 #: src/effects/EffectUI.cpp
 msgid "Latency: 0"
 msgstr "Forsinkelse: 0"
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Active State"
@@ -6750,9 +7726,19 @@ msgid "Options..."
 msgstr "Valgmuligheder..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Typer:"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Navn: %s"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Beskrivelse: %s"
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -6805,6 +7791,11 @@ msgstr "Sto&p afspilning"
 msgid "Play"
 msgstr "Afspil"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
@@ -6850,6 +7841,10 @@ msgid "Low rolloff for speech"
 msgstr "Lav rolloff for tale"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefon"
 
@@ -6886,12 +7881,41 @@ msgid "Effect Unavailable"
 msgstr "Effekt utilgængelig"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Maks. dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Min. dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -6966,8 +7990,16 @@ msgid "D&efault"
 msgstr "Stan&dard"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "&SSE-trådet"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7212,7 +8244,8 @@ msgid "Builtin Effects"
 msgstr "Indbyggede effekter"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Leverer indbyggede effekter til Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7222,6 +8255,10 @@ msgstr "Ukendt navn for indbygget effekt"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "opfattet loudness"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7248,6 +8285,19 @@ msgstr "Bearbejder: %s"
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "&Normalisér"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7293,6 +8343,11 @@ msgid "&Noise type:"
 msgstr "&Støjtype:"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Median"
+msgstr "Medium bånd"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Second greatest"
 msgstr "Anden største"
 
@@ -7313,7 +8368,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (standard)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, ingen"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, ingen"
 
 #: src/effects/NoiseReduction.cpp
@@ -7413,8 +8477,9 @@ msgid "Step 1"
 msgstr "Trin 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Markér nogle få sekunder kun med støj, så Audacity ved, hvad der skal bortfiltreres.\n"
@@ -7466,13 +8531,62 @@ msgstr "&Vinduestyper:"
 msgid "Window si&ze:"
 msgstr "Vindues&størrelse:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (standard)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Trin pr. vindue:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7588,12 +8702,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&ormalisér stereokanalerne hver for sig"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Stræk"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch er kun til en ekstrem tidsstrækning eller \"stasis\"-effekt"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "&Forlængelsesfaktor:"
@@ -7875,6 +8995,11 @@ msgstr "Gør den markerede lyd baglæns"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS-tid/tonehøjdestræk"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -7884,6 +9009,15 @@ msgstr "Chebyshew, type I"
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type II"
 msgstr "Chebyshev, type II"
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Highpass"
+msgstr "Høj:"
 
 #: src/effects/ScienFilter.cpp
 msgid "Classic Filters"
@@ -8023,6 +9157,11 @@ msgstr "Brug standarder"
 msgid "Restore Defaults"
 msgstr "Genskab standarder"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8110,6 +9249,14 @@ msgid "Square, no alias"
 msgstr "Firkant, ingen alias"
 
 #: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Generates an ascending or descending tone of one of four types"
 msgstr "Genererer en stigende eller faldende tone fra en af fire typer"
 
@@ -8173,6 +9320,10 @@ msgstr "Find stilhed"
 msgid "Tr&uncate to:"
 msgstr "&Afkort til:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "&Komprimér til:"
@@ -8186,7 +9337,8 @@ msgid "VST Effects"
 msgstr "VST-effekter"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Tilføjer muligheden for at bruge VST-effekter i Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8198,7 +9350,8 @@ msgstr "Skanner Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registrerer %d af %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Kunne ikke indlæse biblioteket"
 
@@ -8218,7 +9371,8 @@ msgstr "Bufferstørrelsen styrer antallet af datapunkter som sendes til effekten
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Bufferstørrelse (8 til 1.048.576 datapunkter):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Korrektion for forsinkelse"
 
@@ -8226,7 +9380,8 @@ msgstr "Korrektion for forsinkelse"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Som del af deres bearbejdning returnerer nogle VST-effekter deres lyd forsinket til Audacity. Når der ikke kompenseres for denne forsinkelse, så kan det være du bemærker små stilheder som er blevet indsat i lyden. Når valgmuligheden aktiveres, så kompenseres der for det, men det virker måske ikke for alle VST-effekter."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Aktivér &kompensering"
 
@@ -8260,7 +9415,8 @@ msgid "Standard VST program file"
 msgstr "Standard VST-programfil"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity VST-forudindstillingsfil"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8287,7 +9443,8 @@ msgstr "Fejl ved indlæsning af VST-forudindstillinger"
 msgid "Unable to load presets file."
 msgstr "Kan ikke indlæse fil med forudindstillinger."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Effektindstillinger"
 
@@ -8303,6 +9460,16 @@ msgstr "Kan ikke læse fil med forudindstillinger."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Denne parameterfil blev gemt fra %s. Fortsæt?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8334,7 +9501,8 @@ msgid "Audio Unit Effects"
 msgstr "Lydenhedseffekter"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Leverer understøttelse af lydenhedseffekter i Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8350,7 +9518,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Valgmuligheder for lydenhedseffekt"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Som del af deres bearbejdning returnerer nogle lydenhedseffekter deres lyd forsinket til Audacity. Når der ikke kompenseres for denne forsinkelse, så kan det være du bemærker små stilheder som er blevet indsat i lyden. Når valgmuligheden aktiveres, så kompenseres der for det, men det virker måske ikke for alle lydenhedseffekter."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8494,6 +9663,7 @@ msgstr "Lydenhed"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA-effekter"
@@ -8503,7 +9673,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Leverer LADSPA-effekter"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity bruger ikke længere vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -8511,12 +9682,30 @@ msgid "LADSPA Effect Options"
 msgstr "Valgmuligheder for LADSPA-effekt"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Som del af deres bearbejdning returnerer nogle LADSPA-effekter deres lyd forsinket til Audacity. Når der ikke kompenseres for denne forsinkelse, så kan det være du bemærker små stilheder som er blevet indsat i lyden. Når valgmuligheden aktiveres, så kompenseres der for det, men det virker måske ikke for alle LADSPA-effekter."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s i:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Effektoutput"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA-effekter"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8528,7 +9717,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Bufferstørrelse (8 til %d) datapunkter:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Som del af deres bearbejdning returnerer nogle LV2-effekter deres lyd forsinket til Audacity. Når der ikke kompenseres for denne forsinkelse, så kan det være du bemærker små stilheder som er blevet indsat i lyden. Når indstillingen aktiveres, så kompenseres der for det, men det virker måske ikke for alle LV2-effekter."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -8549,12 +9739,24 @@ msgstr "%s kræver ikke-understøttet funktionalitet %s\n"
 msgid "%s requires unsupported option %s\n"
 msgstr "%s kræver ikke-understøttet valgmulighed %s\n"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Generér"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-effekter"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Leverer understøttelse af LV2-effekter i Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8562,7 +9764,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist-effekter"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Leverer understøttelse af Nyquist-effekter i Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8577,6 +9780,12 @@ msgstr "Nyquist-arbejder"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Dårligt udformet Nyquist-plugin-hovede"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -8782,7 +9991,8 @@ msgstr "Vælg en fil"
 msgid "Save file as"
 msgstr "Gem fil som"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "uden titel"
 
@@ -8791,7 +10001,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-effekter"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Leverer understøttelse af Vamp-effekter i Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -8809,6 +10020,17 @@ msgstr "Beklager, Vamp-plugin kunne ikke initiere."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Pluginindstillinger"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -8965,6 +10187,10 @@ msgid "Command Output"
 msgstr "Kommando-output"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "Du har angivet et filnavn uden en endelse. Er du sikker?"
 
@@ -9103,7 +10329,8 @@ msgstr "Eksporterer lyden som %s"
 msgid "Invalid sample rate"
 msgstr "Ugyldig samplingshastighed"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Ny samplingshastighed"
 
@@ -9133,6 +10360,14 @@ msgstr "Du kan vælge blandt hastighederne herunder."
 msgid "Sample Rates"
 msgstr "Samplingshastigheder"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Bithastighed:"
@@ -9141,6 +10376,48 @@ msgstr "Bithastighed:"
 msgid "Quality (kbps):"
 msgstr "Kvalitet (kbps):"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f sekunder"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Til"
@@ -9148,6 +10425,10 @@ msgstr "Til"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Constrained"
 msgstr "Hæmmet"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -9160,6 +10441,27 @@ msgstr "Lav forsinkelse"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9246,8 +10548,17 @@ msgid "Replace preset '%s'?"
 msgstr "Erstat forudindstilling \"%s\"?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "V"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Hoved"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9317,6 +10628,12 @@ msgstr "Importér forudindstillinger"
 msgid "Export Presets"
 msgstr "Eksportér forudindstillinger"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Nuværende codec:"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
 msgstr "Ikke alle formater og codec er kompatible. Heller ikke alle valgmulighedskombinationer er kompatible med alle codec."
@@ -9350,6 +10667,10 @@ msgstr "Sprog:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bit-reservoir"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9485,6 +10806,11 @@ msgstr ""
 "maks. - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Brug LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -9513,6 +10839,11 @@ msgstr ""
 "-1 - standard\n"
 "min. - 0\n"
 "maks. - 32 (med LPC) eller 4 (uden LPC)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Min. PdO"
+msgstr "PtO-minimum"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9659,6 +10990,16 @@ msgid "Failed to find the codec"
 msgstr "Kunne ikke finde codecet"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "%s, 64 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "%s, 64 bit"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (hurtigst)"
 
@@ -9727,6 +11068,39 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (bedste kvalitet)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Ekstrem, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (mindre filer)"
 
@@ -9739,6 +11113,15 @@ msgstr "Vanvittig, 320 kbps"
 msgid "Extreme, 220-260 kbps"
 msgstr "Ekstrem, 220-260 kbps"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Standard, 170-210 kbps"
+msgstr "Ekstrem, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
 msgid "Insane"
@@ -9747,6 +11130,12 @@ msgstr "Vanvittig"
 #: src/export/ExportMP3.cpp
 msgid "Extreme"
 msgstr "Ekstrem"
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Standard"
+msgstr "Standard"
 
 #: src/export/ExportMP3.cpp
 msgid "Medium"
@@ -9767,6 +11156,11 @@ msgstr "Konstant"
 #: src/export/ExportMP3.cpp
 msgid "Joint Stereo"
 msgstr "Sammenføjet stereo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
 
 #: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
@@ -9791,8 +11185,8 @@ msgid "Locate LAME"
 msgstr "Find LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity skal bruge filen %s for at kunne oprette MP3-filer."
 
 #: src/export/ExportMP3.cpp
@@ -9820,10 +11214,10 @@ msgid "Where is %s?"
 msgstr "Hvor er %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Du linker til lame_enc.dll v%d.%d. Versionen er ikke kompatibel med Audacity %d.%d.%d.\n"
 "Download venligst den seneste version af 'LAME for Audacity'."
@@ -10123,6 +11517,14 @@ msgstr "Eksporterer den markerede lyd som Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Eksporterer lyden som Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Filhoved:"
@@ -10136,9 +11538,10 @@ msgid "Other uncompressed files"
 msgstr "Andre ukomprimerede filer"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Du forsøgte at eksportere en WAV- eller AIFF-fil som ville være større end 4 GB.\n"
 "Det kan Audacity ikke. Eksporten blev afbrudt."
@@ -10148,8 +11551,9 @@ msgid "Error Exporting"
 msgstr "Fejl ved eksport"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Din eksporterede WAV-fil er blevet afkortet eftersom Audacity ikke kan\n"
@@ -10189,11 +11593,11 @@ msgid "All supported files"
 msgstr "Alle understøttede filer"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10202,11 +11606,11 @@ msgstr ""
 "redigere den ved at vælge Fil > Importér > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "er en MIDI-fil, ikke en lydfil. \n"
@@ -10218,18 +11622,18 @@ msgid "Select stream(s) to import"
 msgstr "Vælg strøm(me) der skal importeres"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Denne version af Audacity er ikke bygget med understøttelse af %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er et lyd-CD-spor. \n"
 "Audacity kan ikke åbne lyd-CD'er direkte. \n"
@@ -10238,10 +11642,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" er en spillelistefil. \n"
@@ -10250,10 +11654,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en Windows Media Audio-fil. \n"
@@ -10262,10 +11666,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en Advanced Audio Coding-fil.\n"
@@ -10274,12 +11678,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en krypteret lydfil. \n"
@@ -10290,10 +11694,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en RealPlayer-mediefil. \n"
@@ -10302,12 +11706,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" er en notebaseret fil, ikke en lydfil. \n"
 "Audacity kan ikke åbne denne filtype. \n"
@@ -10316,10 +11720,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10332,10 +11736,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en Wavpack-lydfil. \n"
@@ -10344,10 +11748,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en Dolby Digital-lydfil. \n"
@@ -10356,10 +11760,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en Ogg Speex-lydfil. \n"
@@ -10368,10 +11772,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" er en videofil. \n"
@@ -10385,20 +11789,31 @@ msgstr "Filen \"%s\" blev ikke fundet."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity kunne ikke genkende typen af filen \"%s\".\n"
 "Prøv at installere FFmpeg. Hvis filen er ukomprimeret, så prøv Fil > Importér > Rå data."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10407,6 +11822,11 @@ msgstr ""
 "Importfiltre, der menes at understøtte sådanne filer, er:\n"
 "%s,\n"
 "men ingen af dem kunne læse dette filformat."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Gemmer projektdatafiler"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10424,8 +11844,57 @@ msgid "Import Project"
 msgstr "Importér forudindstillinger"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Intern fejl rapporteret under forsøg på at opstille på linje."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Ugyldig samplingshastighed"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10433,16 +11902,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Kunne ikke finde projektets datamappe: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Projektets begyndelse"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Ugyldig samplingshastighed"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Ugyldig samplingshastighed"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10472,40 +11999,6 @@ msgstr "Indeks[%02x] Codec[%s], Sprog[%s], Bithastighed[%s], Kanaler[%d], Varigh
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC-filer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-kompatible filer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Kan ikke tilføj afkoder til pipeline"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer-importør"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Kan ikke sætte strømtilstand til pauset."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indeks[%02d], Type[%s], Kanaler[%d], Hastighed[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Filen indeholder ikke nogen lydstrømme."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Kan ikke importere fil, ændring af tilstand mislykkedes."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer-fejl: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10563,6 +12056,14 @@ msgstr "Kunne ikke åbne filen %s."
 msgid "MP3 files"
 msgstr "MP3-filer"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis-filer"
@@ -10597,12 +12098,97 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF og andre ukomprimerede typer"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG-containerformat)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (hovedløs)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -10625,12 +12211,70 @@ msgid "Unsigned 8 bit PCM"
 msgstr "8 bit PCM uden fortegn"
 
 #: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "32kbs G721 ADPCM"
 msgstr "32 kbs G721 ADPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "24kbs G723 ADPCM"
 msgstr "24 kbs G723 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DPCM"
+msgstr "16 bit PCM med fortegn"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "8 bit PCM med fortegn"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -10679,6 +12323,18 @@ msgstr "Importér rå data"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Ingen byterækkefølge"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Big-endian"
+msgstr ""
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -10729,6 +12385,10 @@ msgstr "Samplingshastighed:"
 msgid "&Import"
 msgstr "&Importér"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -10749,6 +12409,7 @@ msgstr "%s højre"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -10772,6 +12433,7 @@ msgstr "slutning"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -10798,7 +12460,8 @@ msgstr "Tidsforskød klip til højre"
 msgid "Time shifted clips to the left"
 msgstr "Tidsforskød klip til venstre"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Tidsforskydning"
 
@@ -10936,7 +12599,8 @@ msgstr "Beskær markerede lydspor fra %.2f sekunder til %.2f sekunder"
 msgid "Trim Audio"
 msgstr "Beskær lyd"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Opdel"
 
@@ -11041,6 +12705,11 @@ msgid "Detac&h at Silences"
 msgstr "Fra&hæft ved stilhed"
 
 #: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "&Metadata..."
+msgstr "&Rå data..."
+
+#: src/menus/EditMenus.cpp
 msgid "Pre&ferences..."
 msgstr "&Præferencer..."
 
@@ -11055,30 +12724,6 @@ msgstr "Slettetast&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "E&kstra"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "&Justér lydstyrke for afspilning..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Forøg lydstyrke for afspilning"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Sænk lydstyrke for afspilning"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "&Justér lydstyrke for optagelse..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "F&orøg lydstyrke for optagelse"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "S&ænk lydstyrke for optagelse"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -11254,6 +12899,11 @@ msgid "&Labels..."
 msgstr "&Etiketter..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Eksportér &MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Rå data..."
 
@@ -11270,6 +12920,10 @@ msgstr "&Udskriv..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "A&fslut"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -11338,12 +12992,17 @@ msgid "&Getting Started"
 msgstr "&Kom godt i gang"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity-&manual"
+#, fuzzy
+msgid "&Manual"
+msgstr "Ad&ministrér"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&Hurtig hjælp..."
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -11361,11 +13020,8 @@ msgstr "Information om &MIDI-enheder..."
 msgid "Show &Log..."
 msgstr "Vis &log..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Om Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etiket tilføjet"
 
@@ -11613,6 +13269,11 @@ msgstr "&Skift mellem fokuseret spor"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Ukategoriseret"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Nyt..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12051,6 +13712,7 @@ msgstr "Ryk markør langt mod h&øjre"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Sø&g"
@@ -12088,6 +13750,13 @@ msgstr "&Nulstil værktøjslinjer"
 #, c-format
 msgid "Rendered all audio in track '%s'"
 msgstr "Renderede alt lyd i spor \"%s\""
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Render"
+msgstr "Mix og render"
 
 #: src/menus/TrackMenus.cpp
 #, c-format
@@ -12256,18 +13925,21 @@ msgid "Created new label track"
 msgstr "Oprettet nyt etiketspor"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Denne version af Audacity tillader kun én tidslinje for hvert projektvindue."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Oprettet nyt tidspor"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Ny samplingshastighed (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Den indtastede værdi er ugyldig"
 
@@ -12345,6 +14017,10 @@ msgstr "&Etiketspor"
 #: src/menus/TrackMenus.cpp
 msgid "&Time Track"
 msgstr "&Tidsspor"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
@@ -12520,7 +14196,9 @@ msgstr "Afspiller"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Optager"
 
@@ -12602,6 +14280,11 @@ msgid "&Loop Play"
 msgstr "&Afspil i sløjfe"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "%s sat på pause."
+
+#: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "&Optagelse"
 
@@ -12665,10 +14348,6 @@ msgstr "&Afspil under optagelse (til/fra)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Softwarea&fspil optagelse under optagelse (til/fra)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomatisk justering af optagelsesniveau (til/fra)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -12760,6 +14439,13 @@ msgstr "Flyt til &næste etiket"
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Vis"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "&Zoomværktøj"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
@@ -12878,13 +14564,17 @@ msgstr "Præferencer for kvalitet"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Afslut Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
 msgid "&Check for Updates"
 msgstr "&Søg efter opdateringer..."
+
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+msgid "Batch"
+msgstr ""
 
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
@@ -12921,7 +14611,8 @@ msgstr "&Vært:"
 msgid "Using:"
 msgstr "Bruger:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Afspilning"
 
@@ -12941,7 +14632,8 @@ msgstr "&Kanaler:"
 msgid "Latency"
 msgstr "Forsinkelse"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "millisekunder"
 
@@ -12970,7 +14662,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Mapper"
 
@@ -12983,8 +14676,22 @@ msgid "Default directories"
 msgstr "Mapper"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Gennemse..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -13062,7 +14769,8 @@ msgid "Directory %s is not writable"
 msgstr "Kan ikke skrive til mappen %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Ændringen af den midlertidige mappe træder først i kraft, når Audacity starter næste gang"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13093,6 +14801,40 @@ msgstr "Grupperet efter udgiver"
 msgid "Grouped by Type"
 msgstr "Grupperet efter type"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Nyquist-fejl"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Aktivér effekter"
@@ -13114,11 +14856,13 @@ msgid "Plugin Options"
 msgstr "Valgmuligheder for plugin"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Søg efter opdateret plugins, når Audacity starter"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Genskan plugins, næste gang Audacity startes"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13298,13 +15042,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Bevar e&tiketter, hvis markeringen fastgøres til en etiket"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "&Bland system- og Audacity-tema"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Brug hovedsageligt venstre mod højre-layouts i RTL-sprog"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13472,7 +15221,8 @@ msgstr ""
 "   *   \"%s\"  (fordi genvejen '%s' bruges af \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Vælg en XML-fil, der indeholder Audacity-tastaturgenveje..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13601,8 +15351,13 @@ msgid "Loca&te..."
 msgstr "Fin&d..."
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity har automatisk fundet gyldige FFmpeg-biblioteker.\n"
@@ -13661,8 +15416,9 @@ msgid "Preferences for Module"
 msgstr "Præferencer for modul"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Disse er forsøgsmoduler. Aktivér dem kun, hvis du har læst Audacity-manualen\n"
@@ -13670,12 +15426,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'Spørg' betyder, at Audacity vil spørge, om du vil indlæse modulet, hver gang programmet starter."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'Mislykkedes' betyder, at Audacity tror, at modulet er ødelagt, og derfor ikke starter det."
 
 #. i18n-hint preserve the leading spaces
@@ -13684,7 +15442,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Ny' betyder, at der ikke er foretaget noget valg."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Ændringen af disse indstillinger træder først i kraft, når Audacity starter næste gang."
 
 #: src/prefs/ModulePrefs.cpp
@@ -13702,6 +15461,10 @@ msgstr "Ingen moduler fundet"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modul"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -13743,7 +15506,10 @@ msgstr "Træk med venstre museknap"
 msgid "Set Selection Range"
 msgstr "Sæt markeringsområde"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Skift+Venstreklik"
 
@@ -13831,6 +15597,15 @@ msgstr "+Træk med venstre museknap"
 msgid "Move clip up/down between tracks"
 msgstr "Flyt klip op/ned mellem spor"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "+Træk med venstre museknap"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -13859,6 +15634,11 @@ msgstr "Ret adskillige datapunkter"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Lav kun om på ét datapunkt"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Multiværktøj"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -13950,7 +15730,8 @@ msgid "Always scrub un&pinned"
 msgstr "Skrub altid når &ikke er fastgjort"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity-præferencer"
 
 #: src/prefs/PrefsDialog.cpp
@@ -13966,8 +15747,18 @@ msgid "Preferences for Quality"
 msgstr "Præferencer for kvalitet"
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Anden..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "Datapunkter"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Rate:"
@@ -14002,6 +15793,14 @@ msgstr "Konver&tering af samplingshastighed:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Dit&her (udjævn støj):"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14071,39 +15870,6 @@ msgid "System T&ime"
 msgstr "Systemets &klokkeslæt"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatisk justering af optagelsesniveau"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Aktivér automatisk justering af optagelsesniveau."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Ønsket spidspunkt:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Inden for:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Analyseringstid:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "millisekunder (tid på en analyse)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Antal af på hinanden følgende analyser:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 betyder endeløs"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Slag-og-rul-optagelse"
 
@@ -14114,6 +15880,21 @@ msgstr "&Forrul:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Kryds&fade:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14248,6 +16029,10 @@ msgid "1024 - default"
 msgstr "1024 - standard"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - smalleste bånd"
 
@@ -14345,13 +16130,14 @@ msgid "Info"
 msgstr "Information"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14534,7 +16320,8 @@ msgstr "Datapunkter"
 msgid "4 Pixels per Sample"
 msgstr "4 pixels pr. datapunkt"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Maks. zoom"
 
@@ -14664,6 +16451,19 @@ msgid "Skip to End"
 msgstr "Hop til slutningen"
 
 #: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Pause"
+msgstr "%s sat på pause."
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Markér til begyndelsen"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Markér til slutningen"
+
+#: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
 msgstr "Afspil i sløjfe"
 
@@ -14675,20 +16475,17 @@ msgstr "Optag nyt spor"
 msgid "Append Record"
 msgstr "Tilføj optagelse"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Markér til slutningen"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Markér til begyndelsen"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s sat på pause."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -14768,11 +16565,17 @@ msgstr "Erstat markering med stilhed"
 msgid "Sync-Lock Tracks"
 msgstr "Lås spor synkront"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zoom ind"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zoom ud"
 
@@ -14839,43 +16642,6 @@ msgstr "&Optagelsesmålerlinje"
 msgid "&Playback Meter Toolbar"
 msgstr "&Afspilningsmålerlinje"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Lydstyrke for optagelse"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Lydstyrke for afspilning"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Lydstyrke for optagelse: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Lydstyrke for optagelse (utilgængelig. Brug systemets mixer)."
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Lydstyrke for afspilning: %.2f (emuleret)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Lydstyrke for afspilning: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Lydstyrke for afspilning (utilgængelig. Brug systemets mixer)."
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Mi&xerlinje"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Søg"
@@ -14891,6 +16657,7 @@ msgstr "Skrubning"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Stop skrubning"
@@ -14898,6 +16665,7 @@ msgstr "Stop skrubning"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Start skrubning"
@@ -14905,6 +16673,7 @@ msgstr "Start skrubning"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Stop søgning"
@@ -14912,6 +16681,7 @@ msgstr "Stop søgning"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Start søgning"
@@ -14968,7 +16738,9 @@ msgstr "Længde"
 
 # scootergrisen: der står "Balance: centreret" så det skal vel være med småt
 # på dansk
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "centreret"
 
@@ -15032,8 +16804,8 @@ msgstr "&Tidslinje"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity-værktøjslinje: %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -15060,7 +16832,8 @@ msgstr "Tidsforskydningsværktøj"
 msgid "Zoom Tool"
 msgstr "Zoomværktøj"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Tegneværktøj"
 
@@ -15136,11 +16909,13 @@ msgstr "Træk i grænsen på en eller flere etiketter."
 msgid "Drag label boundary."
 msgstr "Træk i etikettens grænse."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Ændret etiket"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Etiketredigering"
 
@@ -15195,31 +16970,42 @@ msgstr "Redigerede etiketter"
 msgid "New label"
 msgstr "Ny etiket"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "&Oktav op"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Okta&v ned"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klik for at zoome ind lodret. Skift+klik for at zoome ud. Træk for at markere et zoomområde."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Højreklik for menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zoom nulstil"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Skift+Højreklik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Venstreklik/Venstretræk"
 
@@ -15261,7 +17047,8 @@ msgstr "Forén"
 msgid "Expanded Cut Line"
 msgstr "Udvidede skærelinje"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Udvid"
 
@@ -15284,6 +17071,11 @@ msgstr "Flyttede datapunkter"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Redigering af datapunkt"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15310,6 +17102,11 @@ msgid "S&pectrogram Settings..."
 msgstr "S&pektrogramindstillinger..."
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Ændring af format"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Ugyldig samplingshastighed"
 
@@ -15325,7 +17122,8 @@ msgstr "Bearbejder: %s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Ændrede \"%s\" til %s"
@@ -15337,6 +17135,54 @@ msgstr "Ændring af format"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Hastighed"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15356,7 +17202,8 @@ msgstr "Ændret hastighed"
 msgid "Set Rate"
 msgstr "Sæt hastighed"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Multivisning"
 
@@ -15375,6 +17222,11 @@ msgstr "Opdel s&tereospor"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Opdel stereo til &mono"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -15444,10 +17296,18 @@ msgstr "Venstre, %d Hz"
 msgid "Right, %dHz"
 msgstr "Højre, %d Hz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 # scootergrisen: der står "Balance: X% venstre" så det skal vel være med småt
 # på dansk
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% venstre"
@@ -15455,7 +17315,8 @@ msgstr "%.0f%% venstre"
 # scootergrisen: der står "Balance: % højre" så det skal vel være med småt på
 # dansk
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% højre"
@@ -15477,6 +17338,16 @@ msgid "Close sub-view"
 msgstr "Luk undervisning"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Zoom ind"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Zoom ind"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
 msgstr "Halv bølge"
 
@@ -15487,6 +17358,11 @@ msgstr "Bøl&geform"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "&Bølgefarve"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Musikinstrument"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -15560,9 +17436,8 @@ msgstr "Logaritmisk &interpolation"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klik-og-træk for at flytte et spor langs tidsaksen"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15613,6 +17488,7 @@ msgstr "Justeret niveau."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Skrub"
@@ -15624,6 +17500,7 @@ msgstr "Søgning"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Skrubbe&lineal"
@@ -15819,6 +17696,12 @@ msgstr "V"
 msgid "R"
 msgstr "H"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -15852,13 +17735,28 @@ msgstr "Tom"
 msgid "Backwards"
 msgstr "Bagud"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Fremad"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Hjælp på internettet"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Menuer"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -15917,6 +17815,10 @@ msgstr "Målerens opdateringshastighed pr. sekund [1-100]: "
 #: src/widgets/Meter.cpp
 msgid "Meter Style"
 msgstr "Målerens udseende"
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
 
 #: src/widgets/Meter.cpp
 msgid "Meter Type"
@@ -16059,6 +17961,7 @@ msgstr "0100 t 060 m 060 s+># datapunkter"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "datapunkter"
@@ -16220,6 +18123,15 @@ msgstr "01000,01000 billeder|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000<0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -16227,6 +18139,10 @@ msgstr "0100000<0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0,001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -16292,6 +18208,11 @@ msgstr "(brug genvejsmenuen for at ændre format)."
 msgid "centiseconds"
 msgstr "centisekunder"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Tidsforbrug:"
@@ -16333,6 +18254,11 @@ msgstr "Bekræft luk"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Kan ikke læse forudindstillingen fra \"%s\""
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -16404,6 +18330,11 @@ msgid "Value must not be greater than %s"
 msgstr "Værdien må ikke være større end %s"
 
 #: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Dialog"
+msgstr "Fildialog"
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Vælg en mappe"
 
@@ -16433,15 +18364,27 @@ msgstr "Kunne ikke åbne filen"
 msgid "Spectral edit multi tool"
 msgstr "Spektrummarkering-multiværktøj"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrerer..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Udgivet under vilkårene i GNU General Public License version 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aVælg venligst frekvenser."
@@ -16468,7 +18411,8 @@ msgstr ""
 "                      Prøv at forøge lavfrekvensgrænsen~%~\n"
 "                      eller reducér filtrerets 'Bredde'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Fejl.~%"
@@ -16529,6 +18473,25 @@ msgstr "Studieudtoning"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Anvender fade..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Sæt som stan&dard"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Udgivet under vilkårene i GNU General Public License version 2"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16672,6 +18635,11 @@ msgstr "Taktslagsfinder"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Finder taktslag..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Audacity-log"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -16996,13 +18964,38 @@ msgstr "High-pass-filter"
 msgid "Performing High-Pass Filter..."
 msgstr "Udfører high-pass-filter..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvens (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Rulaf (dB pr. oktav)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17023,10 +19016,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Etiket sammenføj"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Udgivet under vilkårene i GNU General Public License version 2"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17069,14 +19058,36 @@ msgid "Point after sound"
 msgstr "Sammenføjet stereo"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "~aOmrådelængde = ~a sekunder."
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "~aOmrådelængde = ~a sekunder."
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum leading silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum trailing silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
 
 #. i18n-hint: hours minutes and seconds. Do not translate "~a".
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "~ah ~am ~as"
 msgstr "~at ~am ~as"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -17089,6 +19100,11 @@ msgstr "Markeringen skal være større end %d datapunkter."
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "Ingen lyde fundet. Prøv at reducere stilhedens~%niveau og stilhedens minimum varighed."
 
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
 #: plug-ins/limiter.ny
 msgid "Limiter"
 msgstr "Begrænser"
@@ -17096,6 +19112,11 @@ msgstr "Begrænser"
 #: plug-ins/limiter.ny
 msgid "Limiting..."
 msgstr "Begrænser..."
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Type"
+msgstr "Typer:"
 
 #: plug-ins/limiter.ny
 msgid "Soft Limit"
@@ -17134,6 +19155,10 @@ msgstr ""
 msgid "Limit to (dB)"
 msgstr "Begræns til (dB)"
 
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
 msgstr "Anvend make-up-forstærkning"
@@ -17153,6 +19178,10 @@ msgstr "Støjgate"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Vælg funktion"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -17202,6 +19231,14 @@ msgstr ""
 "\"Gate frekvenser over: ~s kHz\"\n"
 "er for højt til det valgte spor.\n"
 "Sæt styringen under ~a kHz."
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Markeringen skal være større end %d datapunkter."
 
 #: plug-ins/noisegate.ny
 #, lisp-format
@@ -17276,7 +19313,8 @@ msgstr "Lisp-fil"
 msgid "HTML file"
 msgstr "HTML-fil"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Tekstfil"
 
@@ -17341,12 +19379,20 @@ msgid "Error.~%No file selected."
 msgstr "Fejl.~%Ingen fil valgt."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Genererer pluck-lyd..."
 
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI-værdier til C-toner: 36, 48, 60 [mellem C], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
@@ -17395,6 +19441,10 @@ msgstr "1 - 20 taktslag/måling"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Svingmængde"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -17465,6 +19515,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI-tonehøjde af stærkt taktslag"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI-tonehøjde af svagt taktslag"
 
@@ -17485,6 +19539,10 @@ msgid "Generating Risset Drum..."
 msgstr "Genererer rissettromme..."
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Fratagning (sekunder)"
 
@@ -17499,6 +19557,11 @@ msgstr "Bredde af støjbånd (Hz)"
 #: plug-ins/rissetdrum.ny
 msgid "Amount of noise in mix (percent)"
 msgstr "Mængden af støj i mix (procent)"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amplitude (0 - 1)"
+msgstr "Amplitude slutning"
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
@@ -17854,6 +19917,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Fejl.~%Sporets samplingshastighed under 100 Hz understøttes ikke."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Anvender tremolo..."
 
@@ -17880,6 +19947,10 @@ msgstr "Vokalreduktion og -isolering"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Anvender handling..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18022,8 +20093,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Pluginet virker kun på stereospor."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Bearbejder vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18065,6 +20144,205 @@ msgstr "Frekvens af radarnåle (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Fejl.~%Stereospor kræves."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Afslut Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Kanal"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Fejl ved afkodning af fil"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Fejl ved indlæsning af metadata"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity-værktøjslinje: %s"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Optager"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Commit-id:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Grafisk brugerflade-bibliotek på tværs af platforme"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Import gennem GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Den automatiske justering af indgangsniveauet standsede. Det var ikke muligt at optimere det yderligere. Det er stadig for højt."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Den automatiske justering af indgangsniveauet mindskede lydstyrken til %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Den automatiske justering af indgangsniveauet standsede. Det var ikke muligt at optimere det yderligere. Det er stadig for lavt."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Den automatiske justering af indgangsniveauet forøgede lydstyrken til %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Den automatiske justering af indgangsniveauet standsede. Det samlede antal analyser er overskredet, uden at en passende lydstyrke blev fundet. Den er stadig for høj."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Den automatiske justering af indgangsniveauet standsede. Det samlede antal analyser er overskredet, uden at en passende lydstyrke blev fundet. Den er stadig for lav."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Den automatiske justering af indgangsniveauet standsede. %.2f synes at være en passende lydstyrke."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Modtog %d ved åbning af enheder\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Kan ikke åbne portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Tilgængelige mixere:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Tilgængelige kilder for optagelse:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Tilgængelige lydstyrker for afspilning:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Lydstyrke for optagelse er emuleret\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Lydstyrke for optagelse er systemets\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Lydstyrke for afspilning er emuleret\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Lydstyrke for afspilning er systemets\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Slutdato og -tid"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-kompatible filer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Kan ikke tilføj afkoder til pipeline"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer-importør"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Kan ikke sætte strømtilstand til pauset."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indeks[%02d], Type[%s], Kanaler[%d], Hastighed[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Filen indeholder ikke nogen lydstrømme."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Kan ikke importere fil, ændring af tilstand mislykkedes."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer-fejl: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "&Justér lydstyrke for afspilning..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Forøg lydstyrke for afspilning"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Sænk lydstyrke for afspilning"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "&Justér lydstyrke for optagelse..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "F&orøg lydstyrke for optagelse"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "S&ænk lydstyrke for optagelse"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity-&manual"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Om Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomatisk justering af optagelsesniveau (til/fra)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatisk justering af optagelsesniveau"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Aktivér automatisk justering af optagelsesniveau."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Ønsket spidspunkt:"
+
+#~ msgid "Within:"
+#~ msgstr "Inden for:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Analyseringstid:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "millisekunder (tid på en analyse)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Antal af på hinanden følgende analyser:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 betyder endeløs"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Lydstyrke for optagelse"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Lydstyrke for afspilning"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Lydstyrke for optagelse: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Lydstyrke for optagelse (utilgængelig. Brug systemets mixer)."
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Lydstyrke for afspilning: %.2f (emuleret)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Lydstyrke for afspilning: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Lydstyrke for afspilning (utilgængelig. Brug systemets mixer)."
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Mi&xerlinje"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klik-og-træk for at flytte et spor langs tidsaksen"
 
 #~ msgid "Program build date:"
 #~ msgstr "Programmets bygdato:"

--- a/locale/de.po
+++ b/locale/de.po
@@ -33,82 +33,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-02 18:11+0000\n"
 "Last-Translator: J. Lavoie <j.lavoie@net-c.ca>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/tenacity/tenacity/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Tenacity aktualisieren"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Überspringen"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Update installieren"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Änderungsprotokoll"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Lese auf GitHub mehr"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Während der Suche nach einem Update ist ein Fehler aufgetreten"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Der Tenacity-Update-Server antwortet nicht."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Die Update-Daten sind beschädigt."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Fehler beim Herunterladen der Aktualisierung."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Der Download-Link von Tenacity kann nicht geöffnet werden."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s ist verfügbar!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Aufnahme"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -119,9 +53,31 @@ msgstr "Kann nicht bestimmt werden"
 msgid "%s bytes"
 msgstr "%s Bytes"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Vereinfacht"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr "System"
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -240,7 +196,8 @@ msgid "Script"
 msgstr "Skript"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Ausgabe"
 
@@ -256,7 +213,12 @@ msgstr "Nyquist-Skripte (*.ny)|*.ny|Lisp-Skripte (*.lsp)|*.lsp|Alle Dateien|*"
 msgid "Script was not saved."
 msgstr "Skript wurde nicht gespeichert."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Warnung"
 
@@ -277,14 +239,17 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango-Symbolgalerie (Werkzeugleistensymbole)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 von Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
-msgstr ""
-"Externes Tenacity-Modul, das eine einfache IDE zum Schreiben von Effekten "
-"bereitstellt."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr "Externes Tenacity-Modul, das eine einfache IDE zum Schreiben von Effekten bereitstellt."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -306,7 +271,8 @@ msgstr "Unbenannt"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist-Effektwerkbank - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Neu"
 
@@ -346,7 +312,8 @@ msgstr "Kopieren"
 msgid "Copy to clipboard"
 msgstr "In Zwischenablage kopieren"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Ausschneiden"
 
@@ -354,7 +321,8 @@ msgstr "Ausschneiden"
 msgid "Cut to clipboard"
 msgstr "Zur Zwischenablage ausschneiden"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Einfügen"
 
@@ -379,7 +347,8 @@ msgstr "Alles auswählen"
 msgid "Select all text"
 msgstr "Sämtlichen Text auswählen"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Rückgängig"
 
@@ -387,7 +356,8 @@ msgstr "Rückgängig"
 msgid "Undo last change"
 msgstr "Letzte Änderung rückgängig machen"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Wiederherstellen"
 
@@ -443,11 +413,18 @@ msgstr "Nächste"
 msgid "Go to next S-expr"
 msgstr "Gehe zu nächster S-expr"
 
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+msgid "Start"
+msgstr "Start"
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Start script"
 msgstr "Skript starten"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Stopp"
 
@@ -461,15 +438,23 @@ msgstr "Skript stoppen"
 msgid "About %s"
 msgstr "Über %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "OK"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Build-Informationen"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Deaktiviert"
 
@@ -479,6 +464,11 @@ msgid "The Build"
 msgstr "Build-Informationen"
 
 #: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Version: %s"
+
+#: src/AboutDialog.cpp
 msgid "Build type:"
 msgstr "Buildtyp:"
 
@@ -486,22 +476,28 @@ msgstr "Buildtyp:"
 msgid "Compiler:"
 msgstr "Kompilierer:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Installationspräfix:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Einstellungen-Ordner:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Einstellungen-Ordner:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Dateiformat-Unterstützung"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Plattformübergreifende GUI-Bibliothek"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -515,7 +511,6 @@ msgstr "Abtastratenumwandlung"
 msgid "MP3 Importing"
 msgstr "MP3-Import"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg-Vorbis-Import und -Export"
@@ -524,7 +519,6 @@ msgstr "Ogg-Vorbis-Import und -Export"
 msgid "ID3 tag support"
 msgstr "ID3-Tag-Unterstützung"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC-Import und -Export"
@@ -542,14 +536,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg Import und Export"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Import per GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Funktionen"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Erweiterungsunterstützung"
 
@@ -564,6 +550,10 @@ msgstr "Unterstützung für Änderung von Tonhöhe und Tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Unterstützung für extreme Änderung von Tonhöhe und Tempo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Funktionen"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -682,16 +672,22 @@ msgstr "%s, Audacity-Grafiken"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (bindet %s, %s, %s, %s und %s ein)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Eine freie, kostenlose, quelloffene, plattformübergreifende Software zur "
-"Aufnahme und Bearbeitung von Klängen."
+msgstr "Eine freie, kostenlose, quelloffene, plattformübergreifende Software zur Aufnahme und Bearbeitung von Klängen."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Mitwirkende"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Bitte beachten Sie, dass Namen in alphabetischer Reihenfolge sortiert werden, nicht nach Wichtigkeit."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -740,6 +736,7 @@ msgstr "Audacity-Webpräsenz und -Grafiken"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Deutsche Übersetzung von Andreas Klug, Heiko Abler, Pennywize, Edgar M. Franke, Daniel Winzen, Ralf Gebauer und Joachim Huffer, Sebastian Rüth, fossdd, ZeroDot1"
@@ -764,6 +761,16 @@ msgstr "%s-Website: "
 msgid "%s %s 1999-%s %s contributors"
 msgstr "%s %s 1999-%s %s Beitragende"
 
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Die Audacity%s-Handelsmarke wird innerhalb dieser Software nur für beschreibende und informative Zwecke verwendet."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity wird nicht von MuseCY SM Ltd. oder Dominic M Mazzoni produziert oder befürwortet."
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "Zeitleistenaktionen während Aufnahme deaktiviert"
@@ -785,6 +792,7 @@ msgstr "Zeitleiste"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klicken oder Ziehen, um die Suche zu beginnen"
@@ -792,6 +800,7 @@ msgstr "Klicken oder Ziehen, um die Suche zu beginnen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klicken oder Ziehen, um Schrubben zu beginnen"
@@ -799,6 +808,7 @@ msgstr "Klicken oder Ziehen, um Schrubben zu beginnen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Zum Schrubben klicken & bewegen. Zum Suchen klicken & ziehen."
@@ -806,6 +816,7 @@ msgstr "Zum Schrubben klicken & bewegen. Zum Suchen klicken & ziehen."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Zum Suchen bewegen"
@@ -813,6 +824,7 @@ msgstr "Zum Suchen bewegen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Zum Schrubben bewegen"
@@ -869,7 +881,17 @@ msgstr ""
 "Bereich jenseits des Projektendes\n"
 "kann nicht gesperrt werden."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Fehler"
 
@@ -893,7 +915,8 @@ msgstr ""
 "Dies ist eine einmalige Frage nach einer „Installation“, bei der Sie darum gebeten haben, die Einstellungen zurückzusetzen."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Tenacity-Einstellungen zurücksetzen"
 
 #: src/AudacityApp.cpp
@@ -908,7 +931,8 @@ msgstr ""
 "Sie wurde aus der Liste der zuletzt geöffneten Dateien entfernt."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite-Bibliothek konnte nicht initialisiert werden. Tenacity kann nicht fortfahren."
 
 #: src/AudacityApp.cpp
@@ -933,7 +957,7 @@ msgstr "&Öffnen …"
 msgid "Open &Recent..."
 msgstr "Zuletzt ge&öffnet …"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&Über Tenacity …"
 
@@ -946,9 +970,10 @@ msgid "&File"
 msgstr "&Datei"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity konnte keinen sicheren Ort zum Speichern temporärer Dateien finden.\n"
@@ -956,22 +981,23 @@ msgstr ""
 "Bitte geben sie ein geeignetes Verzeichnis im Einstellungsdialog ein."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity konnte keinen Platz zum Speichern der temporären Dateien finden.\n"
 "Bitte geben sie ein geeignetes Verzeichnis im Einstellungsdialog ein."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"Tenacity wird nun beendet. Bitte starten Sie Tenacity neu, damit das neue "
-"temporäre Verzeichnis verwendet werden kann."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "Tenacity wird nun beendet. Bitte starten Sie Tenacity neu, damit das neue temporäre Verzeichnis verwendet werden kann."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -980,15 +1006,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity konnte das temporäre Verzeichnis nicht sperren.\n"
 "Es kann sein, dass es anderweitig verwendet wird.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Wollen Sie Tenacity trotzdem starten?"
 
 #: src/AudacityApp.cpp
@@ -996,20 +1024,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Fehler beim Sperren des temporären Ordners"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Das System hat festgestellt, dass Tenacity bereits läuft.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
-"Benutzen Sie die Befehle „Neu“ oder „Öffnen“ im aktuell laufenden Tenacity-"
-"Prozess,\n"
+"Benutzen Sie die Befehle „Neu“ oder „Öffnen“ im aktuell laufenden Tenacity-Prozess,\n"
 "um mehrere Projekte gleichzeitig zu öffnen.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity ist bereits gestartet"
 
 #: src/AudacityApp.cpp
@@ -1025,7 +1055,8 @@ msgstr ""
 "und ein Neustart könnte erforderlich sein."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Tenacity-Startfehler"
 
 #: src/AudacityApp.cpp
@@ -1065,8 +1096,9 @@ msgstr ""
 "und ein Neustart könnte erforderlich sein."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1098,7 +1130,8 @@ msgstr "Selbstdiagnose starten"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Tenacity-Version anzeigen"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1108,9 +1141,10 @@ msgid "audio or project file name"
 msgstr "Audio- oder Projekt-Dateiname"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1123,16 +1157,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tenacity-Projektdateien"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Nachricht"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Tenacity-Konfigurationsfehler"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1142,30 +1178,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Auf die folgende Konfigurationsdatei konnte nicht zugegriffen werden:\n"
 "\n"
 "\t%s\n"
 "\n"
-"Dies kann viele Gründe haben. Am wahrscheinlichsten ist jedoch, dass die "
-"Festplatte voll ist oder Sie keine Schreibberechtigungen für die Datei "
-"besitzen. Weitere Informationen erhalten Sie, indem Sie unten auf den Hilfe-"
-"Knopf klicken.\n"
+"Dies kann viele Gründe haben. Am wahrscheinlichsten ist jedoch, dass die Festplatte voll ist oder Sie keine Schreibberechtigungen für die Datei besitzen. Weitere Informationen erhalten Sie, indem Sie unten auf den Hilfe-Knopf klicken.\n"
 "\n"
-"Sie können versuchen, das Problem zu beheben und dann „Erneut“ klicken, um "
-"fortzufahren.\n"
+"Sie können versuchen, das Problem zu beheben und dann „Erneut“ klicken, um fortzufahren.\n"
 "\n"
-"Wenn Sie „Tenacity beenden“ wählen, befindet sich Ihr Projekt möglicherweise "
-"in einem nicht gespeicherten Zustand, der beim nächsten Öffnen "
-"wiederhergestellt wird."
+"Wenn Sie „Tenacity beenden“ wählen, befindet sich Ihr Projekt möglicherweise in einem nicht gespeicherten Zustand, der beim nächsten Öffnen wiederhergestellt wird."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Hilfe"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Tenacity &beenden"
 
 #: src/AudacityFileConfig.cpp
@@ -1173,7 +1206,8 @@ msgid "&Retry"
 msgstr "E&rneut"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacity-Protokoll"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1185,7 +1219,8 @@ msgstr "&Speichern …"
 msgid "Cl&ear"
 msgstr "&Löschen"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "Schlie&ßen"
 
@@ -1240,7 +1275,8 @@ msgid "Error Initializing Midi"
 msgstr "Fehler bei MIDI-Initialisierung"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity-Audio"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1255,37 +1291,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Kein Speicher mehr vorhanden!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automatische Aufnahmeeinpegelung gestoppt. Eine weitere Optimierung war nicht möglich. Immer noch zu hoch."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automatische Aufnahmeeinpegelung verringerte die Lautstärke auf %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatische Aufnahmeeinpegelung gestoppt. Eine weitere Optimierung war nicht möglich. Immer noch zu niedrig."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automatische Aufnahmeeinpegelung erhöhte die Lautstärke auf %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automatische Aufnahmeeinpegelung gestoppt. Es konnte keine akzeptable Lautstärke mit der gegebenen Analysezahl ermittelt werden. Immer noch zu hoch."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automatische Aufnahmeeinpegelung gestoppt. Es konnte keine akzeptable Lautstärke mit der gegebenen Analysezahl ermittelt werden. Immer noch zu niedrig."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatische Aufnahmeeinpegelung gestoppt. %.2f scheint eine akzeptable Lautstärke zu sein."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1384,43 +1389,6 @@ msgstr "Kein Wiedergabegerät für „%s“ gefunden.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Gemeinsame Abtastraten können nicht ohne beide Geräte geprüft werden.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "%d während des Öffnens der Geräte empfangen\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Portmixer kann nicht geöffnet werden\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Verfügbare Mixer:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Verfügbare Aufnahmequellen:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Verfügbare Wiedergabelautstärken:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Aufnahmelautstärke wird emuliert\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Aufnahmelautstärke ist nativ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Wiedergabelautstärke wird emuliert\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Wiedergabelautstärke ist nativ\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1463,8 +1431,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatische Wiederherstellung nach Absturz"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1477,9 +1446,16 @@ msgid "Recoverable &projects"
 msgstr "Wiederherstellbare &Projekte"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Auswählen"
+
+#. i18n-hint: (noun).  It's the name of the project to recover.
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
+msgid "Name"
+msgstr "Name"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "&Discard Selected"
@@ -1505,8 +1481,7 @@ msgid ""
 msgstr ""
 "Möchten Sie die ausgewählten Projekte wirklich verwerfen?\n"
 "\n"
-"Wenn Sie „Ja“ wählen, werden die ausgewählten Projekte sofort permanent "
-"gelöscht."
+"Wenn Sie „Ja“ wählen, werden die ausgewählten Projekte sofort permanent gelöscht."
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -1527,6 +1502,10 @@ msgstr "Voreinstellung &verwenden"
 #: src/BatchCommandDialog.cpp
 msgid "&Parameters"
 msgstr "&Parameter"
+
+#: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr "&Details"
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
@@ -1560,6 +1539,11 @@ msgstr "Effekt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menübefehl (mit Parametern)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1705,13 +1689,19 @@ msgstr "&Wiederherstellen"
 msgid "I&mport..."
 msgstr "&Import …"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Export …"
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Schritte bearbeiten"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr "Num"
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1741,7 +1731,8 @@ msgstr "Nach &oben"
 msgid "Move &Down"
 msgstr "Nach &unten"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Speichern"
 
@@ -1788,6 +1779,11 @@ msgstr "Namen dürfen „%c“ und „%c“ nicht enthalten"
 msgid "Are you sure you want to delete %s?"
 msgstr "Möchten Sie %s wirklich löschen?"
 
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+msgid "Benchmark"
+msgstr "Benchmark"
+
 #: src/Benchmark.cpp
 msgid "Disk Block Size (KB):"
 msgstr "Disk-Blockgröße (KB):"
@@ -1819,9 +1815,16 @@ msgid "Run"
 msgstr "Starten"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Schließen"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "benchmark.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1959,10 +1962,6 @@ msgid "No revision identifier was provided"
 msgstr "Es wurde keine Revisionskennung angegeben"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Datum und Zeit unbekannt"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Debug-Build (Debuglevel %d)"
@@ -2017,11 +2016,9 @@ msgid ""
 msgstr ""
 "Wählen Sie Audio, das mit %s bearbeitet werden soll.\n"
 "\n"
-"1. Audio wählen, das Rauschen beinhaltet und %s verwenden, um ein "
-"„Rauschprofil“ zu erstellen.\n"
+"1. Audio wählen, das Rauschen beinhaltet und %s verwenden, um ein „Rauschprofil“ zu erstellen.\n"
 "\n"
-"2. Sobald ein Rauschprofil erstellt ist, wählen Sie Audio aus, das verändert "
-"werden soll\n"
+"2. Sobald ein Rauschprofil erstellt ist, wählen Sie Audio aus, das verändert werden soll\n"
 "und verwenden Sie %s, um das Audio zu verändern."
 
 #: src/CommonCommandFlags.cpp
@@ -2047,6 +2044,11 @@ msgid ""
 msgstr ""
 "Für diese Aktion bitte erst Audio auswählen.\n"
 "(Andere Spurtypen sind nicht möglich.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2209,6 +2211,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Namen in Zwischenablage kopieren"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "„%s“, „%s“, „%s“\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Fehlt"
 
@@ -2217,25 +2224,28 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Wenn Sie fortfahren wird Ihr Projekt nicht gespeichert. Sind Sie sicher?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
 "Ihr Projekt ist eigenständig; es hängt nicht von externen Audiodateien ab. \n"
 "\n"
 "Einige ältere Tenacity-Projekte sind möglicherweise nicht eigenständig –\n"
-"Sorgfalt ist nötig um deren externe Abhängigkeiten am richtigen Platz zu "
-"halten.\n"
+"Sorgfalt ist nötig um deren externe Abhängigkeiten am richtigen Platz zu halten.\n"
 "Neue Projekte sind eigenständig und weniger riskant."
 
 #: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "Abhängigkeiten prüfen"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Aus"
 
@@ -2243,7 +2253,7 @@ msgstr "Aus"
 msgid "Rectangle"
 msgstr "Rechteck"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Dreieck"
 
@@ -2254,6 +2264,36 @@ msgstr "Geformt"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Rechteck"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2275,9 +2315,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg-Unterstützung wurde nicht mit kompiliert"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2299,8 +2340,8 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg suchen"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity benötigt die Datei „%s“, um Audio per FFmpeg zu im- und exportieren."
 
 #: src/FFmpeg.cpp
@@ -2313,7 +2354,8 @@ msgstr "Ort von „%s“:"
 msgid "To find '%s', click here -->"
 msgstr "Um „%s“ zu suchen, klicken Sie hier -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Durchsuchen …"
 
@@ -2339,8 +2381,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg nicht gefunden"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2349,8 +2392,7 @@ msgstr ""
 "Tenacity versuchte, FFmpeg für den Import einer Audiodatei zu verwenden,\n"
 "konnte die Bibliotheken aber nicht finden.\n"
 "\n"
-"Um den FFmpeg-Import zu verwenden, gehen Sie zu „Bearbeiten > Einstellungen "
-"> Bibliotheken“,\n"
+"Um den FFmpeg-Import zu verwenden, gehen Sie zu „Bearbeiten > Einstellungen > Bibliotheken“,\n"
 "um die FFmpeg-Bibliotheken herunterzuladen oder zuzuordnen."
 
 #: src/FFmpeg.cpp
@@ -2371,24 +2413,24 @@ msgid "Only libavformat.so"
 msgstr "Nur libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity konnte eine Datei in %s nicht öffnen."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity konnte eine Datei in %s nicht lesen."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Tenacity hat erfolgreich eine Datei in %s geschrieben, konnte sie aber nicht nach %s umbenennen."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2426,7 +2468,9 @@ msgstr "&Audio nicht kopieren"
 msgid "As&k"
 msgstr "&Fragen"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Alle Dateien"
 
@@ -2451,6 +2495,10 @@ msgstr "Textdateien"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML-Dateien"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ", "
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2492,6 +2540,13 @@ msgstr "Kubikwurzel-Autokorrelation"
 msgid "Enhanced Autocorrelation"
 msgstr "Erweiterte Autokorrelation"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+msgid "Cepstrum"
+msgstr "Cepstrum"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2508,9 +2563,33 @@ msgstr "Lineardarstellung"
 msgid "Log frequency"
 msgstr "Log. Darstellung"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Bildlauf"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+msgid "Zoom"
+msgstr "Zoom"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
@@ -2540,6 +2619,10 @@ msgstr "&Algorithmus:"
 msgid "&Size:"
 msgstr "&Größe:"
 
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "&Export..."
+msgstr "&Exportieren …"
+
 #: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "&Funktion:"
@@ -2565,6 +2648,23 @@ msgstr "Es wurde zu viel Audio ausgewählt. Nur die ersten %.1f Sekunden werden 
 msgid "Not enough data selected."
 msgstr "Nicht ausreichend Daten ausgewählt."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2587,7 +2687,8 @@ msgstr "Spektrum.txt"
 msgid "Export Spectral Data As:"
 msgstr "Spektraldaten exportieren als:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "In Datei konnte nicht geschrieben werden: %s"
@@ -2676,10 +2777,7 @@ msgstr "Wir empfehlen dringend, unsere letzte stabile veröffentlichte Version z
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"Sie können uns helfen, Tenacity zur Veröffentlichung fertig zu stellen, "
-"indem Sie unserer [[https://tenacityaudio.org|community|Community]] "
-"beitreten.<hr><br><br>"
+msgstr "Sie können uns helfen, Tenacity zur Veröffentlichung fertig zu stellen, indem Sie unserer [[https://tenacityaudio.org|community|Community]] beitreten.<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2692,15 +2790,12 @@ msgstr "Unsere Unterstützungsangebote:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[file:Quick_Help|Schnellhilfe]] – wenn nicht lokal installiert, online "
-"anschauen"
+msgstr "[[file:Quick_Help|Schnellhilfe]] – wenn nicht lokal installiert, online anschauen"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
-msgstr ""
-" [[file:Main_Page|Handbuch]] – wenn nicht lokal installiert, online anschauen"
+msgstr " [[file:Main_Page|Handbuch]] – wenn nicht lokal installiert, online anschauen"
 
 #: src/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
@@ -2708,23 +2803,15 @@ msgstr " Forum – stellen Sie Ihre Fragen direkt online."
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"Mehr:</b> Besuchen Sie unser Wiki für Tipps, Tricks, weitere Tutorials und "
-"Effekt-Erweiterungen."
+msgstr "Mehr:</b> Besuchen Sie unser Wiki für Tipps, Tricks, weitere Tutorials und Effekt-Erweiterungen."
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"Tenacity kann eine Vielzahl weiterer ungeschützter Formate importieren (etwa "
-"M4A und WMA, komprimierte WAV-Dateien von portablen Aufnahmegeräten und "
-"Audio aus Videodateien), wenn Sie die optionale FFmpeg-Bibliothek auf Ihren "
-"Computer herunterladen und installieren."
+msgstr "Tenacity kann eine Vielzahl weiterer ungeschützter Formate importieren (etwa M4A und WMA, komprimierte WAV-Dateien von portablen Aufnahmegeräten und Audio aus Videodateien), wenn Sie die optionale FFmpeg-Bibliothek auf Ihren Computer herunterladen und installieren."
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"Sie können auch unsere Hilfe zum Importieren von MIDI-Dateien und Liedern "
-"von Audio-CDs lesen."
+msgstr "Sie können auch unsere Hilfe zum Importieren von MIDI-Dateien und Liedern von Audio-CDs lesen."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
@@ -2732,11 +2819,7 @@ msgstr "Das Handbuch scheint nicht installiert zu sein. Bitte [[*URL*|schauen Si
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Das Handbuch scheint nicht installiert zu sein. Bitte [[*URL*|schauen Sie "
-"sich das Handbuch online an]] oder laden Sie das Handbuch "
-"herunter.<br><br>Um das Handbuch immer online anzuschauen, ändern Sie „Ort "
-"der Anleitung“ in den Programmoberflächeneinstellungen zu „Aus dem Internet“."
+msgstr "Das Handbuch scheint nicht installiert zu sein. Bitte [[*URL*|schauen Sie sich das Handbuch online an]] oder laden Sie das Handbuch herunter.<br><br>Um das Handbuch immer online anzuschauen, ändern Sie „Ort der Anleitung“ in den Programmoberflächeneinstellungen zu „Aus dem Internet“."
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2795,19 +2878,19 @@ msgid "&History..."
 msgstr "&Verlauf …"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Interner Fehler in %s bei %s, Zeile %d.\n"
 "Bitte das Tenacity-Team informieren unter https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Interner Fehler in %s bei %s, Zeile %d.\n"
 "Bitte das Tenacity-Team informieren unter https://tenacityaudio.org/."
@@ -2826,7 +2909,9 @@ msgid "Track"
 msgstr "Spur"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Textmarke"
 
@@ -2886,7 +2971,8 @@ msgstr "Spurname eingeben"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Textspur"
 
@@ -2897,11 +2983,13 @@ msgstr "Eine oder mehrere gespeicherte Textmarken konnten nicht gelesen werden."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Erster Start von Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Bitte eine Sprache für Tenacity auswählen:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2911,7 +2999,8 @@ msgstr "Bitte eine Sprache für Tenacity auswählen:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Die Sprache, die Sie gewählt haben, %s (%s), weicht von der Systemsprache ab: %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Bestätigen"
 
@@ -2929,13 +3018,18 @@ msgstr ""
 "Die alte Datei wurde als: „%s“ gespeichert"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Öffne Tenacity-Projekt"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Tenacity-Karaoke%s"
+
+#: src/LyricsWindow.cpp
+msgid "&Karaoke..."
+msgstr "&Karaoke …"
 
 #: src/Menus.cpp
 #, c-format
@@ -2982,19 +3076,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Spuren werden gemischt und gerendert"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tenacity-Mixer%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Verstärkung"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Geschwindigkeit"
 
@@ -3003,23 +3101,42 @@ msgid "Musical Instrument"
 msgstr "Musikinstrument"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panorama"
+
+#. i18n-hint: This is on a button that will silence this track.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Mute"
+msgstr "Stumm"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Aussteuerungsanzeige"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Verstärkungsregler verschoben"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Geschwindigkeitsregler verschoben"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Panoramaregler verschoben"
 
@@ -3054,9 +3171,9 @@ msgstr ""
 "Es wird nicht geladen."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3090,16 +3207,19 @@ msgstr ""
 "\n"
 "Verwenden Sie nur Module von vertrauenswürdigen Quellen"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Ja"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nein"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity-Modullader"
 
 #: src/ModuleManager.cpp
@@ -3122,6 +3242,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Notenspur"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "C"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "C♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "D"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "D♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "E"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "F"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "F♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "G"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "G♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "A"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "A♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "B"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "D♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "E♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "G♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "A♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "B♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "C♯/D♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "D♯/E♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "F♯/G♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "G♯/A♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "A♯/B♭"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3231,7 +3461,8 @@ msgstr "Alle au&swählen"
 msgid "C&lear All"
 msgstr "Alle &löschen"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Aktivi&eren"
 
@@ -3311,9 +3542,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Nicht übereinstimmende Abtastraten"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Für Aufnahme mit dieser Abtastrate sind zu wenige Spuren gewählt.\n"
@@ -3342,15 +3574,15 @@ msgid "Dropouts"
 msgstr "Aussetzer"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
-"Aufgezeichneter Ton ging an den gekennzeichneten Stellen verloren. Mögliche "
-"Ursachen:\n"
+"Aufgezeichneter Ton ging an den gekennzeichneten Stellen verloren. Mögliche Ursachen:\n"
 "\n"
 "Andere Anwendungen lassen Tenacity nicht genügend Prozessorzeit übrig\n"
 "\n"
@@ -3386,11 +3618,11 @@ msgid "Inspecting project file data"
 msgstr "Inspiziere Projektdatei-Daten"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3433,11 +3665,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Warnung - Verknüpfte Datei(en) fehlen"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Projekt-Überprüfung des Ordners „%s“ \n"
@@ -3462,12 +3694,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Warnung - Fehlende verknüpfte Datei(en)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3525,7 +3757,8 @@ msgstr "Warnung - Verwaiste Blockdatei(en)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Fortschritt"
 
@@ -3539,8 +3772,7 @@ msgid ""
 "\n"
 "Select 'Help > Diagnostics > Show Log...' to see details."
 msgstr ""
-"Projekt-Überprüfung ergab Datei-Unstimmigkeiten während der automatischen "
-"Wiederherstellung.\n"
+"Projekt-Überprüfung ergab Datei-Unstimmigkeiten während der automatischen Wiederherstellung.\n"
 "\n"
 "Wählen Sie „Hilfe > Diagnose > Protokoll anzeigen …“, um Details zu sehen."
 
@@ -3551,6 +3783,11 @@ msgstr "Warnung: Probleme bei der automatischen Wiederherstellung"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<unbenannt>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3620,12 +3857,14 @@ msgstr ""
 "(Benötigte temporäre Dateien können nicht angelegt werden)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Dies ist keine Tenacity-Projektdatei"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3640,9 +3879,7 @@ msgstr "Projektdatei kann nicht initialisiert werden"
 #. i18n-hint: An error message.  Don't translate inset or blockids.
 #: src/ProjectFileIO.cpp
 msgid "Unable to add 'inset' function (can't verify blockids)"
-msgstr ""
-"„inset“-Funktion kann nicht hinzugefügt werden (blockids können nicht "
-"überprüft werden)"
+msgstr "„inset“-Funktion kann nicht hinzugefügt werden (blockids können nicht überprüft werden)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: src/ProjectFileIO.cpp
@@ -3759,16 +3996,15 @@ msgid "Error Writing to File"
 msgstr "Fehler beim Speichern der Datei"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
 "Tenacity konnte die Datei %s nicht schreiben.\n"
 "Vielleicht ist die Festplatte voll oder nicht schreibbar.\n"
-"Um Tipps zu erhalten, wie Platz freigemacht werden kann, klicken Sie den "
-"Hilfe-Knopf."
+"Um Tipps zu erhalten, wie Platz freigemacht werden kann, klicken Sie den Hilfe-Knopf."
 
 #: src/ProjectFileIO.cpp
 msgid "Compacting project"
@@ -3776,12 +4012,15 @@ msgstr "Komprimiere Projekt"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekt %02i] Tenacity „%s“"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -3791,14 +4030,13 @@ msgstr "(wiederhergestellt)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Diese Datei wurde mit Tenacity %s gespeichert.\n"
-"Sie nutzen Tenacity %s. Bitte verwenden Sie eine neuere Version, um diese "
-"Datei zu öffnen."
+"Sie nutzen Tenacity %s. Bitte verwenden Sie eine neuere Version, um diese Datei zu öffnen."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
@@ -3867,19 +4105,20 @@ msgid "Backing up project"
 msgstr "Sichere Projekt"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
-"Dieses Projekt wurde bei der letzten Tenacity-Ausführung nicht korrekt "
-"gespeichert.\n"
+"Dieses Projekt wurde bei der letzten Tenacity-Ausführung nicht korrekt gespeichert.\n"
 "\n"
 "Es wurde bis zum letzten Snapshot wiederhergestellt."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3958,8 +4197,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sProjekt „%s“ speichern unter …"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "„Projekt speichern“ ist nicht für Audiodateien, sondern für Tenacity-Projekte.\n"
@@ -4037,11 +4277,12 @@ msgid "Error Opening Project"
 msgstr "Fehler beim Öffnen des Projekts"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Sie versuchen, eine automatisch erzeugte Sicherungsdatei zu öffnen.\n"
 "Das kann zu ernsthaftem Datenverlust führen.\n"
@@ -4150,8 +4391,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatische Datenbanksicherung fehlgeschlagen."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Herzlich Willkommen zu Tenacity-Version %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4214,10 +4455,8 @@ msgid ""
 "This recovery file was saved by Audacity 2.3.0 or before.\n"
 "You need to run that version of Audacity to recover the project."
 msgstr ""
-"Diese Wiederherstellungsdatei wurde von Tenacity 2.3.0 oder älter "
-"gespeichert.\n"
-"Sie müssen diese Version von Tenacity benutzen, um das Projekt "
-"wiederherzustellen."
+"Diese Wiederherstellungsdatei wurde von Tenacity 2.3.0 oder älter gespeichert.\n"
+"Sie müssen diese Version von Tenacity benutzen, um das Projekt wiederherzustellen."
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -4368,42 +4607,64 @@ msgstr "Alle Einstellungen"
 msgid "SelectionBar"
 msgstr "AuswahlLeiste"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektralauswahl"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Timer"
+msgstr "Zeitauslöser"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Werkzeuge"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+msgid "Transport"
+msgstr "Transport"
+
+#: src/Screenshot.cpp
+msgid "Mixer"
+msgstr "Mixer"
+
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Aussteuerungsanzeige"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Wiedergabepegel"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Aufnahmepegel"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Bearbeitungswerkzeuge"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Gerät"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Schnellere/langsamere Wiedergabe"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Schrubben"
 
@@ -4418,7 +4679,10 @@ msgstr "Zeitlineal"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Spuren"
 
@@ -4503,6 +4767,10 @@ msgstr "Tr&ockenes Vorhören"
 msgid "&Settings"
 msgstr "&Einstellungen"
 
+#: src/ShuttleGui.cpp
+msgid "Debu&g"
+msgstr "Debu&g"
+
 #: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
 msgid "Off"
 msgstr "Aus"
@@ -4524,7 +4792,8 @@ msgid "Activation level (dB):"
 msgstr "Startpegel (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Willkommen bei Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4555,6 +4824,10 @@ msgstr "Spurnummer"
 msgid "Year"
 msgstr "Jahr"
 
+#: src/Tags.cpp
+msgid "Genre"
+msgstr "Genre"
+
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Kommentare"
@@ -4562,6 +4835,10 @@ msgstr "Kommentare"
 #: src/Tags.cpp
 msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
 msgstr "Verwenden Sie zum Navigieren in den Feldern die Pfeiltasten (oder die Eingabetaste nach der Bearbeitung)."
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr "Tag"
 
 #: src/Tags.cpp
 msgid "Value"
@@ -4574,6 +4851,10 @@ msgstr "&Hinzufügen"
 #: src/Tags.cpp
 msgid "&Remove"
 msgstr "Ent&fernen"
+
+#: src/Tags.cpp
+msgid "Genres"
+msgstr "Genres"
 
 #: src/Tags.cpp
 msgid "E&dit..."
@@ -4659,9 +4940,9 @@ msgstr ""
 "Klicken Sie für Tipps zu geeigneten Laufwerken auf den Hilfe-Knopf."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity konnte die Datei nicht schreiben:\n"
@@ -4681,9 +4962,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4692,9 +4973,9 @@ msgstr ""
 "(schreibgeschützt)."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity konnte die Grafiken nicht in die Datei schreiben:\n"
@@ -4711,9 +4992,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4723,9 +5004,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4734,8 +5015,9 @@ msgstr ""
 "Vielleicht falsches PNG-Format?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity konnte sein Standard-Thema nicht lesen.\n"
@@ -4773,9 +5055,9 @@ msgstr ""
 "waren schon vorhanden. Überschreiben?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity konnte die Datei nicht speichern:\n"
@@ -4814,7 +5096,11 @@ msgstr "Eigenes"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Dauer"
 
@@ -4825,7 +5111,8 @@ msgid "Time Track"
 msgstr "Zeitspur"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Tenacity Zeitgesteuerte Aufnahme"
 
 #: src/TimerRecordDialog.cpp
@@ -4900,7 +5187,8 @@ msgstr "Aktuelles Projekt"
 msgid "Recording start:"
 msgstr "Aufnahmebeginn:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Dauer:"
 
@@ -4921,7 +5209,8 @@ msgid "Action after Timer Recording:"
 msgstr "Aktion nach zeitgesteuerter Aufnahme:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Fortschritt von zeitgesteuerter Tenacity-Aufnahme"
 
 #: src/TimerRecordDialog.cpp
@@ -5002,6 +5291,11 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Zeitgesteuerte Aufnahme"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr "099 h 060 min 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -5012,6 +5306,7 @@ msgstr "099 Tage 024 h 060 min 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Startdatum und -zeit"
@@ -5056,7 +5351,8 @@ msgstr "Automatisches &Exportieren aktivieren?"
 msgid "Export Project As:"
 msgstr "Projekt exportieren als:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Optionen"
 
@@ -5069,7 +5365,8 @@ msgid "Do nothing"
 msgstr "Nichts tun"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Tenacity beenden"
 
 #: src/TimerRecordDialog.cpp
@@ -5093,7 +5390,8 @@ msgid "Scheduled to stop at:"
 msgstr "Stop geplant um:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Zeitgesteuerte Tenacity-Aufnahme – Warten auf Beginn"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5119,8 +5417,13 @@ msgid "Recording Exported:"
 msgstr "Aufnahme exportiert:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Zeitgesteuerte Tenacity-Aufnahme – Warte"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, 999999 Hz"
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5311,6 +5614,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s wird angewendet …"
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "FEHLER"
@@ -5329,13 +5642,15 @@ msgstr "%s ist kein Parameter der von %s akzeptiert wird"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Ungültiger Wert für Parameter „%s“: Sollte %s sein"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Befehl"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s wiederholen"
@@ -5370,6 +5685,10 @@ msgid "Compares a range on two tracks."
 msgstr "Vergleicht einen Bereich auf zwei Spuren."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr "Demo"
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Verzögerung (Sekunden):"
 
@@ -5385,6 +5704,10 @@ msgstr "Führt die Demoaktion durch."
 msgid "Drag"
 msgstr "Ziehen"
 
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+msgid "Panel"
+msgstr "Paneel"
+
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
 msgstr "Anwendung"
@@ -5396,6 +5719,11 @@ msgstr "Spur 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Spur 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr "ID:"
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5441,17 +5769,32 @@ msgstr "Menüs"
 msgid "Preferences"
 msgstr "Voreinstellungen"
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+msgid "Clips"
+msgstr "Übersteuerungen"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Hüllen"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Textmarken"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Kästen"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr "JSON"
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr "Lisp"
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5460,6 +5803,11 @@ msgstr "Knapp"
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Typ:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+msgid "Format:"
+msgstr "Format:"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -5485,6 +5833,10 @@ msgstr "Kommentar"
 msgid "Command:"
 msgstr "Befehl:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr "_"
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Gibt Hilfe zu einem Befehl."
@@ -5493,9 +5845,17 @@ msgstr "Gibt Hilfe zu einem Befehl."
 msgid "For comments in a macro."
 msgstr "Für Kommentare in einem Makro."
 
+#: src/commands/ImportExportCommands.cpp
+msgid "Import2"
+msgstr "Import2"
+
 #: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
 msgid "File Name:"
 msgstr "Dateiname:"
+
+#: src/commands/ImportExportCommands.cpp
+msgid "Export2"
+msgstr "Export2"
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Number of Channels:"
@@ -5513,17 +5873,26 @@ msgstr "Exportiert zu einer Datei."
 msgid "Builtin Commands"
 msgstr "Integrierte Befehle"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Das Tenacity-Team"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Stellt integrierte Befehle für Tenacity bereit"
 
 #: src/commands/LoadCommands.cpp
 msgid "Unknown built-in command name"
 msgstr "Unbekannter Name von integriertem Befehl"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr "Text:"
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -5577,6 +5946,13 @@ msgstr "Löscht die Inhalte des Protokolls."
 msgid "Get Preference"
 msgstr "Einstellung erhalten"
 
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
+msgid "Name:"
+msgstr "Name:"
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "Einstellung setzen"
@@ -5598,6 +5974,10 @@ msgid "Sets the value of a single preference."
 msgstr "Setzt den Wert einer einzelnen Einstellung."
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Screenshot"
+msgstr "Screenshot"
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Window"
 msgstr "Fenster"
 
@@ -5617,7 +5997,8 @@ msgstr "Vollbild"
 msgid "Toolbars"
 msgstr "Werkzeugleisten"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effekte"
 
@@ -5757,7 +6138,8 @@ msgstr "Setzen"
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -5817,6 +6199,10 @@ msgstr "Bei:"
 msgid "Color:"
 msgstr "Farbe:"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Start:"
+msgstr "Start:"
+
 #: src/commands/SetClipCommand.h
 msgid "Sets various values for a clip."
 msgstr "Setzt verschiedene Werte für einen Clip."
@@ -5838,7 +6224,8 @@ msgid "Edited Envelope"
 msgstr "Bearbeitete Hüllkurve"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Hüllkurve"
 
@@ -5875,8 +6262,20 @@ msgid "Set Project"
 msgstr "Projekt setzen"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "Rate:"
+msgstr "Frequenz:"
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Größe anpassen:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr "X:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr "Y:"
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5926,6 +6325,13 @@ msgstr "Panorama:"
 msgid "Set Track Visuals"
 msgstr "Spurvisualisierung einstellen"
 
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Linear"
+msgstr "Linear"
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Zurücksetzen"
@@ -5945,6 +6351,10 @@ msgstr "Anzeige:"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
 msgstr "Maßstab:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "VZoom:"
+msgstr "VZoom:"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
@@ -6022,12 +6432,18 @@ msgstr "Sie haben eine Spur ausgewählt, die kein Audio enthält. Auto-Duck kann
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto-Duck benötigt eine Steuerspur, die unter der/den ausgewählten Spur(en) liegen muss."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr "db"
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Lautstärke-&Absenkung:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "Sekunden"
 
@@ -6051,7 +6467,8 @@ msgstr "Inneres Abblenden-L&änge:"
 msgid "Inner &fade up length:"
 msgstr "Inneres Au&fblenden-Länge:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Schwellenwer&t:"
 
@@ -6070,6 +6487,18 @@ msgstr "Einfacher Klang-Steuerungseffekt"
 #: src/effects/BassTreble.cpp
 msgid "Tone controls"
 msgstr "Klang-Steuerung"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass (dB):"
+msgstr "Bass (dB):"
+
+#: src/effects/BassTreble.cpp
+msgid "Ba&ss (dB):"
+msgstr "Ba&ss (dB):"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr "Bass"
 
 #: src/effects/BassTreble.cpp
 msgid "&Treble (dB):"
@@ -6177,11 +6606,13 @@ msgstr "auf (Hz)"
 msgid "t&o"
 msgstr "&auf"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Änderung in &Prozent:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Änderung in Prozent"
 
@@ -6189,9 +6620,23 @@ msgstr "Änderung in Prozent"
 msgid "&Use high quality stretching (slow)"
 msgstr "Dehn&ung mit hochwertiger Qualität verwenden (langsam)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr "33⅓"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr "45"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr "78"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "nicht verfügbar"
 
@@ -6219,6 +6664,7 @@ msgstr "Standard Schallplatte U/Min:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Von U/Min"
@@ -6231,6 +6677,7 @@ msgstr "&von"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Auf U/Min"
@@ -6373,6 +6820,12 @@ msgstr "Kompressor"
 msgid "Compresses the dynamic range of audio"
 msgstr "Komprimiert die dynamische Reichweite von Audio"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6382,6 +6835,20 @@ msgstr "%.2f Sekunden"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f Sekunden"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr "%.1f:1"
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6498,7 +6965,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Kontrast-Analyse, zur Berechnung von RMS-Lautstärken-Unterschieden zwischen zwei ausgewählten Audiobereichen."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Ende"
 
@@ -6558,6 +7026,18 @@ msgstr "&Differenz:"
 msgid "&Help"
 msgstr "&Hilfe"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr "QMW = %s."
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr "%s dB"
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "null"
@@ -6565,6 +7045,13 @@ msgstr "null"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "unbestimmt"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB QMW"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6618,6 +7105,12 @@ msgstr "Aktueller Unterschied"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Gemessener Vordergrund-Pegel"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6686,6 +7179,12 @@ msgstr "Erfolgskriterien 1.4.7 von WCAG 2.0: Ungenügend"
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
 msgstr "Daten gesammelt"
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr "%d %s %02d %02dh %02dmin %02ds"
 
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
@@ -6826,6 +7325,14 @@ msgid "Upper Threshold"
 msgstr "Oberer Schwellenwert"
 
 #: src/effects/Distortion.cpp
+msgid "Parameter 1"
+msgstr "Parameter 1"
+
+#: src/effects/Distortion.cpp
+msgid "Parameter 2"
+msgstr "Parameter 2"
+
+#: src/effects/Distortion.cpp
 msgid "Number of repeats"
 msgstr "Anzahl der Wiederholungen"
 
@@ -6898,6 +7405,10 @@ msgid "Degree of Levelling"
 msgstr "Nivellierungsgrad"
 
 #: src/effects/Distortion.cpp
+msgid "dB Limit"
+msgstr "dB-Limit"
+
+#: src/effects/Distortion.cpp
 msgid "Wet level"
 msgstr "Nassstufe"
 
@@ -6935,9 +7446,7 @@ msgstr "DTMF-Töne"
 
 #: src/effects/DtmfGen.cpp
 msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
-msgstr ""
-"Erzeugt Zwei-Ton-Multi-Frequenz-Töne (DTMF), wie die von Telefontasten "
-"erzeugten"
+msgstr "Erzeugt Zwei-Ton-Multi-Frequenz-Töne (DTMF), wie die von Telefontasten erzeugten"
 
 #: src/effects/DtmfGen.cpp
 msgid ""
@@ -6951,7 +7460,13 @@ msgstr ""
 msgid "DTMF &sequence:"
 msgstr "DTMF-&Abfolge:"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
+msgid "&Amplitude (0-1):"
+msgstr "&Amplitude (0-1):"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Dauer:"
 
@@ -6964,18 +7479,40 @@ msgid "Duty cycle:"
 msgstr "Aufgabenablauf:"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr "%.1f %%"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Dauer des Tons:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Dauer der Stille:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr "%0.f ms"
+
+#: src/effects/Echo.cpp
+msgid "Echo"
+msgstr "Echo"
+
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Wiederholt das ausgewählten Audio immer wieder"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Geforderter Wert übersteigt die Speicherkapazität."
 
@@ -6999,7 +7536,8 @@ msgstr "Voreinstellungen"
 msgid "Export Effect Parameters"
 msgstr "Effektparameter exportieren"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Konnte Datei nicht öffnen: „%s“"
@@ -7036,6 +7574,14 @@ msgstr "Vorhören wird vorbereitet"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Vorhören"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7084,8 +7630,7 @@ msgstr ""
 "\n"
 "%s\n"
 "\n"
-"Weitere Informationen sind eventuell unter „Hilfe > Diagnose > Protokoll "
-"anzeigen“ verfügbar"
+"Weitere Informationen sind eventuell unter „Hilfe > Diagnose > Protokoll anzeigen“ verfügbar"
 
 #: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
@@ -7104,8 +7649,7 @@ msgstr ""
 "\n"
 "%s\n"
 "\n"
-"Weitere Informationen sind eventuell unter „Hilfe > Diagonse > Protokoll "
-"anzeigen“ verfügbar"
+"Weitere Informationen sind eventuell unter „Hilfe > Diagonse > Protokoll anzeigen“ verfügbar"
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -7261,6 +7805,16 @@ msgstr "Typ: %s"
 
 #: src/effects/EffectUI.cpp
 #, c-format
+msgid "Name: %s"
+msgstr "Name: %s"
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Version: %s"
+msgstr "Version: %s"
+
+#: src/effects/EffectUI.cpp
+#, c-format
 msgid "Vendor: %s"
 msgstr "Anbieter: %s"
 
@@ -7344,6 +7898,10 @@ msgid "100Hz Rumble"
 msgstr "100Hz Rumpeln"
 
 #: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr "MW-Radio"
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Bass-Anhebung"
 
@@ -7354,6 +7912,10 @@ msgstr "Bass-Absenkung"
 #: src/effects/Equalization.cpp
 msgid "Low rolloff for speech"
 msgstr "Niedriges Abperlen für Sprache"
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr "RIAA"
 
 #: src/effects/Equalization.cpp
 msgid "Telephone"
@@ -7372,10 +7934,8 @@ msgid ""
 "To use this filter curve in a macro, please choose a new name for it.\n"
 "Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
 msgstr ""
-"Um diese Filterkurve in einem Makro zu verwenden, geben Sie ihr bitte einen "
-"neuen Namen.\n"
-"Wählen Sie den „Kurven speichern/verwalten …“-Button und benennen Sie die "
-"„unbenannte“ Kurve um. Danach verwenden Sie diese."
+"Um diese Filterkurve in einem Makro zu verwenden, geben Sie ihr bitte einen neuen Namen.\n"
+"Wählen Sie den „Kurven speichern/verwalten …“-Button und benennen Sie die „unbenannte“ Kurve um. Danach verwenden Sie diese."
 
 #: src/effects/Equalization.cpp
 msgid "Filter Curve EQ needs a different name"
@@ -7392,6 +7952,43 @@ msgstr "Spur-Abtastrate ist zu niedrig für diesen Effekt."
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Effekt nicht verfügbar"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr "+ dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr "Max. dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr "%d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr "Min. dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr "- dB"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr "%g kHz"
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr "%gk"
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7464,6 +8061,22 @@ msgstr "&Verarbeitung: "
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "S&tandard"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr "&SSE"
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr "SSE ge&threadet"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr "A&VX"
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr "AV&X gethreadet"
 
 #: src/effects/Equalization.cpp
 msgid "&Bench"
@@ -7704,7 +8317,8 @@ msgid "Builtin Effects"
 msgstr "Integrierte Effekte"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Stellt integrierte Effekte für Tenacity bereit"
 
 #: src/effects/LoadEffects.cpp
@@ -7749,6 +8363,14 @@ msgstr "&Normalisieren"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Lautheit LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr "LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr "QMW dB"
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7818,8 +8440,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (Standard)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr "Blackman, Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
 msgstr "Hamming, keine"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr "Hamming, Hann"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Hamming, Reciprocal Hamming"
@@ -7918,12 +8548,12 @@ msgid "Step 1"
 msgstr "Schritt 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
-"Wählen Sie ein paar Sekunden Rauschen aus, damit Tenacity weiß, was zu "
-"heraus zu filtern ist.\n"
+"Wählen Sie ein paar Sekunden Rauschen aus, damit Tenacity weiß, was zu heraus zu filtern ist.\n"
 "Danach „Rauschprofil ermitteln“ wählen:"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
@@ -7972,13 +8602,62 @@ msgstr "Fenstert&ypen:"
 msgid "Window si&ze:"
 msgstr "Fenstergr&öße:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr "16"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr "32"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr "64"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr "128"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr "256"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr "512"
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr "1024"
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (Standard)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr "4096"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr "8192"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr "16384"
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Schri&tte pro Fenster:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8094,14 +8773,17 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Stereokanäle unabhängig voneinander n&ormalisieren"
 
 #: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr "Paulstretch"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
-msgstr ""
-"Paulstretch ist nur für eine extreme Zeitdehnung oder einen "
-"„Stillstand“-Effekt"
+msgstr "Paulstretch ist nur für eine extreme Zeitdehnung oder einen „Stillstand“-Effekt"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Dehnung&s-Faktor:"
@@ -8151,6 +8833,10 @@ msgstr ""
 "\n"
 "Versuchen Sie, die Audioauswahl um mindestens %.1f Sekunden zu verlängern,\n"
 "oder reduzieren Sie die „Zeitauflösung“ auf weniger als %.1f Sekunden."
+
+#: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr "Phaser"
 
 #: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
@@ -8379,6 +9065,11 @@ msgstr "Kehrt das ausgewählte Audio um"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS Zeit / Tonhöhe Dehnung"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr "Butterworth"
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8535,6 +9226,11 @@ msgstr "Standardeinstellungen verwenden"
 msgid "Restore Defaults"
 msgstr "Standardeinstellungen wiederherstellen"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr "%.3f"
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8661,6 +9357,10 @@ msgstr "Start-Amplitude"
 msgid "Amplitude End"
 msgstr "End-Amplitude"
 
+#: src/effects/ToneGen.cpp
+msgid "I&nterpolation:"
+msgstr "I&nterpolation:"
+
 #: src/effects/TruncSilence.cpp
 msgid "Truncate Detected Silence"
 msgstr "Erkannte Stille abschneiden"
@@ -8689,6 +9389,10 @@ msgstr "Stille erkennen"
 msgid "Tr&uncate to:"
 msgstr "K&ürzen bis:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr "%"
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "K&omprimieren bis:"
@@ -8702,7 +9406,8 @@ msgid "VST Effects"
 msgstr "VST-Effekte"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Fügt Tenacity die Fähigkeit VST-Effekte zu benutzen hinzu."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8714,7 +9419,8 @@ msgstr "Durchsuche Shell-VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registriere %d von %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Konnte die Bibliothek nicht laden"
 
@@ -8734,21 +9440,17 @@ msgstr "Die Puffergröße steuert die Sampleanzahl, die an den Effekt bei jedem 
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Puffergröße (8 bis 1048576 Samples):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Latenzkompensation"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
-msgstr ""
-"Einige VST-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe von "
-"Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht kompensieren, "
-"werden Sie feststellen, dass kleine Stummschaltungen in das Audio eingefügt "
-"wurden. Durch Aktivieren dieser Option wird diese Kompensation "
-"bereitgestellt, sie funktioniert jedoch möglicherweise nicht für alle VST-"
-"Effekte."
+msgstr "Einige VST-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe von Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht kompensieren, werden Sie feststellen, dass kleine Stummschaltungen in das Audio eingefügt wurden. Durch Aktivieren dieser Option wird diese Kompensation bereitgestellt, sie funktioniert jedoch möglicherweise nicht für alle VST-Effekte."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "&Kompensierung aktivieren"
 
@@ -8782,7 +9484,8 @@ msgid "Standard VST program file"
 msgstr "Standard-VST-Programmdatei"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Tenacity-VST-Voreinstellungsdatei"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8809,7 +9512,8 @@ msgstr "Fehler beim Laden der VST-Voreinstellungen"
 msgid "Unable to load presets file."
 msgstr "Voreinstellungsdatei konnte nicht geladen werden."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Effekt-Einstellungen"
 
@@ -8825,6 +9529,16 @@ msgstr "Konnte die Voreinstellungsdatei nicht lesen."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Diese Parameter-Datei wurde von %s gespeichert. Fortfahren?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr "VST"
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr "Wah-Wah"
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8856,7 +9570,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio-Unit-Effekte"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Stellt Unterstützung für Audio-Unit-Effekte für Tenacity bereit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8872,14 +9587,9 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio-Unit-Effektoptionen"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
-msgstr ""
-"Einige Audio-Unit-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe "
-"von Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht "
-"kompensieren, werden Sie feststellen, dass kleine Stummschaltungen in das "
-"Audio eingefügt wurden. Durch Aktivieren dieser Option wird diese "
-"Kompensation bereitgestellt, sie funktioniert jedoch möglicherweise nicht "
-"für alle Audio-Unit-Effekte."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr "Einige Audio-Unit-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe von Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht kompensieren, werden Sie feststellen, dass kleine Stummschaltungen in das Audio eingefügt wurden. Durch Aktivieren dieser Option wird diese Kompensation bereitgestellt, sie funktioniert jedoch möglicherweise nicht für alle Audio-Unit-Effekte."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -8887,12 +9597,7 @@ msgstr "Benutzeroberfläche"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
-msgstr ""
-"Wählen Sie „Voll“, um die grafische Oberfläche zu verwenden, sofern diese "
-"von der Audio-Unit bereitgestellt wird. Wählen Sie „Generisch“, um die vom "
-"System bereitgestellte generische Schnittstelle zu verwenden. Wählen Sie "
-"„Einfach“ für eine einfache Nur-Text-Oberfläche. Öffnen Sie den Effekt "
-"erneut, damit dies wirksam wird."
+msgstr "Wählen Sie „Voll“, um die grafische Oberfläche zu verwenden, sofern diese von der Audio-Unit bereitgestellt wird. Wählen Sie „Generisch“, um die vom System bereitgestellte generische Schnittstelle zu verwenden. Wählen Sie „Einfach“ für eine einfache Nur-Text-Oberfläche. Öffnen Sie den Effekt erneut, damit dies wirksam wird."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9017,8 +9722,7 @@ msgstr "Fehler beim Erstellen der Eigenschaftsliste für die Voreinstellung"
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to set class info for \"%s\" preset"
-msgstr ""
-"Fehler beim Festlegen der Klasseninformationen für die Voreinstellung „%s“"
+msgstr "Fehler beim Festlegen der Klasseninformationen für die Voreinstellung „%s“"
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -9028,6 +9732,7 @@ msgstr "Audio-Unit"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA-Effekte"
@@ -9037,7 +9742,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Stellt LADSPA-Effekte bereit"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity verwendet VST-Bridge nicht mehr"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9045,18 +9751,29 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA-Effekt-Optionen"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
-msgstr ""
-"Einige LADSPA-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe von "
-"Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht kompensieren, "
-"werden Sie feststellen, dass kleine Stummschaltungen in das Audio eingefügt "
-"wurden. Durch Aktivieren dieser Option wird diese Kompensation "
-"bereitgestellt, sie funktioniert jedoch möglicherweise nicht für alle LADSPA-"
-"Effekte."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr "Einige LADSPA-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe von Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht kompensieren, werden Sie feststellen, dass kleine Stummschaltungen in das Audio eingefügt wurden. Durch Aktivieren dieser Option wird diese Kompensation bereitgestellt, sie funktioniert jedoch möglicherweise nicht für alle LADSPA-Effekte."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr "%s:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Effekt-Ausgabe"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9068,14 +9785,9 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Puffergröße (8 bis %d) Samples:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
-msgstr ""
-"Einige LV2-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe von "
-"Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht kompensieren, "
-"werden Sie feststellen, dass kleine Stummschaltungen in das Audio eingefügt "
-"wurden. Durch Aktivieren dieser Einstellung wird diese Kompensation "
-"bereitgestellt, sie funktioniert jedoch möglicherweise nicht für alle "
-"LV2-Effekte."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr "Einige LV2-Effekte müssen im Rahmen ihrer Verarbeitung die Rückgabe von Audio an Tenacity verzögern. Wenn Sie diese Verzögerung nicht kompensieren, werden Sie feststellen, dass kleine Stummschaltungen in das Audio eingefügt wurden. Durch Aktivieren dieser Einstellung wird diese Kompensation bereitgestellt, sie funktioniert jedoch möglicherweise nicht für alle LV2-Effekte."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -9095,12 +9807,23 @@ msgstr "%s erfordert die nicht unterstützte Funktion %s\n"
 msgid "%s requires unsupported option %s\n"
 msgstr "%s erfordert die nicht unterstützte Option %s\n"
 
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Generator"
+msgstr "Generator"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-Effekte"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Stellt Unterstützung für LV2-Effekte für Tenacity bereit"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9108,7 +9831,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist-Effekte"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Stellt Tenacity die Unterstützung für Nyquist-Effekte bereit"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9145,8 +9869,7 @@ msgstr ""
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
-msgstr ""
-"Fehler: Datei „%s“ im Header angegeben aber nicht im Plug-In-Pfad gefunden.\n"
+msgstr "Fehler: Datei „%s“ im Header angegeben aber nicht im Plug-In-Pfad gefunden.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
@@ -9236,9 +9959,7 @@ msgstr "[Warnung: Nyquist gab eine ungültige UTF-8 Zeichenkette zurück, hier k
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
-msgstr ""
-"Diese Version von Tenacity unterstützt die Nyquist-Erweiterung mit Version "
-"%ld nicht"
+msgstr "Diese Version von Tenacity unterstützt die Nyquist-Erweiterung mit Version %ld nicht"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not open file"
@@ -9339,7 +10060,8 @@ msgstr "Datei wählen"
 msgid "Save file as"
 msgstr "Datei speichern als"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "unbenannt"
 
@@ -9348,7 +10070,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-Effekte"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Stellt Unterstützung für Vamp-Effekte für Tenacity bereit"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9370,6 +10093,12 @@ msgstr "Erweiterungseinstellungen"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programm"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9449,6 +10178,18 @@ msgstr "Format-Optionen"
 msgid "Channel: %2d"
 msgstr "Kanal: %2d"
 
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr "%s – L"
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr "%s – R"
+
 #: src/export/Export.cpp
 #, c-format
 msgid "Output Channels: %2d"
@@ -9516,6 +10257,10 @@ msgid "Command Output"
 msgstr "Befehlsausgabe"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr "&OK"
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "Sie haben einen Dateinamen ohne Endung angegeben. Sind Sie sicher?"
 
@@ -9562,9 +10307,7 @@ msgstr "FFmpeg : FEHLER - Kann Audiostream nicht zur Ausgabedatei „%s“ hinzu
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
-msgstr ""
-"FFmpeg: FEHLER – In Ausgabedatei „%s“ kann nicht geschrieben werden. "
-"Fehlercode ist %d."
+msgstr "FFmpeg: FEHLER – In Ausgabedatei „%s“ kann nicht geschrieben werden. Fehlercode ist %d."
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -9656,7 +10399,8 @@ msgstr "Exportiere Audio als %s"
 msgid "Invalid sample rate"
 msgstr "Ungültige Abtastrate"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Abtastratenkonvertierung"
 
@@ -9686,6 +10430,14 @@ msgstr "Sie können in eine dieser Raten umwandeln."
 msgid "Sample Rates"
 msgstr "Abtastraten"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr "%d kbit/s"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Bitrate:"
@@ -9693,6 +10445,48 @@ msgstr "Bitrate:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualität (kbit/s):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr "%.2f kbit/s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr "0"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr "3"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr "5"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr "6"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr "9"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr "10"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9703,12 +10497,40 @@ msgid "Constrained"
 msgstr "Beschränkt"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr "VOIP"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Audio"
+msgstr "Audio"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Geringe Verzögerung"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr "5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr "10 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr "20 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr "40 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr "60 ms"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9795,6 +10617,18 @@ msgid "Replace preset '%s'?"
 msgstr "Voreinstellung „%s“ ersetzen?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Main"
+msgstr "Haupt"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr "LTP"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
 msgstr "M4A (AAC)-Dateien (FFmpeg)"
 
@@ -9862,6 +10696,11 @@ msgstr "Voreinstellungen importieren"
 msgid "Export Presets"
 msgstr "Voreinstellungen exportieren"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Codec:"
+msgstr "Codec:"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
 msgstr "Es lassen sich nicht alle Formate, Codecs und Optionen miteinander kombinieren."
@@ -9896,6 +10735,10 @@ msgstr "Sprache:"
 msgid "Bit Reservoir"
 msgstr "Bit-Vorrat"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr "VBL"
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9906,6 +10749,10 @@ msgstr ""
 "Codec-Tag (FOURCC)\n"
 "Optional\n"
 "leer – automatisch"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr "Tag:"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10008,6 +10855,10 @@ msgstr ""
 "max - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Frame:"
+msgstr "Frame:"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "LPC coefficients precision\n"
 "Optional\n"
@@ -10020,6 +10871,10 @@ msgstr ""
 "0 - Standard\n"
 "min - 1\n"
 "max - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr "LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10052,6 +10907,10 @@ msgstr ""
 "max - 32 (mit LPC) oder 4 (ohne LPC)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr "Min. PdO"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal prediction order\n"
 "Optional\n"
@@ -10064,6 +10923,10 @@ msgstr ""
 "-1 - Standard\n"
 "min - 0\n"
 "max - 32 (mit LPC) or 4 (ohne LPC)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr "Max. PdO"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10080,6 +10943,10 @@ msgstr ""
 "max - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr "Min. PtO"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal partition order\n"
 "Optional\n"
@@ -10092,6 +10959,10 @@ msgstr ""
 "-1 - Standard\n"
 "min - 0\n"
 "max - 8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr "Max. PtO"
 
 #. i18n-hint:  Abbreviates "Linear Predictive Coding",
 #. but this text needs to be kept very short
@@ -10260,6 +11131,38 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbit/s (Beste Qualität)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr "200-250 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr "170-210 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr "155-195 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr "145-185 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr "110-150 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr "95-135 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr "80-120 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr "65-105 kbit/s"
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbit/s (Kleinere Dateien)"
 
@@ -10273,6 +11176,10 @@ msgid "Extreme, 220-260 kbps"
 msgstr "Extrem, 220-260 kbit/s"
 
 #: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr "Standard, 170-210 kbit/s"
+
+#: src/export/ExportMP3.cpp
 msgid "Medium, 145-185 kbps"
 msgstr "Mittel, 145-185 kbit/s"
 
@@ -10284,6 +11191,11 @@ msgstr "Überragend"
 #: src/export/ExportMP3.cpp
 msgid "Extreme"
 msgstr "Extrem"
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr "Standard"
 
 #: src/export/ExportMP3.cpp
 msgid "Medium"
@@ -10304,6 +11216,10 @@ msgstr "Konstant"
 #: src/export/ExportMP3.cpp
 msgid "Joint Stereo"
 msgstr "Kanalkopplung"
+
+#: src/export/ExportMP3.cpp
+msgid "Stereo"
+msgstr "Stereo"
 
 #: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
@@ -10328,8 +11244,8 @@ msgid "Locate LAME"
 msgstr "LAME suchen"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity benötigt die Datei %s, um MP3s zu erzeugen."
 
 #: src/export/ExportMP3.cpp
@@ -10357,13 +11273,12 @@ msgid "Where is %s?"
 msgstr "Wo befindet sich die Datei „%s“?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
-"Sie möchten lame_enc.dll v%d.%d einsetzen. Diese Version ist nicht "
-"kompatibel mit Tenacity %d.%d.%d.\n"
+"Sie möchten lame_enc.dll v%d.%d einsetzen. Diese Version ist nicht kompatibel mit Tenacity %d.%d.%d.\n"
 "Bitte laden Sie die neueste Version von „LAME für Tenacity“ herunter."
 
 #: src/export/ExportMP3.cpp
@@ -10622,8 +11537,7 @@ msgid ""
 "\n"
 "Suggested replacement:"
 msgstr ""
-"Textmarke oder Spur „%s“ ist kein zulässiger Dateiname. Sie dürfen „%s“ "
-"nicht verwenden.\n"
+"Textmarke oder Spur „%s“ ist kein zulässiger Dateiname. Sie dürfen „%s“ nicht verwenden.\n"
 "\n"
 "Vorgeschlagene Alternative:"
 
@@ -10667,6 +11581,18 @@ msgstr "Ausgewähltes Audio als Ogg-Vorbis-Datei exportieren"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Exportiere Audio als Ogg-Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr "AIFF (Apple/SGI)"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft)"
+
+#: src/export/ExportPCM.cpp
+msgid "Header:"
+msgstr "Header:"
+
 #: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
 msgid "Encoding:"
 msgstr "Encodierung:"
@@ -10676,12 +11602,12 @@ msgid "Other uncompressed files"
 msgstr "Andere unkomprimierte Dateien"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
-"Sie haben versucht, eine WAV oder AIFF-Datei zu exportieren, die größer als "
-"4 GB wäre.\n"
+"Sie haben versucht, eine WAV oder AIFF-Datei zu exportieren, die größer als 4 GB wäre.\n"
 "Tenacity kann dies nicht. Der Export wurde abgebrochen."
 
 #: src/export/ExportPCM.cpp
@@ -10689,12 +11615,12 @@ msgid "Error Exporting"
 msgstr "Fehler beim Exportieren"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
-"Ihre exportierte WAV-Datei wurde abgeschnitten, da Tenacity keine WAV-"
-"Dateien\n"
+"Ihre exportierte WAV-Datei wurde abgeschnitten, da Tenacity keine WAV-Dateien\n"
 "exportieren kann, die größer als 4 GB sind."
 
 #: src/export/ExportPCM.cpp
@@ -10731,11 +11657,11 @@ msgid "All supported files"
 msgstr "Alle unterstützten Dateien"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "„%s“ \n"
@@ -10744,11 +11670,11 @@ msgstr ""
 "sie über „Datei > Import > MIDI“ bearbeiten."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "„%s“\n"
 "ist keine Audiodatei.\n"
@@ -10759,18 +11685,18 @@ msgid "Select stream(s) to import"
 msgstr "Stream(s) für den Import auswählen"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Diese Version von Tenacity wurde ohne Unterstützung für %s kompiliert."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Audio-CD-Spur. \n"
 "Tenacity kann Audio-CDs nicht direkt öffnen. \n"
@@ -10779,116 +11705,104 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "„%s“ ist eine Wiedergabeliste.\n"
-"Tenacity kann diese Datei nicht öffnen, weil sie nur Links auf andere "
-"Dateien enthält. \n"
-"Vielleicht können Sie sie in einem Texteditor öffnen und die tatsächlichen "
-"Audiodateien herunterladen."
+"Tenacity kann diese Datei nicht öffnen, weil sie nur Links auf andere Dateien enthält. \n"
+"Vielleicht können Sie sie in einem Texteditor öffnen und die tatsächlichen Audiodateien herunterladen."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Windows-Media-Audiodatei. \n"
-"Aufgrund von Patent-Beschränkungen kann Tenacity diesen Dateityp nicht "
-"öffnen. \n"
-"Sie müssen die Datei zunächst in ein unterstütztes Audioformat wie WAV oder "
-"AIFF umwandeln."
+"Aufgrund von Patent-Beschränkungen kann Tenacity diesen Dateityp nicht öffnen. \n"
+"Sie müssen die Datei zunächst in ein unterstütztes Audioformat wie WAV oder AIFF umwandeln."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Advanced-Audio-Coding-Datei. \n"
-"Tenacity kann diesen Dateityp ohne der optionalen FFmpeg-Bibliothek nicht "
-"öffnen. \n"
-"Sie müssen die Datei ansonsten in ein unterstütztes Audioformat wie WAV oder "
-"AIFF umwandeln."
+"Tenacity kann diesen Dateityp ohne der optionalen FFmpeg-Bibliothek nicht öffnen. \n"
+"Sie müssen die Datei ansonsten in ein unterstütztes Audioformat wie WAV oder AIFF umwandeln."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine verschlüsselte Audiodatei. \n"
 "Vermutlich stammt sie von einem Online-Musikladen. \n"
 "Wegen der Verschlüsselung kann Tenacity die Datei nicht öffnen. \n"
-"Versuchen Sie, die Datei mit Tenacity aufzunehmen, oder brennen Sie sie als "
-"Audio-CD, \n"
-"dann extrahieren und in ein unterstütztes Audioformat wie WAV oder AIFF "
-"umwandeln."
+"Versuchen Sie, die Datei mit Tenacity aufzunehmen, oder brennen Sie sie als Audio-CD, \n"
+"dann extrahieren und in ein unterstütztes Audioformat wie WAV oder AIFF umwandeln."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine RealPlayer-Mediendatei. \n"
 "Tenacity kann dieses proprietäre Format nicht öffnen. \n"
-"Sie müssen die Datei zunächst in ein unterstütztes Audioformat wie WAV oder "
-"AIFF umwandeln."
+"Sie müssen die Datei zunächst in ein unterstütztes Audioformat wie WAV oder AIFF umwandeln."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "„%s“ ist eine notenbasierte Datei, keine Audiodatei. \n"
 "Tenacity kann diesen Dateityp nicht öffnen. \n"
-"Versuchen Sie die Datei zunächst in ein unterstütztes Audioformat wie WAV "
-"oder AIFF umzuwandeln und \n"
+"Versuchen Sie die Datei zunächst in ein unterstütztes Audioformat wie WAV oder AIFF umzuwandeln und \n"
 "sie dann zu importieren oder sie in Tenacity aufzunehmen."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Musepack-Audiodatei. \n"
 "Tenacity kann diesen Dateityp nicht öffnen. \n"
-"Falls Sie denken, dass es sich um eine MP3-Datei handelt, geben Sie ihr die "
-"Endung „.mp3“ \n"
-"und versuchen Sie erneut, zu importieren. Andernfalls müssen Sie sie in ein "
-"unterstütztes Format wie WAV oder AIFF \n"
+"Falls Sie denken, dass es sich um eine MP3-Datei handelt, geben Sie ihr die Endung „.mp3“ \n"
+"und versuchen Sie erneut, zu importieren. Andernfalls müssen Sie sie in ein unterstütztes Format wie WAV oder AIFF \n"
 "umwandeln."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Wavpack-Audiodatei. \n"
@@ -10897,10 +11811,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Dolby-Digital-Audiodatei. \n"
@@ -10909,10 +11823,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Ogg-Speex-Audiodatei. \n"
@@ -10921,10 +11835,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "„%s“ ist eine Videodatei. \n"
@@ -10938,16 +11852,15 @@ msgstr "Datei „%s“ nicht gefunden."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Tenacity hat den Typ der Datei „%s“ nicht erkannt.\n"
 "\n"
-"%sVersuchen Sie auch Datei > Importieren > Rohdaten bei unkomprimierte "
-"Dateien."
+"%sVersuchen Sie auch Datei > Importieren > Rohdaten bei unkomprimierte Dateien."
 
 #: src/import/Import.cpp
 msgid ""
@@ -10957,11 +11870,16 @@ msgstr ""
 "Versuchen Sie, FFmpeg zu installieren.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr "%s, %s"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10991,19 +11909,18 @@ msgid "Import Project"
 msgstr "Projekt importieren"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Dieses Projekt wurde von Tenacity Version 1.0 oder früher gespeichert.\n"
-"Das Format hat sich geändert und diese Version von Tenacity kann das Projekt "
-"nicht importieren.\n"
+"Das Format hat sich geändert und diese Version von Tenacity kann das Projekt nicht importieren.\n"
 "\n"
-"Verwenden Sie eine Tenacity-Version vor 3.0.0, um das Projekt zu "
-"aktualisieren.\n"
+"Verwenden Sie eine Tenacity-Version vor 3.0.0, um das Projekt zu aktualisieren.\n"
 "Anschließend können Sie es mit dieser Version von Tenacity importieren."
 
 #: src/import/ImportAUP.cpp
@@ -11049,10 +11966,9 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Projektdatenordner konnte nicht gefunden werden: „%s“"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
-msgstr ""
-"MIDI-Spuren in Projektdatei gefunden. Dieser Build von Tenacity unterstützt "
-"MIDI nicht. Lasse Spuren aus."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr "MIDI-Spuren in Projektdatei gefunden. Dieser Build von Tenacity unterstützt MIDI nicht. Lasse Spuren aus."
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
@@ -11155,40 +12071,6 @@ msgstr "Index[%02x] Codec[%s], Sprache[%s], Bitrate[%s], Kanäle[%d], Dauer[%d]"
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC-Dateien"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-kompatible Dateien"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Decoder konnte nicht zur Pipeline hinzugefügt werden"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer-Importierer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Strom-Zustand kann nicht auf Pausiert gestellt werden."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index[%02d], Typ[%s], Kanäle[%d], Rate[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Datei enthält keine Audioströme."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Datei kann nicht importiert werden, Zustandsänderung fehlgeschlagen."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer-Fehler: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -11294,6 +12176,14 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF und andere unkomprimierte Typen"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr "AU (Sun/NeXT)"
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr "AVR (Audio Visual Research)"
+
+#: src/import/ImportPCM.cpp
 msgid "CAF (Apple Core Audio File)"
 msgstr "CAF (Apple Core Audiodatei)"
 
@@ -11303,12 +12193,80 @@ msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (FLAC Verlustfreier Audiocodec)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr "HTK (HMM Tool Kit)"
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr "IFF (Amiga IFF/SVX8/SV16)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr "MPC (Akai MPC 2k)"
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG Containerformat)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr "PAF (Ensoniq PARIS)"
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr "PVF (Portable Voice Format)"
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (ohne Header)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr "RF64 (RIFF 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr "SD2 (Sound Designer II)"
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr "SDS (Midi Sample Dump Standard)"
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr "SF (Berkeley/IRCAM/CARL)"
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr "VOC (Creative Labs)"
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr "W64 (SoundFoundry WAVE 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr "WAV (NIST Sphere)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr "WAVEX (Microsoft)"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr "WVE (Psion Series 3)"
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr "XI (FastTracker 2)"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11339,6 +12297,34 @@ msgid "64 bit float"
 msgstr "64-Bit-Fließkomma"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr "μ-law"
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr "A-law"
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr "IMA ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr "Microsoft ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr "GSM 6.10"
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr "32 kbit/s G721 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr "24kbit/s G723 ADPCM"
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12-Bit-DWVW"
 
@@ -11351,12 +12337,20 @@ msgid "24 bit DWVW"
 msgstr "24-Bit-DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr "VOX ADPCM"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-Bit-DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8-Bit-DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr "Vorbis"
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11491,6 +12485,7 @@ msgstr "%s rechts"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11514,6 +12509,7 @@ msgstr "Ende"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11540,7 +12536,8 @@ msgstr "Clips nach rechts zeitverschoben"
 msgid "Time shifted clips to the left"
 msgstr "Clips nach links zeitverschoben"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Zeitverschiebung"
 
@@ -11678,7 +12675,8 @@ msgstr "Ausgewählte Audiospuren von %.2f Sekunden auf %.2f Sekunden zuschneiden
 msgid "Trim Audio"
 msgstr "Audio zuschneiden"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Trennen"
 
@@ -11799,28 +12797,8 @@ msgid "Delete Key&2"
 msgstr "Löschtaste&2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Wiedergabe&lautstärke einstellen …"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "W&iedergabelautstärke erhöhen"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Wiedergabelautstär&ke reduzieren"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Aufnahmela&utstärke einstellen …"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Auf&nahmelautstärke erhöhen"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Aufnahmelautstärke v&erringern"
+msgid "Ext&ra"
+msgstr "Ext&ra"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -11988,8 +12966,16 @@ msgid "Export MI&DI..."
 msgstr "MI&DI exportieren …"
 
 #: src/menus/FileMenus.cpp
+msgid "&Audio..."
+msgstr "&Audio …"
+
+#: src/menus/FileMenus.cpp
 msgid "&Labels..."
 msgstr "&Textmarken …"
+
+#: src/menus/FileMenus.cpp
+msgid "&MIDI..."
+msgstr "&MIDI …"
 
 #: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
@@ -12080,8 +13066,9 @@ msgid "&Getting Started"
 msgstr "&Loslegen"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Tenacity-&Handbuch"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Handbuch …"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12107,11 +13094,8 @@ msgstr "&MIDI-Geräteinfo …"
 msgid "Show &Log..."
 msgstr "&Protokoll anzeigen …"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Über Tenacity …"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Textmarke hinzugefügt"
 
@@ -12361,6 +13345,10 @@ msgid "Uncategorized"
 msgstr "Unkategorisiert"
 
 #: src/menus/PluginMenus.cpp
+msgid "..."
+msgstr "…"
+
+#: src/menus/PluginMenus.cpp
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -12419,8 +13407,16 @@ msgid "&Apply Macro"
 msgstr "Makro &anwenden"
 
 #: src/menus/PluginMenus.cpp
+msgid "Palette..."
+msgstr "Palette …"
+
+#: src/menus/PluginMenus.cpp
 msgid "Reset &Configuration"
 msgstr "&Konfiguration zurücksetzen"
+
+#: src/menus/PluginMenus.cpp
+msgid "&Screenshot..."
+msgstr "&Screenshot …"
 
 #: src/menus/PluginMenus.cpp
 msgid "&Run Benchmark..."
@@ -12532,6 +13528,10 @@ msgstr "Screenshot (Schnellformat) …"
 #: src/menus/SelectMenus.cpp
 msgid "Set Left Selection Boundary"
 msgstr "Linke Auswahlgrenze einstellen"
+
+#: src/menus/SelectMenus.cpp
+msgid "Position"
+msgstr "Position"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Right Selection Boundary"
@@ -12785,6 +13785,7 @@ msgstr "Cursor weit nach re&chts springen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Suche"
@@ -12996,19 +13997,21 @@ msgid "Created new label track"
 msgstr "Neue Textspur erstellt"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
-msgstr ""
-"Diese Tenacity-Version unterstützt nur eine Zeitspur pro Projektfenster."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr "Diese Tenacity-Version unterstützt nur eine Zeitspur pro Projektfenster."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Neue Zeitspur erstellt"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Neue Abtastrate (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Der eingegebene Wert ist ungültig"
 
@@ -13086,6 +14089,10 @@ msgstr "&Textspur"
 #: src/menus/TrackMenus.cpp
 msgid "&Time Track"
 msgstr "&Zeitspur"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr "Mi&x"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
@@ -13261,7 +14268,9 @@ msgstr "Wiedergabe"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Aufnahme"
 
@@ -13319,6 +14328,12 @@ msgstr "Bitte wählen Sie mindestens %d-Kanäle aus."
 msgid "Please select a time within a clip."
 msgstr "Bitte wählen Sie eine Zeit innerhalb eines Clip aus."
 
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+msgid "Tra&nsport"
+msgstr "Tra&nsport"
+
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
 msgstr "Wiederg&abe"
@@ -13335,6 +14350,10 @@ msgstr "Wiedergabe/Stopp und Cursor fe&stlegen"
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play"
 msgstr "&Endloswiedergabe"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Pause"
+msgstr "&Pause"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
@@ -13400,10 +14419,6 @@ msgstr "&Overdub (an/aus)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "So&ftware durchschleifen (an/aus)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomatische Aufnahmeeinpegelung (ein/aus)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13495,6 +14510,12 @@ msgstr "Zur n&ächsten Bezeichnung bewegen"
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Ansicht"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+msgid "&Zoom"
+msgstr "&Zoom"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
@@ -13612,7 +14633,8 @@ msgid "Preferences for Application"
 msgstr "Einstellungen für Qualität"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Tenacity aktualisieren"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13649,11 +14671,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Schnittstelle"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr "&Host:"
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "Verwendet:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Wiedergabe"
 
@@ -13673,7 +14701,8 @@ msgstr "Ka&näle:"
 msgid "Latency"
 msgstr "Latenz"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "Millisekunden"
 
@@ -13693,8 +14722,17 @@ msgstr "Keine Audio-Schnittstellen"
 msgid "No devices found"
 msgstr "Keine Geräte gefunden"
 
+#: src/prefs/DevicePrefs.cpp
+msgid "1 (Mono)"
+msgstr "1 (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+msgid "2 (Stereo)"
+msgstr "2 (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Verzeichnisse"
 
@@ -13731,8 +14769,16 @@ msgid "B&rowse..."
 msgstr "S&uchen …"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "&Import:"
+msgstr "&Import:"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Br&owse..."
 msgstr "Su&chen …"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "&Export:"
+msgstr "&Export:"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Bro&wse..."
@@ -13794,10 +14840,9 @@ msgid "Directory %s is not writable"
 msgstr "Verzeichnis %s ist schreibgeschützt"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
-msgstr ""
-"Änderungen am temporären Verzeichnis werden erst nach dem Neustart von "
-"Tenacity wirksam"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr "Änderungen am temporären Verzeichnis werden erst nach dem Neustart von Tenacity wirksam"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -13827,6 +14872,39 @@ msgstr "Gruppiert nach Veröffentlicher"
 msgid "Grouped by Type"
 msgstr "Gruppiert nach Typ"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr "LV&2"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr "N&yquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr "&Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr "V&ST"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Effekte aktivieren"
@@ -13848,11 +14926,13 @@ msgid "Plugin Options"
 msgstr "Erweiterung-Optionen"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Auf aktualisierte Erweiterungen prüfen, sobald Tenacity startet"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Beim nächsten Start von Tenacity die Erweiterungen erneut durchsuchen"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13923,12 +15003,7 @@ msgstr "Unbenutzte Filter:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"Es sind Leerzeichen (Leerzeichen, Zeilenumbrüche, Tabs oder Zeilenvorschübe) "
-"in einem der Elemente vorhanden. Sie werden voraussichtlich den "
-"Musterabgleich verhindern. Außer, Sie wissen, was Sie tun, wird es "
-"empfohlen, Leerzeichen zu kürzen. Soll Tenacity die Leerzeichen für Sie "
-"kürzen?"
+msgstr "Es sind Leerzeichen (Leerzeichen, Zeilenumbrüche, Tabs oder Zeilenvorschübe) in einem der Elemente vorhanden. Sie werden voraussichtlich den Musterabgleich verhindern. Außer, Sie wissen, was Sie tun, wird es empfohlen, Leerzeichen zu kürzen. Soll Tenacity die Leerzeichen für Sie kürzen?"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -14037,7 +15112,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Textmarken beibehal&ten, wenn die Auswahl an einer Textmarke einrastet"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "System- und Tenacity-Thema mischen"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14067,6 +15143,10 @@ msgid "GUI"
 msgstr "Benutzeroberfläche"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "Import / Export"
+msgstr "Import / Export"
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "Preferences for ImportExport"
 msgstr "Voreinstellungen für Import/Export"
 
@@ -14079,12 +15159,20 @@ msgid "&Use Advanced Mixing Options"
 msgstr "Erweiterte Misch-Optionen &verwenden"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr "S&tandard"
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "E&xtended (with frequency ranges)"
 msgstr "E&rweitert (mit Frequenzbereichen)"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
 msgstr "&Sekunden"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Beats"
+msgstr "&Beats"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "When exporting tracks to an audio file"
@@ -14129,6 +15217,10 @@ msgid "Open a new project to modify keyboard shortcuts."
 msgstr "Öffnen Sie ein neues Projekt um Tastaturkürzel zu ändern."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr "&Schnelltaste:"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Tastatur-Bindungen"
 
@@ -14139,6 +15231,10 @@ msgstr "Anzeigen nach:"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "&Tree"
 msgstr "&Baum"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Name"
+msgstr "&Name"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "&Key"
@@ -14177,6 +15273,10 @@ msgstr "&Setzen"
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
 msgstr "Anmerkung: Drücken von Cmd+Q beendet das Programm. Alle anderen Tasten sind gültig."
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Import..."
+msgstr "&Import …"
+
 #: src/prefs/KeyConfigPrefs.cpp src/prefs/ThemePrefs.cpp
 msgid "&Defaults"
 msgstr "&Standards"
@@ -14191,7 +15291,8 @@ msgstr ""
 "   *   „%s“  (weil die Verknüpfung „%s“ von „%s“ verwendet wird)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Wählen Sie eine XML-Datei mit Tenacity-Tastaturkürzeln aus …"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14204,8 +15305,7 @@ msgid ""
 "The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
 "Nothing is imported."
 msgstr ""
-"Die Datei mit den Verknüpfungen enthält ungültige Verknüpfungsduplikate für "
-"„%s“ und „%s“.\n"
+"Die Datei mit den Verknüpfungen enthält ungültige Verknüpfungsduplikate für „%s“ und „%s“.\n"
 "Nichts wird importiert."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14325,8 +15425,9 @@ msgid "Dow&nload"
 msgstr "Herunterl&aden"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity hat automatisch geeignete FFmpeg-Bibliotheken gefunden.\n"
@@ -14385,27 +15486,25 @@ msgid "Preferences for Module"
 msgstr "Einstellungen für Modul"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
-"Dies sind experimentelle Module. Aktivieren Sie diese nur, wenn Sie die "
-"Tenacity-Anleitung\n"
+"Dies sind experimentelle Module. Aktivieren Sie diese nur, wenn Sie die Tenacity-Anleitung\n"
 "gelesen haben und Sie wissen, was Sie tun."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
-msgstr ""
-"  „Fragen“ bedeutet, dass Tenacity Sie bei jedem Start fragt, ob das Modul "
-"geladen werden soll."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr "  „Fragen“ bedeutet, dass Tenacity Sie bei jedem Start fragt, ob das Modul geladen werden soll."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr ""
-"  „Fehlgeschlagen“ bedeutet, dass Tenacity annimmt, dass dieses Modul defekt "
-"ist und es nicht ausführen wird."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr "  „Fehlgeschlagen“ bedeutet, dass Tenacity annimmt, dass dieses Modul defekt ist und es nicht ausführen wird."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -14413,10 +15512,9 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  „Neu“ bedeutet, dass noch keine Auswahl getroffen wurde."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
-msgstr ""
-"Änderungen an diesen Einstellungen werden erst nach einem Neustart von "
-"Tenacity aktiv."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "Änderungen an diesen Einstellungen werden erst nach einem Neustart von Tenacity aktiv."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -14478,7 +15576,10 @@ msgstr "Links ziehen"
 msgid "Set Selection Range"
 msgstr "Auswahlbereich einstellen"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Umschalt-Linksklick"
 
@@ -14566,6 +15667,15 @@ msgstr "-Links ziehen"
 msgid "Move clip up/down between tracks"
 msgstr "Clip zwischen Spuren nach oben/unten schieben"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Links ziehen"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14594,6 +15704,10 @@ msgstr "Mehrere Samples ändern"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Nur EIN Sample ändern"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Multi"
+msgstr "Multi"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14685,7 +15799,8 @@ msgid "Always scrub un&pinned"
 msgstr "Immer abge&pinnt schrubben"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Tenacity-Einstellungen"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14699,6 +15814,11 @@ msgstr "Einstellungen:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Einstellungen für Qualität"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr "%i Hz"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14724,6 +15844,11 @@ msgstr "Echtzeit-Umwandlung"
 msgid "Sample Rate Con&verter:"
 msgstr "Abtastraten-Kon&verter:"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr "&Dither:"
+
 #: src/prefs/QualityPrefs.cpp
 msgid "High-quality Conversion"
 msgstr "Hochwertige Umwandlung"
@@ -14731,6 +15856,11 @@ msgstr "Hochwertige Umwandlung"
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "Abtastraten-Konver&ter:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr "Dit&her:"
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -14808,39 +15938,6 @@ msgid "System T&ime"
 msgstr "Systemze&it"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatische Aufnahmepegeleinstellung"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Automatische Aufnahmepegeleinstellung aktivieren."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Höchstwert-Ziel:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Innerhalb:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Analysezeit:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "Millisekunden (Zeit einer Analyse)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Anzahl fortlaufender Analysen:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 bedeutet endlos"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "„Punch and Roll“-Aufnahmen"
 
@@ -14851,6 +15948,21 @@ msgstr "Vorlau&f:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Über&blenden:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr "Mel"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr "Bark"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr "ERB"
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14985,6 +16097,10 @@ msgid "1024 - default"
 msgstr "1024 - Standard"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr "2048"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - meist Schmalband"
 
@@ -15082,28 +16198,26 @@ msgid "Info"
 msgstr "Hinweise"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
 msgstr ""
 "Themen sind eine experimentelle Funktion.\n"
 "\n"
-"Um sie auszuprobieren, klicken Sie auf „Thema-Cache speichern“, danach "
-"finden und ändern Sie die Bilder und Farben in\n"
+"Um sie auszuprobieren, klicken Sie auf „Thema-Cache speichern“, danach finden und ändern Sie die Bilder und Farben in\n"
 "ImageCacheVxx.png mit einem Bildbearbeitungsprogramm, wie Gimp.\n"
 "\n"
-"Klicken Sie auf „Thema-Cache laden“ um die geänderten Bilder und Farben "
-"wieder in Tenacity zu laden.\n"
+"Klicken Sie auf „Thema-Cache laden“ um die geänderten Bilder und Farben wieder in Tenacity zu laden.\n"
 "\n"
-"(Nur die Transport-Werkzeugleiste und die Farben in der Wellenspur sind zur "
-"Zeit änderbar, obwohl\n"
+"(Nur die Transport-Werkzeugleiste und die Farben in der Wellenspur sind zur Zeit änderbar, obwohl\n"
 "die Bilddatei auch andere Symbole anzeigt.)"
 
 #: src/prefs/ThemePrefs.cpp
@@ -15267,10 +16381,15 @@ msgid "MilliSeconds"
 msgstr "Millisekunden"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Samples"
+msgstr "Samples"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "4 Pixels per Sample"
 msgstr "4 Pixel pro Sample"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Max. Zoom"
 
@@ -15400,6 +16519,18 @@ msgid "Skip to End"
 msgstr "Ans Ende springen"
 
 #: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pause"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Auswahl auf Anfang"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Auswahl auf Ende"
+
+#: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
 msgstr "Endloswiedergabe"
 
@@ -15411,20 +16542,17 @@ msgstr "Neue Spur aufzeichnen"
 msgid "Append Record"
 msgstr "Aufnahme anhängen"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Auswahl auf Ende"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Auswahl auf Anfang"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s pausiert."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr "%s."
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15504,11 +16632,17 @@ msgstr "Auswahl in Stille umwandeln"
 msgid "Sync-Lock Tracks"
 msgstr "Spuren bei Bearbeitung synchron halten"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Heranzoomen"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Herauszoomen"
 
@@ -15575,43 +16709,6 @@ msgstr "&Aufnahmeaussteuerung-Werkzeugleiste"
 msgid "&Playback Meter Toolbar"
 msgstr "&Wiedergabeaussteuerung-Werkzeugleiste"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Aufnahmelautstärke"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Wiedergabelautstärke"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Aufnahmelautstärke: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Aufnahmelautstärke (Nicht verfügbar; Systemmixer verwenden.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Wiedergabelautstärke: %.2f (emuliert)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Wiedergabelautstärke: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Wiedergabelautstärke (Nicht verfügbar; Systemmixer verwenden.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "&Mixer-Werkzeugleiste"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Suchen"
@@ -15627,6 +16724,7 @@ msgstr "Schrubbe"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Schrubben stoppen"
@@ -15634,6 +16732,7 @@ msgstr "Schrubben stoppen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Schrubben starten"
@@ -15641,6 +16740,7 @@ msgstr "Schrubben starten"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Suche stoppen"
@@ -15648,6 +16748,7 @@ msgstr "Suche stoppen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Suche starten"
@@ -15702,7 +16803,9 @@ msgstr "Einrasten"
 msgid "Length"
 msgstr "Länge"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Mitte"
 
@@ -15766,8 +16869,8 @@ msgstr "&Zeit-Werkzeugleiste"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Tenacity-%s-Werkzeugleiste"
 
 #: src/toolbars/ToolBar.cpp
@@ -15794,7 +16897,8 @@ msgstr "Verschiebewerkzeug"
 msgid "Zoom Tool"
 msgstr "Zoomwerkzeug"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Zeichenwerkzeug"
 
@@ -15870,11 +16974,13 @@ msgstr "Eine oder mehrere Markierungsgrenzen verschieben."
 msgid "Drag label boundary."
 msgstr "Markierungsgrenze verschieben."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Textmarke geändert"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Textmarke bearbeiten"
 
@@ -15929,31 +17035,42 @@ msgstr "Bearbeitete Textmarken"
 msgid "New label"
 msgstr "Neue Textmarke"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Eine &Oktave höher"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Eine Okta&ve tiefer"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klicken um vertikal heran zu zoomen. Umschalt-Klicken um heraus zu zoomen. Ziehen um einen Zoom-Bereich festzulegen."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Für Menü rechtsklicken."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zoom zurücksetzen"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Umschalt-Rechtsklick"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Linksklick/Links-Ziehen"
 
@@ -15995,7 +17112,8 @@ msgstr "Zusammenführen"
 msgid "Expanded Cut Line"
 msgstr "Schnittlinie erweitert"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Erweitern"
 
@@ -16018,6 +17136,11 @@ msgstr "Samples verschoben"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Sample bearbeiten"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr "k"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16044,6 +17167,10 @@ msgid "S&pectrogram Settings..."
 msgstr "S&pektrogramm-Einstellungen …"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "&Format"
+msgstr "&Format"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Ändere Abtastformat"
 
@@ -16059,7 +17186,8 @@ msgstr "Verarbeite …   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "„%s“ in %s geändert"
@@ -16067,6 +17195,54 @@ msgstr "„%s“ in %s geändert"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Format Change"
 msgstr "Format ändern"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Rat&e"
+msgstr "Fr&equenz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr "8000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr "11025 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr "16000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr "22050 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr "44100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr "48000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr "88200 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr "96000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr "176400 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr "192000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr "352800 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "384000 Hz"
@@ -16090,7 +17266,8 @@ msgstr "Änderung der Rate"
 msgid "Set Rate"
 msgstr "Rate einstellen"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Mehrfachansicht"
 
@@ -16109,6 +17286,10 @@ msgstr "Stereospur aufte&ilen"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Stereo zu Mo&no aufteilen"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16160,6 +17341,16 @@ msgstr "In Mono trennen"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
+msgid "Stereo, %dHz"
+msgstr "Stereo, %d Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Mono, %dHz"
+msgstr "Mono, %d Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
 msgid "Left, %dHz"
 msgstr "Links, %dHz"
 
@@ -16168,14 +17359,23 @@ msgstr "Links, %dHz"
 msgid "Right, %dHz"
 msgstr "Rechts, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr "%+.1f dB"
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Links"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Rechts"
@@ -16197,6 +17397,14 @@ msgid "Close sub-view"
 msgstr "Unteransicht schließen"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom x1/2"
+msgstr "Zoom ×1/2"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom x2"
+msgstr "Zoom ×2"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
 msgstr "Halbwelle"
 
@@ -16207,6 +17415,11 @@ msgstr "We&llenform"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "&Wellenfarbe"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr "Instrument %i"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -16280,8 +17493,12 @@ msgstr "Logarithmische &Interpolation"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klicken und Ziehen zum Anpassen, Doppelklick zum Zurücksetzen"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
+
+#: src/tracks/ui/CommonTrackControls.cpp
+msgid "&Name..."
+msgstr "&Name …"
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "Move Track &Up"
@@ -16328,6 +17545,7 @@ msgstr "Hüllkurve eingestellt."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Schrubben"
@@ -16339,6 +17557,7 @@ msgstr "Suchen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Schrub-&Regler"
@@ -16522,6 +17741,24 @@ msgstr "Drücke"
 msgid "Button"
 msgstr "Knopf"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr "L"
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr "R"
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr "%.2f×"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16555,9 +17792,19 @@ msgstr "Leer"
 msgid "Backwards"
 msgstr "Rückwärts"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr "<"
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Vorwärts"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ">"
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16642,6 +17889,10 @@ msgid "Automatic"
 msgstr "Automatisch"
 
 #: src/widgets/Meter.cpp
+msgid "Horizontal"
+msgstr "Horizontal"
+
+#: src/widgets/Meter.cpp
 msgid "Vertical"
 msgstr "Vertikal"
 
@@ -16681,6 +17932,27 @@ msgstr "Bitte eine Aktion wählen"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000,01000 seconds"
 msgstr "01000 01000 Sekunden"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr "0100 h 060 min 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr "dd:hh:mm:ss"
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -16745,6 +18017,7 @@ msgstr "0100 h 060 m 060 s+<# Samples"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "Samples"
@@ -16910,6 +18183,11 @@ msgstr "010 01000<0100 Hz"
 msgid "centihertz"
 msgstr "Centihertz"
 
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr "kHz"
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -16986,6 +18264,11 @@ msgstr "(Kontextmenü verwenden, um Format zu ändern.)"
 msgid "centiseconds"
 msgstr "Zentisekunden"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Vergangene Zeit:"
@@ -17049,6 +18332,10 @@ msgid "Don't show this warning again"
 msgstr "Warnung nicht mehr anzeigen"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr "NaN"
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "Unendlich"
 
@@ -17097,6 +18384,10 @@ msgid "Value must not be greater than %s"
 msgstr "Wert darf nicht größer als %s sein"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr "Dialog"
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Verzeichnis wählen"
 
@@ -17126,15 +18417,27 @@ msgstr "XML konnte nicht analysiert werden"
 msgid "Spectral edit multi tool"
 msgstr "Spektralbearbeitung - Mehrfachwerkzeug"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtern …"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr "Paul Licameli"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Veröffentlicht unter den Bedingungen der GNU General Public Lizenz Version 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aBitte Frequenzen wählen."
@@ -17158,11 +18461,11 @@ msgid ""
 "                      or reduce the filter 'Width'."
 msgstr ""
 "~aKerbfilter-Parameter können nicht angewendet werden.~%~\n"
-"                      Versuchen Sie die niedrige Frequenzgrenze zu erhören~%~"
-"\n"
+"                      Versuchen Sie die niedrige Frequenzgrenze zu erhören~%~\n"
 "                      oder reduzieren Sie die „Breite“ des Filters."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Fehler.~%"
@@ -17223,6 +18526,24 @@ msgstr "Studio-Ausblendung"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Blende wird angewendet …"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr "Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Veröffentlicht unter den Bedingungen der GNU General Public Lizenz Version 2 oder später."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17368,6 +18689,10 @@ msgid "Finding beats..."
 msgstr "Finde Beats …"
 
 #: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
+
+#: plug-ins/beat.ny
 msgid "Threshold Percentage"
 msgstr "Schwellenwertprozentsatz"
 
@@ -17462,6 +18787,10 @@ msgstr "Ein / Aus wechselnd"
 #, lisp-format
 msgid "Error.~%Select 2 (or more) tracks to crossfade."
 msgstr "Fehler.~%Wählen Sie 2 (oder mehr) Spuren zur Überblendung aus."
+
+#: plug-ins/delay.ny
+msgid "Delay"
+msgstr "Verzögerung"
 
 #: plug-ins/delay.ny
 msgid "Applying Delay Effect..."
@@ -17646,6 +18975,10 @@ msgid "Message on completion"
 msgstr "Nachricht bei Fertigstellung"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr "Details"
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "Nur Warnungen"
 
@@ -17682,13 +19015,38 @@ msgstr "Hochpassfilter"
 msgid "Performing High-Pass Filter..."
 msgstr "Wende Hochpassfilter an …"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr "Dominic Mazzoni"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequenz (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Abperlen (dB pro Oktave)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr "6 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr "12 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr "24 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr "36 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr "48 dB"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17709,10 +19067,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Geräusche beschriften"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Veröffentlicht unter den Bedingungen der GNU General Public Lizenz Version 2 oder später."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17774,6 +19128,12 @@ msgstr "Maximale nachlaufende Stille"
 msgid "Sound ##1"
 msgstr "Geräusch ##1"
 
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr "~ah ~amin ~as"
+
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Too many silences detected.~%Only the first 10000 labels added."
@@ -17794,6 +19154,10 @@ msgstr "Keine Geräusche gefunden.~%Versuchen Sie den Schwellenwert zu senken od
 #, lisp-format
 msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
 msgstr "Bereiche zwischen Geräuschen zu beschriften erfordert~%mindestens zwei Geräusche.~%Nur ein Geräusch wurde gefunden."
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr "Begrenzer"
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -17863,6 +19227,10 @@ msgstr "Noise-Gate"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Funktion wählen"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr "Gate"
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -17944,6 +19312,12 @@ msgstr ""
 "Peak basierend auf ersten ~a Sekunden ~a dB~%\n"
 "Vorgeschlagene Schwellenwerteinstellung ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr "~ah ~amin"
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Kerbfilter"
@@ -17992,7 +19366,8 @@ msgstr "Lisp-Datei"
 msgid "HTML file"
 msgstr "HTML-Datei"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Textdatei"
 
@@ -18069,12 +19444,20 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI Werte für C-Noten: 36, 48, 60 [mittleres C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr "David R. Sky"
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Zupf MIDI-Tonhöhe"
 
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Abblendtyp"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr "Abrupt"
 
 #: plug-ins/pluck.ny
 msgid "Gradual"
@@ -18093,6 +19476,10 @@ msgid "Generating Rhythm..."
 msgstr "Rhythmus wird erzeugt …"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr "Tempo (BPM)"
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 Beats/Minute"
 
@@ -18109,9 +19496,12 @@ msgid "Swing amount"
 msgstr "Swing-Wert"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr "+/- 1"
+
+#: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
-msgstr ""
-"Stellen Sie „Taktanzahl“ auf Null, um die „Rhythmusspurdauer“ zu aktivieren."
+msgstr "Stellen Sie „Taktanzahl“ auf Null, um die „Rhythmusspurdauer“ zu aktivieren."
 
 #: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
@@ -18178,6 +19568,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI-Tonhöhe von starkem Beat"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr "18-116"
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI-Tonhöhe von schwachem Beat"
 
@@ -18198,6 +19592,10 @@ msgid "Generating Risset Drum..."
 msgstr "Risset-Trommel wird erzeugt …"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr "Steven Jones"
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Abklingen (Sekunden)"
 
@@ -18212,6 +19610,10 @@ msgstr "Breite des Rauschbandes (Hz)"
 #: plug-ins/rissetdrum.ny
 msgid "Amount of noise in mix (percent)"
 msgstr "Rauschanteil im Mix (Prozent)"
+
+#: plug-ins/rissetdrum.ny
+msgid "Amplitude (0 - 1)"
+msgstr "Amplitude (0-1)"
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
@@ -18258,6 +19660,10 @@ msgid "Include header information"
 msgstr "Headerinformationen ausgeben"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr "Minimal"
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Alle"
 
@@ -18290,6 +19696,11 @@ msgstr "Mitteilungen anzeigen"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Nur Fehler"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr "[-unendlich]"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18338,6 +19749,11 @@ msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~a linear, ~a dB."
+msgstr "~a linear, ~a dB."
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
 msgstr "Links: ~a lin, ~a dB | Rechts: ~a lin, ~a dB."
 
@@ -18380,12 +19796,21 @@ msgstr "<b>DC-Versatz:</b> &nbsp;&nbsp;~a"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr "~a linear, &nbsp;&nbsp;~a dB."
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
 msgstr "Links: ~a lin, ~a dB | Rechts: ~a linear, &nbsp;&nbsp;~a dB."
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
 msgstr "Sampledaten"
+
+#: plug-ins/sample-data-export.ny
+msgid "Sample #"
+msgstr "Sample #"
 
 #: plug-ins/sample-data-export.ny
 msgid "Value (linear)"
@@ -18425,6 +19850,10 @@ msgstr ""
 "Erzeugt mit <span>Sample-Datenexport</span> für\n"
 "<a href=\"~a\">Tenacity</a> von Steve\n"
 "Daulton"
+
+#: plug-ins/sample-data-export.ny
+msgid "linear"
+msgstr "linear"
 
 #: plug-ins/sample-data-export.ny
 msgid "2 channels (stereo)"
@@ -18540,6 +19969,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Fehler.~%Spur-Abtastrate unter 100 Hz wird nicht unterstützt."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr "Tremolo"
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Tremolo wird angewendet …"
 
@@ -18566,6 +19999,10 @@ msgstr "Gesang-Reduzierung und Isolation"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Aktion wird angewendet …"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr "Robert Haenggi"
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18708,8 +20145,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Diese Erweiterung funktioniert nur bei Stereospuren."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr "Vocoder"
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Verarbeite Vocoder …"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr "Edgar-RFT"
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18751,6 +20196,223 @@ msgstr "Frequenz der Radarnadeln (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Fehler.~%Stereospur erforderlich."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Tenacity aktualisieren"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Überspringen"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Update installieren"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Änderungsprotokoll"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Lese auf GitHub mehr"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Während der Suche nach einem Update ist ein Fehler aufgetreten"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Der Tenacity-Update-Server antwortet nicht."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Die Update-Daten sind beschädigt."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Fehler beim Herunterladen der Aktualisierung."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Der Download-Link von Tenacity kann nicht geöffnet werden."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s ist verfügbar!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Aufnahme"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Plattformübergreifende GUI-Bibliothek"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Import per GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automatische Aufnahmeeinpegelung gestoppt. Eine weitere Optimierung war nicht möglich. Immer noch zu hoch."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automatische Aufnahmeeinpegelung verringerte die Lautstärke auf %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatische Aufnahmeeinpegelung gestoppt. Eine weitere Optimierung war nicht möglich. Immer noch zu niedrig."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automatische Aufnahmeeinpegelung erhöhte die Lautstärke auf %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automatische Aufnahmeeinpegelung gestoppt. Es konnte keine akzeptable Lautstärke mit der gegebenen Analysezahl ermittelt werden. Immer noch zu hoch."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automatische Aufnahmeeinpegelung gestoppt. Es konnte keine akzeptable Lautstärke mit der gegebenen Analysezahl ermittelt werden. Immer noch zu niedrig."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatische Aufnahmeeinpegelung gestoppt. %.2f scheint eine akzeptable Lautstärke zu sein."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "%d während des Öffnens der Geräte empfangen\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Portmixer kann nicht geöffnet werden\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Verfügbare Mixer:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Verfügbare Aufnahmequellen:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Verfügbare Wiedergabelautstärken:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Aufnahmelautstärke wird emuliert\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Aufnahmelautstärke ist nativ\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Wiedergabelautstärke wird emuliert\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Wiedergabelautstärke ist nativ\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Datum und Zeit unbekannt"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-kompatible Dateien"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Decoder konnte nicht zur Pipeline hinzugefügt werden"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer-Importierer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Strom-Zustand kann nicht auf Pausiert gestellt werden."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index[%02d], Typ[%s], Kanäle[%d], Rate[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Datei enthält keine Audioströme."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Datei kann nicht importiert werden, Zustandsänderung fehlgeschlagen."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer-Fehler: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Wiedergabe&lautstärke einstellen …"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "W&iedergabelautstärke erhöhen"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Wiedergabelautstär&ke reduzieren"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Aufnahmela&utstärke einstellen …"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Auf&nahmelautstärke erhöhen"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Aufnahmelautstärke v&erringern"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Tenacity-&Handbuch"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Über Tenacity …"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomatische Aufnahmeeinpegelung (ein/aus)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatische Aufnahmepegeleinstellung"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Automatische Aufnahmepegeleinstellung aktivieren."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Höchstwert-Ziel:"
+
+#~ msgid "Within:"
+#~ msgstr "Innerhalb:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Analysezeit:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "Millisekunden (Zeit einer Analyse)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Anzahl fortlaufender Analysen:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 bedeutet endlos"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Aufnahmelautstärke"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Wiedergabelautstärke"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Aufnahmelautstärke: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Aufnahmelautstärke (Nicht verfügbar; Systemmixer verwenden.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Wiedergabelautstärke: %.2f (emuliert)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Wiedergabelautstärke: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Wiedergabelautstärke (Nicht verfügbar; Systemmixer verwenden.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "&Mixer-Werkzeugleiste"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klicken und Ziehen zum Anpassen, Doppelklick zum Zurücksetzen"
 
 #~ msgid "Program build date:"
 #~ msgstr "Programm-Builddatum:"
@@ -18876,1556 +20538,12 @@ msgstr "Fehler.~%Stereospur erforderlich."
 #~ msgid "[Project %02i] Audacity "
 #~ msgstr "[Projekt %02i] Tenacity "
 
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
+#~ msgid "Commit Id:"
+#~ msgstr "Commit-ID:"
 
-#: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Commit-ID:"
-
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "OK"
-
-#. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
-msgid "Start"
-msgstr "Start"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#: libraries/lib-strings/Languages.cpp
-msgid "System"
-msgstr "System"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
 #, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s KB"
-msgstr "%s kB"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
-msgid "Zoom x1/2"
-msgstr "Zoom ×1/2"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "8000 Hz"
-msgstr "8000 Hz"
-
-#: src/prefs/TracksPrefs.cpp
-msgid "Samples"
-msgstr "Samples"
-
-#: src/prefs/SpectrumPrefs.cpp
-msgid "2048"
-msgstr "2048"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
-#: src/prefs/SpectrogramSettings.cpp
-msgid "ERB"
-msgstr "ERB"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Bark"
-msgstr "Bark"
-
-#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
-#: src/prefs/QualityPrefs.cpp
-msgid "Dit&her:"
-msgstr "Dit&her:"
-
-#: src/prefs/ImportExportPrefs.cpp
-msgid "Import / Export"
-msgstr "Import / Export"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/prefs/EffectsPrefs.cpp
-msgid "V&ST"
-msgstr "V&ST"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/prefs/EffectsPrefs.cpp
-msgid "&Vamp"
-msgstr "&Vamp"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/prefs/EffectsPrefs.cpp
-msgid "N&yquist"
-msgstr "N&yquist"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/prefs/EffectsPrefs.cpp
-msgid "LV&2"
-msgstr "LV&2"
-
-#: src/prefs/DevicePrefs.cpp
-msgid "1 (Mono)"
-msgstr "1 (Mono)"
-
-#: src/menus/TransportMenus.cpp
-msgid "&Pause"
-msgstr "&Pause"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ext&ra"
-msgstr "Ext&ra"
-
-#: src/export/ExportMP3.cpp
-msgid "155-195 kbps"
-msgstr "155-195 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "170-210 kbps"
-msgstr "170-210 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "200-250 kbps"
-msgstr "200-250 kbit/s"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Max. PtO"
-msgstr "Max. PtO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Min. PtO"
-msgstr "Min. PtO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Max. PdO"
-msgstr "Max. PdO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Min. PdO"
-msgstr "Min. PdO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LTP"
-msgstr "LTP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Main"
-msgstr "Haupt"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LC"
-msgstr "LC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "60 ms"
-msgstr "60 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "40 ms"
-msgstr "40 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "20 ms"
-msgstr "20 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10 ms"
-msgstr "10 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "5 ms"
-msgstr "5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Audio"
-msgstr "Audio"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VOIP"
-msgstr "VOIP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10"
-msgstr "10"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "9"
-msgstr "9"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "7"
-msgstr "7"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "6"
-msgstr "6"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "5"
-msgstr "5"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "4"
-msgstr "4"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "3"
-msgstr "3"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "1"
-msgstr "1"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "0"
-msgstr "0"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#: src/export/ExportFFmpegDialogs.cpp
-#, c-format
-msgid "%.2f kbps"
-msgstr "%.2f kbit/s"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
-#, c-format
-msgid "%d kbps"
-msgstr "%d kbit/s"
-
-#: src/export/ExportCL.cpp
-msgid "&OK"
-msgstr "&OK"
-
-#. i18n-hint: track name and R abbreviating Right channel
-#: src/export/Export.cpp
-#, c-format
-msgid "%s - R"
-msgstr "%s – R"
-
-#. i18n-hint: track name and L abbreviating Left channel
-#: src/export/Export.cpp
-#, c-format
-msgid "%s - L"
-msgstr "%s – L"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/effects/vamp/VampEffect.h
-msgid "Vamp"
-msgstr "Vamp"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/effects/lv2/LV2Effect.h
-msgid "LV2"
-msgstr "LV2"
-
-#: src/effects/lv2/LV2Effect.cpp
-msgid "Generator"
-msgstr "Generator"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/effects/ladspa/LadspaEffect.h
-msgid "LADSPA"
-msgstr "LADSPA"
-
-#. i18n-hint: An item name introducing a value, which is not part of the string but
-#. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
-#, c-format
-msgid "%s:"
-msgstr "%s:"
-
-#: src/effects/Wahwah.cpp
-msgid "Wahwah"
-msgstr "Wah-Wah"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/effects/VST/VSTEffect.h
-msgid "VST"
-msgstr "VST"
-
-#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
-msgid "%"
-msgstr "%"
-
-#: src/effects/ToneGen.cpp
-msgid "I&nterpolation:"
-msgstr "I&nterpolation:"
-
-#: src/effects/ScoreAlignDialog.cpp
-#, c-format
-msgid "%.3f"
-msgstr "%.3f"
-
-#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
-#: src/effects/ScienFilter.cpp
-msgid "Butterworth"
-msgstr "Butterworth"
-
-#: src/effects/Phaser.cpp
-msgid "Phaser"
-msgstr "Phaser"
-
-#: src/effects/Paulstretch.cpp
-msgid "Paulstretch"
-msgstr "Paulstretch"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "2"
-msgstr "2"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16384"
-msgstr "16384"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "8192"
-msgstr "8192"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "4096"
-msgstr "4096"
-
-#: src/effects/NoiseReduction.cpp
-msgid "1024"
-msgstr "1024"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "512"
-msgstr "512"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "256"
-msgstr "256"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "128"
-msgstr "128"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "64"
-msgstr "64"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "32"
-msgstr "32"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16"
-msgstr "16"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
-msgid "8"
-msgstr "8"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Hamming, Hann"
-msgstr "Hamming, Hann"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Blackman, Hann"
-msgstr "Blackman, Hann"
-
-#: src/effects/Loudness.cpp
-msgid "RMS dB"
-msgstr "QMW dB"
-
-#: src/effects/Loudness.cpp
-msgid "LUFS"
-msgstr "LUFS"
-
-#: src/effects/Equalization.cpp
-msgid "AV&X Threaded"
-msgstr "AV&X gethreadet"
-
-#: src/effects/Equalization.cpp
-msgid "A&VX"
-msgstr "A&VX"
-
-#: src/effects/Equalization.cpp
-msgid "SSE &Threaded"
-msgstr "SSE ge&threadet"
-
-#: src/effects/Equalization.cpp
-msgid "&SSE"
-msgstr "&SSE"
-
-#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%gk"
-msgstr "%gk"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%g kHz"
-msgstr "%g kHz"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "- dB"
-msgstr "- dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "Min dB"
-msgstr "Min. dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-#, c-format
-msgid "%d dB"
-msgstr "%d dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "Max dB"
-msgstr "Max. dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "+ dB"
-msgstr "+ dB"
-
-#: src/effects/Equalization.cpp
-msgid "RIAA"
-msgstr "RIAA"
-
-#: src/effects/Equalization.cpp
-msgid "AM Radio"
-msgstr "MW-Radio"
-
-#: src/effects/EffectUI.cpp
-#, c-format
-msgid "Version: %s"
-msgstr "Version: %s"
-
-#: src/effects/EffectUI.cpp
-#, c-format
-msgid "Name: %s"
-msgstr "Name: %s"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/effects/Effect.h
-msgid "Nyquist"
-msgstr "Nyquist"
-
-#: src/effects/Echo.cpp
-msgid "Echo"
-msgstr "Echo"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%0.f ms"
-msgstr "%0.f ms"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.0f ms"
-msgstr "%.0f ms"
-
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.1f %%"
-msgstr "%.1f %%"
-
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
-msgid "&Amplitude (0-1):"
-msgstr "&Amplitude (0-1):"
-
-#: src/effects/Distortion.cpp
-msgid "dB Limit"
-msgstr "dB-Limit"
-
-#: src/effects/Distortion.cpp
-msgid "Parameter 2"
-msgstr "Parameter 2"
-
-#: src/effects/Distortion.cpp
-msgid "Parameter 1"
-msgstr "Parameter 1"
-
-#. i18n-hint: day of month, month, year, hour, minute, second
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%d %s %02d %02dh %02dm %02ds"
-msgstr "%d %s %02d %02dh %02dmin %02ds"
-
-#. i18n-hint: short form of 'decibels'
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB"
-msgstr "%.2f dB"
-
-#. i18n-hint: dB abbreviates decibels
-#. * RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB RMS"
-msgstr "%.2f dB QMW"
-
-#. i18n-hint: dB abbreviates decibels
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%s dB"
-msgstr "%s dB"
-
-#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "RMS = %s."
-msgstr "QMW = %s."
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.1f:1"
-msgstr "%.1f:1"
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.0f:1"
-msgstr "%.0f:1"
-
-#. i18n-hint: usually leave this as is as dB doesn't get translated
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%3d dB"
-msgstr "%3d dB"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "78"
-msgstr "78"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "45"
-msgstr "45"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "33⅓"
-msgstr "33⅓"
-
-#: src/effects/BassTreble.cpp
-msgid "Bass"
-msgstr "Bass"
-
-#: src/effects/BassTreble.cpp
-msgid "Ba&ss (dB):"
-msgstr "Ba&ss (dB):"
-
-#: src/effects/BassTreble.cpp
-msgid "Bass (dB):"
-msgstr "Bass (dB):"
-
-#: src/commands/SetTrackInfoCommand.cpp
-msgid "VZoom:"
-msgstr "VZoom:"
-
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "Linear"
-msgstr "Linear"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "Y:"
-msgstr "Y:"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "X:"
-msgstr "X:"
-
-#: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
-msgid "Start:"
-msgstr "Start:"
-
-#: src/commands/ScreenshotCommand.cpp
-msgid "Screenshot"
-msgstr "Screenshot"
-
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
-msgid "Name:"
-msgstr "Name:"
-
-#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
-msgid "Text:"
-msgstr "Text:"
-
-#: src/commands/ImportExportCommands.cpp
-msgid "Export2"
-msgstr "Export2"
-
-#: src/commands/ImportExportCommands.cpp
-msgid "Import2"
-msgstr "Import2"
-
-#: src/commands/HelpCommand.cpp
-msgid "_"
-msgstr "_"
-
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
-msgid "Format:"
-msgstr "Format:"
-
-#. i18n-hint name of a computer programming language
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "LISP"
-msgstr "Lisp"
-
-#. i18n-hint JavaScript Object Notation
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "JSON"
-msgstr "JSON"
-
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
-msgid "Clips"
-msgstr "Übersteuerungen"
-
-#. i18n-hint abbreviates "Identity" or "Identifier"
-#: src/commands/DragCommand.cpp
-msgid "Id:"
-msgstr "ID:"
-
-#: src/commands/Demo.cpp
-msgid "Demo"
-msgstr "Demo"
-
-#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%s: %s"
-msgstr "%s: %s"
-
-#: src/TrackInfo.cpp
-msgid "Stereo, 999999Hz"
-msgstr "Stereo, 999999 Hz"
-
-#. i18n-hint a format string for hours, minutes, and seconds
-#: src/TimerRecordDialog.cpp
-msgid "099 h 060 m 060 s"
-msgstr "099 h 060 min 060 s"
-
-#: src/Tags.cpp
-msgid "Genres"
-msgstr "Genres"
-
-#: src/Tags.cpp
-msgid "Genre"
-msgstr "Genre"
-
-#: src/ShuttleGui.cpp
-msgid "Debu&g"
-msgstr "Debu&g"
-
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
-msgid "Mixer"
-msgstr "Mixer"
-
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
-msgid "Transport"
-msgstr "Transport"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "A♯/B♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "G♯/A♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "F♯/G♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "D♯/E♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "C♯/D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "B♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "A♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "G♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "B"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "A♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "A"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "G♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "G"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "F♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "F"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "E"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "D♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "D"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "C♯"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Projekt %02i] "
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "C"
-
-#. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Solo"
-msgstr "Solo"
-
-#. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Mute"
-msgstr "Stumm"
-
-#: src/LyricsWindow.cpp
-msgid "&Karaoke..."
-msgstr "&Karaoke …"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/prefs/KeyConfigPrefs.cpp
-msgid "&Export..."
-msgstr "&Exportieren …"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
-msgid "Zoom"
-msgstr "Zoom"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#. i18n-hint: This is a technical term, derived from the word
-#. * "spectrum".  Do not translate it unless you are sure you
-#. * know the correct technical word in your language.
-#: src/FreqWindow.cpp
-msgid "Cepstrum"
-msgstr "Cepstrum"
-
-#: src/FileNames.cpp
-msgid ", "
-msgstr ", "
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "„%s“, „%s“, „%s“\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "benchmark.txt"
-
-#. i18n-hint: Benchmark means a software speed test
-#: src/Benchmark.cpp
-msgid "Benchmark"
-msgstr "Benchmark"
-
-#. i18n-hint: This is the number of the command in the list
-#: src/BatchProcessDialog.cpp
-msgid "Num"
-msgstr "Num"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/BatchCommandDialog.cpp
-msgid "&Details"
-msgstr "&Details"
-
-#. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
-msgid "Name"
-msgstr "Name"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d – %s\n"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity wird nicht von MuseCY SM Ltd. oder Dominic M Mazzoni produziert "
-"oder befürwortet."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Die Audacity%s-Handelsmarke wird innerhalb dieser Software nur für "
-"beschreibende und informative Zwecke verwendet."
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Bitte beachten Sie, dass Namen in alphabetischer Reihenfolge sortiert "
-"werden, nicht nach Wichtigkeit."
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
-#, c-format
-msgid "Instrument %i"
-msgstr "Instrument %i"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
-msgid "Zoom x2"
-msgstr "Zoom ×2"
-
-#. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%+.1f dB"
-msgstr "%+.1f dB"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-#, c-format
-msgid "Mono, %dHz"
-msgstr "Mono, %d Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-#, c-format
-msgid "Stereo, %dHz"
-msgstr "Stereo, %d Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "Mono"
-msgstr "Mono"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "352800 Hz"
-msgstr "352800 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "192000 Hz"
-msgstr "192000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "176400 Hz"
-msgstr "176400 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "96000 Hz"
-msgstr "96000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "88200 Hz"
-msgstr "88200 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "48000 Hz"
-msgstr "48000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "44100 Hz"
-msgstr "44100 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "22050 Hz"
-msgstr "22050 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "16000 Hz"
-msgstr "16000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "11025 Hz"
-msgstr "11025 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "&Format"
-msgstr "&Format"
-
-#. i18n-hint k abbreviating kilo meaning thousands
-#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
-msgid "k"
-msgstr "k"
-
-#: src/toolbars/ControlToolBar.cpp
-#, c-format
-msgid "%s."
-msgstr "%s."
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pause"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Mel"
-msgstr "Mel"
-
-#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
-#: src/prefs/QualityPrefs.cpp
-msgid "&Dither:"
-msgstr "&Dither:"
-
-#: src/prefs/QualityPrefs.cpp
-#, c-format
-msgid "%i Hz"
-msgstr "%i Hz"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Multi"
-msgstr "Multi"
-
-#: src/prefs/KeyConfigPrefs.cpp
-msgid "&Import..."
-msgstr "&Import …"
-
-#: src/prefs/KeyConfigPrefs.cpp
-msgid "&Name"
-msgstr "&Name"
-
-#: src/prefs/KeyConfigPrefs.cpp
-msgid "&Hotkey:"
-msgstr "&Schnelltaste:"
-
-#: src/prefs/ImportExportPrefs.cpp
-msgid "&Beats"
-msgstr "&Beats"
-
-#: src/prefs/ImportExportPrefs.cpp
-msgid "S&tandard"
-msgstr "S&tandard"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/prefs/EffectsPrefs.cpp
-msgid "&LADSPA"
-msgstr "&LADSPA"
-
-#: src/prefs/DirectoriesPrefs.cpp
-msgid "&Export:"
-msgstr "&Export:"
-
-#: src/prefs/DirectoriesPrefs.cpp
-msgid "&Import:"
-msgstr "&Import:"
-
-#: src/prefs/DevicePrefs.cpp
-msgid "2 (Stereo)"
-msgstr "2 (Stereo)"
-
-#. i18n-hint: (noun)
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
-msgid "&Host:"
-msgstr "&Host:"
-
-#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
-#. * window) full sized
-#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
-msgid "&Zoom"
-msgstr "&Zoom"
-
-#. i18n-hint: 'Transport' is the name given to the set of controls that
-#. play, record, pause etc.
-#: src/menus/TransportMenus.cpp
-msgid "Tra&nsport"
-msgstr "Tra&nsport"
-
-#: src/menus/TrackMenus.cpp
-msgid "Mi&x"
-msgstr "Mi&x"
-
-#: src/menus/SelectMenus.cpp
-msgid "Position"
-msgstr "Position"
-
-#: src/menus/PluginMenus.cpp
-msgid "&Screenshot..."
-msgstr "&Screenshot …"
-
-#: src/menus/PluginMenus.cpp
-msgid "Palette..."
-msgstr "Palette …"
-
-#: src/menus/PluginMenus.cpp
-msgid "..."
-msgstr "…"
-
-#: src/menus/FileMenus.cpp
-msgid "&MIDI..."
-msgstr "&MIDI …"
-
-#: src/menus/FileMenus.cpp
-msgid "&Audio..."
-msgstr "&Audio …"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mi&xer"
-
-#: src/import/ImportPCM.cpp
-msgid "Vorbis"
-msgstr "Vorbis"
-
-#: src/import/ImportPCM.cpp
-msgid "VOX ADPCM"
-msgstr "VOX ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "24kbs G723 ADPCM"
-msgstr "24kbit/s G723 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "GSM 6.10"
-msgstr "GSM 6.10"
-
-#: src/import/ImportPCM.cpp
-msgid "Microsoft ADPCM"
-msgstr "Microsoft ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "IMA ADPCM"
-msgstr "IMA ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "A-Law"
-msgstr "A-law"
-
-#: src/import/ImportPCM.cpp
-msgid "U-Law"
-msgstr "μ-law"
-
-#: src/import/ImportPCM.cpp
-msgid "XI (FastTracker 2)"
-msgstr "XI (FastTracker 2)"
-
-#: src/import/ImportPCM.cpp
-msgid "WVE (Psion Series 3)"
-msgstr "WVE (Psion Series 3)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAVEX (Microsoft)"
-msgstr "WAVEX (Microsoft)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAV (NIST Sphere)"
-msgstr "WAV (NIST Sphere)"
-
-#: src/import/ImportPCM.cpp
-msgid "W64 (SoundFoundry WAVE 64)"
-msgstr "W64 (SoundFoundry WAVE 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "VOC (Creative Labs)"
-msgstr "VOC (Creative Labs)"
-
-#: src/import/ImportPCM.cpp
-msgid "SF (Berkeley/IRCAM/CARL)"
-msgstr "SF (Berkeley/IRCAM/CARL)"
-
-#: src/import/ImportPCM.cpp
-msgid "SDS (Midi Sample Dump Standard)"
-msgstr "SDS (Midi Sample Dump Standard)"
-
-#: src/import/ImportPCM.cpp
-msgid "SD2 (Sound Designer II)"
-msgstr "SD2 (Sound Designer II)"
-
-#: src/import/ImportPCM.cpp
-msgid "RF64 (RIFF 64)"
-msgstr "RF64 (RIFF 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "PVF (Portable Voice Format)"
-msgstr "PVF (Portable Voice Format)"
-
-#: src/import/ImportPCM.cpp
-msgid "PAF (Ensoniq PARIS)"
-msgstr "PAF (Ensoniq PARIS)"
-
-#: src/import/ImportPCM.cpp
-msgid "MPC (Akai MPC 2k)"
-msgstr "MPC (Akai MPC 2k)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-
-#: src/import/ImportPCM.cpp
-msgid "IFF (Amiga IFF/SVX8/SV16)"
-msgstr "IFF (Amiga IFF/SVX8/SV16)"
-
-#: src/import/ImportPCM.cpp
-msgid "HTK (HMM Tool Kit)"
-msgstr "HTK (HMM Tool Kit)"
-
-#: src/import/ImportPCM.cpp
-msgid "AVR (Audio Visual Research)"
-msgstr "AVR (Audio Visual Research)"
-
-#: src/import/ImportPCM.cpp
-msgid "AU (Sun/NeXT)"
-msgstr "AU (Sun/NeXT)"
-
-#: src/import/Import.cpp src/menus/ClipMenus.cpp
-#, c-format
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: src/export/ExportPCM.cpp
-msgid "Header:"
-msgstr "Header:"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "WAV (Microsoft)"
-msgstr "WAV (Microsoft)"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "AIFF (Apple/SGI)"
-msgstr "AIFF (Apple/SGI)"
-
-#: src/export/ExportMP3.cpp
-msgid "Stereo"
-msgstr "Stereo"
-
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
-msgid "Standard"
-msgstr "Standard"
-
-#: src/export/ExportMP3.cpp
-msgid "Standard, 170-210 kbps"
-msgstr "Standard, 170-210 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "65-105 kbps"
-msgstr "65-105 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "80-120 kbps"
-msgstr "80-120 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "95-135 kbps"
-msgstr "95-135 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "110-150 kbps"
-msgstr "110-150 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "145-185 kbps"
-msgstr "145-185 kbit/s"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LPC"
-msgstr "LPC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Frame:"
-msgstr "Frame:"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VBL"
-msgstr "VBL"
-
-#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Codec:"
-msgstr "Codec:"
-
-#: src/import/ImportPCM.cpp
-msgid "32kbs G721 ADPCM"
-msgstr "32 kbit/s G721 ADPCM"
-
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
-msgid "db"
-msgstr "db"
-
-#: plug-ins/noisegate.ny
-msgid "Gate"
-msgstr "Gate"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Tag:"
-msgstr "Tag:"
-
-#: src/Tags.cpp
-msgid "Tag"
-msgstr "Tag"
-
-#: src/tracks/ui/CommonTrackControls.cpp
-msgid "&Name..."
-msgstr "&Name …"
-
-#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
-msgid "Panel"
-msgstr "Paneel"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "Rat&e"
-msgstr "Fr&equenz"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "Rate:"
-msgstr "Frequenz:"
-
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
-msgid "Timer"
-msgstr "Zeitauslöser"
-
-#: plug-ins/vocoder.ny
-msgid "Edgar-RFT"
-msgstr "Edgar-RFT"
-
-#: plug-ins/vocoder.ny
-msgid "Vocoder"
-msgstr "Vocoder"
-
-#: plug-ins/vocalrediso.ny
-msgid "Robert Haenggi"
-msgstr "Robert Haenggi"
-
-#: plug-ins/tremolo.ny
-msgid "Tremolo"
-msgstr "Tremolo"
-
-#: plug-ins/sample-data-export.ny
-msgid "linear"
-msgstr "linear"
-
-#: plug-ins/sample-data-export.ny
-msgid "Sample #"
-msgstr "Sample #"
-
-#: plug-ins/sample-data-export.ny
-#, lisp-format
-msgid "~a linear, &nbsp;&nbsp;~a dB."
-msgstr "~a linear, &nbsp;&nbsp;~a dB."
-
-#: plug-ins/sample-data-export.ny
-#, lisp-format
-msgid "~a linear, ~a dB."
-msgstr "~a linear, ~a dB."
-
-#. i18n-hint abbreviates negative infinity
-#: plug-ins/sample-data-export.ny
-msgid "[-inf]"
-msgstr "[-unendlich]"
-
-#: plug-ins/sample-data-export.ny
-msgid "Minimal"
-msgstr "Minimal"
-
-#: plug-ins/rissetdrum.ny
-msgid "Amplitude (0 - 1)"
-msgstr "Amplitude (0-1)"
-
-#: plug-ins/rissetdrum.ny
-msgid "Steven Jones"
-msgstr "Steven Jones"
-
-#: plug-ins/rhythmtrack.ny
-msgid "18 - 116"
-msgstr "18-116"
-
-#: plug-ins/rhythmtrack.ny
-msgid "+/- 1"
-msgstr "+/- 1"
-
-#: plug-ins/rhythmtrack.ny
-msgid "Tempo (bpm)"
-msgstr "Tempo (BPM)"
-
-#: plug-ins/pluck.ny
-msgid "Abrupt"
-msgstr "Abrupt"
-
-#: plug-ins/pluck.ny
-msgid "David R.Sky"
-msgstr "David R. Sky"
-
-#. i18n-hint: hours and minutes. Do not translate "~a".
-#: plug-ins/noisegate.ny
-#, lisp-format
-msgid "~ah ~am"
-msgstr "~ah ~amin"
-
-#: plug-ins/limiter.ny
-msgid "Limiter"
-msgstr "Begrenzer"
-
-#. i18n-hint: hours minutes and seconds. Do not translate "~a".
-#: plug-ins/label-sounds.ny
-#, lisp-format
-msgid "~ah ~am ~as"
-msgstr "~ah ~amin ~as"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "48 dB"
-msgstr "48 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "36 dB"
-msgstr "36 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "24 dB"
-msgstr "24 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "12 dB"
-msgstr "12 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "6 dB"
-msgstr "6 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
-msgid "Dominic Mazzoni"
-msgstr "Dominic Mazzoni"
-
-#: plug-ins/equalabel.ny
-msgid "Details"
-msgstr "Details"
-
-#: plug-ins/delay.ny
-msgid "Delay"
-msgstr "Verzögerung"
-
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
-msgid "Steve Daulton"
-msgstr "Steve Daulton"
-
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
-msgid "Paul Licameli"
-msgstr "Paul Licameli"
-
-#: src/widgets/wxPanelWrapper.h
-msgid "Dialog"
-msgstr "Dialog"
-
-#: src/widgets/numformatter.cpp
-msgid "NaN"
-msgstr "NaN"
-
-#: src/widgets/PopupMenuTable.h
-#, c-format
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. i18n-hint: Name of display format that shows frequency in kilohertz
-#: src/widgets/NumericTextCtrl.cpp
-msgid "kHz"
-msgstr "kHz"
-
-#. i18n-hint: Name of time display format that shows time in days, hours,
-#. * minutes and seconds
-#: src/widgets/NumericTextCtrl.cpp
-msgid "dd:hh:mm:ss"
-msgstr "dd:hh:mm:ss"
-
-#. i18n-hint: Format string for displaying time in hours, minutes and
-#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
-#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
-#. * change the numbers unless there aren't 60 seconds in a minute in your
-#. * locale
-#: src/widgets/NumericTextCtrl.cpp
-msgid "0100 h 060 m 060 s"
-msgstr "0100 h 060 min 060 s"
-
-#. i18n-hint: Name of time display format that shows time in hours, minutes
-#. * and seconds
-#: src/widgets/NumericTextCtrl.cpp
-msgid "hh:mm:ss"
-msgstr "hh:mm:ss"
-
-#: src/widgets/Meter.cpp
-msgid "Horizontal"
-msgstr "Horizontal"
-
-#. i18n-hint arrowhead meaning forward movement
-#: src/widgets/HelpSystem.cpp
-msgid ">"
-msgstr ">"
-
-#. i18n-hint arrowhead meaning backward movement
-#: src/widgets/HelpSystem.cpp
-msgid "<"
-msgstr "<"
-
-#. i18n-hint: "x" suggests a multiplicative factor
-#: src/widgets/ASlider.cpp
-#, c-format
-msgid "%.2fx"
-msgstr "%.2f×"
-
-#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
-#. i18n-hint: One-letter abbreviation for Right, in VU Meter
-#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
-msgid "R"
-msgstr "R"
-
-#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
-#. i18n-hint: One-letter abbreviation for Left, in VU Meter
-#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
-msgid "L"
-msgstr "L"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d – %s\n"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mi&xer"

--- a/locale/el.po
+++ b/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/tenacity/tenacity/el/>\n"
@@ -19,75 +19,32 @@ msgstr ""
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Ενημέρωση του Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Παράλειψη"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "Ε&γκατάσταση ενημέρωσης"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Αρχείο αλλαγών"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Διαβάστε περισσότερα στο GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Σφάλμα κατά τον έλεγχο για ενημέρωση"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Αδυναμία σύνδεσης με τον διακομιστή ενημέρωσης του Audacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Τα δεδομένα ενημέρωσης ήταν κατεστραμμένα."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Σφάλμα κατά τη λήψη της ενημέρωσης."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Αδυναμία ανοίγματος του συνδέσμου λήψης του Audacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Το Audacity %s είναι διαθέσιμο!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Ηχογράφηση"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Αδύνατη η διευκρίνηση"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -214,7 +171,8 @@ msgid "Script"
 msgstr "Δέσμη ενεργειών"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Έξοδος"
 
@@ -230,7 +188,12 @@ msgstr "Δέσμες ενεργειών Nyquist (*.ny)|*.ny|Δέσμες ενε�
 msgid "Script was not saved."
 msgstr "Η δέσμη ενεργειών δεν αποθηκεύτηκε."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
@@ -251,11 +214,17 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Συλλογή εικονιδίων Tango (εικονίδια γραμμής εργαλείων)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 από Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 από Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Εξωτερικό άρθρωμα του Audacity που παρέχει ένα απλό IDE για εφέ εγγραφής."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -278,7 +247,8 @@ msgstr "Χωρίς τίτλο"
 msgid "Nyquist Effect Workbench - "
 msgstr "Πάγκος εργασίας εφέ Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Νέο"
 
@@ -318,7 +288,8 @@ msgstr "Αντιγραφή"
 msgid "Copy to clipboard"
 msgstr "Αντιγραφή στο πρόχειρο"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Αποκοπή"
 
@@ -326,7 +297,8 @@ msgstr "Αποκοπή"
 msgid "Cut to clipboard"
 msgstr "Αποκοπή στο πρόχειρο"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Επικόλληση"
 
@@ -351,7 +323,8 @@ msgstr "Επιλογή όλων"
 msgid "Select all text"
 msgstr "Επιλογή όλου του κειμένου"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Αναίρεση"
 
@@ -359,7 +332,8 @@ msgstr "Αναίρεση"
 msgid "Undo last change"
 msgstr "Αναίρεση τελευταίας αλλαγής"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Ακύρωση αναίρεσης"
 
@@ -416,7 +390,8 @@ msgid "Go to next S-expr"
 msgstr "Μετάβαση στην επόμενη S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Έναρξη"
 
@@ -424,7 +399,8 @@ msgstr "Έναρξη"
 msgid "Start script"
 msgstr "Έναρξη δέσμης ενεργειών"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Διακοπή"
 
@@ -439,7 +415,8 @@ msgid "About %s"
 msgstr "Περί %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Εντάξει"
 
@@ -447,11 +424,13 @@ msgstr "Εντάξει"
 msgid "Build Information"
 msgstr "Πληροφορίες έκδοσης"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Ενεργοποιημένο"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Απενεργοποιημένο"
 
@@ -461,8 +440,9 @@ msgid "The Build"
 msgstr "Η δόμηση"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Αναγνωριστικό υποβολής:"
+#, fuzzy
+msgid "Version:"
+msgstr "Έκδοση"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -472,22 +452,28 @@ msgstr "Τύπος δόμησης:"
 msgid "Compiler:"
 msgstr "Μεταγλωττιστής:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Πρόθεμα εγκατάστασης:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Φάκελος ρυθμίσεων:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Φάκελος ρυθμίσεων:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Μορφές αρχείων που υποστηρίζονται"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Διαλειτουργική βιβλιοθήκη GUI"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -501,7 +487,6 @@ msgstr "Μετατροπή ρυθμού δειγματοληψίας"
 msgid "MP3 Importing"
 msgstr "Εισαγωγή Mp3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Εισαγωγή και εξαγωγή Ogg Vorbis"
@@ -510,7 +495,6 @@ msgstr "Εισαγωγή και εξαγωγή Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Υποστήριξη ετικέτας ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Εισαγωγή και εξαγωγή FLAC"
@@ -528,14 +512,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Εισαγωγή/Εξαγωγή FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Εισαγωγή μέσω GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Χαρακτηριστικά"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Υποστήριξη προσθέτων"
 
@@ -550,6 +526,10 @@ msgstr "Υποστήριξη αλλαγής ρυθμού (τέμπο) και τ�
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Υποστήριξη ακραίας αλλαγής τόνου και ρυθμού (τέμπο)"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Χαρακτηριστικά"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -668,6 +648,10 @@ msgstr "%s, γραφικά"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (ενσωμάτωση %s, %s, %s, %s και %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -677,6 +661,10 @@ msgstr "Το %s είναι ελεύθερο, ανοικτού κώδικα, δι
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Εύσημα"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -731,6 +719,7 @@ msgstr "Ιστότοπος και γραφικά"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Ελληνική μετάφραση από τους Δημήτρη Σπίγγο, Νίκο Παπαδόπουλο και hicaz"
@@ -748,6 +737,22 @@ msgstr "Ευχαριστούμε ιδιαίτερα:"
 #, c-format
 msgid "%s website: "
 msgstr "Ιστότοπος %s: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Συντελεστές"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -770,6 +775,7 @@ msgstr "Λωρίδα χρόνου"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Πάτημα ή μεταφορά για έναρξη αναζήτησης"
@@ -777,6 +783,7 @@ msgstr "Πάτημα ή μεταφορά για έναρξη αναζήτηση�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Πάτημα ή μεταφορά για έναρξη τριψίματος"
@@ -784,6 +791,7 @@ msgstr "Πάτημα ή μεταφορά για έναρξη τριψίματο�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Πάτημα και μετακίνηση για τρίψιμο. Πάτημα και μεταφορά για αναζήτηση."
@@ -791,6 +799,7 @@ msgstr "Πάτημα και μετακίνηση για τρίψιμο. Πάτη
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Μετακίνηση για αναζήτηση"
@@ -798,6 +807,7 @@ msgstr "Μετακίνηση για αναζήτηση"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Μετακίνηση για τρίψιμο"
@@ -854,7 +864,17 @@ msgstr ""
 "Αδύνατο το κλείδωμα περιοχής πέρα από\n"
 "το τέλος του έργου."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Σφάλμα"
 
@@ -878,7 +898,8 @@ msgstr ""
 "Αυτή είναι μια ερώτηση μιας φοράς, μετά από μια 'εγκατάσταση' όπου ζητήσατε να έχετε νέα ρύθμιση προτιμήσεων."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Επαναφορά στις αρχικές προτιμήσεις του Audacity"
 
 #: src/AudacityApp.cpp
@@ -893,7 +914,8 @@ msgstr ""
 "Έχει αφαιρεθεί από τον κατάλογο των πρόσφατων αρχείων."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Η βιβλιοθήκη του SQLite απέτυχε να ξεκινήσει. Το Audacity δεν μπορεί να συνεχίσει."
 
 #: src/AudacityApp.cpp
@@ -919,7 +941,7 @@ msgstr "&Άνοιγμα..."
 msgid "Open &Recent..."
 msgstr "Άνοιγμα &προσφάτου..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Σχετικά με το Audacity..."
@@ -933,9 +955,10 @@ msgid "&File"
 msgstr "&Αρχείο"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Το Audacity δεν μπόρεσε να βρει ασφαλή θέση για να αποθηκεύσει τα προσωρινά αρχεία.\n"
@@ -943,20 +966,23 @@ msgstr ""
 "Παρακαλούμε εισάγετε έναν κατάλληλο κατάλογο στον διάλογο προτιμήσεων."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Το Audacity δεν μπόρεσε να βρει τοποθεσία για να αποθηκεύσει τα προσωρινά αρχεία.\n"
 "Παρακαλώ προσθέστε μία κατάλληλη τοποθεσία στις προτιμήσεις."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Το Audacity τώρα θα κλείσει. Παρακαλούμε επανεκκινήστε το Audacity για να χρησιμοποιήσετε τον νέο προσωρινό κατάλογο."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -965,15 +991,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Το Audacity δεν μπόρεσε να κλειδώσει τον κατάλογο προσωρινών αρχείων.\n"
 "Ο φάκελος μπορεί να χρησιμοποιείται από άλλο αντίγραφο του Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Θέλετε ακόμα να ξεκινήσετε το Audacity;"
 
 #: src/AudacityApp.cpp
@@ -981,19 +1009,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Σφάλμα κλειδώματος του προσωρινού φακέλου"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Το σύστημα ανέγνωσε ότι ένα άλλο αντίγραφο του Audacity βρρίσκεται σε λειτουργία.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Χρησιμοποιήστε τις εντολές Άνοιγμα ή Νέο από το Audacity που ήδη τρέχει\n"
 "για να ανοίξετε πολλά έργα συγχρόνως.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Το Audacity είναι είδη σε λειτουργία"
 
 #: src/AudacityApp.cpp
@@ -1009,7 +1040,8 @@ msgstr ""
 "και μπορεί να χρειαστεί επανεκκίνηση."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Αποτυχία εκκίνησης Audacity"
 
 #: src/AudacityApp.cpp
@@ -1049,8 +1081,9 @@ msgstr ""
 "και μπορεί να χρειαστεί επανεκκίνηση."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1082,7 +1115,8 @@ msgstr "εκτέλεση αυτοδιαγνωστικών"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "εμφάνιση της έκδοσης του Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1092,9 +1126,10 @@ msgid "audio or project file name"
 msgstr "όνομα αρχείου ήχου ή έργου"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1107,16 +1142,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Αρχεία έργου Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Μήνυμα"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Σφάλμα διαμόρφωσης του Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1126,7 +1163,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Το παρακάτω αρχείο ρυθμίσεων δεν μπόρεσε να προσπελαστεί:\n"
 "\n"
@@ -1138,12 +1175,15 @@ msgstr ""
 "\n"
 "Εάν επιλέξετε \"Έξοδος από το Audacity\", το έργο σας μπορεί να αφεθεί σε αναποθήκευτη κατάσταση που θα ανακτηθεί την επόμενη φορά που θα το ανοίξετε."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Βοήθεια"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Έ&ξοδος από το Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1151,7 +1191,8 @@ msgid "&Retry"
 msgstr "Ε&πανάληψη"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Ημερολόγιο Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1163,9 +1204,14 @@ msgstr "Απο&θήκευση..."
 msgid "Cl&ear"
 msgstr "Καθ&αρισμός"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Κλείσιμο ανοιχτής εργασίας"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1214,7 +1260,8 @@ msgid "Error Initializing Midi"
 msgstr "Σφάλμα στην αρχικοποίηση midi"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Ήχος Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1229,37 +1276,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Η μνήμη εξαντλήθηκε!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Δεν ήταν δυνατό να βελτιωθεί περισσότερο. Εξακολουθεί να είναι υπερβολικά υψηλή."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής μείωσε την ένταση σε %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Δεν ήταν δυνατό να βελτιωθεί περισσότερο. Εξακολουθεί να είναι υπερβολικά χαμηλή."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής αύξησε την ένταση σε %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Ο συνολικός αριθμός των αναλύσεων έχει ξεπεραστεί χωρίς να βρεθεί μια αποδεκτή ένταση. Εξακολουθεί να είναι υπερβολικά υψηλή."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Ο συνολικός αριθμός των αναλύσεων έχει ξεπεραστεί χωρίς να βρεθεί μια αποδεκτή ένταση. Εξακολουθεί να είναι υπερβολικά χαμηλή."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Το %.2f φαίνεται να είναι μια αποδεκτή ένταση."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1358,43 +1374,6 @@ msgstr "Δεν βρέθηκε συσκευή αναπαραγωγής για τ�
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Αδυναμία ελέγχου κοινών ρυθμών δειγμάτων χωρίς και τις δύο συσκευές.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Ελήφθησαν %d κατά το άνοιγμα των συσκευών\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Αδύνατο το άνοιγμα Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Διαθέσιμοι μείκτες:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Διαθέσιμες πηγές ηχογράφησης:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Διαθέσιμες εντάσεις αναπαραγωγής:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Η ένταση ηχογράφησης είναι προσομοιωμένη\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Η ένταση ηχογράφησης είναι εγγενής\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Η ένταση αναπαραγωγής είναι προσομοιωμένη\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Η ένταση αναπαραγωγής είναι εγγενής\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1437,8 +1416,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Αυτόματη ανάκτηση δεδομένων κατάρρευσης"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1451,12 +1431,14 @@ msgid "Recoverable &projects"
 msgstr "Ανακτήσιμα έ&ργα"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Επιλογή"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Όνομα"
 
@@ -1542,6 +1524,11 @@ msgstr "Εφέ"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Εντολή μενού (με παραμέτρους)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1687,7 +1674,8 @@ msgstr "Επανα&φορά"
 msgid "I&mport..."
 msgstr "Ε&ισαγωγή..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "Ε&ξαγωγή..."
 
@@ -1728,7 +1716,8 @@ msgstr "Μετακίνηση &Πάνω"
 msgid "Move &Down"
 msgstr "Μετακίνηση &Κάτω"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Απο&θήκευση"
 
@@ -1811,9 +1800,17 @@ msgid "Run"
 msgstr "Εκτέλεση"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Κλείσιμο"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "Έλεγχος επιδόσεων"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1951,11 +1948,6 @@ msgid "No revision identifier was provided"
 msgstr "Δεν δόθηκε αναγνωριστικό αναθεώρησης"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Ημερομηνία και ώρα λήξης"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Δομή αποσφαλμάτωσης (επίπεδο αποσφαλμάτωσης %d)"
@@ -1964,6 +1956,10 @@ msgstr "Δομή αποσφαλμάτωσης (επίπεδο αποσφαλμά
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Δομή έκδοσης (επίπεδο αποσφαλμάτωσης %d)"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -2033,6 +2029,11 @@ msgid ""
 msgstr ""
 "Πρέπει πρώτα να επιλέξετε κάποιον ήχο για να εκτελέσετε αυτήν\n"
 "την ενέργεια. (Η επιλογή άλλων ειδών κομματιού δεν θα δουλέψει.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2195,6 +2196,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Α&ντιγραφή ονομάτων στο πρόχειρο"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Λείπει"
 
@@ -2203,10 +2209,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Εάν συνεχίσετε, το έργο σας δεν θα αποθηκευθεί στον δίσκο. Είναι αυτό που θέλετε;"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2220,7 +2227,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Έλεγχος εξαρτήσεων"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Κανένα"
 
@@ -2228,7 +2238,7 @@ msgstr "Κανένα"
 msgid "Rectangle"
 msgstr "Ορθογώνιο"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Τρίγωνο"
 
@@ -2239,6 +2249,38 @@ msgstr "Μορφοποιημένο"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Ορθογώνιο"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, καμία"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Καλωσήρθατε!"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2260,9 +2302,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Η υποστήριξη FFmpeg δεν μεταγλωττίστηκε στο"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2284,8 +2327,8 @@ msgid "Locate FFmpeg"
 msgstr "Εντοπισμός FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Το Audacity χρειάζεται το αρχείο '%s' για να εισαγάγει και να εξαγάγει ήχο μέσω του FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2298,7 +2341,8 @@ msgstr "Τοπθεσία του '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Για να βρείτε το '%s', πατήστε εδώ -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Αναζήτηση..."
 
@@ -2324,8 +2368,9 @@ msgid "FFmpeg not found"
 msgstr "To FFmpeg δεν βρέθηκε"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2355,24 +2400,24 @@ msgid "Only libavformat.so"
 msgstr "Μόνο libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Το Audacity απέτυχε να ανοίξει ένα αρχείο στο %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Το Audacity απέτυχε να διαβάσει από αρχείο στο %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Το Audacity έγραψε με επιτυχία ένα αρχείο στο %s, αλλά απέτυχε να το μετονομάσει ως %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2411,7 +2456,9 @@ msgstr "Να μην γίνεται αποθήκευση κανενός ακου�
 msgid "As&k"
 msgstr "Να γίνεται ε&ρώτηση"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Όλα τα αρχεία"
 
@@ -2436,6 +2483,10 @@ msgstr "Αρχεία κειμένου"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Αρχεία XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2477,6 +2528,14 @@ msgstr "Αυτόματη συσχέτιση κυβικής ρίζας"
 msgid "Enhanced Autocorrelation"
 msgstr "Βελτιωμένη αυτόματη συσχέτιση"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Φάσμα"
+
 #  i18n-hint: This refers to a "window function", used in the
 #  Frequency analyze dialog box.
 #. i18n-hint: This refers to a "window function",
@@ -2495,6 +2554,17 @@ msgstr "Γραμμική συχνότητα"
 msgid "Log frequency"
 msgstr "Λογαριθμική συχνότητα"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Κύλιση"
@@ -2502,6 +2572,15 @@ msgstr "Κύλιση"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Μεγέθυνση"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2562,6 +2641,37 @@ msgstr "Έχει επιλεχθεί πολύ μεγάλο μέρος ήχου. �
 msgid "Not enough data selected."
 msgstr "Δεν έχουν επιλεγεί αρκετά δεδομένα."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "φάσμασυχνοτήτων.txt"
@@ -2570,7 +2680,8 @@ msgstr "φάσμασυχνοτήτων.txt"
 msgid "Export Spectral Data As:"
 msgstr "Εξαγωγή δεδομένων φάσματος ως:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Αδύνατη η εγγραφή στο αρχείο: %s"
@@ -2760,19 +2871,19 @@ msgid "&History..."
 msgstr "&Ιστορικό..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Εσωτερικό σφάλμα στο %s του %s γραμμή %d.\n"
 "Παρακαλούμε, ειδοποιήστε την ομάδα Audacity στο https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Εσωτερικό σφάλμα στη %s γραμμή %d.\n"
 "Παρακαλούμε, ειδοποιήστε την ομάδα Audacity στο https://forum.audacityteam.org/."
@@ -2791,7 +2902,9 @@ msgid "Track"
 msgstr "Κομμάτι"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Ετικέτα"
 
@@ -2851,7 +2964,8 @@ msgstr "Εισάγετε το όνομα του ίχνους"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Κομμάτι ετικέτας"
 
@@ -2862,11 +2976,13 @@ msgstr "Μία ή περισσότερες αποθηκευμένες ετικέ
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Η πρώτη φορά λειτουργίας του Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Επιλέξτε την γλώσσα που θα χρησιμοποιηθεί από το Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2876,7 +2992,8 @@ msgstr "Επιλέξτε την γλώσσα που θα χρησιμοποιη�
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Η γλώσσα που έχετε επιλέξει, %s (%s), δεν είναι η ίδια με την γλώσσα του συστήματος, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Επιβεβαίωση"
 
@@ -2894,12 +3011,13 @@ msgstr ""
 "Το παλιό αρχείο έχει αποθηκευτεί ως '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Άνοιγμα έργου του Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Καρακόε%s του Audacity"
 
 #: src/LyricsWindow.cpp
@@ -2950,20 +3068,24 @@ msgid "Mixing and rendering tracks"
 msgstr "Μίξη κομματιών"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Πίνακας μείκτη %s του Audacity"
 
 #  i18n-hint: Title of the Gain slider, used to adjust the volume
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Απολαβή"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Ταχύτητα"
 
@@ -2972,17 +3094,23 @@ msgid "Musical Instrument"
 msgstr "Μουσικό όργανο"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Μετατόπιση"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Σιγή"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Σόλο"
 
@@ -2990,15 +3118,18 @@ msgstr "Σόλο"
 msgid "Signal Level Meter"
 msgstr "Μετρητής επιπέδου σήματος"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Μετακινημένος ολισθητής απολαβής"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Μετακινήθηκε ο ολισθητής ταχύτητας"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Μετακινήθηκε ο ολισθητής μετακίνησης"
 
@@ -3033,9 +3164,9 @@ msgstr ""
 "Δεν θα φορτωθεί."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3069,16 +3200,19 @@ msgstr ""
 "\n"
 "Να χρησιμοποιηθούν αρθρώματα μόνο από έμπιστες πηγές"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Ναι"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Όχι"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Φορτωτής αρθρώματος του Audacity"
 
 #: src/ModuleManager.cpp
@@ -3101,6 +3235,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Κομμάτι με νότες"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3210,7 +3454,8 @@ msgstr "Ε&πιλογή όλων"
 msgid "C&lear All"
 msgstr "&Καθαρισμός όλων"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Ενεργοποίηση"
 
@@ -3290,9 +3535,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Ασύμφωνοι ρυθμοί δειγματοληψίας"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Πολύ λίγα κομμάτια είναι επιλεγμένα για ηχογράφηση με αυτόν τον ρυθμό δειγματοληψίας.\n"
@@ -3321,10 +3567,11 @@ msgid "Dropouts"
 msgstr "Διακοπές"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3364,11 +3611,11 @@ msgid "Inspecting project file data"
 msgstr "Επιθεώρηση δεδομένων αρχείου έργου"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3411,11 +3658,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Προειδοποίηση - Λείπουν αρχεία με ψευδώνυμα"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Ο έλεγχος έργου του φακέλου \"%s\" \n"
@@ -3440,12 +3687,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Προειδοποίηση - Λείπουν αρχεία περίληψης ψευδωνύμων"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3503,7 +3750,8 @@ msgstr "Προειδοποίηση - Ορφανά αρχεία ομάδας"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Πρόοδος"
 
@@ -3528,6 +3776,11 @@ msgstr "Προειδοποίηση: Προβλήματα στην αυτόματ
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<χωρίς όνομα>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Έργο %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3597,12 +3850,14 @@ msgstr ""
 "(Αδυναμία δημιουργίας των απαιτούμενων προσωρινών αρχείων)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Αυτό δεν είναι αρχείο έργου του Audacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3734,9 +3989,9 @@ msgid "Error Writing to File"
 msgstr "Σφάλμα κατά την εγγραφή στο αρχείο"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3750,9 +4005,16 @@ msgstr "Συμπύκνωση έργου"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Έργο %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Ταχύτητα"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3761,10 +4023,10 @@ msgstr "(Ανακτημένο)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Αυτό το αρχείο αποθηκεύτηκε χρησιμοποιώντας το %s Audacity.\n"
 "Χρησιμοποιείτε %s Audacity. Μπορεί να χρειαστεί να αναβαθμίσετε σε μια νεότερη έκδοση για να ανοίξετε αυτό το αρχείο."
@@ -3836,8 +4098,9 @@ msgid "Backing up project"
 msgstr "Δημιουργία αντιγράφου ασφαλείας του έργου"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3846,8 +4109,9 @@ msgstr ""
 "Έχει ανακτηθεί στο τελευταίο στιγμιότυπο."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3926,8 +4190,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sΑποθήκευση έργου \"%s\" ως..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "Το 'Αποθήκευση έργου' είναι για έργο του Audacity, όχι για αρχείο ήχου.\n"
@@ -4004,11 +4269,12 @@ msgid "Error Opening Project"
 msgstr "Σφάλμα κατά το άνοιγμα έργου"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Προσπαθείτε να ανοίξετε ένα αυτόματα δημιουργημένο εφεδρικό αρχείο.\n"
 "Κάνοντας το αυτό μπορεί να καταλήξει σε σοβαρή απώλεια δεδομένων.\n"
@@ -4117,8 +4383,8 @@ msgid "Automatic database backup failed."
 msgstr "Αποτυχία αυτόματου αντιγράφου ασφαλείας της βάσης δεδομένων."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Καλώς ήλθατε στην έκδοση %s του Audacity"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4333,7 +4599,8 @@ msgstr "Όλες οι προτιμήσεις"
 msgid "SelectionBar"
 msgstr "Γραμμή επιλογής"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Φασματική επιλογή"
 
@@ -4341,46 +4608,55 @@ msgstr "Φασματική επιλογή"
 msgid "Timer"
 msgstr "Χρονόμετρο"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Εργαλεία"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Μεταφορά"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Μίκτης"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Μετρητής"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Μετρητής αναπαραγωγής"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Μετρητής ηχογράφησης"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Συσκευή"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Αναπαραγωγή-με-ταχύτητα"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Τρίψιμο (Scrub)"
 
@@ -4395,7 +4671,10 @@ msgstr "Χάρακας"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Κομμάτια"
 
@@ -4505,7 +4784,8 @@ msgid "Activation level (dB):"
 msgstr "Επίπεδο ήχου για καταγραφή (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Καλωσήρθατε στο Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4652,9 +4932,9 @@ msgstr ""
 "Για συμβουλές κατάλληλων δίσκων, πατήστε το πλήκτρο της βοήθειας."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Το Audacity δεν μπόρεσε να γράψει το αρχείο:\n"
@@ -4674,9 +4954,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4685,9 +4965,9 @@ msgstr ""
 "για εγγραφή."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Το Audacity δεν μπόρεσε να γράψει τις εικόνες στο αρχείο:\n"
@@ -4704,9 +4984,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4716,9 +4996,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4727,8 +5007,9 @@ msgstr ""
 "Ίσως κακή μορφή png;"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Το Audacity δεν μπόρεσε να διαβάσει το προεπιλεγμένο θέμα του.\n"
@@ -4766,9 +5047,9 @@ msgstr ""
 "ήταν ήδη παρόντα. Να αντικατασταθούν;"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Το Audacity δεν μπόρεσε να αποθηκεύσει το αρχείο:\n"
@@ -4807,7 +5088,11 @@ msgstr "Προσαρμοσμένο"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Διάρκεια"
 
@@ -4818,7 +5103,8 @@ msgid "Time Track"
 msgstr "Κομμάτι χρόνου"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Εγγραφή με χρονοδιακόπτη στο Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4892,7 +5178,8 @@ msgstr "Τρέχον έργο"
 msgid "Recording start:"
 msgstr "Αρχή ηχογράφησης:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Διάρκεια:"
 
@@ -4913,7 +5200,8 @@ msgid "Action after Timer Recording:"
 msgstr "Ενεργεια μετά την ηχογράφηση με χρονοδιακόπτη:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Πρόοδος της προγραμματισμένης ηχογράφησης"
 
 #: src/TimerRecordDialog.cpp
@@ -5009,6 +5297,7 @@ msgstr "099 ημέρες 024 ω 060 λ 060 δ"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Ημερομηνία και ώρα εκκίνησης"
@@ -5053,7 +5342,8 @@ msgstr "Ενεργοποίηση αυτόματης ε&ξαγωγής;"
 msgid "Export Project As:"
 msgstr "Εξαγωγή έργου ως:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Επιλογές"
 
@@ -5066,7 +5356,8 @@ msgid "Do nothing"
 msgstr "Να μην κάνει τίποτα"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Έξοδος από το Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5090,7 +5381,8 @@ msgid "Scheduled to stop at:"
 msgstr "Προγραμματισμένο να σταματήσει στο:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Προγραμματισμένη ηχογράφηση - Αναμονή για την έναρξη"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5116,7 +5408,8 @@ msgid "Recording Exported:"
 msgstr "Ηχογράφηση που εξάχθηκε:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Ηχογράφηση με χρονοδιακόπτη στο Audacity - Αναμονή"
 
 #: src/TrackInfo.cpp
@@ -5312,6 +5605,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Εφαρμογή του %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "ΑΠΟΤΥΧΙΑ"
@@ -5330,13 +5633,15 @@ msgstr "το %s δεν είναι αποδεκτή παράμετρος από �
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Άκυρη τιμή για την παράμετρο '%s': πρέπει να είναι %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Εντολή"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Επανάληψη %s"
@@ -5463,13 +5768,24 @@ msgstr "Αποσπάσματα"
 msgid "Envelopes"
 msgstr "Καμπύλες ακουστότητας"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Ετικέτες"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Πλαίσια"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5479,7 +5795,8 @@ msgstr "Σύντομο"
 msgid "Type:"
 msgstr "Τύπος:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Μορφή:"
 
@@ -5506,6 +5823,10 @@ msgstr "Σχόλιο"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Εντολή:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5543,12 +5864,17 @@ msgstr "Εξαγωγή σε αρχείο."
 msgid "Builtin Commands"
 msgstr "Ενσωματωμένες εντολές"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Η ομάδα του Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Παρέχει ενσωματωμένες εντολές στο Audacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5611,7 +5937,10 @@ msgstr "Καθαρίζει τα περιεχόμενα του ημερολογί
 msgid "Get Preference"
 msgstr "Λήψη προτίμησης"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Όνομα:"
 
@@ -5661,7 +5990,8 @@ msgstr "Πλήρης οθόνη"
 msgid "Toolbars"
 msgstr "Γραμμές εργαλείων"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Εφέ"
 
@@ -5801,7 +6131,8 @@ msgstr "Ορισμός"
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Αφαίρεση"
 
@@ -5886,7 +6217,8 @@ msgid "Edited Envelope"
 msgstr "Επεξεργασμένος φάκελος"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Καμπύλη ακουστότητας"
 
@@ -5987,7 +6319,10 @@ msgstr "Μετακίνηση:"
 msgid "Set Track Visuals"
 msgstr "Ορισμός οπτικών κομματιού"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Γραμμικό"
 
@@ -6091,12 +6426,18 @@ msgstr "Επιλέξατε ένα κομμάτι που δεν περιέχει 
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Η αυτόματη μείωση έντασης χρειάζεται ένα κομμάτι ελέγχου που πρέπει να τοποθετηθεί κάτω από τα επιλεγμένα κομμάτια."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "&Ποσότητα μείωσης:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "δευτερόλεπτα"
 
@@ -6120,7 +6461,8 @@ msgstr "Διάρκεια εσωτερικού &σβησίματος:"
 msgid "Inner &fade up length:"
 msgstr "Διάρκεια εσωτερικής ενίσ&χυσης:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Κατώφλι:"
 
@@ -6258,11 +6600,13 @@ msgstr "σε (Hz)"
 msgid "t&o"
 msgstr "σ&ε"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Ποσοστιαία α&λλαγή:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Ποσοστιαία αλλαγή"
 
@@ -6270,13 +6614,27 @@ msgstr "Ποσοστιαία αλλαγή"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Χρήση επιμήκυνσης υψηλής ποιότητας (αργό)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #  i18n-hint: n/a is an English
 #  abbreviation meaning "not
 #  applicable" (in other words,
 #  unimportant, not relevant).
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "μή εφαρμόσιμο"
 
@@ -6304,6 +6662,7 @@ msgstr "Τυπικές στροφές ανά λεπτό βινυλίου:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Από στροφές ανά λεπτό"
@@ -6316,6 +6675,7 @@ msgstr "α&πό"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Σε στροφές ανά λεπτό"
@@ -6458,6 +6818,12 @@ msgstr "Συμπιεστής"
 msgid "Compresses the dynamic range of audio"
 msgstr "Συμπιέζει τη δυναμική περιοχή του ήχου"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6467,6 +6833,20 @@ msgstr "%.2f δευτερόλρπτα"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f δευτερόλεπτα"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6583,7 +6963,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Ο αναλυτής αντίθεσης, για τη μέτρηση διαφορών έντασης RMS μεταξύ δύο επιλογών του ήχου."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Τέλος"
 
@@ -6643,6 +7024,18 @@ msgstr "&Διαφορά:"
 msgid "&Help"
 msgstr "&Βοήθεια"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "μηδέν"
@@ -6650,6 +7043,13 @@ msgstr "μηδέν"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "ενδιάμεσο"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB μέσος όρος RMS"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6703,6 +7103,12 @@ msgstr "Διαφορά ρεύματος"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Το επίπεδο προσκηνίου μετρήθηκε"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f δευτερόλρπτα"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6771,6 +7177,12 @@ msgstr "Κριτήρια επιτυχίας 1.4.7 του WCAG 2.0: Αποτυχ�
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
 msgstr "Συγκεντρωμένα δεδομένα"
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
@@ -6867,6 +7279,10 @@ msgid "2nd Harmonic (Octave)"
 msgstr "2η αρμονική (οκτάβα)"
 
 #: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Leveller, Light, -70dB noise floor"
 msgstr "Ισοσταθμιστής, ελαφρύς, -70dB δάπεδο θορύβου"
 
@@ -6945,6 +7361,10 @@ msgstr "Έλεγχοι παραμέτρου"
 #: src/effects/Distortion.cpp
 msgid "Clipping level"
 msgstr "Επίπεδο ψαλιδίσματος"
+
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Make-up Gain"
@@ -7042,7 +7462,9 @@ msgstr "Α&κολουθία DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Πλάτος σήματος (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Διάρκεια:"
 
@@ -7055,12 +7477,29 @@ msgid "Duty cycle:"
 msgstr "Κύκλος δραστηριότητας:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f δευτερόλεπτα"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Διάρκεια τόνου:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Διάρκεια σιγής:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7070,7 +7509,8 @@ msgstr "Ηχώ"
 msgid "Repeats the selected audio again and again"
 msgstr "Επαναλαμβάνει τον επιλεγμένο ήχο ξανά και ξανά"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Η ζητούμενη τιμή ξεπερνά την ικανότητα της μνήμης."
 
@@ -7094,7 +7534,8 @@ msgstr "Προρυθμίσεις"
 msgid "Export Effect Parameters"
 msgstr "Εξαγωγή παραμέτρων εφέ"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Αδύνατο το άνοιγμα του αρχείου: \"%s\""
@@ -7131,6 +7572,15 @@ msgstr "Προετοιμασία προεπισκόπισης"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Προεπισκόπηση"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Σφάλμα Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7203,6 +7653,11 @@ msgstr ""
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
 msgstr "Αποτυχία αρχικοποίησης εντολής"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Effects Rack"
+msgstr "Εμφάνιση Effects Rack"
 
 #: src/effects/EffectUI.cpp
 msgid "&Apply"
@@ -7459,6 +7914,10 @@ msgid "Low rolloff for speech"
 msgstr "Χαμηλή εξασθένιση ομιλίας"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Τηλέφωνο"
 
@@ -7495,12 +7954,41 @@ msgid "Effect Unavailable"
 msgstr "Μη διαθέσιμο εφέ"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Μέγιστα dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Ελάχιστα dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7575,8 +8063,26 @@ msgid "D&efault"
 msgstr "&Προεπιλεγμένα"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "&Κατώφλι SSE"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "AV&X Threaded"
+msgstr "&Κατώφλι SSE"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "Έλεγχος επιδόσεων"
 
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
@@ -7813,7 +8319,8 @@ msgid "Builtin Effects"
 msgstr "Ενσωματωμένα εφέ"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Παρέχει ενσωματωμένα εφέ στο Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7823,6 +8330,10 @@ msgstr "Άγνωστο όνομα ενσωματωμένου εφέ"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "αντιλαμβανόμενη ακουστότητας"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7854,6 +8365,14 @@ msgstr "&Κανονικοποίηση"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Ακουστότητα LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7923,7 +8442,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (προεπιλογή)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, καμία"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, καμία"
 
 #: src/effects/NoiseReduction.cpp
@@ -8023,8 +8551,9 @@ msgid "Step 1"
 msgstr "Βήμα 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Επιλέξτε μερικά δευτερόλεπτα θορύβου, ώστε το Audacity να γνωρίζει τι θα αποβάλει,\n"
@@ -8076,13 +8605,62 @@ msgstr "Τύποι &παραθύρου:"
 msgid "Window si&ze:"
 msgstr "Μέ&γεθος παραθύρου:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (προεπιλογή)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Βήματα ανά παράθυρο:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8198,12 +8776,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Ανεξάρτητη κα&νονικοποίηση στερεοφωνικών καναλιών"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Επέκταση"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Το Paulstretch είναι μόνο για ακραία επιμήκυνση χρόνου ή το εφέ \"στάση\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Συντελεστής ε&πέκτασης:"
@@ -8485,6 +9069,11 @@ msgstr "Αντιστρέφει τον επιλεγμένο ήχο"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Χρόνος SBSMS / Επιμήκυνση τονικού ύψους"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8640,6 +9229,11 @@ msgstr "Χρήση προεπιλογών"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Επαναφορά προεπιλογών"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8799,6 +9393,10 @@ msgstr "Αναγνώριση σιγής"
 msgid "Tr&uncate to:"
 msgstr "&Περικοπή σε:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Σ&υμπίεση σε:"
@@ -8812,7 +9410,8 @@ msgid "VST Effects"
 msgstr "Εφέ VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Προσθέτει τη δυνατότητα χρήσης εφέ VST στο Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8824,7 +9423,8 @@ msgstr "Σάρωση των Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Καταχωρούνται %d από %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Αδυναμία φόρτωσης της βιβλιοθήκης"
 
@@ -8844,7 +9444,8 @@ msgstr "Το μέγεθος βοηθητικής μνήμης ελέγχει τ�
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Μέγεθος ε&νδιάμεσης μνήμης (8 έως 1048576 δείγματα):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Αντιστάθμιση αναμονής"
 
@@ -8852,7 +9453,8 @@ msgstr "Αντιστάθμιση αναμονής"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Ως μέρος της επεξεργασίας τους, κάποια εφέ VST πρέπει να καθυστερήσουν την επιστροφή ήχου στο Audacity. Όταν δεν αντισταθμίζεται αυτή η καθυστέρηση, θα σημειώσετε ότι θα έχουν εισαχθεί μικρές σιγάσεις στον ήχο. Ενεργοποιώντας αυτήν την επιλογή θα παράχεται αυτή η αντιστάθμιση, αλλά μπορεί να μην δουλεύει για όλα τα εφέ VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Ενεργοποίηση α&ντιστάθμισης"
 
@@ -8886,7 +9488,8 @@ msgid "Standard VST program file"
 msgstr "Αρχείου προγράμματος τυπικού VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Αρχείο προρύθμισης Audacity VST"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8913,7 +9516,8 @@ msgstr "Σφάλμα κατά τη φόρτωση των προεπιλογών 
 msgid "Unable to load presets file."
 msgstr "Αδύνατη η φόρτωση του αρχείου προεπιλογών."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Ρυθμίσεις των εφέ"
 
@@ -8929,6 +9533,16 @@ msgstr "Αδύνατη η ανάγνωση του αρχείου προεπιλ�
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Αυτό το αρχείο παραμέτρων αποθηκεύτηκε από το %s. Να συνεχιστεί;"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8960,7 +9574,8 @@ msgid "Audio Unit Effects"
 msgstr "Εφέ μονάδας ήχου"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Παρέχει υποστήριξη εφέ μονάδας ήχου στο Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8976,7 +9591,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Επιλογές εφέ μονάδας ήχου"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Ως μέρος της επεξεργασίας τους, κάποια εφέ μονάδας ήχου πρέπει να καθυστερούν την επιστροφή ήχου στο Audacity. Όταν δεν αντισταθμίζεται αυτή η καθυστέρηση, θα σημειώσετε ότι έχουν εισαχθεί στον ήχο μικρές σιγάσεις. Η ενεργοποίηση αυτής της επιλογής θα δώσει αυτήν την αντιστάθμιση, αλλά μπορεί να μην δουλεύει σε όλα τα εφέ μονάδας ήχου."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9120,6 +9736,7 @@ msgstr "Μονάδα ήχου"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Εφέ LADSPA"
@@ -9129,7 +9746,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Παρέχει τα εφέ LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Το Audacity δεν χρησιμοποιεί πια το vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9137,12 +9755,30 @@ msgid "LADSPA Effect Options"
 msgstr "Επιλογές των εφέ LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Ως μέρος των επεξεργασιών τους, κάποια εφέ LADSPA πρέπει να καθυστερήσουν την επιστροφή ήχου στο Audacity. Όταν δεν αντισταθμίζεται αυτή η καθυστέρηση, θα σημειώσετε ότι έχουν εισαχθεί μικρές σιγάσεις στον ήχο. Ενεργοποιώντας αυτήν την επιλογή θα δίνεται αυτή η αντιστάθμιση, αλλά μπορεί να μην δουλεύει για όλα τα εφέ LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "το %s σε:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Έξοδος εφέ"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Εφέ LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9154,7 +9790,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Μέγεθος ε&νδιάμεσης μνήμης (8 έως %d δείγματα):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Ως μέρος των επεξεργασιών τους, κάποια εφέ LV2 μπορεί να καθυστερούν την επιστροφή ήχου στο Audacity. Όταν δεν αντισταθμίζεται αυτή η καθυστέρηση, θα σημειώσετε ότι έχουν εισαχθεί μικρές σιγάσεις στον ήχο. Ενεργοποιώντας αυτήν τη ρύθμιση θα δίνεται αυτή η αντιστάθμιση, αλλά μπορεί να μην δουλεύει για όλα τα εφέ LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9179,12 +9816,19 @@ msgstr "το %s απαιτεί τη μη υποστηριζόμενη επιλο
 msgid "Generator"
 msgstr "Δημιουργία"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Εφέ LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Παρέχει υποστήριξη στα εφέ LV2 για το Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9192,7 +9836,8 @@ msgid "Nyquist Effects"
 msgstr "Εφέ Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Παρέχει υποστήριξη στα εφέ Nyquist για το Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9421,7 +10066,8 @@ msgstr "Επιλογή αρχείου"
 msgid "Save file as"
 msgstr "Αποθήκευση αρχείου ως"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "χωρίς τίτλο"
 
@@ -9430,7 +10076,8 @@ msgid "Vamp Effects"
 msgstr "Εφέ Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Δίνει υποστήριξη στα εφέ Vamp για το Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9452,6 +10099,12 @@ msgstr "Ρυθμίσεις προσθέτων"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Πρόγραμμα"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9530,6 +10183,18 @@ msgstr "Επιλογές μορφής"
 #, c-format
 msgid "Channel: %2d"
 msgstr "Κανάλι: %2d"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -9740,7 +10405,8 @@ msgstr "Εξαγωγή του ήχου ως %s"
 msgid "Invalid sample rate"
 msgstr "Μη αποδεκτός ρυθμός δειγματοληψίας"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Επαναδειγματοληψία"
 
@@ -9770,6 +10436,14 @@ msgstr "Μπορείτε να κάνετε επαναδειγματοληψία 
 msgid "Sample Rates"
 msgstr "Ρυθμοί δειγματοληψίας"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Ρυθμός μεταφοράς δυαδικών ψηφίων:"
@@ -9778,6 +10452,48 @@ msgstr "Ρυθμός μεταφοράς δυαδικών ψηφίων:"
 msgid "Quality (kbps):"
 msgstr "Ποιότητα (kbps):"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f δευτερόλρπτα"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Άνοιγμα"
@@ -9785,6 +10501,10 @@ msgstr "Άνοιγμα"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Constrained"
 msgstr "Περιορισμένος"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -9797,6 +10517,27 @@ msgstr "Μικρή καθυστέρηση"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9883,8 +10624,17 @@ msgid "Replace preset '%s'?"
 msgstr "Να αντικατασταθεί η προεπιλογή '%s';"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Δ-Κ"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Κύριο"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9992,6 +10742,10 @@ msgstr "Γλώσσα:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Απόθεμα δυαδικών ψηφίων"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10125,6 +10879,11 @@ msgstr ""
 "0 - προεπιλογή\n"
 "ελάχιστο - 1\n"
 "μέγιστο - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Δ-Κ"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10305,6 +11064,14 @@ msgid "Failed to find the codec"
 msgstr "Αποτυχία εύρεσης κωδικοποιητή"
 
 #: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (γρηγορότερο)"
 
@@ -10373,6 +11140,42 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (Άριστη ποιότητα)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Ακραίο, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "Τυπικό, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "Μεσαίο, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "Μεσαίο, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (Μικρότερα αρχεία)"
 
@@ -10402,7 +11205,8 @@ msgstr "Εξωφρενικό"
 msgid "Extreme"
 msgstr "Ακραίο"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Τυπικό"
 
@@ -10453,8 +11257,8 @@ msgid "Locate LAME"
 msgstr "Εντοπισμός του LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Το Audacity χρειάζεται το αρχείο %s για να δημιουργήσει MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10485,10 +11289,10 @@ msgid "Where is %s?"
 msgstr "Πού βρίσκεται το %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Συνδέεστε στο lame_enc.dll v%d.%d. Αυτή η έκδοση δεν είναι συμβατή με το Audacity %d.%d.%d.\n"
 "Παρακαλούμε μεταφορτώστε την τελευταία έκδοση του 'LAME for Audacity'."
@@ -10793,6 +11597,15 @@ msgstr "Εξαγωγή του επιλεγμένου ακουστικού σήμ
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Εξαγωγή του ήχου ως Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft) με υπογραφή 16 δυαδικών PCM"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Κεφαλίδα:"
@@ -10806,9 +11619,10 @@ msgid "Other uncompressed files"
 msgstr "Άλλα μη συμπιεσμένα αρχεία"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Προσπαθήσατε να εξάγετε ένα αρχείο WAV ή AIFF που μπορεί να είναι μεγαλύτερο από 4GB.\n"
 "Το Audacity δεν μπορεί να το κάνει αυτό, η εξαγωγή εγκαταλείφθηκε."
@@ -10818,8 +11632,9 @@ msgid "Error Exporting"
 msgstr "Σφάλμα εξαγωγής"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Το εξαγόμενο αρχείο σας WAV έχει περικοπεί επειδή το Audacity\n"
@@ -10859,11 +11674,11 @@ msgid "All supported files"
 msgstr "Όλα τα υποστηριζόμενα αρχεία"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "Το \"%s\" \n"
@@ -10872,11 +11687,11 @@ msgstr ""
 "αναπαραγωγή, αλλά μπορείτε να το επεξεργαστείτε πατώντας Αρχείο > Εισαγωγή > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "Το \"%s\" \n"
 "δεν είναι αρχείο ήχου. \n"
@@ -10887,18 +11702,18 @@ msgid "Select stream(s) to import"
 msgstr "Επιλέξτε τις ροές για εισαγωγή"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Αυτή η έκδοση του Audacity δεν μεταφράστηκε/προσαρμόστηκε με %s υποστήριξη."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα κομμάτι ήχου CD. \n"
 "Το Audacity δεν μπορεί να ανοίξει άμεσα ηχητικά CDs. \n"
@@ -10907,10 +11722,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "Το \"%s\" είναι ένα αρχείο καταλόγου αναπαραγωγής. \n"
@@ -10919,10 +11734,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα αρχείο ήχου πολυμέσων Windows. \n"
@@ -10931,10 +11746,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα προχωρημένο αρχείο κωδικοποίησης ήχου.\n"
@@ -10943,12 +11758,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα κρυπτογραφημένο αρχείο ήχου.\n"
@@ -10959,10 +11774,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα αρχείο πολυμέσων RealPlayer.\n"
@@ -10971,12 +11786,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "Το \"%s\" είναι ένα αρχείο με βάση νότες, δεν είναι αρχείο ήχου.\n"
 "Το Audacity δεν μπορεί να ανοίξει αυτόν τον τύπο αρχείου.\n"
@@ -10985,10 +11800,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11001,10 +11816,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα αρχείο ήχου Wavpack.\n"
@@ -11013,10 +11828,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα ψηφιακό αρχείο ήχου Dolby.\n"
@@ -11025,10 +11840,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα αρχείο ήχου Ogg Speex.\n"
@@ -11037,10 +11852,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "Το \"%s\" είναι ένα αρχείο βίντεο.\n"
@@ -11054,9 +11869,9 @@ msgstr "Δεν βρέθηκε το αρχείο \"%s\"."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11072,11 +11887,16 @@ msgstr ""
 "Προσπαθήστε να εγκαταστήσετε το FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, δοκιμαστής"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11106,12 +11926,13 @@ msgid "Import Project"
 msgstr "Εισαγωγή έργου"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Αυτό το έργο αποθηκεύτηκε με την έκδοση 1.0 του Audacity ή παλιότερη. Η μορφή έχει\n"
 "αλλάξει και αυτή η έκδοση του Audacity δεν μπορεί να εισάγει το έργο.\n"
@@ -11162,7 +11983,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Αδύνατη η εύρεση του φακέλου των δεδομένων έργου: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Τα κομμάτια MIDI βρέθηκαν σε αρχείο έργου, αλλά αυτή η έκδοση του Audacity δεν περιλαμβάνει υποστήριξη MIDI, παράκαμψη του κομματιού."
 
 #: src/import/ImportAUP.cpp
@@ -11266,40 +12088,6 @@ msgstr "Δείκτης[%02x] Κωδικοποιητής[%s], Γλώσσα[%s], �
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Αρχεία FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Αρχεία συμβατά με GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Αδύνατη η προσθήκη αποκωδικοποιητή στη διοχέτευση"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Εισαγωγέας GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Αδύνατη η ρύθμιση της κατάστασης ροής σε παύση."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Δείκτης[%02d], Τύπος[%s], Κανάλια[%d], Ρυθμός[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Το αρχείο δεν περιέχει ροές ήχου."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Αδύνατη η εισαγωγή αρχείου, αποτυχία αλλαγής κατάστασης."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Σφάλμα GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -11407,8 +12195,120 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, και άλλοι μη συμπιεσμένοι τύποι"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "AVR (Audio Visual Research)"
 msgstr "AVR (Οπτικοακουστική αναζήτηση)"
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAVEX (Microsoft)"
+msgstr "WAV (Microsoft) με υπογραφή 16 δυαδικών PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 16 bit PCM"
+msgstr "PCM 16 δυαδικών"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 24 bit PCM"
+msgstr "PCM 24 δυαδικών"
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -11417,6 +12317,64 @@ msgstr "κιν υποδ 32-bit"
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "κιν υποδ 32-bit"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DPCM"
+msgstr "PCM 16 δυαδικών"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "PCM 16 δυαδικών"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11519,6 +12477,10 @@ msgid "Start offset:"
 msgstr "Ξεκίνημα μετατόπισης:"
 
 #: src/import/ImportRaw.cpp
+msgid "bytes"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
 msgid "Amount to import:"
 msgstr "Μέγεθος προς εισαγωγή:"
 
@@ -11555,6 +12517,7 @@ msgstr "το %s δεξιά"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11578,6 +12541,7 @@ msgstr "τέλος"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11604,7 +12568,8 @@ msgstr "Αποσπάσματα μετατοπισμένου χρόνου δεξ�
 msgid "Time shifted clips to the left"
 msgstr "Αποσπάσματα μετατοπισμένου χρόνου αριστερά"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Χρονική μετατόπιση"
 
@@ -11742,7 +12707,8 @@ msgstr "Περικοπή επιλεγμένων κομματιών ήχου απ
 msgid "Trim Audio"
 msgstr "Περικοπή ήχου"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Διαχωρισμός"
 
@@ -11865,34 +12831,6 @@ msgstr "Πλήκτρο διαγραφής&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "Ε&πιπρόσθετα"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Μεί&κτης"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Ρύ&θμιση έντασης αναπαραγωγής..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Αύ&ξηση έντασης αναπαραγωγής"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Μεί&ωση έντασης αναπαραγωγής"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Ρύ&θμιση έντασης ηχογράφησης..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Αύξ&ηση έντασης ηχογράφησης"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Μείω&ση έντασης ηχογράφησης"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12068,6 +13006,11 @@ msgid "&Labels..."
 msgstr "&Ετικέτες..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Εξαγωγή MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Ανεπεξέργαστα &δεδομένα(Raw)..."
 
@@ -12156,8 +13099,9 @@ msgid "&Getting Started"
 msgstr "&Ξεκίνημα"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Εγ&χειρίδιο του Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "Εγ&χειρίδιο..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12183,11 +13127,8 @@ msgstr "Πληροφορίες συσκευής &MIDI..."
 msgid "Show &Log..."
 msgstr "Εμφάνιση &ημερολογίου..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Σχετικά με το Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Προστέθηκε ετικέτα"
 
@@ -12435,6 +13376,11 @@ msgstr "Εναλλαγή εστιασ&μένου κομματιού"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Χωρίς κατηγορία"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Νέο..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12873,6 +13819,7 @@ msgstr "Μεγάλο άλ&μα δεξιά δρομέα"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Ανα&ζήτηση"
@@ -13084,18 +14031,21 @@ msgid "Created new label track"
 msgstr "Δημιουργήθηκε νέο κομμάτι ετικέτας"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Αυτή η έκδοση του Audacity επιτρέπει μόνο ένα κομμάτι χρόνου σε κάθε παράθυρο έργου."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Δημιουργήθηκε νέο κομμάτι χρόνου"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Νέος ρυθμός δειγματοληψίας (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Η τιμή που εισήγαγες δεν είναι έγκυρη"
 
@@ -13352,7 +14302,9 @@ msgstr "Αναπαράγεται"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Ηχογράφηση"
 
@@ -13501,10 +14453,6 @@ msgstr "&Προσθήκη ήχου (ναι/όχι)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Πλήρης αναπαραγωγή &λογισμικού (ναι/όχι)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Α&υτόματη ρύθμιση επιπέδου ηχογράφησης (ναι/όχι)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13722,7 +14670,7 @@ msgstr "Προτιμήσεις για"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Ενημέρωση του Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13769,7 +14717,8 @@ msgstr "&Δέκτης:"
 msgid "Using:"
 msgstr "Χρησιμοποιεί:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Αναπαραγωγή"
 
@@ -13789,7 +14738,8 @@ msgstr "Κα&νάλια:"
 msgid "Latency"
 msgstr "Καθυστέρηση"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "χιλιοστοδευτερόλεπτα"
 
@@ -13818,7 +14768,8 @@ msgid "2 (Stereo)"
 msgstr "2 (Στέρεο)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Φάκελοι"
 
@@ -13926,7 +14877,8 @@ msgid "Directory %s is not writable"
 msgstr "Ο φάκελος %s δεν είναι εγγράψιμος"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Οι αλλαγές στο προσωρινό κατάλογο δεν θα εφαρμοστούν μέχρι να γίνει επανεκκίνηση του Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13957,6 +14909,40 @@ msgstr "Ομαδοποιημένο κατά δισκογραφική εταιρ�
 msgid "Grouped by Type"
 msgstr "Ομαδοποιημένο κατά τύπο"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Σφάλμα Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Ενεργοποίηση εφέ"
@@ -13978,11 +14964,13 @@ msgid "Plugin Options"
 msgstr "Επιλογές προσθέτου"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Έλεγχος για ενημερωμένα πρόσθετα όταν ξεκινά το Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Να επανασαρώνονται τα πρόσθετα την επόμενη φορά που αρχίζει το Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14162,7 +15150,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "&Διατήρηση των ετικετών εάν η επιλογή προσκολλάται σε ετικέτα"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Α&νάμειξη θέματος συστήματος και Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14340,7 +15329,8 @@ msgstr ""
 "   *   \"%s\"  (επειδή η συντόμευση '%s' χρησιμοποιείται από \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Επιλέξτε ένα αρχείο XML που να περιέχει συντομεύσεις πληκτρολογίου του Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14472,8 +15462,9 @@ msgid "Dow&nload"
 msgstr "Λή&ψη"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Το Audacity έχει ανιχνεύσει αυτόματα έγκυρες βιβλιοθήκες FFmpeg.\n"
@@ -14532,8 +15523,9 @@ msgid "Preferences for Module"
 msgstr "Προτιμήσεις για άρθρωμα"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Αυτά είναι πειραματικά αρθρώματα. Ενεργοποιήστε τα μόνο αν έχετε διαβάσει\n"
@@ -14541,12 +15533,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'Ερώτηση' σημαίνει ότι το Audacity θα σας ζητήσει εάν θέλετε να φορτώσετε το άρθρωμα κάθε φορά που ξεκινά."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'Αποτυχία' σημαίνει ότι το Audacity θεωρεί ότι το άρθρωμα έχει αλλοιωθεί και δεν θα το ξεκινήσει."
 
 #. i18n-hint preserve the leading spaces
@@ -14555,7 +15549,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Νέο' σημαίνει ότι δεν έχει γίνει καμιά επιλογή ακόμα."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Οι αλλαγές σε αυτές τις ρυθμίσεις θα γίνουν μόνο το Audacity ξεκινήσει."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14573,6 +15568,10 @@ msgstr "Δεν βρέθηκαν αρθρώματα"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Άρθρωμα"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14614,7 +15613,10 @@ msgstr "Αριστερό-σύρσιμο"
 msgid "Set Selection Range"
 msgstr "Ορισμός περιοχής επιλογής"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-αριστερό-πάτημα"
 
@@ -14701,6 +15703,15 @@ msgstr "-Αριστερό-σύρσιμο"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Μετακίνηση αποσπάσματος πάνω/κάτω μεταξύ κομματιών"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Αριστερό-σύρσιμο"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14825,7 +15836,8 @@ msgid "Always scrub un&pinned"
 msgstr "Πάντα &ξεκαρφιτσωμένο τρίψιμο"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Προτιμήσεις του Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14839,6 +15851,11 @@ msgstr "Προτιμήσεις:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Προτιμήσεις για"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14958,39 +15975,6 @@ msgid "System T&ime"
 msgstr "Ώ&ρα συστήματος"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Αυτόματη ρύθμιση επιπέδου ηχογράφησης"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Ενεργοποίηση αυτόματης ρύθμισης επιπέδου ηχογράφησης."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Κορυφή στόχου:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Μέσα σε:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Χρόνος ανάλυσης:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "ms (χρόνος μιας ανάλυσης)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Αριθμός διαδοχικών αναλύσεων:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 σημαίνει ατελείωτο"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Ηχογράφηση με σήμανση και διόρθωση (Punch and Roll)"
 
@@ -15001,6 +15985,21 @@ msgstr "Προε&κκίνηση:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Ομαλή &μετάβαση:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15135,6 +16134,10 @@ msgid "1024 - default"
 msgstr "1024 - προεπιλογή"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - περισσότερο περιορισμένη ζώνη"
 
@@ -15232,13 +16235,14 @@ msgid "Info"
 msgstr "Πληροφορίες"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15421,7 +16425,8 @@ msgstr "Δείγματα"
 msgid "4 Pixels per Sample"
 msgstr "4 εικονοστοιχεία ανά δείγμα"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Μέγιστη εστίαση"
 
@@ -15543,16 +16548,24 @@ msgid "Stopped"
 msgstr "Σταματημένο"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Παύση"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Μεταπήδηση στην αρχή"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Μεταπήδηση στο τέλος"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Παύση"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Επιλογή αρχής"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Επιλογή τέλους"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15566,20 +16579,17 @@ msgstr "Ηχογράφηση νέου κομματιού"
 msgid "Append Record"
 msgstr "Προσάρτηση ηχογράφησης"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Επιλογή τέλους"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Επιλογή αρχής"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Το %s σε παύση."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15659,11 +16669,17 @@ msgstr "Σίγαση επιλογής ακουστικού σήματος"
 msgid "Sync-Lock Tracks"
 msgstr "Κλείδωμα συγχρονισμού των κομματιών"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Μεγέθυνση"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Σμίκρυνση"
 
@@ -15730,43 +16746,6 @@ msgstr "Γραμμή εργαλείων μετρητή &ηχογράφησης"
 msgid "&Playback Meter Toolbar"
 msgstr "Γραμμή εργαλείων μετρητή &αναπαραγωγής"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Ένταση ηχογράφησης"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Ένταση αναπαραγωγής"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Ένταση ηχογράφησης: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Ένταση ηχογράφησης (μη διαθέσιμη; χρησιμοποίησε τον μείκτη του συστήματος.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Ένταση αναπαραγωγής: %.2f (προσομοιωμένη)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Ένταση αναπαραγωγής: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Ένταση αναπαραγωγής (μη διαθέσιμη; χρησιμοποίησε τον μείκτη του συστήματος.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Γραμμή εργαλείων μεί&κτη"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Αναζήτηση (Seek)"
@@ -15782,6 +16761,7 @@ msgstr "Τρίψιμο (Scrubbing)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Παύση τριψίματος"
@@ -15789,6 +16769,7 @@ msgstr "Παύση τριψίματος"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Έναρξη τριψίματος"
@@ -15796,6 +16777,7 @@ msgstr "Έναρξη τριψίματος"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Παύση αναζήτησης"
@@ -15803,6 +16785,7 @@ msgstr "Παύση αναζήτησης"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Έναρξη αναζήτησης"
@@ -15857,7 +16840,9 @@ msgstr "Προσκόλληση σε"
 msgid "Length"
 msgstr "Διάρκεια"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Κέντρο"
 
@@ -15921,8 +16906,8 @@ msgstr "Γραμμή εργαλείων &χρόνου"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Γραμμή εργαλείων %s του Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15949,7 +16934,8 @@ msgstr "Εργαλείο χρονικής μετατόπισης"
 msgid "Zoom Tool"
 msgstr "Εργαλείο μεγέθυνσης"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Εργαλείο σχεδίασης"
 
@@ -16025,11 +17011,13 @@ msgstr "Μετακινήστε ένα ή περισσότερα όρια ετι�
 msgid "Drag label boundary."
 msgstr "Μετακινήστε το όριο ετικέτας."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Τροποποιημένη ετικέτα"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Επεξεργασία ετικέτας"
 
@@ -16084,31 +17072,42 @@ msgstr "Επεξεργασμένες ετικέτες"
 msgid "New label"
 msgstr "Νέα ετικέτα"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Πάνω &οκτάβα"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Κάτω ο&κτάβα"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Πάτημα για κάθετη μεγέθυνση. Shift-πάτημα για σμίκρυνση. Μεταφορά για ορισμό περιοχής εστίασης."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Δεξιό πάτημα για μενού."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Επαναφορά εστίασης"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-δεξιό-πάτημα"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Αριστερό πάτημα/αριστερή μεταφορά"
 
@@ -16150,7 +17149,8 @@ msgstr "Συγχώνευση"
 msgid "Expanded Cut Line"
 msgstr "Επέκταση της γραμμής αποκοπής"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Επέκταση"
 
@@ -16173,6 +17173,11 @@ msgstr "Μετακινήθηκαν δείγματα"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Επεξεργασία δείγματος"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16218,7 +17223,8 @@ msgstr "Επεξεργασία...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Αλλαγμένο '%s' σε %s"
@@ -16230,6 +17236,54 @@ msgstr "Αλλαγή μορφής"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Ρ&υθμός"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16249,7 +17303,8 @@ msgstr "Αλλαγή ρυθμού δειγματοληψίας"
 msgid "Set Rate"
 msgstr "Ορισμός ρυθμού δειγματοληψίας"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Πολλαπλή προβολή"
 
@@ -16341,14 +17396,23 @@ msgstr "Αριστερό, %dHz"
 msgid "Right, %dHz"
 msgstr "Δεξιό, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Αριστερά"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Δεξιά"
@@ -16466,9 +17530,8 @@ msgstr "Λογαριθμικό &παρεμβολή"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Πατήστε και σύρετε για να μετακινήσετε ένα κομμάτι στο χρόνο"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16519,6 +17582,7 @@ msgstr "Ρυθμίστηκε η καμπύλη ακουστότητας."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Τρίψιμο"
@@ -16530,6 +17594,7 @@ msgstr "Αναζήτηση"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Χάρακας τριψίματος"
@@ -16713,6 +17778,24 @@ msgstr "Πατήστε"
 msgid "Button"
 msgstr "Κουμπί"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16746,9 +17829,19 @@ msgstr "Άδειο"
 msgid "Backwards"
 msgstr "Προς τα πίσω"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Μπροστά"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16961,6 +18054,7 @@ msgstr "0100 h 060 m 060 s+># δείγματα"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "δείγματα"
@@ -17114,6 +18208,24 @@ msgstr "CDDA καρέ (75 fps)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 καρέ|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "01000<01000 kHz|0,001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -17121,6 +18233,10 @@ msgstr "01000,01000 καρέ|75"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0,001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -17186,6 +18302,11 @@ msgstr "(Χρησιμοποιήστε το μενού περιεχομένων �
 msgid "centiseconds"
 msgstr "εκατοστοδευτερόλεπτα"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Χρόνος που πέρασε:"
@@ -17228,6 +18349,11 @@ msgstr "Επιβεβαίωση κλεισίματος"
 msgid "Unable to write files to directory: %s."
 msgstr "Αδύνατη η ανάγνωση της προρύθμισης από το \"%s\""
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17244,6 +18370,10 @@ msgstr "Προτιμήσεις καταλόγων"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Να μην εμφανιστεί ξανά"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17327,15 +18457,27 @@ msgstr "Αδυναμία ανάλυσης του XML"
 msgid "Spectral edit multi tool"
 msgstr "Πολυεργαλείο φασματικής επεξεργασίας"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Φιλτράρισμα..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Εκδόθηκε με τους όρους της Γενικής Δημόσιας Άδειας GNU, έκδοσης 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aΕπιλέξτε συχνότητες."
@@ -17362,7 +18504,8 @@ msgstr ""
 "                      Προσπαθήστε να αυξήσετε το κάτω όριο της συχνότητας~%~\n"
 "                      ή να μειώσετε το φίλτρο πλάτους ('Width')."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Σφάλμα.~%"
@@ -17423,6 +18566,25 @@ msgstr "Σταδιακή εξασθένιση στούντιο"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Εφαρμογή σταδιακής μεταβολής..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Ορισμός πρ&οεπιλογής"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Εκδόθηκε με τους όρους της Γενικής Δημόσιας Άδειας GNU, έκδοσης 2 ή μεταγενέστερης."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17567,6 +18729,11 @@ msgstr "Εύρεση κτύπου (Beat)"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Εύρεση κτύπων (beats)..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Ημερολόγιο Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17891,13 +19058,38 @@ msgstr "Υψίσυχνο φίλτρο"
 msgid "Performing High-Pass Filter..."
 msgstr "Εκτελείται υψιπερατό φίλτρο..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Συχνότητα (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Απότομη εξασθένιση (Roll-off) (dB ανά οκτάβα)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17918,10 +19110,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Label Sounds (Ετικέτες ήχων)"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Εκδόθηκε με τους όρους της Γενικής Δημόσιας Άδειας GNU, έκδοσης 2 ή μεταγενέστερης."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17982,6 +19170,12 @@ msgstr "Μέγιστη σιγή τέλους"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Ήχος ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -18161,6 +19355,12 @@ msgstr ""
 "Κορυφή βασισμένη στα πρώτα ~a δευτερόλεπτα ~a dB~%\n"
 "Προτεινόμενη ρύθμιση κατωφλίου ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Φίλτρο εγκοπής (Notch Filter)"
@@ -18209,7 +19409,8 @@ msgstr "Αρχείο Lisp"
 msgid "HTML file"
 msgstr "Αρχείο HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Αρχείο κειμένου"
 
@@ -18286,6 +19487,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Τιμές MIDI για νότες ντο (C): 36, 48, 60 [μεσαίο C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Τονικό ύψος MIDI με τράβηγμα χορδών (Pluck)"
 
@@ -18334,12 +19539,20 @@ msgid "Swing amount"
 msgstr "Ποσότητα ταλάντωσης"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
 msgstr "Ορίστε το 'Αριθμός γραμμών' σε μηδέν για να ενεργοποιηθεί το 'Διάρκεια κομματιού ρυθμού'."
 
 #: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Αριθμός γραμμών"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -18398,6 +19611,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Τονικό ύψος MIDI του ισχυρού κτύπου (beat)"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Τονικό ύψος MIDI του ασθενούς κτύπου (beat)"
 
@@ -18416,6 +19633,10 @@ msgstr "Τύμπανο Ρισέ (Risset Drum)"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Δημιουργία τύμπανου Risset..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18823,6 +20044,10 @@ msgid "Applying Action..."
 msgstr "Εφαρμογή ενέργειας..."
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "Αφαίρεση φωνητικών: σε μονοφωνικό"
 
@@ -18963,8 +20188,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Αυτό το πρόσθετο δουλεύει μόνο με στερεοφωνικά κομμάτια."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Επεξεργασία Vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -19006,6 +20239,232 @@ msgstr "Συχνότητα βελονών ραντάρ (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Σφάλμα. Απαιτείται ~%Stereo κομμάτι."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Ενημέρωση του Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Παράλειψη"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "Ε&γκατάσταση ενημέρωσης"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Αρχείο αλλαγών"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Διαβάστε περισσότερα στο GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Σφάλμα κατά τον έλεγχο για ενημέρωση"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Αδυναμία σύνδεσης με τον διακομιστή ενημέρωσης του Audacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Τα δεδομένα ενημέρωσης ήταν κατεστραμμένα."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Σφάλμα κατά τη λήψη της ενημέρωσης."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Αδυναμία ανοίγματος του συνδέσμου λήψης του Audacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Το Audacity %s είναι διαθέσιμο!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Ηχογράφηση"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Αναγνωριστικό υποβολής:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Διαλειτουργική βιβλιοθήκη GUI"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Εισαγωγή μέσω GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Δεν ήταν δυνατό να βελτιωθεί περισσότερο. Εξακολουθεί να είναι υπερβολικά υψηλή."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής μείωσε την ένταση σε %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Δεν ήταν δυνατό να βελτιωθεί περισσότερο. Εξακολουθεί να είναι υπερβολικά χαμηλή."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής αύξησε την ένταση σε %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Ο συνολικός αριθμός των αναλύσεων έχει ξεπεραστεί χωρίς να βρεθεί μια αποδεκτή ένταση. Εξακολουθεί να είναι υπερβολικά υψηλή."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Ο συνολικός αριθμός των αναλύσεων έχει ξεπεραστεί χωρίς να βρεθεί μια αποδεκτή ένταση. Εξακολουθεί να είναι υπερβολικά χαμηλή."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Η αυτόματη ρύθμιση επιπέδου εγγραφής σταμάτησε. Το %.2f φαίνεται να είναι μια αποδεκτή ένταση."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Ελήφθησαν %d κατά το άνοιγμα των συσκευών\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Αδύνατο το άνοιγμα Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Διαθέσιμοι μείκτες:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Διαθέσιμες πηγές ηχογράφησης:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Διαθέσιμες εντάσεις αναπαραγωγής:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Η ένταση ηχογράφησης είναι προσομοιωμένη\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Η ένταση ηχογράφησης είναι εγγενής\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Η ένταση αναπαραγωγής είναι προσομοιωμένη\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Η ένταση αναπαραγωγής είναι εγγενής\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Ημερομηνία και ώρα λήξης"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Αρχεία συμβατά με GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Αδύνατη η προσθήκη αποκωδικοποιητή στη διοχέτευση"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Εισαγωγέας GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Αδύνατη η ρύθμιση της κατάστασης ροής σε παύση."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Δείκτης[%02d], Τύπος[%s], Κανάλια[%d], Ρυθμός[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Το αρχείο δεν περιέχει ροές ήχου."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Αδύνατη η εισαγωγή αρχείου, αποτυχία αλλαγής κατάστασης."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Σφάλμα GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Μεί&κτης"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Ρύ&θμιση έντασης αναπαραγωγής..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Αύ&ξηση έντασης αναπαραγωγής"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Μεί&ωση έντασης αναπαραγωγής"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Ρύ&θμιση έντασης ηχογράφησης..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Αύξ&ηση έντασης ηχογράφησης"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Μείω&ση έντασης ηχογράφησης"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Εγ&χειρίδιο του Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Σχετικά με το Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Α&υτόματη ρύθμιση επιπέδου ηχογράφησης (ναι/όχι)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Αυτόματη ρύθμιση επιπέδου ηχογράφησης"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Ενεργοποίηση αυτόματης ρύθμισης επιπέδου ηχογράφησης."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Κορυφή στόχου:"
+
+#~ msgid "Within:"
+#~ msgstr "Μέσα σε:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Χρόνος ανάλυσης:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "ms (χρόνος μιας ανάλυσης)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Αριθμός διαδοχικών αναλύσεων:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 σημαίνει ατελείωτο"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Ένταση ηχογράφησης"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Ένταση αναπαραγωγής"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Ένταση ηχογράφησης: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Ένταση ηχογράφησης (μη διαθέσιμη; χρησιμοποίησε τον μείκτη του συστήματος.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Ένταση αναπαραγωγής: %.2f (προσομοιωμένη)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Ένταση αναπαραγωγής: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Ένταση αναπαραγωγής (μη διαθέσιμη; χρησιμοποίησε τον μείκτη του συστήματος.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Γραμμή εργαλείων μεί&κτη"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Πατήστε και σύρετε για να μετακινήσετε ένα κομμάτι στο χρόνο"
 
 #~ msgid "Program build date:"
 #~ msgstr "Ημερομηνία δημιουργίας του προγράμματος:"
@@ -19855,9 +21314,6 @@ msgstr "Σφάλμα. Απαιτείται ~%Stereo κομμάτι."
 #~ msgid "AIFF (Apple) signed 16-bit PCM"
 #~ msgstr "AIFF (Apple) με υπογραφή 16 δυαδικών PCM"
 
-#~ msgid "WAV (Microsoft) signed 16-bit PCM"
-#~ msgstr "WAV (Microsoft) με υπογραφή 16 δυαδικών PCM"
-
 #~ msgid "WAV (Microsoft) signed 24-bit PCM"
 #~ msgstr "WAV (Microsoft) με υπογραφή 24 δυαδικών PCM"
 
@@ -20364,9 +21820,6 @@ msgstr "Σφάλμα. Απαιτείται ~%Stereo κομμάτι."
 #~ msgid "L-E"
 #~ msgstr "Δ-Τ"
 
-#~ msgid "L-C"
-#~ msgstr "Δ-Κ"
-
 #~ msgid "Show start time and end time"
 #~ msgstr "Εμφάνιση χρόνου έναρξης και χρόνου λήξης"
 
@@ -20567,9 +22020,6 @@ msgstr "Σφάλμα. Απαιτείται ~%Stereo κομμάτι."
 #~ msgid "Offset"
 #~ msgstr "Μετατόπιση"
 
-#~ msgid "Version"
-#~ msgstr "Έκδοση"
-
 #~ msgid "Heavy"
 #~ msgstr "Έντονος"
 
@@ -20660,9 +22110,6 @@ msgstr "Σφάλμα. Απαιτείται ~%Stereo κομμάτι."
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "Για να χρησιμοποιήσετε σχεδίαση, επιλέξτε 'κυματομορφή' στο πτυσσόμενο μενού κομματιού."
-
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "%.2f dB μέσος όρος RMS"
 
 #~ msgid "Average RMS = %.2f dB."
 #~ msgstr "Μέσος όρος RMS = %.2f dB."

--- a/locale/en.po
+++ b/locale/en.po
@@ -12,82 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-30 10:00+0000\n"
 "Last-Translator: String E. Fighter <lonely@partyheld.de>\n"
-"Language-Team: English <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/en/>\n"
+"Language-Team: English <https://hosted.weblate.org/projects/tenacity/tenacity/en/>\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Update Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Skip"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Install update"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Changelog"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Read more on GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Error checking for update"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Unable to connect to Tenacity update server."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Update data was corrupted."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Error downloading update."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Can't open the Tenacity download link."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s is available!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Record"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -242,7 +176,8 @@ msgid "Script"
 msgstr "Script"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Output"
 
@@ -258,7 +193,12 @@ msgstr "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
 msgid "Script was not saved."
 msgstr "Script was not saved."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Warning"
 
@@ -287,7 +227,8 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 by Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "External Tenacity module which provides a simple IDE for writing effects."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -310,7 +251,8 @@ msgstr "Untitled"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist Effect Workbench - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "New"
 
@@ -350,7 +292,8 @@ msgstr "Copy"
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Cut"
 
@@ -358,7 +301,8 @@ msgstr "Cut"
 msgid "Cut to clipboard"
 msgstr "Cut to clipboard"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Paste"
 
@@ -383,7 +327,8 @@ msgstr "Select All"
 msgid "Select all text"
 msgstr "Select all text"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Undo"
 
@@ -391,7 +336,8 @@ msgstr "Undo"
 msgid "Undo last change"
 msgstr "Undo last change"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Redo"
 
@@ -448,7 +394,8 @@ msgid "Go to next S-expr"
 msgstr "Go to next S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Start"
 
@@ -456,7 +403,8 @@ msgstr "Start"
 msgid "Start script"
 msgstr "Start script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Stop"
 
@@ -471,7 +419,8 @@ msgid "About %s"
 msgstr "About %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "OK"
 
@@ -479,11 +428,13 @@ msgstr "OK"
 msgid "Build Information"
 msgstr "Build Information"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Enabled"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Disabled"
 
@@ -493,8 +444,9 @@ msgid "The Build"
 msgstr "Build Information"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Commit Id:"
+#, fuzzy
+msgid "Version:"
+msgstr "Version: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -504,22 +456,28 @@ msgstr "Build type:"
 msgid "Compiler:"
 msgstr "Compiler:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Installation Prefix:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Settings folder:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Settings folder:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "File Format Support"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Cross-platform GUI library"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -533,7 +491,6 @@ msgstr "Sample rate conversion"
 msgid "MP3 Importing"
 msgstr "MP3 Importing"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis Import and Export"
@@ -542,7 +499,6 @@ msgstr "Ogg Vorbis Import and Export"
 msgid "ID3 tag support"
 msgstr "ID3 tag support"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC import and export"
@@ -560,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg Import/Export"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Import via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Features"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Plug-in support"
 
@@ -582,6 +530,10 @@ msgstr "Pitch and Tempo Change support"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Extreme Pitch and Tempo Change support"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Features"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -707,8 +659,7 @@ msgstr "<h3>"
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Free, open source, cross-platform software for recording and editing sounds."
+msgstr "Free, open source, cross-platform software for recording and editing sounds."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
@@ -716,9 +667,7 @@ msgstr "Credits"
 
 #: src/AboutDialog.cpp
 msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Please note that names are sorted in alphabetical order, not in order of "
-"importance."
+msgstr "Please note that names are sorted in alphabetical order, not in order of importance."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -767,6 +716,7 @@ msgstr "Audacity Website and Graphics"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "translator_credits"
@@ -795,14 +745,11 @@ msgstr "%s %s 1999-%s %s contributors"
 #: src/AboutDialog.cpp
 #, c-format
 msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"The Audacity%s trademark is used within this software for descriptive and "
-"informational purposes only."
+msgstr "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
 
 #: src/AboutDialog.cpp
 msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -825,6 +772,7 @@ msgstr "Timeline"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Click or drag to begin Seek"
@@ -832,6 +780,7 @@ msgstr "Click or drag to begin Seek"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Click or drag to begin Scrub"
@@ -839,6 +788,7 @@ msgstr "Click or drag to begin Scrub"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Click & move to Scrub. Click & drag to Seek."
@@ -846,6 +796,7 @@ msgstr "Click & move to Scrub. Click & drag to Seek."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Move to Seek"
@@ -853,6 +804,7 @@ msgstr "Move to Seek"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Move to Scrub"
@@ -909,7 +861,17 @@ msgstr ""
 "Cannot lock region beyond\n"
 "end of project."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Error"
 
@@ -933,7 +895,8 @@ msgstr ""
 "This is a one-time question, after an 'install' where you asked to have the Preferences reset."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Reset Tenacity Preferences"
 
 #: src/AudacityApp.cpp
@@ -948,7 +911,8 @@ msgstr ""
 "It has been removed from the list of recent files."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite library failed to initialize.  Tenacity cannot continue."
 
 #: src/AudacityApp.cpp
@@ -973,7 +937,7 @@ msgstr "&Open..."
 msgid "Open &Recent..."
 msgstr "Open &Recent..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&About Tenacity..."
 
@@ -986,9 +950,10 @@ msgid "&File"
 msgstr "&File"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity could not find a safe place to store temporary files.\n"
@@ -996,20 +961,23 @@ msgstr ""
 "Please enter an appropriate directory in the preferences dialog."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -1018,15 +986,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity was not able to lock the temporary files directory.\n"
 "This folder may be in use by another copy of Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Do you still want to start Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -1034,19 +1004,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Error Locking Temporary Folder"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "The system has detected that another copy of Tenacity is running.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity is already running"
 
 #: src/AudacityApp.cpp
@@ -1062,7 +1035,8 @@ msgstr ""
 "and a reboot may be required."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Tenacity Startup Failure"
 
 #: src/AudacityApp.cpp
@@ -1102,8 +1076,9 @@ msgstr ""
 "and a reboot may be required."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1135,7 +1110,8 @@ msgstr "run self diagnostics"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "display Tenacity version"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1145,9 +1121,10 @@ msgid "audio or project file name"
 msgstr "audio or project file name"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1160,16 +1137,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tenacity Project Files"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Message"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Tenacity Configuration Error"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1179,7 +1158,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1191,12 +1170,15 @@ msgstr ""
 "\n"
 "If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Help"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Quit Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1204,7 +1186,8 @@ msgid "&Retry"
 msgstr "&Retry"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacity Log"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1216,7 +1199,8 @@ msgstr "&Save..."
 msgid "Cl&ear"
 msgstr "Cl&ear"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Close"
 
@@ -1271,7 +1255,8 @@ msgid "Error Initializing Midi"
 msgstr "Error Initializing Midi"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity Audio"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1286,37 +1271,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Out of memory!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automated Recording Level Adjustment decreased the volume to %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automated Recording Level Adjustment increased the volume to %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1415,48 +1369,6 @@ msgstr "No playback device found for '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Cannot check mutual sample rates without both devices.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Received %d while opening devices\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Unable to open Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Available mixers:\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Available recording sources:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Available playback volumes:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Recording volume is emulated\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Recording volume is native\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Playback volume is emulated\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Playback volume is native\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1499,8 +1411,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatic Crash Recovery"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1513,12 +1426,14 @@ msgid "Recoverable &projects"
 msgstr "Recoverable &projects"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Select"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Name"
 
@@ -1754,7 +1669,8 @@ msgstr "Re&store"
 msgid "I&mport..."
 msgstr "I&mport..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xport..."
 
@@ -1795,7 +1711,8 @@ msgstr "Move &Up"
 msgid "Move &Down"
 msgstr "Move &Down"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Save"
 
@@ -1878,7 +1795,8 @@ msgid "Run"
 msgstr "Run"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Close"
 
@@ -2022,10 +1940,6 @@ msgstr "Benchmark completed successfully.\n"
 #: src/BuildInfo.h
 msgid "No revision identifier was provided"
 msgstr "No revision identifier was provided"
-
-#: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Unknown date and time"
 
 #: src/BuildInfo.h
 #, c-format
@@ -2290,10 +2204,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "If you proceed, your project will not be saved to disk. Is this what you want?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2307,7 +2222,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Dependency Check"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "None"
 
@@ -2315,7 +2233,7 @@ msgstr "None"
 msgid "Rectangle"
 msgstr "Rectangle"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triangle"
 
@@ -2377,9 +2295,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg support not compiled in"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2401,8 +2320,8 @@ msgid "Locate FFmpeg"
 msgstr "Locate FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2415,7 +2334,8 @@ msgstr "Location of '%s':"
 msgid "To find '%s', click here -->"
 msgstr "To find '%s', click here -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Browse..."
 
@@ -2441,8 +2361,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg not found"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2472,24 +2393,24 @@ msgid "Only libavformat.so"
 msgstr "Only libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity failed to open a file in %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity failed to read from a file in %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2527,7 +2448,9 @@ msgstr "Do &not copy any audio"
 msgid "As&k"
 msgstr "As&k"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "All files"
 
@@ -2622,7 +2545,12 @@ msgstr "Log frequency"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "dB"
 
@@ -2637,7 +2565,9 @@ msgstr "Zoom"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "Hz"
 
@@ -2737,7 +2667,8 @@ msgstr "spectrum.txt"
 msgid "Export Spectral Data As:"
 msgstr "Export Spectral Data As:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Couldn't write to file: %s"
@@ -2827,9 +2758,7 @@ msgstr "We strongly recommend that you use our latest stable released version, w
 #: src/HelpText.cpp
 #, fuzzy
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"You can help us get Tenacity ready for release by joining our "
-"[[https://tenacityaudio.org|community]].<hr><br><br>"
+msgstr "You can help us get Tenacity ready for release by joining our [[https://tenacityaudio.org|community]].<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2930,19 +2859,19 @@ msgid "&History..."
 msgstr "&History..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internal error in %s at %s line %d.\n"
 "Please inform the Tenacity team at https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internal error in %s at %s line %d.\n"
 "Please inform the Tenacity team at https://tenacityaudio.org/."
@@ -2961,7 +2890,9 @@ msgid "Track"
 msgstr "Track"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Label"
 
@@ -3021,7 +2952,8 @@ msgstr "Enter track name"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Label Track"
 
@@ -3032,11 +2964,13 @@ msgstr "One or more saved labels could not be read."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Tenacity First Run"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Choose Language for Tenacity to use:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -3046,7 +2980,8 @@ msgstr "Choose Language for Tenacity to use:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -3064,12 +2999,13 @@ msgstr ""
 "The old file has been saved as '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Opening Tenacity Project"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Tenacity Karaoke%s"
 
 #: src/LyricsWindow.cpp
@@ -3120,19 +3056,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mixing and rendering tracks"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tenacity Mixer Board%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Gain"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocity"
 
@@ -3141,17 +3081,23 @@ msgid "Musical Instrument"
 msgstr "Musical Instrument"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Pan"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Mute"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Solo"
 
@@ -3159,15 +3105,18 @@ msgstr "Solo"
 msgid "Signal Level Meter"
 msgstr "Signal Level Meter"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Moved gain slider"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Moved velocity slider"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Moved pan slider"
 
@@ -3202,9 +3151,9 @@ msgstr ""
 "It will not be loaded."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3238,16 +3187,19 @@ msgstr ""
 "\n"
 "Only use modules from trusted sources"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Yes"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "No"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity Module Loader"
 
 #: src/ModuleManager.cpp
@@ -3489,7 +3441,8 @@ msgstr "&Select All"
 msgid "C&lear All"
 msgstr "C&lear All"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Enable"
 
@@ -3569,9 +3522,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Mismatched Sampling Rates"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Too few tracks are selected for recording at this sample rate.\n"
@@ -3600,10 +3554,11 @@ msgid "Dropouts"
 msgstr "Dropouts"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3643,11 +3598,11 @@ msgid "Inspecting project file data"
 msgstr "Inspecting project file data"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3690,11 +3645,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Warning - Missing Aliased File(s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Project check of \"%s\" folder \n"
@@ -3719,12 +3674,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Warning - Missing Alias Summary File(s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3782,7 +3737,8 @@ msgstr "Warning - Orphan Block File(s)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progress"
 
@@ -3881,12 +3837,14 @@ msgstr ""
 "(Unable to create the required temporary files)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "This is not an Tenacity project file"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -4018,9 +3976,9 @@ msgid "Error Writing to File"
 msgstr "Error Writing to File"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -4034,12 +3992,15 @@ msgstr "Compacting project"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Project %02i] Tenacity \"%s\""
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -4049,10 +4010,10 @@ msgstr "(Recovered)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "This file was saved using Tenacity %s.\n"
 "You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
@@ -4124,8 +4085,9 @@ msgid "Backing up project"
 msgstr "Backing up project"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -4134,8 +4096,9 @@ msgstr ""
 "It has been recovered to the last snapshot."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4214,8 +4177,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sSave Project \"%s\" As..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Save Project' is for an Tenacity project, not an audio file.\n"
@@ -4292,11 +4256,12 @@ msgid "Error Opening Project"
 msgstr "Error Opening Project"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
@@ -4405,8 +4370,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatic database backup failed."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Welcome to Tenacity version %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4621,7 +4586,8 @@ msgstr "All Preferences"
 msgid "SelectionBar"
 msgstr "SelectionBar"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spectral Selection"
 
@@ -4629,46 +4595,55 @@ msgstr "Spectral Selection"
 msgid "Timer"
 msgstr "Timer"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Tools"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Transport"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mixer"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Meter"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Play Meter"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Record Meter"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Edit"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Device"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Play-at-Speed"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Scrub"
 
@@ -4683,7 +4658,10 @@ msgstr "Ruler"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Tracks"
 
@@ -4793,7 +4771,8 @@ msgid "Activation level (dB):"
 msgstr "Activation level (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Welcome to Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4940,9 +4919,9 @@ msgstr ""
 "For tips on suitable drives, click the help button."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity could not write file:\n"
@@ -4962,9 +4941,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4973,9 +4952,9 @@ msgstr ""
 "for writing."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity could not write images to file:\n"
@@ -4992,9 +4971,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -5004,9 +4983,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -5015,8 +4994,9 @@ msgstr ""
 "Bad png format perhaps?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity could not read its default theme.\n"
@@ -5054,9 +5034,9 @@ msgstr ""
 "were already present. Overwrite?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity could not save file:\n"
@@ -5095,7 +5075,11 @@ msgstr "Custom"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Duration"
 
@@ -5106,7 +5090,8 @@ msgid "Time Track"
 msgstr "Time Track"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Tenacity Timer Record"
 
 #: src/TimerRecordDialog.cpp
@@ -5180,7 +5165,8 @@ msgstr "Current Project"
 msgid "Recording start:"
 msgstr "Recording start:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Duration:"
 
@@ -5201,7 +5187,8 @@ msgid "Action after Timer Recording:"
 msgstr "Action after Timer Recording:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Tenacity Timer Record Progress"
 
 #: src/TimerRecordDialog.cpp
@@ -5297,6 +5284,7 @@ msgstr "099 days 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Start Date and Time"
@@ -5341,7 +5329,8 @@ msgstr "Enable Automatic &Export?"
 msgid "Export Project As:"
 msgstr "Export Project As:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Options"
 
@@ -5354,7 +5343,8 @@ msgid "Do nothing"
 msgstr "Do nothing"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Exit Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5378,7 +5368,8 @@ msgid "Scheduled to stop at:"
 msgstr "Scheduled to stop at:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Tenacity Timer Record - Waiting for Start"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5404,7 +5395,8 @@ msgid "Recording Exported:"
 msgstr "Recording Exported:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Tenacity Timer Record - Waiting"
 
 #: src/TrackInfo.cpp
@@ -5601,7 +5593,11 @@ msgid "Applying %s..."
 msgstr "Applying %s..."
 
 #. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
@@ -5624,13 +5620,15 @@ msgstr "%s is not a parameter accepted by %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Invalid value for parameter '%s': should be %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Command"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repeat %s"
@@ -5757,7 +5755,8 @@ msgstr "Clips"
 msgid "Envelopes"
 msgstr "Envelopes"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Labels"
 
@@ -5783,7 +5782,8 @@ msgstr "Brief"
 msgid "Type:"
 msgstr "Type:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Format:"
 
@@ -5851,12 +5851,17 @@ msgstr "Exports to a file."
 msgid "Builtin Commands"
 msgstr "Builtin Commands"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "The Tenacity Team"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Provides builtin commands to Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5919,7 +5924,10 @@ msgstr "Clears the log contents."
 msgid "Get Preference"
 msgstr "Get Preference"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Name:"
 
@@ -5967,7 +5975,8 @@ msgstr "Fullscreen"
 msgid "Toolbars"
 msgstr "Toolbars"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effects"
 
@@ -6107,7 +6116,8 @@ msgstr "Set"
 msgid "Add"
 msgstr "Add"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Remove"
 
@@ -6192,7 +6202,8 @@ msgid "Edited Envelope"
 msgstr "Edited Envelope"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Envelope"
 
@@ -6292,7 +6303,10 @@ msgstr "Pan:"
 msgid "Set Track Visuals"
 msgstr "Set Track Visuals"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linear"
 
@@ -6405,7 +6419,9 @@ msgid "Duck &amount:"
 msgstr "Duck &amount:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "seconds"
 
@@ -6429,7 +6445,8 @@ msgstr "Inner fade d&own length:"
 msgid "Inner &fade up length:"
 msgstr "Inner &fade up length:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Threshold:"
 
@@ -6567,11 +6584,13 @@ msgstr "to (Hz)"
 msgid "t&o"
 msgstr "t&o"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Percent C&hange:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Percent Change"
 
@@ -6593,7 +6612,9 @@ msgstr "78"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n/a"
 
@@ -6621,6 +6642,7 @@ msgstr "Standard Vinyl rpm:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "From rpm"
@@ -6633,6 +6655,7 @@ msgstr "&from"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "To rpm"
@@ -6920,7 +6943,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "End"
 
@@ -7418,7 +7442,9 @@ msgstr "DTMF &sequence:"
 msgid "&Amplitude (0-1):"
 msgstr "&Amplitude (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Duration:"
 
@@ -7463,7 +7489,8 @@ msgstr "Echo"
 msgid "Repeats the selected audio again and again"
 msgstr "Repeats the selected audio again and again"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Requested value exceeds memory capacity."
 
@@ -7487,7 +7514,8 @@ msgstr "Presets"
 msgid "Export Effect Parameters"
 msgstr "Export Effect Parameters"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Could not open file: \"%s\""
@@ -8267,7 +8295,8 @@ msgid "Builtin Effects"
 msgstr "Builtin Effects"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Provides builtin effects to Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -8497,8 +8526,9 @@ msgid "Step 1"
 msgstr "Step 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Select a few seconds of just noise so Tenacity knows what to filter out,\n"
@@ -8602,7 +8632,8 @@ msgstr "16384"
 msgid "S&teps per window:"
 msgstr "S&teps per window:"
 
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
 msgid "2"
 msgstr "2"
 
@@ -8730,6 +8761,7 @@ msgstr "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "&Stretch Factor:"
@@ -9352,7 +9384,8 @@ msgid "VST Effects"
 msgstr "VST Effects"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Adds the ability to use VST effects in Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9364,7 +9397,8 @@ msgstr "Scanning Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registering %d of %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Could not load the library"
 
@@ -9384,7 +9418,8 @@ msgstr "The buffer size controls the number of samples sent to the effect on eac
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Buffer Size (8 to 1048576 samples):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Latency Compensation"
 
@@ -9392,7 +9427,8 @@ msgstr "Latency Compensation"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "As part of their processing, some VST effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Enable &compensation"
 
@@ -9426,7 +9462,8 @@ msgid "Standard VST program file"
 msgstr "Standard VST program file"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Tenacity VST preset file"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9453,7 +9490,8 @@ msgstr "Error Loading VST Presets"
 msgid "Unable to load presets file."
 msgstr "Unable to load presets file."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Effect Settings"
 
@@ -9510,7 +9548,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio Unit Effects"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Provides Audio Unit Effects support to Tenacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9526,7 +9565,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio Unit Effect Options"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9670,6 +9710,7 @@ msgstr "Audio Unit"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA Effects"
@@ -9679,7 +9720,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Provides LADSPA Effects"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity no longer uses vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9687,12 +9729,15 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA Effect Options"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s:"
@@ -9703,6 +9748,7 @@ msgstr "Effect Output"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "LADSPA"
@@ -9717,7 +9763,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Buffer Size (8 to %d) samples:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9753,7 +9800,8 @@ msgid "LV2 Effects"
 msgstr "LV2 Effects"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Provides LV2 Effects support to Tenacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9761,7 +9809,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist Effects"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Provides Nyquist Effects support to Tenacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9989,7 +10038,8 @@ msgstr "Select a file"
 msgid "Save file as"
 msgstr "Save file as"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "untitled"
 
@@ -9998,7 +10048,8 @@ msgid "Vamp Effects"
 msgstr "Vamp Effects"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Provides Vamp Effects support to Tenacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -10326,7 +10377,8 @@ msgstr "Exporting the audio as %s"
 msgid "Invalid sample rate"
 msgstr "Invalid sample rate"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Resample"
 
@@ -10358,7 +10410,8 @@ msgstr "Sample Rates"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbps"
@@ -11117,7 +11170,8 @@ msgstr "Insane"
 msgid "Extreme"
 msgstr "Extreme"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standard"
 
@@ -11168,8 +11222,8 @@ msgid "Locate LAME"
 msgstr "Locate LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity needs the file %s to create MP3s."
 
 #: src/export/ExportMP3.cpp
@@ -11197,10 +11251,10 @@ msgid "Where is %s?"
 msgstr "Where is %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
 "Please download the latest version of 'LAME for Tenacity'."
@@ -11526,9 +11580,10 @@ msgid "Other uncompressed files"
 msgstr "Other uncompressed files"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
 "Tenacity cannot do this, the Export was abandoned."
@@ -11538,8 +11593,9 @@ msgid "Error Exporting"
 msgstr "Error Exporting"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
@@ -11579,11 +11635,11 @@ msgid "All supported files"
 msgstr "All supported files"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -11592,11 +11648,11 @@ msgstr ""
 "edit it by clicking File > Import > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "is a not an audio file. \n"
@@ -11607,18 +11663,18 @@ msgid "Select stream(s) to import"
 msgstr "Select stream(s) to import"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "This version of Tenacity was not compiled with %s support."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is an audio CD track. \n"
 "Tenacity cannot open audio CDs directly. \n"
@@ -11627,10 +11683,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" is a playlist file. \n"
@@ -11639,10 +11695,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is a Windows Media Audio file. \n"
@@ -11651,10 +11707,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is an Advanced Audio Coding file.\n"
@@ -11663,12 +11719,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" is an encrypted audio file. \n"
@@ -11679,10 +11735,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is a RealPlayer media file. \n"
@@ -11691,12 +11747,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" is a notes-based file, not an audio file. \n"
 "Tenacity cannot open this type of file. \n"
@@ -11705,10 +11761,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11721,10 +11777,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is a Wavpack audio file. \n"
@@ -11733,10 +11789,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is a Dolby Digital audio file. \n"
@@ -11745,10 +11801,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is an Ogg Speex audio file. \n"
@@ -11757,10 +11813,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is a video file. \n"
@@ -11774,9 +11830,9 @@ msgstr "File \"%s\" not found."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11799,9 +11855,9 @@ msgstr "%s, %s"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11831,12 +11887,13 @@ msgid "Import Project"
 msgstr "Import Project"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "This project was saved by Tenacity version 1.0 or earlier. The format has\n"
 "changed and this version of Tenacity is unable to import the project.\n"
@@ -11887,7 +11944,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Couldn't find the project data folder: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 
 #: src/import/ImportAUP.cpp
@@ -11991,40 +12049,6 @@ msgstr "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC files"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-compatible files"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Unable to add decoder to pipeline"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer Importer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Unable to set stream state to paused."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "File doesn't contain any audio streams."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Unable to import file, state change failed."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer Error: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -12437,6 +12461,7 @@ msgstr "%s right"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -12460,6 +12485,7 @@ msgstr "end"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -12486,7 +12512,8 @@ msgstr "Time shifted clips to the right"
 msgid "Time shifted clips to the left"
 msgstr "Time shifted clips to the left"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Time-Shift"
 
@@ -12624,7 +12651,8 @@ msgstr "Trim selected audio tracks from %.2f seconds to %.2f seconds"
 msgid "Trim Audio"
 msgstr "Trim Audio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Split"
 
@@ -12747,34 +12775,6 @@ msgstr "Delete Key&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "Ext&ra"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mi&xer"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Ad&just Playback Volume..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Increase Playback Volume"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Decrease Playback Volume"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Adj&ust Recording Volume..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "I&ncrease Recording Volume"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "D&ecrease Recording Volume"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -13042,8 +13042,9 @@ msgid "&Getting Started"
 msgstr "&Getting Started"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Tenacity &Manual"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manual..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -13069,11 +13070,8 @@ msgstr "&MIDI Device Info..."
 msgid "Show &Log..."
 msgstr "Show &Log..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&About Tenacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Added label"
 
@@ -13763,6 +13761,7 @@ msgstr "Cursor Long Ju&mp Right"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "See&k"
@@ -13974,18 +13973,21 @@ msgid "Created new label track"
 msgstr "Created new label track"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "This version of Tenacity only allows one time track for each project window."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Created new time track"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "New sample rate (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "The entered value is invalid"
 
@@ -14242,7 +14244,9 @@ msgstr "Playing"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Recording"
 
@@ -14391,10 +14395,6 @@ msgstr "&Overdub (on/off)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "So&ftware Playthrough (on/off)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomated Recording Level Adjustment (on/off)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -14609,7 +14609,8 @@ msgid "Preferences for Application"
 msgstr "Preferences for Application"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Update Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -14655,7 +14656,8 @@ msgstr "&Host:"
 msgid "Using:"
 msgstr "Using:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Playback"
 
@@ -14675,7 +14677,8 @@ msgstr "Cha&nnels:"
 msgid "Latency"
 msgstr "Latency"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milliseconds"
 
@@ -14704,7 +14707,8 @@ msgid "2 (Stereo)"
 msgstr "2 (Stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Directories"
 
@@ -14812,7 +14816,8 @@ msgid "Directory %s is not writable"
 msgstr "Directory %s is not writable"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Changes to temporary directory will not take effect until Tenacity is restarted"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14845,6 +14850,7 @@ msgstr "Grouped by Type"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&LADSPA"
@@ -14896,11 +14902,13 @@ msgid "Plugin Options"
 msgstr "Plugin Options"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Check for updated plugins when Tenacity starts"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Rescan plugins next time Tenacity is started"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -15080,7 +15088,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Re&tain labels if selection snaps to a label"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "B&lend system and Tenacity theme"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -15258,7 +15267,8 @@ msgstr ""
 "   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Select an XML file containing Tenacity keyboard shortcuts..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -15391,8 +15401,9 @@ msgid "Dow&nload"
 msgstr "Dow&nload"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity has automatically detected valid FFmpeg libraries.\n"
@@ -15451,8 +15462,9 @@ msgid "Preferences for Module"
 msgstr "Preferences for Module"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
@@ -15460,12 +15472,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'Failed' means Tenacity thinks the module is broken and won't run it."
 
 #. i18n-hint preserve the leading spaces
@@ -15474,7 +15488,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'New' means no choice has been made yet."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Changes to these settings only take effect when Tenacity starts up."
 
 #: src/prefs/ModulePrefs.cpp
@@ -15537,7 +15552,10 @@ msgstr "Left-Drag"
 msgid "Set Selection Range"
 msgstr "Set Selection Range"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-Left-Click"
 
@@ -15624,6 +15642,15 @@ msgstr "-Left-Drag"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Move clip up/down between tracks"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Left-Drag"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -15748,7 +15775,8 @@ msgid "Always scrub un&pinned"
 msgstr "Always scrub un&pinned"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Tenacity Preferences"
 
 #: src/prefs/PrefsDialog.cpp
@@ -15884,39 +15912,6 @@ msgstr "System &Date"
 #: src/prefs/RecordingPrefs.cpp
 msgid "System T&ime"
 msgstr "System T&ime"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automated Recording Level Adjustment"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Enable Automated Recording Level Adjustment."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Target Peak:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Within:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Analysis Time:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milliseconds (time of one analysis)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Number of consecutive analysis:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 means endless"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
@@ -16179,13 +16174,14 @@ msgid "Info"
 msgstr "Info"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -16368,7 +16364,8 @@ msgstr "Samples"
 msgid "4 Pixels per Sample"
 msgstr "4 Pixels per Sample"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Max Zoom"
 
@@ -16490,16 +16487,24 @@ msgid "Stopped"
 msgstr "Stopped"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pause"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Skip to Start"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Skip to End"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pause"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Select to Start"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Select to End"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -16512,14 +16517,6 @@ msgstr "Record New Track"
 #: src/toolbars/ControlToolBar.cpp
 msgid "Append Record"
 msgstr "Append Record"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Select to End"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Select to Start"
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
@@ -16611,11 +16608,17 @@ msgstr "Silence audio selection"
 msgid "Sync-Lock Tracks"
 msgstr "Sync-Lock Tracks"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zoom In"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zoom Out"
 
@@ -16682,43 +16685,6 @@ msgstr "&Recording Meter Toolbar"
 msgid "&Playback Meter Toolbar"
 msgstr "&Playback Meter Toolbar"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Recording Volume"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Playback Volume"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Recording Volume: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Recording Volume (Unavailable; use system mixer.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Playback Volume: %.2f (emulated)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Playback Volume: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Playback Volume (Unavailable; use system mixer.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Mi&xer Toolbar"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Seek"
@@ -16734,6 +16700,7 @@ msgstr "Scrubbing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Stop Scrubbing"
@@ -16741,6 +16708,7 @@ msgstr "Stop Scrubbing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Start Scrubbing"
@@ -16748,6 +16716,7 @@ msgstr "Start Scrubbing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Stop Seeking"
@@ -16755,6 +16724,7 @@ msgstr "Stop Seeking"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Start Seeking"
@@ -16809,7 +16779,9 @@ msgstr "Snap To"
 msgid "Length"
 msgstr "Length"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Center"
 
@@ -16873,8 +16845,8 @@ msgstr "&Time Toolbar"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Tenacity %s Toolbar"
 
 #: src/toolbars/ToolBar.cpp
@@ -16901,7 +16873,8 @@ msgstr "Time Shift Tool"
 msgid "Zoom Tool"
 msgstr "Zoom Tool"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Draw Tool"
 
@@ -16977,11 +16950,13 @@ msgstr "Drag one or more label boundaries."
 msgid "Drag label boundary."
 msgstr "Drag label boundary."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Modified Label"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Label Edit"
 
@@ -17036,31 +17011,42 @@ msgstr "Edited labels"
 msgid "New label"
 msgstr "New label"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Up &Octave"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Down Octa&ve"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Right-click for menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zoom Reset"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-Right-Click"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Left-Click/Left-Drag"
 
@@ -17102,7 +17088,8 @@ msgstr "Merge"
 msgid "Expanded Cut Line"
 msgstr "Expanded Cut Line"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expand"
 
@@ -17175,7 +17162,8 @@ msgstr "Processing...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Changed '%s' to %s"
@@ -17254,7 +17242,8 @@ msgstr "Rate Change"
 msgid "Set Rate"
 msgstr "Set Rate"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Multi-view"
 
@@ -17347,19 +17336,22 @@ msgid "Right, %dHz"
 msgstr "Right, %dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%+.1f dB"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Left"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Right"
@@ -17477,8 +17469,8 @@ msgstr "Logarithmic &Interpolation"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Click and drag to adjust, double-click to reset"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -17529,6 +17521,7 @@ msgstr "Adjusted envelope."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Scrub"
@@ -17540,6 +17533,7 @@ msgstr "Seeking"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Scrub &Ruler"
@@ -17999,6 +17993,7 @@ msgstr "0100 h 060 m 060 s+># samples"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "samples"
@@ -18398,19 +18393,27 @@ msgstr "Could not parse XML"
 msgid "Spectral edit multi tool"
 msgstr "Spectral edit multi tool"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtering..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Paul Licameli"
 msgstr "Paul Licameli"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Released under terms of the GNU General Public License version 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aPlease select frequencies."
@@ -18437,7 +18440,8 @@ msgstr ""
 "                      Try increasing the low frequency bound~%~\n"
 "                      or reduce the filter 'Width'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Error.~%"
@@ -18499,9 +18503,23 @@ msgstr "Studio Fade Out"
 msgid "Applying Fade..."
 msgstr "Applying Fade..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Released under terms of the GNU General Public License version 2 or later."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -18645,6 +18663,10 @@ msgstr "Beat Finder"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Finding beats..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18973,7 +18995,8 @@ msgstr "Performing High-Pass Filter..."
 msgid "Dominic Mazzoni"
 msgstr "Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequency (Hz)"
 
@@ -19020,10 +19043,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Label Sounds"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Released under terms of the GNU General Public License version 2 or later."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -19323,7 +19342,8 @@ msgstr "Lisp file"
 msgid "HTML file"
 msgstr "HTML file"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Text file"
 
@@ -20152,6 +20172,233 @@ msgstr "Frequency of Radar Needles (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Error.~%Stereo track required."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Update Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Skip"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Install update"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Changelog"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Read more on GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Error checking for update"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Unable to connect to Tenacity update server."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Update data was corrupted."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Error downloading update."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Can't open the Tenacity download link."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s is available!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Record"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Commit Id:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Cross-platform GUI library"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Import via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automated Recording Level Adjustment decreased the volume to %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automated Recording Level Adjustment increased the volume to %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Received %d while opening devices\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Unable to open Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Available mixers:\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Available recording sources:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Available playback volumes:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Recording volume is emulated\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Recording volume is native\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Playback volume is emulated\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Playback volume is native\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Unknown date and time"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-compatible files"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Unable to add decoder to pipeline"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer Importer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Unable to set stream state to paused."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "File doesn't contain any audio streams."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Unable to import file, state change failed."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer Error: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mi&xer"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Ad&just Playback Volume..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Increase Playback Volume"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Decrease Playback Volume"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Adj&ust Recording Volume..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "I&ncrease Recording Volume"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "D&ecrease Recording Volume"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Tenacity &Manual"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&About Tenacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomated Recording Level Adjustment (on/off)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automated Recording Level Adjustment"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Enable Automated Recording Level Adjustment."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Target Peak:"
+
+#~ msgid "Within:"
+#~ msgstr "Within:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Analysis Time:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milliseconds (time of one analysis)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Number of consecutive analysis:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 means endless"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Recording Volume"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Playback Volume"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Recording Volume: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Recording Volume (Unavailable; use system mixer.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Playback Volume: %.2f (emulated)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Playback Volume: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Playback Volume (Unavailable; use system mixer.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Mi&xer Toolbar"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Click and drag to adjust, double-click to reset"
 
 #~ msgid "Program build date:"
 #~ msgstr "Program build date:"

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-07 18:56+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/tenacity/tenacity/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,81 +18,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Actualizar Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Saltar"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Instalar actualización"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Cambios de la versión"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Más información en GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Error al buscar actualizaciones"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "No se pudo conectar con el servidor de actualizaciones de Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Los datos de actualización estaban dañados."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Error al descargar la actualización."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "No se puede abrir el enlace de descarga de Tenacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s está disponible."
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Grabación"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "No se puede determinar"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr "%s bytes"
 
 #. i18n-hint: Abbreviation for Kilo bytes
 #: libraries/lib-strings/Internat.cpp
 #, c-format
 msgid "%s KB"
 msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -215,8 +165,13 @@ msgstr "&Detener\tF6"
 msgid "&About"
 msgstr "&Acerca de"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script"
+msgstr "Secuencia de órdenes"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Salida"
 
@@ -232,7 +187,12 @@ msgstr "Secuencia Nyquist (*.ny)|*.ny|Secuencia Lisp (*.lsp)|*.lsp|Todos los arc
 msgid "Script was not saved."
 msgstr "No se guardó la secuencia."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Advertencia"
 
@@ -245,15 +205,24 @@ msgid "Find dialog"
 msgstr "Cuadro de diálogo de búsqueda"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr "Harvey Lubin (logotipo)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galería de iconos Tango (iconos de la barra de herramientas)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "© 2009 de Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Módulo externo de Tenacity que proporciona un EID sencillo para crear efectos."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -276,7 +245,8 @@ msgstr "Sin nombre"
 msgid "Nyquist Effect Workbench - "
 msgstr "Mesa de trabajo de efectos Nyquist -"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nuevo"
 
@@ -316,7 +286,8 @@ msgstr "Copiar"
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Cortar"
 
@@ -324,7 +295,8 @@ msgstr "Cortar"
 msgid "Cut to clipboard"
 msgstr "Cortar al portapapeles"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Pegar"
 
@@ -349,7 +321,8 @@ msgstr "Seleccionar todo"
 msgid "Select all text"
 msgstr "Seleccionar todo el texto"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Deshacer"
 
@@ -357,7 +330,8 @@ msgstr "Deshacer"
 msgid "Undo last change"
 msgstr "Deshacer el último cambio"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Rehacer"
 
@@ -414,7 +388,8 @@ msgid "Go to next S-expr"
 msgstr "Ir a la S-expr siguiente"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Comentar"
 
@@ -422,7 +397,8 @@ msgstr "Comentar"
 msgid "Start script"
 msgstr "Comenzar secuencia"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Detener"
 
@@ -437,7 +413,8 @@ msgid "About %s"
 msgstr "Acerca de %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Aceptar"
 
@@ -445,11 +422,13 @@ msgstr "Aceptar"
 msgid "Build Information"
 msgstr "Información de compilación"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Activado"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Desactivado"
 
@@ -459,8 +438,9 @@ msgid "The Build"
 msgstr "Compilación"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Id. de consigna:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versión"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -470,22 +450,28 @@ msgstr "Tipo de compilación:"
 msgid "Compiler:"
 msgstr "Compilador:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefijo de instalación:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Carpeta de configuración:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Carpeta de configuración:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Formatos de archivo compatibles"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Biblioteca de interfaz gráfica multiplataforma"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -499,7 +485,6 @@ msgstr "Conversión de frecuencia de muestreo"
 msgid "MP3 Importing"
 msgstr "Importación de MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importación y exportación de Ogg Vorbis"
@@ -508,7 +493,6 @@ msgstr "Importación y exportación de Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Compatibilidad con etiquetas ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importación y exportación de FLAC"
@@ -526,14 +510,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importación/exportación FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importación mediante GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Características"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Compatibilidad de complementos"
 
@@ -548,6 +524,10 @@ msgstr "Compatibilidad con cambio de tono y ritmo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Compatibilidad con cambio extremo de tono y ritmo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Características"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -666,16 +646,22 @@ msgstr "%s, diseño gráfico de Audacity"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (incorporando %s, %s, %s, %s y %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Programa libre, de código abierto y multiplataforma para la grabación y "
-"edición de sonido."
+msgstr "Programa libre, de código abierto y multiplataforma para la grabación y edición de sonido."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Créditos"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Observe que los nombres se enumeran en orden alfabético, no por importancia."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -724,6 +710,7 @@ msgstr "Sitio web y diseño gráfico de Audacity"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Traducción al español por Antonio Paniagua Navarro y Adolfo Jayme Barrientos."
@@ -741,6 +728,22 @@ msgstr "Agradecimientos especiales de Audacity:"
 #, c-format
 msgid "%s website: "
 msgstr "Sitio web de %s: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s de los contribuidores de %s"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "La marca registrada Audacity%s se utiliza en este programa únicamente para fines descriptivos e informativos."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Ni MuseCY SM Ltd. ni Dominic M. Mazzoni producen ni avalan Tenacity."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -763,6 +766,7 @@ msgstr "Línea de tiempo"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Pulse y arrastre para comenzar a buscar"
@@ -770,6 +774,7 @@ msgstr "Pulse y arrastre para comenzar a buscar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Haga clic y arrastre para comenzar la reproducción por desplazamiento"
@@ -777,6 +782,7 @@ msgstr "Haga clic y arrastre para comenzar la reproducción por desplazamiento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Clic y mover para reproducción por desplazamiento. Clic y arrastrar para buscar."
@@ -784,6 +790,7 @@ msgstr "Clic y mover para reproducción por desplazamiento. Clic y arrastrar par
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Mover para buscar"
@@ -791,6 +798,7 @@ msgstr "Mover para buscar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Mover para reproducir por desplazamiento"
@@ -847,6 +855,20 @@ msgstr ""
 "No se puede bloquear la región más allá del\n"
 "final del proyecto."
 
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Error"
+msgstr "Error"
+
 #: src/AudacityApp.cpp
 #, c-format
 msgid "Failed to remove %s"
@@ -867,7 +889,8 @@ msgstr ""
 "Esto solo se preguntará esta vez, después de una instalación en la que se indicó que se restableciesen las preferencias."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Restablecer preferencias de Tenacity"
 
 #: src/AudacityApp.cpp
@@ -882,7 +905,8 @@ msgstr ""
 "Ha sido eliminado de la lista de archivos recientes."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "No se pudo inicializar la biblioteca SQLite. Tenacity no puede continuar."
 
 #: src/AudacityApp.cpp
@@ -907,7 +931,7 @@ msgstr "&Abrir..."
 msgid "Open &Recent..."
 msgstr "Abrir &reciente..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&Acerca de Tenacity…"
 
@@ -920,9 +944,10 @@ msgid "&File"
 msgstr "&Archivo"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity no pudo encontrar un lugar donde almacenar los archivos temporales.\n"
@@ -930,20 +955,23 @@ msgstr ""
 "Indique una carpeta apropiada en el cuadro de diálogo de preferencias."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity no pudo encontrar un lugar donde almacenar los archivos temporales.\n"
 "Indique una carpeta apropiada en el cuadro de diálogo de preferencias."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Tenacity se cerrará ahora. Inicie Tenacity otra vez para utilizar la carpeta temporal nueva."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -952,15 +980,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity no pudo bloquear el directorio de archivos temporales.\n"
 "Puede que otra copia de Tenacity esté utilizando esta carpeta.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "¿Aún quiere iniciar Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -968,19 +998,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Error al bloquear la carpeta temporal"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "El sistema detectó que ya se está ejecutando otra copia de Tenacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Utilice la opción Nuevo o Abrir en la copia de Tenacity que ya se está \n"
 "ejecutando para abrir múltiples proyectos simultáneamente.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity ya se está ejecutando"
 
 #: src/AudacityApp.cpp
@@ -996,7 +1029,8 @@ msgstr ""
 "que requiere un reinicio."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Fallo en el arranque de Tenacity"
 
 #: src/AudacityApp.cpp
@@ -1036,8 +1070,9 @@ msgstr ""
 "que requiere un reinicio."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1069,7 +1104,8 @@ msgstr "ejecutar diagnósticos internos"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "mostrar la versión de Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1079,9 +1115,10 @@ msgid "audio or project file name"
 msgstr "audio o nombre del archivo de proyecto"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1094,16 +1131,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Archivos de proyecto de Tenacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Mensaje"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Error en la configuración de Tenacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1113,28 +1152,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "No se pudo acceder a este archivo de configuración:\n"
 "\n"
 "\t%s\n"
 "\n"
-"Este error se puede producir por varios motivos, pero el más habitual es que "
-"el disco esté lleno o que no tenga permiso de escritura. Puede obtener más "
-"información pulsando en el botón Ayuda.\n"
+"Este error se puede producir por varios motivos, pero el más habitual es que el disco esté lleno o que no tenga permiso de escritura. Puede obtener más información pulsando en el botón Ayuda.\n"
 "\n"
-"Puede intentar corregir el problema y pulsar en «Reintentar» para continuar."
+"Puede intentar corregir el problema y pulsar en «Reintentar» para continuar.\n"
 "\n"
-"\n"
-"Si pulsa en «Cerrar Tenacity» el proyecto puede quedar en un estado no "
-"guardado, en cuyo caso se intentará recuperar la próxima vez que se abra."
+"Si pulsa en «Cerrar Tenacity» el proyecto puede quedar en un estado no guardado, en cuyo caso se intentará recuperar la próxima vez que se abra."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Ayuda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Salir de Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1142,7 +1180,8 @@ msgid "&Retry"
 msgstr "&Reintentar"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Registro de Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1154,9 +1193,14 @@ msgstr "&Guardar..."
 msgid "Cl&ear"
 msgstr "L&impiar"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Cerrar"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr "registro.txt"
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1180,6 +1224,11 @@ msgstr ""
 "\n"
 
 #: src/AudioIO.cpp
+#, c-format
+msgid "Error: %s"
+msgstr "Error: %s"
+
+#: src/AudioIO.cpp
 msgid "Error Initializing Audio"
 msgstr "Error al inicializar el audio"
 
@@ -1200,7 +1249,8 @@ msgid "Error Initializing Midi"
 msgstr "Error al inicializar el audio Midi"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audio de Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1215,37 +1265,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Se agotó la memoria"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es demasiado alto."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Autoajuste de nivel de grabación ha reducido el volumen a %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es demasiado bajo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Autoajuste de nivel de grabación ha incrementado el volumen a %2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Autoajuste de nivel de grabación detenido. Se ha excedido el número total de análisis sin encontrar un volumen aceptable. Aún es demasiado alto."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Autoajuste de nivel de grabación detenido. Se ha excedido el número total de análisis sin encontrar un volumen aceptable. Aún es demasiado bajo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Autoajuste de nivel de grabación detenido. %.2f parece ser un volumen aceptable."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1344,43 +1363,6 @@ msgstr "No se encontró ningún dispositivo de reproducción para «%s».\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "No se puede comprobar las frecuencias de muestreo sin los dos dispositivos.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Se han recibido %d abriendo los dispositivos\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "No se ha podido abrir Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Mezcladores disponibles:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Fuentes de grabación disponibles:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volúmenes de reproducción disponibles:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "El volumen de grabación es emulado\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "El volumen de grabación es nativo\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "El volumen de reproducción es emulado\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "El volumen de reproducción es nativo\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1423,28 +1405,29 @@ msgid "Automatic Crash Recovery"
 msgstr "Recuperación automática de cierres inesperados"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
-"Algunos proyectos no se guardaron correctamente la última vez que se ejecutó "
-"Tenacity y pueden recuperarse automáticamente.\n"
+"Algunos proyectos no se guardaron correctamente la última vez que se ejecutó Tenacity y pueden recuperarse automáticamente.\n"
 "\n"
-"Tras la recuperación, guarde los proyectos para asegurar que los cambios "
-"queden almacenados."
+"Tras la recuperación, guarde los proyectos para asegurar que los cambios queden almacenados."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "&Proyectos recuperables"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Seleccionar"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nombre"
 
@@ -1531,6 +1514,11 @@ msgstr "Efecto"
 msgid "Menu Command (With Parameters)"
 msgstr "Menú Orden (con parámetros)"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
 msgstr "Menú Orden (sin parámetros)"
@@ -1599,6 +1587,12 @@ msgstr "Gestionar macros"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Seleccionar macro"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Macros…"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
@@ -1670,13 +1664,19 @@ msgstr "Re&staurar"
 msgid "I&mport..."
 msgstr "I&mportar…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xportar..."
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Editar pasos"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1706,7 +1706,8 @@ msgstr "D&esplazar hacia arriba"
 msgid "Move &Down"
 msgstr "&Desplazar hacia abajo"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Guardar"
 
@@ -1789,9 +1790,16 @@ msgid "Run"
 msgstr "Ejecutar"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Cerrar"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "bancodepruebas.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1929,10 +1937,6 @@ msgid "No revision identifier was provided"
 msgstr "No hay ningún identificador de revisión"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Fecha y hora desconocidas"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Generación de depuración (nivel de depuración %d)"
@@ -1941,6 +1945,11 @@ msgstr "Generación de depuración (nivel de depuración %d)"
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Generación de distribución (nivel de depuración %d)"
+
+#: src/BuildInfo.h
+#, fuzzy
+msgid ", 64 bits"
+msgstr "24 bits"
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -2014,6 +2023,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "No se ha podido establecer el modo seguro en la conexión primaria a %s"
 
@@ -2049,8 +2063,7 @@ msgid ""
 msgstr ""
 "El disco está lleno.\n"
 "%s\n"
-"Pulse en el botón Ayuda para obtener recomendaciones sobre cómo liberar "
-"espacio."
+"Pulse en el botón Ayuda para obtener recomendaciones sobre cómo liberar espacio."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2187,10 +2200,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "El proyecto no se guardará en el disco. ¿Es esto lo que desea hacer?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2203,7 +2217,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Comprobación de dependencias"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ninguno"
 
@@ -2211,13 +2228,47 @@ msgstr "Ninguno"
 msgid "Rectangle"
 msgstr "Rectángulo"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triángulo"
 
 #: src/Dither.cpp
 msgid "Shaped"
 msgstr "Perfilado"
+
+#: src/FFT.cpp
+msgid "Rectangular"
+msgstr "Rectangular"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2239,9 +2290,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "La compatibilidad con FFmpeg no ha sido incluida en la compilación"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2262,11 +2314,9 @@ msgid "Locate FFmpeg"
 msgstr "Localizar FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"Tenacity necesita el archivo «%s» para importar y exportar audio mediante "
-"FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "Tenacity necesita el archivo «%s» para importar y exportar audio mediante FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2278,7 +2328,8 @@ msgstr "Ubicación de «%s»:"
 msgid "To find '%s', click here -->"
 msgstr "Para encontrar «%s», pulse aquí →"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Explorar..."
 
@@ -2304,8 +2355,9 @@ msgid "FFmpeg not found"
 msgstr "No se encontró FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2335,33 +2387,30 @@ msgid "Only libavformat.so"
 msgstr "Solo libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity no pudo abrir un archivo en %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity no pudo leer de un archivo en %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
-msgstr ""
-"Tenacity escribió correctamente un archivo en %s pero no pudo cambiarle el "
-"nombre a %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr "Tenacity escribió correctamente un archivo en %s pero no pudo cambiarle el nombre a %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
 "Tenacity no pudo escribir en un archivo.\n"
 "Tal vez %s no se pueda escribir o el disco esté lleno.\n"
-"Pulse en el botón Ayuda para obtener recomendaciones sobre cómo liberar "
-"espacio."
+"Pulse en el botón Ayuda para obtener recomendaciones sobre cómo liberar espacio."
 
 #: src/FileException.h
 msgid "File Error"
@@ -2393,7 +2442,9 @@ msgstr "&No copiar ninguna parte del audio"
 msgid "As&k"
 msgstr "&Preguntar"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Todos los archivos"
 
@@ -2418,6 +2469,10 @@ msgstr "Archivos de texto"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Archivos XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2459,6 +2514,14 @@ msgstr "Autocorrelación de raíz cúbica"
 msgid "Enhanced Autocorrelation"
 msgstr "Autocorrelación mejorada"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Espectro"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2475,6 +2538,17 @@ msgstr "Frecuencia lineal"
 msgid "Log frequency"
 msgstr "Frecuencia logarítmica"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Desplazamiento"
@@ -2483,6 +2557,15 @@ msgstr "Desplazamiento"
 msgid "Zoom"
 msgstr "Ampliar"
 
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
+
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
 msgstr "Dividir &horizontalmente"
@@ -2490,6 +2573,11 @@ msgstr "Dividir &horizontalmente"
 #: src/FreqWindow.cpp
 msgid "Zoom Horizontal"
 msgstr "Dividir &horizontalmente"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cursor:"
+msgstr "&Cursor a"
 
 #: src/FreqWindow.cpp
 msgid "Peak:"
@@ -2530,13 +2618,28 @@ msgstr "Para analizar el espectro, todas las pistas seleccionadas deberán tener
 #: src/FreqWindow.cpp
 #, c-format
 msgid "Too much audio was selected. Only the first %.1f seconds of audio will be analyzed."
-msgstr ""
-"Se ha seleccionado demasiado audio. Solo los primeros %.1f segundos de audio "
-"se analizarán."
+msgstr "Se ha seleccionado demasiado audio. Solo los primeros %.1f segundos de audio se analizarán."
 
 #: src/FreqWindow.cpp
 msgid "Not enough data selected."
 msgstr "No hay suficientes datos seleccionados."
+
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f seg. (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f seg. (%d Hz) (%s) = %.3f"
 
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
@@ -2560,7 +2663,8 @@ msgstr "espectro.txt"
 msgid "Export Spectral Data As:"
 msgstr "Exportar datos del espectro como:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "No se ha podido escribir en el archivo: %s"
@@ -2637,15 +2741,11 @@ msgstr "No hay ayuda local"
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
-msgstr ""
-"<br><br>La versión de Tenacity que utiliza es una <b>versión alfa para "
-"pruebas</b>."
+msgstr "<br><br>La versión de Tenacity que utiliza es una <b>versión alfa para pruebas</b>."
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
-msgstr ""
-"<br><br>La versión de Tenacity que utiliza es una <b>versión beta para "
-"pruebas</b>."
+msgstr "<br><br>La versión de Tenacity que utiliza es una <b>versión beta para pruebas</b>."
 
 #: src/HelpText.cpp
 msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
@@ -2679,9 +2779,7 @@ msgstr " Foro. Formule su pregunta directamente, en internet."
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"Más:</b> visite nuestro wiki para obtener trucos, consejos, tutoriales y "
-"complementos de efectos."
+msgstr "Más:</b> visite nuestro wiki para obtener trucos, consejos, tutoriales y complementos de efectos."
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
@@ -2756,19 +2854,19 @@ msgid "&History..."
 msgstr "&Historial…"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Error interno en %s, en %s renglón %d.\n"
 "Informe al equipo de Tenacity en https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Error interno en %s, renglón %d.\n"
 "Informe al equipo de Tenacity en https://tenacityaudio.org/."
@@ -2787,7 +2885,9 @@ msgid "Track"
 msgstr "Pista"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -2847,7 +2947,8 @@ msgstr "Introduzca el nombre de la pista"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Pista de etiqueta"
 
@@ -2858,11 +2959,13 @@ msgstr "Una o más etiquetas guardadas no pueden ser leídas."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Primera ejecución de Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Seleccione el idioma que desea utilizar:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2872,7 +2975,8 @@ msgstr "Seleccione el idioma que desea utilizar:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "El idioma que ha elegido, %s (%s), no es el predeterminado del sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -2890,13 +2994,18 @@ msgstr ""
 "El archivo antiguo se guardó como «%s»"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Abriendo proyecto de Tenacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke de Tenacity%s"
+
+#: src/LyricsWindow.cpp
+msgid "&Karaoke..."
+msgstr "&Karaoke…"
 
 #: src/Menus.cpp
 #, c-format
@@ -2942,19 +3051,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mezclando y generando pistas"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Panel mezclador de Audacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Ganancia"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocidad"
 
@@ -2963,28 +3076,43 @@ msgid "Musical Instrument"
 msgstr "Instrumento musical"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panorama"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Silencio"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo establecido"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Medidor de nivel de señal"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Desplazado el control de ganancia"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Desplazado el control de velocidad"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Desplazado el control de panorámica"
 
@@ -3019,9 +3147,9 @@ msgstr ""
 "No se cargará."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3055,12 +3183,19 @@ msgstr ""
 "\n"
 "Utilice solo módulos de fuentes confiables"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Sí"
 
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
+msgid "No"
+msgstr "No"
+
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Cargador de módulos de Tenacity"
 
 #: src/ModuleManager.cpp
@@ -3239,8 +3374,7 @@ msgstr "Gestionar complementos"
 
 #: src/PluginRegistrationDialog.cpp
 msgid "Select effects, click the Enable or Disable button, then click OK."
-msgstr ""
-"Seleccione efectos, pulse en Activar o Desactivar y confirme con Aceptar."
+msgstr "Seleccione efectos, pulse en Activar o Desactivar y confirme con Aceptar."
 
 #. i18n-hint: This is before radio buttons selecting which effects to show
 #: src/PluginRegistrationDialog.cpp
@@ -3303,7 +3437,8 @@ msgstr "&Seleccionar todo"
 msgid "C&lear All"
 msgstr "&Limpiar todo"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "A&ctivar"
 
@@ -3384,9 +3519,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Discordancia en la frecuencia de muestras"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "No se han seleccionado pistas suficientes para grabar con esta frecuencia de muestra.\n"
@@ -3415,10 +3551,11 @@ msgid "Dropouts"
 msgstr "Pérdidas"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3458,11 +3595,11 @@ msgid "Inspecting project file data"
 msgstr "Inspeccionando los datos de archivos del proyecto"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3505,11 +3642,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Atención: faltan archivos con alias"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "La comprobación del proyecto en la carpeta «%s»\n"
@@ -3534,12 +3671,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Atención: faltan archivos de resumen de alias"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3595,7 +3732,8 @@ msgstr "Atención: archivos de bloque huérfanos"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progreso"
 
@@ -3609,8 +3747,7 @@ msgid ""
 "\n"
 "Select 'Help > Diagnostics > Show Log...' to see details."
 msgstr ""
-"La comprobación del proyecto encontró incoherencias de archivos al efectuar "
-"la recuperación automática.\n"
+"La comprobación del proyecto encontró incoherencias de archivos al efectuar la recuperación automática.\n"
 "\n"
 "Para obtener detalles, seleccione Ayuda ▸ Diagnósticos ▸ Mostrar registro."
 
@@ -3621,6 +3758,11 @@ msgstr "Atención: problemas en la recuperación automática"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<proyecto sin nombre>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Proyecto %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3690,12 +3832,14 @@ msgstr ""
 "(no se pueden crear los archivos temporales necesarios)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Esto no es un archivo de proyecto de Tenacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3710,9 +3854,7 @@ msgstr "No se puede inicializar el archivo de proyecto"
 #. i18n-hint: An error message.  Don't translate inset or blockids.
 #: src/ProjectFileIO.cpp
 msgid "Unable to add 'inset' function (can't verify blockids)"
-msgstr ""
-"No se pudo añadir la función «inset» (no se pueden verificar los "
-"identificadores de bloque)"
+msgstr "No se pudo añadir la función «inset» (no se pueden verificar los identificadores de bloque)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: src/ProjectFileIO.cpp
@@ -3829,20 +3971,32 @@ msgid "Error Writing to File"
 msgstr "Error al escribir el archivo"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
 "Tenacity no pudo escribir en el archivo %s.\n"
 "Tal vez el disco esté lleno o protegido contra escritura.\n"
-"Pulse en el botón Ayuda para obtener recomendaciones sobre cómo liberar "
-"espacio."
+"Pulse en el botón Ayuda para obtener recomendaciones sobre cómo liberar espacio."
 
 #: src/ProjectFileIO.cpp
 msgid "Compacting project"
 msgstr "Compactando proyecto"
+
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr "[Proyecto %02i] Tenacity «%s»"
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3851,14 +4005,13 @@ msgstr "(Recuperado)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Este archivo se guardó utilizando Tenacity %s.\n"
-"Utiliza Tenacity %s. Deberá actualizar a una versión más moderna para poder "
-"abrir este archivo."
+"Utiliza Tenacity %s. Deberá actualizar a una versión más moderna para poder abrir este archivo."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
@@ -3927,25 +4080,25 @@ msgid "Backing up project"
 msgstr "Creando copia de seguridad del proyecto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
-"Este proyecto no se guardó correctamente la última vez que se ejecutó "
-"Tenacity.\n"
+"Este proyecto no se guardó correctamente la última vez que se ejecutó Tenacity.\n"
 "\n"
 "Se ha recuperado desde la última instantánea."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
 msgstr ""
-"Este proyecto no se guardó correctamente la última vez que se ejecutó "
-"Tenacity.\n"
+"Este proyecto no se guardó correctamente la última vez que se ejecutó Tenacity.\n"
 "\n"
 "Se ha recuperado desde la última instantánea, pero debe guardarlo\n"
 "para preservar su contenido."
@@ -4020,14 +4173,13 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sGuardar proyecto «%s» como…"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
-"La opción «Guardar proyecto» se emplea con un proyecto de Tenacity, no con "
-"un archivo de audio.\n"
-"Para crear un archivo de audio que se abrirá con otras aplicaciones utilice "
-"la opción «Exportar».\n"
+"La opción «Guardar proyecto» se emplea con un proyecto de Tenacity, no con un archivo de audio.\n"
+"Para crear un archivo de audio que se abrirá con otras aplicaciones utilice la opción «Exportar».\n"
 
 #. i18n-hint: In each case, %s is the name
 #. of the file being overwritten.
@@ -4100,14 +4252,14 @@ msgid "Error Opening Project"
 msgstr "Error al abrir el proyecto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
-"Está intentado abrir un archivo de copia de respaldo generado "
-"automáticamente.\n"
+"Está intentado abrir un archivo de copia de respaldo generado automáticamente.\n"
 "Esto puede conllevar una grave pérdida de datos.\n"
 "\n"
 "En su lugar, abra el archivo de proyecto de Tenacity."
@@ -4214,8 +4366,8 @@ msgid "Automatic database backup failed."
 msgstr "No se ha podido realizar la copia de seguridad automática de la base de datos."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Le damos la bienvenida a Tenacity, versión %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4432,7 +4584,8 @@ msgstr "Todas las preferencias"
 msgid "SelectionBar"
 msgstr "Barra de selección"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Selección espectral"
 
@@ -4440,46 +4593,55 @@ msgstr "Selección espectral"
 msgid "Timer"
 msgstr "Temporizador"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Herramientas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Reproducción "
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mezclador"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Medidor"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Medidor de reproducción"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Medidor de grabación"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Edición"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Dispositivo"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Reproducir a velocidad"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Reproducción por desplazamiento"
 
@@ -4494,7 +4656,10 @@ msgstr "Regla"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Pistas"
 
@@ -4604,7 +4769,8 @@ msgid "Activation level (dB):"
 msgstr "Nivel de activación (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "¡Le damos la bienvenida a Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4705,9 +4871,7 @@ msgstr "Restablecer géneros"
 
 #: src/Tags.cpp
 msgid "Are you sure you want to reset the genre list to defaults?"
-msgstr ""
-"¿Confirma que quiere restablecer la lista de géneros a los valores "
-"predeterminados?"
+msgstr "¿Confirma que quiere restablecer la lista de géneros a los valores predeterminados?"
 
 #: src/Tags.cpp
 msgid "Unable to open genre file."
@@ -4753,9 +4917,9 @@ msgstr ""
 "Haga clic en el botón de ayuda para obtener recomendaciones sobre unidades apropiadas."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "No se ha podido escribir en el archivo:\n"
@@ -4775,9 +4939,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4786,9 +4950,9 @@ msgstr ""
 "para escribir en el."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "No se ha podido insertar imágenes en el archivo:\n"
@@ -4805,9 +4969,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4817,9 +4981,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4828,8 +4992,9 @@ msgstr ""
 "Quizás el formato PNG del archivo es erróneo."
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity no pudo leer el tema predeterminado.\n"
@@ -4867,9 +5032,9 @@ msgstr ""
 "ya están presentes. ¿Desea sobrescribirlos?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "No se ha podido guardar el archivo:\n"
@@ -4908,7 +5073,11 @@ msgstr "Personalizado"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Duración"
 
@@ -4919,7 +5088,8 @@ msgid "Time Track"
 msgstr "Pista de tiempo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Grabación programada de Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4974,8 +5144,7 @@ msgid ""
 "Planned recording duration:   %s\n"
 "Recording time remaining on disk:   %s"
 msgstr ""
-"Según la configuración actual puede que no tenga suficiente espacio libre "
-"para esta grabación programada\n"
+"Según la configuración actual puede que no tenga suficiente espacio libre para esta grabación programada\n"
 "\n"
 "¿Confirma que quiere continuar?\n"
 "\n"
@@ -4994,7 +5163,8 @@ msgstr "Proyecto actual"
 msgid "Recording start:"
 msgstr "Inicio de la grabación:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Duración:"
 
@@ -5015,7 +5185,8 @@ msgid "Action after Timer Recording:"
 msgstr "Acción tras la grabación programada:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Progreso de grabación programada de Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5096,6 +5267,12 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Grabación programada"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 días 024 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -5106,6 +5283,7 @@ msgstr "099 días 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Fecha y hora de inicio"
@@ -5150,7 +5328,8 @@ msgstr "Habilitar &exportación automática"
 msgid "Export Project As:"
 msgstr "Exportar proyecto como:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opciones"
 
@@ -5163,7 +5342,8 @@ msgid "Do nothing"
 msgstr "No hacer nada"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Salir de Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5187,7 +5367,8 @@ msgid "Scheduled to stop at:"
 msgstr "Programar detención en:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Grabación programada de Audacity. Esperando para comenzar"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5213,7 +5394,8 @@ msgid "Recording Exported:"
 msgstr "Grabación exportada:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Grabación programada de Audacity. Esperando"
 
 #: src/TrackInfo.cpp
@@ -5409,6 +5591,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Aplicando %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "FALLO"
@@ -5427,13 +5619,15 @@ msgstr "%s no es un parámetro aceptado por %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Valor incorrecto para el parámetro '%s': debe ser %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Orden"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repetir %s"
@@ -5449,10 +5643,7 @@ msgstr ""
 
 #: src/commands/CommandManager.cpp
 msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
-msgstr ""
-"Se eliminaron los atajos de teclado de las órdenes siguientes, porque los "
-"valores predeterminados nuevos o que han cambiado coinciden con algunos de "
-"los que estaban asignados."
+msgstr "Se eliminaron los atajos de teclado de las órdenes siguientes, porque los valores predeterminados nuevos o que han cambiado coinciden con algunos de los que estaban asignados."
 
 #: src/commands/CommandManager.cpp
 msgid "Shortcuts have been removed"
@@ -5490,6 +5681,11 @@ msgstr "Realiza una demostración."
 msgid "Drag"
 msgstr "Arrastrar"
 
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Panel"
+msgstr "Panel de pista"
+
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
 msgstr "Aplicación"
@@ -5501,6 +5697,11 @@ msgstr "Pista 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Pista 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr "Id.:"
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5554,13 +5755,24 @@ msgstr "Bloques"
 msgid "Envelopes"
 msgstr "Envolventes"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiquetas"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Cajas"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr "JSON"
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr "LISP"
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5570,7 +5782,8 @@ msgstr "Resumen"
 msgid "Type:"
 msgstr "Tipo:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formato:"
 
@@ -5597,6 +5810,10 @@ msgstr "Comentario"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Orden:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5634,12 +5851,17 @@ msgstr "Exporta a un archivo."
 msgid "Builtin Commands"
 msgstr "Órdenes incorporadas"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "El equipo de Tenacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Proporciona órdenes preconstruidas a Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5702,7 +5924,10 @@ msgstr "Limpia el contenido del registro."
 msgid "Get Preference"
 msgstr "Obtener preferencias"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nombre:"
 
@@ -5750,9 +5975,14 @@ msgstr "Pantalla completa"
 msgid "Toolbars"
 msgstr "Barras de herramientas"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efectos"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Scriptables"
+msgstr "Secuenciables"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -5886,7 +6116,8 @@ msgstr "Establecer"
 msgid "Add"
 msgstr "Agregar"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -5922,9 +6153,29 @@ msgstr "Selecciona audio."
 msgid "Set Clip"
 msgstr "Establecer bloque"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr "Color 0"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr "Color 1"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr "Color 2"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr "Color 3"
+
 #: src/commands/SetClipCommand.cpp
 msgid "At:"
 msgstr "En:"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr "Color:"
 
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
@@ -5951,7 +6202,8 @@ msgid "Edited Envelope"
 msgstr "Envolvente editada"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Envolvente"
 
@@ -5994,6 +6246,14 @@ msgstr "Frecuencia:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Redimensionar:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr "X:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr "Y:"
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -6043,7 +6303,10 @@ msgstr "Panorámica:"
 msgid "Set Track Visuals"
 msgstr "Establecer visuales de la pista"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineal"
 
@@ -6066,6 +6329,11 @@ msgstr "Visualización:"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
 msgstr "Escala:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "Ampliar"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
@@ -6122,6 +6390,10 @@ msgid "Allo&w clipping"
 msgstr "Permi&tir recorte"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Reduce (duck) el volumen de una o mas pistas cada vez que el volumen de una pista de \"control\" concreta alcanza el nivel específico."
 
@@ -6139,12 +6411,18 @@ msgstr "Se ha seleccionado una pista que no contiene audio. AutoDuck solo puede 
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck necesita una pista de control que debe situarse bajo la(s) pista(s) seleccionada(s)."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "C&antidad de Duck:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segundos"
 
@@ -6168,7 +6446,8 @@ msgstr "Duración de caída interi&or:"
 msgid "Inner &fade up length:"
 msgstr "Duración de su&bida interior:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "U&mbral:"
 
@@ -6306,11 +6585,13 @@ msgstr "a (Hz)"
 msgid "t&o"
 msgstr "&a"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "&Porcentaje de cambio:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Porcentaje de cambio"
 
@@ -6318,9 +6599,23 @@ msgstr "Porcentaje de cambio"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Usar estiramiento de alta calidad (lento)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr "45"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr "78"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "no disponible"
 
@@ -6348,6 +6643,7 @@ msgstr "rpm de vinilo estándar:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Desde rpm"
@@ -6360,6 +6656,7 @@ msgstr "&desde"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "A rpm"
@@ -6502,6 +6799,12 @@ msgstr "Compresor"
 msgid "Compresses the dynamic range of audio"
 msgstr "Comprime el rango dinámico del audio"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6511,6 +6814,20 @@ msgstr "%.2f seg"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f seg"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6627,7 +6944,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analizador de contraste para medir las diferencias de volumen RMS entre dos selecciones de audio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Final"
 
@@ -6687,6 +7005,18 @@ msgstr "&Diferencia:"
 msgid "&Help"
 msgstr "&Ayuda"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "cero"
@@ -6694,6 +7024,13 @@ msgstr "cero"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "indeterminado"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB RMS de media"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6747,6 +7084,12 @@ msgstr "Diferencia actual"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Nivel de medición de sonido principal"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f×"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6816,6 +7159,12 @@ msgstr "Criterio de éxito 1.4.7 de WCAG 2.0: No superado"
 msgid "Data gathered"
 msgstr "Información recopilada"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Análisis de contraste (conforme a WCAG 2)"
@@ -6881,6 +7230,10 @@ msgstr "Recorte suave −12 dB, 80 % de ganancia de composición"
 #: src/effects/Distortion.cpp
 msgid "Fuzz Box"
 msgstr "Caja de distorsión"
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Blues drive sustain"
@@ -6991,6 +7344,10 @@ msgid "Clipping level"
 msgstr "Nivel de recorte"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Make-up Gain"
 msgstr "Ganancia de composición"
 
@@ -7086,7 +7443,9 @@ msgstr "&Secuencia DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Amplitud (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Duración:"
 
@@ -7099,12 +7458,29 @@ msgid "Duty cycle:"
 msgstr "Ciclo de trabajo:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f seg"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Duración de tono:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Duración del silencio:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7114,7 +7490,8 @@ msgstr "Eco"
 msgid "Repeats the selected audio again and again"
 msgstr "Repite el audio seleccionado una y otra vez"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "El valor requerido supera la capacidad de la memoria."
 
@@ -7138,7 +7515,8 @@ msgstr "Valores predefinidos"
 msgid "Export Effect Parameters"
 msgstr "Exportar parámetros del efecto"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "No se pudo abrir el archivo: «%s»"
@@ -7175,6 +7553,14 @@ msgstr "Preparando vista previa"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Mostrando vista previa"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7487,6 +7873,10 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "Ajusta el nivel de volumen de una frecuencia concreta"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "AM Radio"
 msgstr "Radio AM"
 
@@ -7501,6 +7891,10 @@ msgstr "Recorte de graves"
 #: src/effects/Equalization.cpp
 msgid "Low rolloff for speech"
 msgstr "Atenuación progresiva para locuciones"
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr "RIAA"
 
 #: src/effects/Equalization.cpp
 msgid "Telephone"
@@ -7520,8 +7914,7 @@ msgid ""
 "Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
 msgstr ""
 "Para utilizar esta curva de filtro en una macro, dele un nombre nuevo.\n"
-"Pulse en el botón «Guardar/gestionar curvas», cambie el nombre de la curva "
-"denominada «sin nombre» y utilice esa."
+"Pulse en el botón «Guardar/gestionar curvas», cambie el nombre de la curva denominada «sin nombre» y utilice esa."
 
 #: src/effects/Equalization.cpp
 msgid "Filter Curve EQ needs a different name"
@@ -7540,12 +7933,41 @@ msgid "Effect Unavailable"
 msgstr "Efecto no disponible"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr "+ dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Máximo de dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr "%d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Mínimo de dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr "− dB"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7620,8 +8042,16 @@ msgid "D&efault"
 msgstr "Valor&es predeterminados"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE en &paralelo"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7866,7 +8296,8 @@ msgid "Builtin Effects"
 msgstr "Efectos preconstruidos "
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Proporciona efectos preconstruidos a Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7876,6 +8307,10 @@ msgstr "Nombre de efecto interno desconocido"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "volumen percibido"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7907,6 +8342,14 @@ msgstr "&Normalizar"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Volumen LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7976,7 +8419,17 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (predeterminado)"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "Blackman"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, ninguno"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, ninguno"
 
 #: src/effects/NoiseReduction.cpp
@@ -8076,8 +8529,9 @@ msgid "Step 1"
 msgstr "Paso 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Seleccione unos segundos de ruido para que Audacity sepa qué filtrar, luego\n"
@@ -8129,13 +8583,64 @@ msgstr "&Tipos de ventana:"
 msgid "Window si&ze:"
 msgstr "Tamaño &de ventana:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "78"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "16"
+msgstr "6"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr "32"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr "64"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr "128"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr "256"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr "512"
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr "1024"
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (predeterminado)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr "4096"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr "8192"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr "16 384"
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Pasos por ven&tana:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8251,12 +8756,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&ormalizar canales estéreo independientemente"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Estirar"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Utilice Paulstrech únicamente para estirar el tiempo radicalmente o generar un efecto \"éxtasis\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Factor de e&stiramiento:"
@@ -8322,6 +8833,14 @@ msgstr "Etapa&s:"
 #: src/effects/Phaser.cpp
 msgid "Stages"
 msgstr "Etapas"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
@@ -8430,6 +8949,15 @@ msgid "Warning: No repeats."
 msgstr "Atención: no hay repeticiones."
 
 #: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Eliminación vocal"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Bathroom"
 msgstr "Cuarto de baño"
 
@@ -8521,6 +9049,11 @@ msgstr "Invierte el audio seleccionado"
 #: src/effects/SBSMSEffect.h
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Tiempo SBSMS / Estirar tono"
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
 
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
@@ -8678,6 +9211,11 @@ msgstr "Usar valores predeterminados"
 msgid "Restore Defaults"
 msgstr "Restablecer valores predeterminados"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8765,6 +9303,10 @@ msgid "Square, no alias"
 msgstr "Cuadrada, sin alias"
 
 #: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr "Tono"
 
@@ -8832,6 +9374,10 @@ msgstr "Detectar silencio"
 msgid "Tr&uncate to:"
 msgstr "Tr&uncar a:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "C&omprimir a:"
@@ -8845,7 +9391,8 @@ msgid "VST Effects"
 msgstr "Efectos VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Añade la capacidad de usar efectos VST en Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8857,7 +9404,8 @@ msgstr "Comprobando el shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registrando %d de %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "No se ha podido abrir la biblioteca"
 
@@ -8877,7 +9425,8 @@ msgstr "El tamaño de buffer controla el número de muestras enviadas al efecto 
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Tamaño de &buffer (8 a 1048576 muestras):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Compensación de latencia"
 
@@ -8885,7 +9434,8 @@ msgstr "Compensación de latencia"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Algunos efectos VST deben retrasar el audio que se devuelve a Audacity como parte de su procesamiento. Si no se compensa este retardo se pueden provocar pequeños silencios insertados en el audio. Habilitando esta opción se compensará ese problema, aunque puede no funcionar en todos los efectos VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Habilitar &compensación"
 
@@ -8919,7 +9469,8 @@ msgid "Standard VST program file"
 msgstr "Archivo programa  VST estándar"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Archivo de valores predefinidos VST de Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8946,7 +9497,8 @@ msgstr "Error al cargar valores predefinidos VST"
 msgid "Unable to load presets file."
 msgstr "No se puede cargar el archivo de valores predefinidos."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Configuración del efecto"
 
@@ -8962,6 +9514,16 @@ msgstr "No se puede leer el archivo de valores predefinidos."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Este archivo de parámetros fue guardado como %s. ¿Desea continuar?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8993,7 +9555,8 @@ msgid "Audio Unit Effects"
 msgstr "Efectos Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Proporciona compatibilidad a Audacity con efectos Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9009,7 +9572,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Opciones de efectos Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Algunos efectos Audio Unit deben retrasar el audio que se devuelve a Audacity como parte de su procesamiento. Si no se compensa este retardo se pueden provocar pequeños silencios insertados en el audio. Habilitando esta opción se compensará ese problema, aunque puede no funcionar en todos los efectos Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9147,8 +9711,16 @@ msgstr "No se ha podido crear la lista de propiedades para los valores predefini
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "No se ha podido establecer la información de clase para los valores predefinidos \"%s\""
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Efectos Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efectos LADSPA"
@@ -9158,7 +9730,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Proporciona efectos LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity ya no utiliza vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9166,12 +9739,29 @@ msgid "LADSPA Effect Options"
 msgstr "Opciones de efecto LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Algunos efectos LADSPA deben retrasar el audio que se devuelve a Audacity como parte de su procesamiento. Si no se compensa este retardo se pueden provocar pequeños silencios insertados en el audio. Habilitando esta opción se compensará ese problema, aunque puede no funcionar en todos los efectos LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s en:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Salida del efecto"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9183,7 +9773,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Tamaño de &buffer (8 a  %d) muestras:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Algunos efectos LV2 deben retrasar el audio que se devuelve a Audacity como parte de su procesamiento. Si no se compensa este retardo se pueden provocar pequeños silencios insertados en el audio. Habilitando esta opción se compensará ese problema, aunque puede no funcionar en todos los efectos LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9208,12 +9799,19 @@ msgstr "%s necesita una opción no compatible %s\n"
 msgid "Generator"
 msgstr "Generador"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efectos LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Proporciona compatibilidad a Tenacity con efectos LV2"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9221,7 +9819,8 @@ msgid "Nyquist Effects"
 msgstr "Efectos de Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Proporciona a Tenacity compatibilidad con efectos Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9258,9 +9857,7 @@ msgstr ""
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
-msgstr ""
-"error: se especificó el archivo «%s» en la cabecera pero no se encontró en "
-"la ruta de complementos.\n"
+msgstr "error: se especificó el archivo «%s» en la cabecera pero no se encontró en la ruta de complementos.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
@@ -9350,8 +9947,7 @@ msgstr "[Advertencia: Nyquist ha devuelto una secuencia UTF-8 inválida, convert
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
-msgstr ""
-"Esta versión de Tenacity no admite la versión %ld del complemento Nyquist"
+msgstr "Esta versión de Tenacity no admite la versión %ld del complemento Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not open file"
@@ -9452,7 +10048,8 @@ msgstr "Seleccione un archivo"
 msgid "Save file as"
 msgstr "Guardar archivo como"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "sin nombre"
 
@@ -9461,7 +10058,8 @@ msgid "Vamp Effects"
 msgstr "Efectos Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Proporciona compatibilidad a Audacity con efectos Vamp"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9483,6 +10081,12 @@ msgstr "Configuración de complemento"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9524,8 +10128,7 @@ msgid ""
 msgstr ""
 "Va a exportar un archivo %s con el nombre «%s».\n"
 "\n"
-"Estos archivos suelen terminar en «.%s», y algunos programas no abrirán "
-"archivos con extensiones no estándares.\n"
+"Estos archivos suelen terminar en «.%s», y algunos programas no abrirán archivos con extensiones no estándares.\n"
 "\n"
 "¿Confirma que quiere exportar el archivo con este nombre?"
 
@@ -9631,9 +10234,7 @@ msgstr "Exportar"
 
 #: src/export/ExportCL.cpp
 msgid "Exporting the selected audio using command-line encoder"
-msgstr ""
-"Exportando el audio seleccionado utilizando el codificador de línea de "
-"órdenes"
+msgstr "Exportando el audio seleccionado utilizando el codificador de línea de órdenes"
 
 #: src/export/ExportCL.cpp
 msgid "Exporting the audio using command-line encoder"
@@ -9676,9 +10277,7 @@ msgstr ""
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
-msgstr ""
-"FFmpeg : ERROR: no se puede determinar la descripción de formato del archivo "
-"«%s»."
+msgstr "FFmpeg : ERROR: no se puede determinar la descripción de formato del archivo «%s»."
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
@@ -9788,7 +10387,8 @@ msgstr "Exportando audio como %s"
 msgid "Invalid sample rate"
 msgstr "Frecuencia de muestreo inválida"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Remuestrear"
 
@@ -9818,6 +10418,14 @@ msgstr "Puede volver a muestrear a una de las frecuencias indicadas."
 msgid "Sample Rates"
 msgstr "Frecuencias de muestreo"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr "%d kb/s"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Velocidad de transferencia:"
@@ -9825,6 +10433,48 @@ msgstr "Velocidad de transferencia:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Calidad (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr "0"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr "3"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr "5"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr "6"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr "9"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr "10"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9835,8 +10485,40 @@ msgid "Constrained"
 msgstr "Restringido"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr "VOIP"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Audio"
+msgstr "Audio"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Bajo Retardo"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr "5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr "10 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr "20 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr "40 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr "60 ms"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9923,8 +10605,17 @@ msgid "Replace preset '%s'?"
 msgstr "¿Reemplazar el valor predefinido '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Do"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principal"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10028,6 +10719,14 @@ msgstr ""
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Idioma:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10162,6 +10861,11 @@ msgstr ""
 "max - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Usar LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -10192,6 +10896,10 @@ msgstr ""
 "max - 32 (con LPC) o 4 (sin LPC)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal prediction order\n"
 "Optional\n"
@@ -10204,6 +10912,10 @@ msgstr ""
 "-1 - predeterminado\n"
 "min - 0\n"
 "max - 32 (con LPC) o 4 (sin LPC)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10220,6 +10932,10 @@ msgstr ""
 "max - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal partition order\n"
 "Optional\n"
@@ -10232,6 +10948,10 @@ msgstr ""
 "-1 - predeterminado\n"
 "min - 0\n"
 "max - 8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
 
 #. i18n-hint:  Abbreviates "Linear Predictive Coding",
 #. but this text needs to be kept very short
@@ -10324,6 +11044,14 @@ msgid "Failed to find the codec"
 msgstr "No se pudo encontrar el códec"
 
 #: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr "16 bits"
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr "24 bits"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (el más rápido)"
 
@@ -10390,6 +11118,38 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kb/s (la mejor calidad)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr "200-250 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr "170-210 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr "155-195 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr "145-185 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr "110-150 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr "95-135 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr "80-120 kb/s"
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr "65-105 kb/s"
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kb/s (archivos más pequeños)"
 
@@ -10419,13 +11179,18 @@ msgstr "Brutal"
 msgid "Extreme"
 msgstr "Excepcional"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Estándar"
 
 #: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "Medio"
+
+#: src/export/ExportMP3.cpp
+msgid "Variable"
+msgstr "Variable"
 
 #: src/export/ExportMP3.cpp
 msgid "Average"
@@ -10466,8 +11231,8 @@ msgid "Locate LAME"
 msgstr "Localizar LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity necesita el archivo %s para crear MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10495,13 +11260,12 @@ msgid "Where is %s?"
 msgstr "¿Dónde está %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
-"Está enlazando con un lame_enc.dll v%d.%d. Esta versión no es compatible con "
-"Tenacity %d.%d.%d.\n"
+"Está enlazando con un lame_enc.dll v%d.%d. Esta versión no es compatible con Tenacity %d.%d.%d.\n"
 "Descargue la versión más reciente de «LAME para Tenacity»."
 
 #: src/export/ExportMP3.cpp
@@ -10804,6 +11568,14 @@ msgstr "Exportando el audio seleccionado como Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Exportando el audio como Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr "AIFF (Apple/SGI)"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft)"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Cabecera:"
@@ -10817,9 +11589,10 @@ msgid "Other uncompressed files"
 msgstr "Otros archivos sin comprimir"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Se ha intentado exportar un archivo WAV o AIFF de un tamaño mayor de 4GB.\n"
 "Audacity no puede hacerlo y la exportación se ha abandonado."
@@ -10829,8 +11602,9 @@ msgid "Error Exporting"
 msgstr "Error al exportar"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "El archivo WAV exportado se ha truncado porque Tenacity no puede exportar\n"
@@ -10870,11 +11644,11 @@ msgid "All supported files"
 msgstr "Todos los archivos admitidos"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "«%s» \n"
@@ -10883,11 +11657,11 @@ msgstr ""
 "pero puede editarlo pulsando en Archivo ▸ Importar ▸ MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "«%s» \n"
 "no es un archivo de audio. \n"
@@ -10898,18 +11672,18 @@ msgid "Select stream(s) to import"
 msgstr "Seleccione flujo(s) a importar"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Esta versión de Tenacity no fue compilada con compatibilidad para %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "«%s» es una pista de audio de un CD. \n"
 "Tenacity no puede abrir archivos de audio de CD directamente. \n"
@@ -10918,10 +11692,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "«%s» es una archivo de lista de reproducción. \n"
@@ -10930,38 +11704,36 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo de Windows Media Audio. \n"
-"Tenacity no puede abrir este tipo de archivo por restricciones en su "
-"patente. \n"
+"Tenacity no puede abrir este tipo de archivo por restricciones en su patente. \n"
 "Deberá convertirlo a un formato de audio compatible, como WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo Advanced Audio Coding. \n"
-"Tenacity no puede abrir este tipo de archivo sin la biblioteca opcional "
-"FFmpeg. \n"
+"Tenacity no puede abrir este tipo de archivo sin la biblioteca opcional FFmpeg. \n"
 "Deberá convertirlo a un formato de audio compatible, como WAV o AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo de audio cifrado. \n"
@@ -10972,10 +11744,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo de RealPlayer. \n"
@@ -10984,12 +11756,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "«%s» es un archivo basado en notas, no un archivo de audio. \n"
 "Tenacity no puede abrir este tipo de archivo. \n"
@@ -10998,10 +11770,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11014,10 +11786,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo de audio Wavpack. \n"
@@ -11026,10 +11798,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo de audio Dolby Digital. \n"
@@ -11038,10 +11810,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo de audio Ogg Speex. \n"
@@ -11050,10 +11822,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "«%s» es un archivo de vídeo. \n"
@@ -11067,16 +11839,15 @@ msgstr "No se encontró el archivo «%s»."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Tenacity no reconoce el tipo de archivo «%s».\n"
 "\n"
-"%sPara archivos no comprimidos, intente con Archivo ▸ Importar ▸ Datos en "
-"bruto (RAW)."
+"%sPara archivos no comprimidos, intente con Archivo ▸ Importar ▸ Datos en bruto (RAW)."
 
 #: src/import/Import.cpp
 msgid ""
@@ -11086,11 +11857,16 @@ msgstr ""
 "Pruebe a instalar FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, pruebas de Audacity"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11120,12 +11896,13 @@ msgid "Import Project"
 msgstr "Importar proyecto"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Este proyecto se guardó con la versión 1.0 o anterior de Audacity. El formato ha\n"
 "cambiado por lo que esta versión de Audacity no puede importar el proyecto.\n"
@@ -11176,7 +11953,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "No se ha podido encontrar la carpeta de datos de proyecto: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "El proyecto contiene pistas MIDI, pero esta versión de Audacity no cuenta con compatibilidad MIDI, por lo que se omite la pista."
 
 #: src/import/ImportAUP.cpp
@@ -11281,35 +12059,6 @@ msgstr "Índice[%02x] Códec[%s], Idioma[%s], Velocidad de transferencia[%s], Ca
 msgid "FLAC files"
 msgstr "Archivos FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Archivos compatibles con GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "No se puede agregar el decodificador al canal"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importador GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "No se puede establecer el flujo de datos como pausado."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Índice[%02d], Tipo[%s], Canales[%d], Transferencia[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "El archivo no contiene ningún flujo de audio."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "No se puede importar el archivo, el cambio de estado ha fallado."
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Lista de archivos en formato de texto básico"
@@ -11411,18 +12160,99 @@ msgstr "Fallo de lógica interna"
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF y otros tipos de datos sin comprimir"
 
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/import/ImportPCM.cpp
 msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (códec de audio sin pérdidas FLAC)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr "MAT4 (GNU Octave 2.0/Matlab 4.2)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr "MAT5 (GNU Octave 2.1/Matlab 5.0)"
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (formato de contenedor OGG)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "PVF (Portable Voice Format)"
 msgstr "PVF (formato de voz portable)"
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr "RAW (sin cabeceras)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAVEX (Microsoft)"
+msgstr "WAV (Microsoft)"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11451,6 +12281,63 @@ msgstr "32 bit flotante"
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "64 bit flotante"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft)"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr "DWVW de 12 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr "DWVW de 16 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr "DWVW de 24 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr "DPCM de 16 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr "DPCM de 8 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11500,6 +12387,19 @@ msgstr "Importar archivo en bruto"
 msgid "No endianness"
 msgstr "Sin endianness"
 
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Mediana"
+
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
 #: src/import/ImportRaw.cpp
@@ -11531,6 +12431,11 @@ msgstr "Canales:"
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
 msgstr "Desplazamiento inicial:"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "bytes"
+msgstr "%s bytes"
 
 #: src/import/ImportRaw.cpp
 msgid "Amount to import:"
@@ -11569,6 +12474,7 @@ msgstr "%s derecho"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11592,6 +12498,7 @@ msgstr "final"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11618,7 +12525,8 @@ msgstr "Bloques con cambio de tiempo a la derecha"
 msgid "Time shifted clips to the left"
 msgstr "Bloques con cambio de tiempo a la izquierda"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Cambio de tiempo"
 
@@ -11756,7 +12664,8 @@ msgstr "Pistas seleccionadas recortadas desde %.2f segundos hasta %.2f segundos"
 msgid "Trim Audio"
 msgstr "Recortar audio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Dividir"
 
@@ -11877,32 +12786,8 @@ msgid "Delete Key&2"
 msgstr "Borrar clave&2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Me&zclador"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "A&justar volumen de reproducción..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Incrementar volumen de reproducción"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Reducir volumen de reproducción"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Aj&ustar volumen de grabación..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "I&ncrementar volumen de grabación"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "R&educir volumen de grabación"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12070,8 +12955,16 @@ msgid "Export MI&DI..."
 msgstr "Exportar MI&DI..."
 
 #: src/menus/FileMenus.cpp
+msgid "&Audio..."
+msgstr "&Audio…"
+
+#: src/menus/FileMenus.cpp
 msgid "&Labels..."
 msgstr "&Etiquetas..."
+
+#: src/menus/FileMenus.cpp
+msgid "&MIDI..."
+msgstr "&MIDI…"
 
 #: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
@@ -12162,12 +13055,17 @@ msgid "&Getting Started"
 msgstr "&Primeros pasos"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manual de Tenacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manual…"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&Ayuda rápida..."
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr "&Manual…"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -12185,11 +13083,8 @@ msgstr "Información del dispositivo &MIDI..."
 msgid "Show &Log..."
 msgstr "&Mostrar registro..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Acerca de Tenacity…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etiqueta añadida"
 
@@ -12439,6 +13334,10 @@ msgid "Uncategorized"
 msgstr "Sin categoría"
 
 #: src/menus/PluginMenus.cpp
+msgid "..."
+msgstr "…"
+
+#: src/menus/PluginMenus.cpp
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -12489,6 +13388,10 @@ msgid "Repeat Last Tool"
 msgstr "Repetir la última Herramienta"
 
 #: src/menus/PluginMenus.cpp
+msgid "&Macros..."
+msgstr "&Macros…"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
 msgstr "&Aplicar macro"
 
@@ -12515,6 +13418,12 @@ msgstr "Simular errores de grabación"
 #: src/menus/PluginMenus.cpp
 msgid "Detect Upstream Dropouts"
 msgstr "Detectar pérdidas ascendentes"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Script&ables I"
+msgstr "Secuenciables"
 
 #: src/menus/PluginMenus.cpp
 msgid "Select Time..."
@@ -12563,6 +13472,12 @@ msgstr "Establecer etiqueta..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Establecer proyecto..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Secuenciables"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -12831,6 +13746,11 @@ msgid "Cursor to Project End"
 msgstr "Cursor al final de proyecto"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Cursor"
+msgstr "&Cursor a"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor &Left"
 msgstr "Cursor a &la izquierda"
 
@@ -12857,6 +13777,7 @@ msgstr "Salto lar&go del cursor a la derecha"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Bus&car"
@@ -13068,20 +13989,21 @@ msgid "Created new label track"
 msgstr "Nueva pista de etiqueta creada"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
-msgstr ""
-"Esta versión de Tenacity solo permite una pista de tiempo en cada ventana de "
-"proyecto."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr "Esta versión de Tenacity solo permite una pista de tiempo en cada ventana de proyecto."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Nueva pista de tiempo creada"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nueva frecuencia de muestreo (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "El valor introducido es inválido"
 
@@ -13101,6 +14023,11 @@ msgstr "Remuestrear pista"
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "Seleccione al menos una pista de audio o una pista MIDI"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr "Error de alineado: la entrada es demasiado breve: MIDI desde %.2f hasta %.2f seg, Audio desde %.2f hasta %.2f seg."
 
 #: src/menus/TrackMenus.cpp
 msgid "Sync MIDI with Audio"
@@ -13333,7 +14260,9 @@ msgstr "Reproduciendo"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Grabación"
 
@@ -13482,10 +14411,6 @@ msgstr "S&obregrabar"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Reproducción a &través del software"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utoajuste del nivel de grabación"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13700,7 +14625,8 @@ msgid "Preferences for Application"
 msgstr "Preferencias de calidad"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Actualizar Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13746,7 +14672,8 @@ msgstr "&Servidor:"
 msgid "Using:"
 msgstr "Usando:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Reproducción"
 
@@ -13766,7 +14693,8 @@ msgstr "Ca&nales:"
 msgid "Latency"
 msgstr "Latencia"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisegundos"
 
@@ -13787,11 +14715,17 @@ msgid "No devices found"
 msgstr "No se han encontrado dispositivos"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Canal (mono)"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "2 (Stereo)"
 msgstr "2 (Estéreo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Carpetas"
 
@@ -13899,10 +14833,9 @@ msgid "Directory %s is not writable"
 msgstr "La carpeta %s no tiene permiso de escritura"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
-msgstr ""
-"Los cambios en la carpeta temporal no surtirán efecto hasta que se reinicie "
-"Tenacity"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr "Los cambios en la carpeta temporal no surtirán efecto hasta que se reinicie Tenacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -13932,6 +14865,40 @@ msgstr "Agrupar por distribuidor"
 msgid "Grouped by Type"
 msgstr "Agrupar por tipo"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr "LV&2"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr "N&yquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "&Vamp"
+msgstr "Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Activar efectos"
@@ -13953,11 +14920,13 @@ msgid "Plugin Options"
 msgstr "Opciones de complemento"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Buscar actualizaciones de complementos al iniciar Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Redetectar complementos la próxima vez que se inicie Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14089,6 +15058,11 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (rango PCM de muestras de 24 bit)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Ubicación"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
 msgstr "Desde Internet"
 
@@ -14133,7 +15107,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Man&tener etiquetas si la selección está ajustada a una etiqueta"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Combinar &la apariencia del sistema y de Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14311,7 +15286,8 @@ msgstr ""
 "   *   \"%s\"  (porque el atajo de teclado '%s' se está usando para \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Seleccione un archivo XML que contenga atajos de teclado de Tenacity…"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14338,8 +15314,7 @@ msgid ""
 "The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
 msgstr ""
 "\n"
-"Las órdenes siguientes no se encontraban en el archivo importado, pero se "
-"han eliminado sus atajos de teclado por conflictos con otros nuevos:\n"
+"Las órdenes siguientes no se encontraban en el archivo importado, pero se han eliminado sus atajos de teclado por conflictos con otros nuevos:\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -14445,8 +15420,9 @@ msgid "Dow&nload"
 msgstr "D&escargar"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity ha detectado automáticamente unas bibliotecas FFmpeg válidas.\n"
@@ -14505,27 +15481,25 @@ msgid "Preferences for Module"
 msgstr "Preferencias de módulo"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
-"Estos son módulos experimentales. Actívelos solo si ha consultado el manual "
-"de Tenacity\n"
+"Estos son módulos experimentales. Actívelos solo si ha consultado el manual de Tenacity\n"
 "y sabe lo que está haciendo."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
-msgstr ""
-"  «Preguntar» significa que Tenacity le preguntará si quiere cargar el "
-"módulo en cada inicio."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr "  «Preguntar» significa que Tenacity le preguntará si quiere cargar el módulo en cada inicio."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr ""
-"  «Fallido» significa que Tenacity considera que el módulo está estropeado y "
-"no lo ejecutará."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr "  «Fallido» significa que Tenacity considera que el módulo está estropeado y no lo ejecutará."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -14533,7 +15507,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  «Nuevo» significa que aún no se ha elegido ninguna opción."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Los cambios de esta configuración surtirán efecto solo al iniciarse Tenacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14551,6 +15526,10 @@ msgstr "No se encontró ningún módulo"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Módulo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr "Ctrl"
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14592,7 +15571,10 @@ msgstr "Arrastre-Izquierdo"
 msgid "Set Selection Range"
 msgstr "Establecer intervalo de selección"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Mayús-Clic izquierdo"
 
@@ -14679,6 +15661,15 @@ msgstr "-Arrastre izquierdo"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Desplazar bloque entre pistas"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Arrastre izquierdo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14803,7 +15794,8 @@ msgid "Always scrub un&pinned"
 msgstr "Siempre re&producir por desplazamiento si está desbloqueado"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferencias de Tenacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14817,6 +15809,11 @@ msgstr "Preferencias:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferencias de calidad"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14936,45 +15933,31 @@ msgid "System T&ime"
 msgstr "&Hora del sistema"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Ajuste de nivel de grabación automatizado"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Activar el ajuste de nivel de grabación automatizado."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Pico objetivo:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Interior:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Tiempo de análisis:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisegundos (tiempo de un análisis)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Número de análisis consecutivos:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 significa infinitos"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Grabación Punch and Roll"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "&Fundido cruzado:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15109,6 +16092,10 @@ msgid "1024 - default"
 msgstr "1024 - predeterminado"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr "2048"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - banda más estrecha"
 
@@ -15206,28 +16193,26 @@ msgid "Info"
 msgstr "Información"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
 msgstr ""
 "Los temas son una funcionalidad experimental.\n"
 "\n"
-"Para ponerlos a prueba, pulse en «Guardar antememoria de tema» y modifique "
-"las imágenes en\n"
+"Para ponerlos a prueba, pulse en «Guardar antememoria de tema» y modifique las imágenes en\n"
 "ImageCacheVxx.png con ayuda de un editor de imágenes como el GIMP.\n"
 "\n"
-"Pulse en «Cargar antememoria de tema» para cargar las imágenes y los colores "
-"modificados en Tenacity.\n"
+"Pulse en «Cargar antememoria de tema» para cargar las imágenes y los colores modificados en Tenacity.\n"
 "\n"
-"(Por el momento, solo la barra de herramientas de reproducción y los colores "
-"de la onda reflejarán los cambios,\n"
+"(Por el momento, solo la barra de herramientas de reproducción y los colores de la onda reflejarán los cambios,\n"
 "pese a que el archivo de imagen también incluye otros iconos.)"
 
 #: src/prefs/ThemePrefs.cpp
@@ -15272,6 +16257,11 @@ msgstr "Comportamiento de pistas"
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Preferences for TracksBehaviors"
 msgstr "Preferencias de comportamiento de pistas"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "Muestras"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -15394,7 +16384,8 @@ msgstr "Muestras"
 msgid "4 Pixels per Sample"
 msgstr "4 píxeles por muestra"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Ampliar al máximo"
 
@@ -15516,16 +16507,24 @@ msgid "Stopped"
 msgstr "Detenido"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Saltar al inicio"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Saltar al final"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Seleccionar hasta el inicio"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Seleccionar hasta el final"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15539,20 +16538,17 @@ msgstr "Grabar Nueva pista"
 msgid "Append Record"
 msgstr "Agregar grabación"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Seleccionar hasta el final"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Seleccionar hasta el inicio"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s Pausado."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15632,11 +16628,17 @@ msgstr "Silenciar selección"
 msgid "Sync-Lock Tracks"
 msgstr "Bloquear sincronización de pistas"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Acercar"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Alejar"
 
@@ -15703,43 +16705,6 @@ msgstr "Barra de herramientas de medición de g&rabación"
 msgid "&Playback Meter Toolbar"
 msgstr "Barra de herramientas de medición de re&producción"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volumen de grabación"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volumen de reproducción"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volumen de grabación: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volumen de grabación (no disponible, utilice el mezclado del sistema.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volumen de reproducción: %.2f (emulado)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volumen de reproducción: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volumen de reproducción (no disponible, use el del sistema.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra de herramientas de me&zcla"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Buscar"
@@ -15755,6 +16720,7 @@ msgstr "Reproduciendo por desplazamiento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Detener reproducción por desplazamiento"
@@ -15762,6 +16728,7 @@ msgstr "Detener reproducción por desplazamiento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Comenzar reproducción por desplazamiento"
@@ -15769,6 +16736,7 @@ msgstr "Comenzar reproducción por desplazamiento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Detener búsqueda"
@@ -15776,6 +16744,7 @@ msgstr "Detener búsqueda"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Comenzar búsqueda"
@@ -15830,7 +16799,9 @@ msgstr "Ajuste a"
 msgid "Length"
 msgstr "Duración"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centro"
 
@@ -15894,8 +16865,8 @@ msgstr "Barra de herramientas de &tiempo"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra de herramientas de %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -15922,7 +16893,8 @@ msgstr "Herramienta de cambio de tiempo"
 msgid "Zoom Tool"
 msgstr "Herramienta de ampliación"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Herramienta de dibujo"
 
@@ -15998,11 +16970,13 @@ msgstr "Arrastrar uno o más límites de etiqueta."
 msgid "Drag label boundary."
 msgstr "Arrastrar límite de etiqueta."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Etiqueta modificada"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Edición de etiqueta"
 
@@ -16057,31 +17031,42 @@ msgstr "Etiquetas editadas"
 msgid "New label"
 msgstr "Etiqueta nueva"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Subir una &octava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Bajar una octa&va"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Haga clic para acercar verticalmente, Mayús-Clic para alejar. Arrastre para acercar una región en concreto."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clic derecho para menú."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Restablecer ampliación"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Mayús-Clic derecho"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Clic izq/Arrastrar izq"
 
@@ -16123,7 +17108,8 @@ msgstr "Combinar"
 msgid "Expanded Cut Line"
 msgstr "Expandida la línea de corte"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expandir"
 
@@ -16146,6 +17132,11 @@ msgstr "Muestras movidas"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Edición de muestra"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16191,7 +17182,8 @@ msgstr "Procesando...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Se cambió «%s» a %s"
@@ -16203,6 +17195,54 @@ msgstr "Cambio de formato"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Fr&ecuencia"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr "8000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr "11 025 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr "16 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr "22 050 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr "44 100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr "48 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr "88 200 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr "96 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr "176 400 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr "192 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr "352 800 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr "384 000 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16222,7 +17262,8 @@ msgstr "Cambio de frecuencia"
 msgid "Set Rate"
 msgstr "Establecer frecuencia"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Vista &Múltiple"
 
@@ -16241,6 +17282,10 @@ msgstr "D&ividir pista estéreo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Dividir pista estéreo a mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16296,6 +17341,11 @@ msgid "Stereo, %dHz"
 msgstr "Estéreo, %dHz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Estéreo, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Izquierdo, %dHz"
@@ -16305,23 +17355,30 @@ msgstr "Izquierdo, %dHz"
 msgid "Right, %dHz"
 msgstr "Derecho,  %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f %% izquierda"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f %% derecha"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
-msgstr ""
-"Pulse y arrastre para redimensionar las subvistas; pulse dos veces para "
-"distribuir uniformemente"
+msgstr "Pulse y arrastre para redimensionar las subvistas; pulse dos veces para distribuir uniformemente"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
@@ -16432,8 +17489,8 @@ msgstr "&Interpolación logarítmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Pulse y arrastre para ajustar, pulsación doble para restablecer"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16484,6 +17541,7 @@ msgstr "Envolvente ajustada."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Reproducción por desplazamiento"
@@ -16495,6 +17553,7 @@ msgstr "Buscando"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Regla de Reproducción por desplazamiento"
@@ -16617,6 +17676,11 @@ msgstr "Ctrl+pulsación para deseleccionar"
 msgid "Open menu..."
 msgstr "Abrir menú…"
 
+#. i18n-hint: Command names a modifier key on Macintosh keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+msgid "Command+Click"
+msgstr "⌘+pulsación"
+
 #. i18n-hint: Ctrl names a modifier key on Windows or Linux keyboards
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
@@ -16673,6 +17737,24 @@ msgstr "Pulsar"
 msgid "Button"
 msgstr "Botón"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr "I"
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr "D"
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr "%.2f×"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16706,9 +17788,19 @@ msgstr "Vacío"
 msgid "Backwards"
 msgstr "Hacia atrás"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Hacia delante"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16794,6 +17886,14 @@ msgid "Automatic"
 msgstr "Automática"
 
 #: src/widgets/Meter.cpp
+msgid "Horizontal"
+msgstr "Horizontal"
+
+#: src/widgets/Meter.cpp
+msgid "Vertical"
+msgstr "Vertical"
+
+#: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr "Monitorización"
 
@@ -16830,6 +17930,29 @@ msgstr "Seleccione una acción"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 segundos"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + muestras"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 días 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -16845,11 +17968,35 @@ msgstr "0100 días 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + centésimas"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 cuadros|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + milisegundos"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 cuadros|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16871,6 +18018,7 @@ msgstr "0100 h 060 m 060 s+># muestras"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "muestras"
@@ -17024,9 +18172,32 @@ msgstr "Cuadros CDDA (75 fps)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 cuadros|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "01000,01000,01000 muestras|#"
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centihertz"
 msgstr "centihercios"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "kHz"
+msgstr "Hz"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hertz"
@@ -17096,6 +18267,11 @@ msgstr "(Utilice el botón derecho para cambiar el formato.)"
 msgid "centiseconds"
 msgstr "centésimas de segundo"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Tiempo transcurrido:"
@@ -17138,6 +18314,11 @@ msgstr "Confirmar cierre"
 msgid "Unable to write files to directory: %s."
 msgstr "No se pudo inicializar el archivo de proyecto"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17154,6 +18335,10 @@ msgstr "Preferencias de carpetas"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "No volver a mostrar esta advertencia de nuevo"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17237,15 +18422,27 @@ msgstr "No se ha podido analizar el código XML"
 msgid "Spectral edit multi tool"
 msgstr "Herramienta múltiple de edición espectral"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrando..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr "Paul Licameli"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Publicado bajo los términos de la Licencia Pública General de GNU versión 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aSeleccione frecuencias."
@@ -17271,6 +18468,12 @@ msgstr ""
 "~aLos parámetros del filtro Notch no se pueden aplicar.~%~\n"
 "                      Intente incrementar el límite de la frecuencia baja~%~\n"
 "                      o reducir el filtro 'Anchura'."
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy, lisp-format
+msgid "Error.~%"
+msgstr "Error"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 msgid "Spectral edit parametric EQ"
@@ -17328,6 +18531,24 @@ msgstr "Desvanecer progresivamente de estudio"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Aplicando fundido..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr "Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Publicado bajo los términos de la Licencia Pública General de GNU versión 2 o posterior."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17439,6 +18660,11 @@ msgid "S-Curve Out"
 msgstr "Salida curva S"
 
 #: plug-ins/adjustable-fade.ny
+#, fuzzy, lisp-format
+msgid "Error~%~%"
+msgstr "Error"
+
+#: plug-ins/adjustable-fade.ny
 #, lisp-format
 msgid "~aPercentage values cannot be negative."
 msgstr "~aLos valores porcentuales no pueden ser negativos."
@@ -17466,6 +18692,10 @@ msgstr "Descubridor de pulsos"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Encontrando pulsos..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17574,6 +18804,11 @@ msgstr "Aplicando efecto Retardo..."
 #: plug-ins/delay.ny
 msgid "Delay type"
 msgstr "Tipo de retardo"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Regular"
+msgstr "Rectangular"
 
 #: plug-ins/delay.ny
 msgid "Bouncing Ball"
@@ -17786,13 +19021,39 @@ msgstr "Filtro de paso alto"
 msgid "Performing High-Pass Filter..."
 msgstr "Aplicando filtro de paso alto..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Dominic Mazzoni"
+msgstr "Reducción de ruido de Dominic Mazzoni"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frecuencia (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Rodamiento (dB por octava)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17813,10 +19074,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Etiquetar sonidos"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Publicado bajo los términos de la Licencia Pública General de GNU versión 2 o posterior."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17877,6 +19134,12 @@ msgstr "Silencio posterior máximo"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Sonido ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -18056,6 +19319,12 @@ msgstr ""
 "Pico basado en los primeros ~a segundos ~a dB~%\n"
 "Configuración de Umbral recomendada ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Filtro Notch"
@@ -18104,7 +19373,8 @@ msgstr "Archivo Lisp"
 msgid "HTML file"
 msgstr "Archivo HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Archivo de texto"
 
@@ -18127,8 +19397,7 @@ msgstr "Permitido"
 #: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Success.~%Files written to:~%~s~%"
-msgstr ""
-"Operación efectuada correctamente.~%Se escribieron los archivos en:~%~s~%"
+msgstr "Operación efectuada correctamente.~%Se escribieron los archivos en:~%~s~%"
 
 #: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
@@ -18138,9 +19407,7 @@ msgstr "Atención.~%No se pudieron copiar algunos archivos:~%"
 #: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
-msgstr ""
-"Complementos instalados. ~%(Utilice el Gestor de complementos para activar "
-"los efectos):"
+msgstr "Complementos instalados. ~%(Utilice el Gestor de complementos para activar los efectos):"
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -18172,12 +19439,20 @@ msgid "Error.~%No file selected."
 msgstr "Error.~%No se seleccionó ningún archivo."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Generando sonido pluck..."
 
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Valores MIDI para notas DO: 36, 48, 60 [DO medio], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr "David R. Sky"
 
 #: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
@@ -18190,6 +19465,10 @@ msgstr "Tipo de desvanecimiento"
 #: plug-ins/pluck.ny
 msgid "Abrupt"
 msgstr "Abrupto"
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr "Gradual"
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -18224,10 +19503,12 @@ msgid "Swing amount"
 msgstr "Cantidad de oscilación"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr "+/− 1"
+
+#: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
-msgstr ""
-"Establezca el «Número de barras» a cero para activar la «Duración de pista "
-"de ritmo»."
+msgstr "Establezca el «Número de barras» a cero para activar la «Duración de pista de ritmo»."
 
 #: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
@@ -18292,6 +19573,10 @@ msgstr "Goteo (largo)"
 #: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of strong beat"
 msgstr "Tono MIDI de pulso fuerte"
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
@@ -18418,6 +19703,11 @@ msgstr "Mostrar mensajes"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Solo errores"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18718,6 +20008,10 @@ msgid "Applying Action..."
 msgstr "Aplicando acción…"
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "Eliminar vocales: a mono"
 
@@ -18799,8 +20093,7 @@ msgid ""
 msgstr ""
 " - Ambos canales son idénticos, es decir, mono dual.\n"
 "                El centro no puede quitarse.\n"
-"                Cualquier diferencia remanente puede ser derivada de una "
-"codificación con pérdida."
+"                Cualquier diferencia remanente puede ser derivada de una codificación con pérdida."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -18859,8 +20152,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Este complemento solo funciona con pistas estéreo."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Procesando Vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18902,6 +20203,226 @@ msgstr "Frecuencia de las agujas del radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Error.~%Se necesita una pista estéreo."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Actualizar Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Saltar"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Instalar actualización"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Cambios de la versión"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Más información en GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Error al buscar actualizaciones"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "No se pudo conectar con el servidor de actualizaciones de Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Los datos de actualización estaban dañados."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Error al descargar la actualización."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "No se puede abrir el enlace de descarga de Tenacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s está disponible."
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Grabación"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Id. de consigna:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Biblioteca de interfaz gráfica multiplataforma"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importación mediante GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es demasiado alto."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Autoajuste de nivel de grabación ha reducido el volumen a %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Autoajuste de nivel de grabación detenido. No se pudo optimizar más. Aún es demasiado bajo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Autoajuste de nivel de grabación ha incrementado el volumen a %2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Autoajuste de nivel de grabación detenido. Se ha excedido el número total de análisis sin encontrar un volumen aceptable. Aún es demasiado alto."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Autoajuste de nivel de grabación detenido. Se ha excedido el número total de análisis sin encontrar un volumen aceptable. Aún es demasiado bajo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Autoajuste de nivel de grabación detenido. %.2f parece ser un volumen aceptable."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Se han recibido %d abriendo los dispositivos\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "No se ha podido abrir Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Mezcladores disponibles:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Fuentes de grabación disponibles:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volúmenes de reproducción disponibles:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "El volumen de grabación es emulado\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "El volumen de grabación es nativo\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "El volumen de reproducción es emulado\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "El volumen de reproducción es nativo\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Fecha y hora desconocidas"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Archivos compatibles con GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "No se puede agregar el decodificador al canal"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importador GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "No se puede establecer el flujo de datos como pausado."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Índice[%02d], Tipo[%s], Canales[%d], Transferencia[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "El archivo no contiene ningún flujo de audio."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "No se puede importar el archivo, el cambio de estado ha fallado."
+
+#~ msgid "Mi&xer"
+#~ msgstr "Me&zclador"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "A&justar volumen de reproducción..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Incrementar volumen de reproducción"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Reducir volumen de reproducción"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Aj&ustar volumen de grabación..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "I&ncrementar volumen de grabación"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "R&educir volumen de grabación"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manual de Tenacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Acerca de Tenacity…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utoajuste del nivel de grabación"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Ajuste de nivel de grabación automatizado"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Activar el ajuste de nivel de grabación automatizado."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Pico objetivo:"
+
+#~ msgid "Within:"
+#~ msgstr "Interior:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Tiempo de análisis:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisegundos (tiempo de un análisis)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Número de análisis consecutivos:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 significa infinitos"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volumen de grabación"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volumen de reproducción"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volumen de grabación: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volumen de grabación (no disponible, utilice el mezclado del sistema.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volumen de reproducción: %.2f (emulado)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volumen de reproducción: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volumen de reproducción (no disponible, use el del sistema.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra de herramientas de me&zcla"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Pulse y arrastre para ajustar, pulsación doble para restablecer"
 
 #~ msgid "Program build date:"
 #~ msgstr "Fecha de compilación:"
@@ -19789,9 +21310,6 @@ msgstr "Error.~%Se necesita una pista estéreo."
 #~ msgid "To use Draw, choose 'Waveform' or 'Waveform (dB)' in the Track Dropdown Menu."
 #~ msgstr "Para usar la herramienta de dibujo seleccione 'Forma de onda' o 'Forma de onda dB' en el menú desplegable del nombre de la pista."
 
-#~ msgid "Vocal Remover"
-#~ msgstr "Eliminación vocal"
-
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "Eliminando audio panoramizado en centro..."
 
@@ -20453,9 +21971,6 @@ msgstr "Error.~%Se necesita una pista estéreo."
 #~ msgid "Offset"
 #~ msgstr "Desplazamiento"
 
-#~ msgid "Version"
-#~ msgstr "Versión"
-
 #~ msgid "C&ategory:"
 #~ msgstr "C&ategoría:"
 
@@ -20519,9 +22034,6 @@ msgstr "Error.~%Se necesita una pista estéreo."
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "Para usar la herramienta de dibujo seleccione 'Forma de onda' en el menú desplegable de pista."
-
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "%.2f dB RMS de media"
 
 #~ msgid "Average RMS = %.2f dB."
 #~ msgstr "Media de RMS = %.2f dB."
@@ -21789,9 +23301,6 @@ msgstr "Error.~%Se necesita una pista estéreo."
 #~ msgid "Noise Threshold (Hiss/Hum/Ambient Noise)"
 #~ msgstr "Umbral de ruido (Hiss/Hum/Ruido ambiental)"
 
-#~ msgid "Noise Removal by Dominic Mazzoni"
-#~ msgstr "Reducción de ruido de Dominic Mazzoni"
-
 #~ msgid "by Nasca Octavian Paul"
 #~ msgstr "de Nasca Octavian Paul"
 
@@ -22042,607 +23551,6 @@ msgstr "Error.~%Se necesita una pista estéreo."
 #~ msgid "Clean Speech"
 #~ msgstr "Limpieza de locución"
 
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Observe que los nombres se enumeran en orden alfabético, no por importancia."
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Script"
-msgstr "Secuencia de órdenes"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Harvey Lubin (logo)"
-msgstr "Harvey Lubin (logotipo)"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
 #, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s bytes"
-msgstr "%s bytes"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Error: %s"
-msgstr "Error: %s"
-
-#: src/AudacityLogger.cpp
-msgid "log.txt"
-msgstr "registro.txt"
-
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
-msgid "Error"
-msgstr "Error"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr "Ni MuseCY SM Ltd. ni Dominic M. Mazzoni producen ni avalan Tenacity."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"La marca registrada Audacity%s se utiliza en este programa únicamente para "
-"fines descriptivos e informativos."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s de los contribuidores de %s"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Proyecto %02i] "
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "bancodepruebas.txt"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
-#, c-format
-msgid "%d kbps"
-msgstr "%d kb/s"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/effects/vamp/VampEffect.h
-msgid "Vamp"
-msgstr "Vamp"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/effects/lv2/LV2Effect.h
-msgid "LV2"
-msgstr "LV2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/effects/ladspa/LadspaEffect.h
-msgid "LADSPA"
-msgstr "LADSPA"
-
-#: src/effects/Equalization.cpp
-msgid "RIAA"
-msgstr "RIAA"
-
-#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
-msgid "Color 0"
-msgstr "Color 0"
-
-#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
-msgid "Color 1"
-msgstr "Color 1"
-
-#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
-msgid "Color 2"
-msgstr "Color 2"
-
-#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
-msgid "Color:"
-msgstr "Color:"
-
-#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
-msgid "Color 3"
-msgstr "Color 3"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "Y:"
-msgstr "Y:"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "X:"
-msgstr "X:"
-
-#. i18n-hint name of a computer programming language
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "LISP"
-msgstr "LISP"
-
-#. i18n-hint JavaScript Object Notation
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "JSON"
-msgstr "JSON"
-
-#. i18n-hint abbreviates "Identity" or "Identifier"
-#: src/commands/DragCommand.cpp
-msgid "Id:"
-msgstr "Id.:"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#: src/LyricsWindow.cpp
-msgid "&Karaoke..."
-msgstr "&Karaoke…"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/effects/Effect.h
-msgid "Nyquist"
-msgstr "Nyquist"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/prefs/EffectsPrefs.cpp
-msgid "N&yquist"
-msgstr "N&yquist"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/prefs/EffectsPrefs.cpp
-msgid "LV&2"
-msgstr "LV&2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/prefs/EffectsPrefs.cpp
-msgid "&LADSPA"
-msgstr "&LADSPA"
-
-#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
-#. i18n-hint: One-letter abbreviation for Left, in VU Meter
-#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
-msgid "L"
-msgstr "I"
-
-#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
-#. i18n-hint: One-letter abbreviation for Right, in VU Meter
-#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
-msgid "R"
-msgstr "D"
-
-#. i18n-hint: "x" suggests a multiplicative factor
-#: src/widgets/ASlider.cpp
-#, c-format
-msgid "%.2fx"
-msgstr "%.2f×"
-
-#: src/widgets/Meter.cpp
-msgid "Horizontal"
-msgstr "Horizontal"
-
-#: src/widgets/Meter.cpp
-msgid "Vertical"
-msgstr "Vertical"
-
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
-msgid "Paul Licameli"
-msgstr "Paul Licameli"
-
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
-msgid "Steve Daulton"
-msgstr "Steve Daulton"
-
-#. i18n-hint: Command names a modifier key on Macintosh keyboards
-#: src/tracks/ui/TrackSelectHandle.cpp
-msgid "Command+Click"
-msgstr "⌘+pulsación"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#: plug-ins/rhythmtrack.ny
-msgid "+/- 1"
-msgstr "+/− 1"
-
-#: plug-ins/pluck.ny
-msgid "Gradual"
-msgstr "Gradual"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-#, c-format
-msgid "%d dB"
-msgstr "%d dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "+ dB"
-msgstr "+ dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "- dB"
-msgstr "− dB"
-
-#: src/commands/ScreenshotCommand.cpp
-msgid "Scriptables"
-msgstr "Secuenciables"
-
-#: src/menus/PluginMenus.cpp
-msgid "&Macros..."
-msgstr "&Macros…"
-
-#: src/menus/PluginMenus.cpp
-msgid "..."
-msgstr "…"
-
-#: src/menus/HelpMenus.cpp
-msgid "&Manual..."
-msgstr "&Manual…"
-
-#: src/menus/FileMenus.cpp
-msgid "&MIDI..."
-msgstr "&MIDI…"
-
-#: src/menus/FileMenus.cpp
-msgid "&Audio..."
-msgstr "&Audio…"
-
-#: src/import/ImportPCM.cpp
-msgid "8 bit DPCM"
-msgstr "DPCM de 8 bits"
-
-#: src/import/ImportPCM.cpp
-msgid "16 bit DPCM"
-msgstr "DPCM de 16 bits"
-
-#: src/import/ImportPCM.cpp
-msgid "24 bit DWVW"
-msgstr "DWVW de 24 bits"
-
-#: src/import/ImportPCM.cpp
-msgid "16 bit DWVW"
-msgstr "DWVW de 16 bits"
-
-#: src/import/ImportPCM.cpp
-msgid "12 bit DWVW"
-msgstr "DWVW de 12 bits"
-
-#: src/import/ImportPCM.cpp
-msgid "RAW (header-less)"
-msgstr "RAW (sin cabeceras)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-msgstr "MAT5 (GNU Octave 2.1/Matlab 5.0)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-msgstr "MAT4 (GNU Octave 2.0/Matlab 4.2)"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Error de GStreamer: %s"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "WAV (Microsoft)"
-msgstr "WAV (Microsoft)"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "AIFF (Apple/SGI)"
-msgstr "AIFF (Apple/SGI)"
-
-#: src/export/ExportMP3.cpp
-msgid "Variable"
-msgstr "Variable"
-
-#: src/export/ExportMP3.cpp
-msgid "65-105 kbps"
-msgstr "65-105 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "80-120 kbps"
-msgstr "80-120 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "95-135 kbps"
-msgstr "95-135 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "110-150 kbps"
-msgstr "110-150 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "145-185 kbps"
-msgstr "145-185 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "155-195 kbps"
-msgstr "155-195 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "170-210 kbps"
-msgstr "170-210 kb/s"
-
-#: src/export/ExportMP3.cpp
-msgid "200-250 kbps"
-msgstr "200-250 kb/s"
-
-#: src/export/ExportFLAC.cpp
-msgid "24 bit"
-msgstr "24 bits"
-
-#: src/export/ExportFLAC.cpp
-msgid "16 bit"
-msgstr "16 bits"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "60 ms"
-msgstr "60 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "40 ms"
-msgstr "40 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "20 ms"
-msgstr "20 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10 ms"
-msgstr "10 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "5 ms"
-msgstr "5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "2.5 ms"
-msgstr "2,5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Audio"
-msgstr "Audio"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VOIP"
-msgstr "VOIP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10"
-msgstr "10"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "9"
-msgstr "9"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "7"
-msgstr "7"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "6"
-msgstr "6"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "5"
-msgstr "5"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "4"
-msgstr "4"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "3"
-msgstr "3"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "1"
-msgstr "1"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "0"
-msgstr "0"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#: src/export/ExportFFmpegDialogs.cpp
-#, c-format
-msgid "%.2f kbps"
-msgstr "%.2f kb/s"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "2"
-msgstr "2"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16384"
-msgstr "16 384"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "8192"
-msgstr "8192"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "4096"
-msgstr "4096"
-
-#: src/effects/NoiseReduction.cpp
-msgid "1024"
-msgstr "1024"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "512"
-msgstr "512"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "256"
-msgstr "256"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "128"
-msgstr "128"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "64"
-msgstr "64"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "32"
-msgstr "32"
-
-#: plug-ins/pluck.ny
-msgid "David R.Sky"
-msgstr "David R. Sky"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "384000 Hz"
-msgstr "384 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "352800 Hz"
-msgstr "352 800 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "192000 Hz"
-msgstr "192 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "176400 Hz"
-msgstr "176 400 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "96000 Hz"
-msgstr "96 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "88200 Hz"
-msgstr "88 200 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "48000 Hz"
-msgstr "48 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "44100 Hz"
-msgstr "44 100 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "22050 Hz"
-msgstr "22 050 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "16000 Hz"
-msgstr "16 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "11025 Hz"
-msgstr "11 025 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "8000 Hz"
-msgstr "8000 Hz"
-
-#: src/prefs/SpectrumPrefs.cpp
-msgid "2048"
-msgstr "2048"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Ctrl"
-msgstr "Ctrl"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "78"
-msgstr "78"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "45"
-msgstr "45"
-
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
-msgid "No"
-msgstr "No"
-
-#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
-msgstr "[Proyecto %02i] Tenacity «%s»"
-
-#: src/FFT.cpp
-msgid "Rectangular"
-msgstr "Rectangular"
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Error de GStreamer: %s"

--- a/locale/eu.po
+++ b/locale/eu.po
@@ -12,53 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-05 05:22+0000\n"
 "Last-Translator: Sergio Varela <sergitroll9@gmail.com>\n"
-"Language-Team: Basque <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"eu/>\n"
+"Language-Team: Basque <https://hosted.weblate.org/projects/tenacity/tenacity/eu/>\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Irten Audacity-tik"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Bidea"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Akatsa agiria dekodeatzerakoan"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Akatsa Metadatuak Gertatzerakoan."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s Tresnabarra"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Grabaketa"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -68,6 +31,24 @@ msgstr "Ezinezkoa zehaztea"
 #, c-format
 msgid "%s bytes"
 msgstr "%s byte"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -124,6 +105,11 @@ msgstr "&Bilatu...\tKtrl+F"
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Matching Paren\tF8"
 msgstr "&Bat datorrena\tF8"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Top S-expr\tF9"
+msgstr "&Hurrengoa S-expr\tF12"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Higher S-expr\tF10"
@@ -190,7 +176,8 @@ msgid "Script"
 msgstr "Eskripta"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Irteera"
 
@@ -206,7 +193,12 @@ msgstr "Nyquist eskriptak (*.ny)|*.ny|Lisp eskriptak (*.lsp)|*.lsp|Agiri guztiak
 msgid "Script was not saved."
 msgstr "Eskripta ez da gorde."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Kontuz"
 
@@ -227,11 +219,16 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango Icon Galeria (tresnabarra ikurrak)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 Leland Lucius-ek egina"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Kanpoko Audacity moduloa IDE arrunt bat eskaintzen duena eraginak idazteko."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -254,7 +251,8 @@ msgstr "Izenburugabea"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist Eragin Lan-azterketa - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Berria"
 
@@ -294,7 +292,8 @@ msgstr "Kopiatu"
 msgid "Copy to clipboard"
 msgstr "Kopiatu gakora"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Ebaki"
 
@@ -302,7 +301,8 @@ msgstr "Ebaki"
 msgid "Cut to clipboard"
 msgstr "Kopiatu gakora"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Itsatsi"
 
@@ -327,7 +327,8 @@ msgstr "Hautatu Denak"
 msgid "Select all text"
 msgstr "Hautatu idazki denak"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Desegin"
 
@@ -335,7 +336,8 @@ msgstr "Desegin"
 msgid "Undo last change"
 msgstr "Desegin azken aldaketa"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Berregin"
 
@@ -392,7 +394,8 @@ msgid "Go to next S-expr"
 msgstr "Joan hurrengo S-expr-ra"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Hasiera"
 
@@ -400,7 +403,8 @@ msgstr "Hasiera"
 msgid "Start script"
 msgstr "Gorde eskripta"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Gelditu"
 
@@ -415,7 +419,8 @@ msgid "About %s"
 msgstr "%s buruz"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Ongi"
 
@@ -423,11 +428,13 @@ msgstr "Ongi"
 msgid "Build Information"
 msgstr "Eraiketa Argibideak"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Gaituta"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Ezgaituta"
 
@@ -437,8 +444,9 @@ msgid "The Build"
 msgstr "Garbiketa eraiketa"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Aurkezpen Id-a:"
+#, fuzzy
+msgid "Version:"
+msgstr "Bertsioa"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -448,22 +456,28 @@ msgstr "Eraiketa mota:"
 msgid "Compiler:"
 msgstr "Biltzailea:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Ezarpen Aurrezenbakia:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Ezarpenen agiritegia:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Ezarpenen agiritegia:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Agiri Heuskarri Sostengua"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Plataforma-arteko EIG liburutegia"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -477,7 +491,6 @@ msgstr "Lagin neurri bihurketa"
 msgid "MP3 Importing"
 msgstr "MP3 Inportazioa"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis Inportazioa eta Esportazioa"
@@ -486,7 +499,6 @@ msgstr "Ogg Vorbis Inportazioa eta Esportazioa"
 msgid "ID3 tag support"
 msgstr "ID3 etiketa sostengua"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC inportazioa eta esportazioa"
@@ -504,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg Inportazio/Esportazioa"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Inportatu GStreamer bidez"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Ezaugarriak"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Plug-in sostengua"
 
@@ -526,6 +530,10 @@ msgstr "Doinu eta Tenpo Aldaketa sostengua"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Hertzeko Doinu eta Tenpo Aldaketa sostengua"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Ezaugarriak"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -644,6 +652,10 @@ msgstr "%s, grafikoak"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (inkorporatuz %s, %s, %s, %s eta %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -653,6 +665,10 @@ msgstr "%s soinua grabatzeko eta editatzeko plataforma-anitzeko sotware askea et
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Kreditoak"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Kontuan izan izenak alfabetoaren arabera ordenatuta daudela, ez garrantziaren arabera."
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -703,6 +719,7 @@ msgstr "Webgunea eta Grafikoak"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Euskarazko Itzulpena: Xabier Aramendi"
@@ -720,6 +737,22 @@ msgstr "Eskerrak:"
 #, c-format
 msgid "%s website: "
 msgstr "%s webgunea: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s zergadunak"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Audacity%s marka komertziala helburu deskribatzaile eta informatiboetarako soilik erabiltzen da software honetan."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity ez dute MuseCY SM Ltd. eta Dominic m Mazzoni-k ekoizten eta bermatzen."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -742,6 +775,7 @@ msgstr "Denbora-lerroa"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klikatu edo arrastatu Bilaketa hasteko"
@@ -749,6 +783,7 @@ msgstr "Klikatu edo arrastatu Bilaketa hasteko"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klikatu edo arrastatu Arrast-irakurtzea hasteko"
@@ -756,6 +791,7 @@ msgstr "Klikatu edo arrastatu Arrast-irakurtzea hasteko"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Klikatu  eta mugitu Arrast-irakurtzeko. Klikatu eta arrastatu Bilatzeko."
@@ -763,6 +799,7 @@ msgstr "Klikatu  eta mugitu Arrast-irakurtzeko. Klikatu eta arrastatu Bilatzeko.
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Mugitu Bilatzeko"
@@ -770,6 +807,7 @@ msgstr "Mugitu Bilatzeko"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Mugitu Arrast-irakurtzeko"
@@ -826,7 +864,17 @@ msgstr ""
 "Ezin da blokeatu egitasmo amaiera\n"
 "baino haragoko eremua."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Akatsa"
 
@@ -850,7 +898,8 @@ msgstr ""
 "Hau behin egiten den galdera da, non 'ezarri' ondoren Hobespenak berrezartzea galdetu duzun."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Berrezarri Audacity Hobespenak"
 
 #: src/AudacityApp.cpp
@@ -863,6 +912,11 @@ msgstr ""
 "%s ez da aurkitu.\n"
 "\n"
 "Azken agirien zerrendatik kendua izan da."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr "Ezin izan zen SQLite liburutegia hasi. Tenacityk ezin du jarraitu."
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -887,7 +941,7 @@ msgstr "&Ireki..."
 msgid "Open &Recent..."
 msgstr "Ireki &Berrikikoa..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Audacity-ri buruz..."
@@ -901,9 +955,10 @@ msgid "&File"
 msgstr "&Agiria"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity-k ezin izan du aldibaterako agiriak biltegiratzeko toki seguru bat aurkitu.\n"
@@ -911,20 +966,23 @@ msgstr ""
 "Mesedez sartu zuzenbide egoki bat hobespen elkarrizketan."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity-k ezin izan du aldibaterako agiriak biltegiratzeko tokia aurkitu.\n"
 "Mesedez sartu zuzenbide egokia hobespen elkarrizketan."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity orain irtetzera doa. Mesedez abiarazi Audacity berriro aldibaterako zuzenbide berria erabiltzeko."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -933,15 +991,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity-k ezin du lotu aldibaterako agiri zuzenbidea.\n"
 "Agiritegia badaiteke Audacity-ren beste kopia batek erabiltzea.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Oraindik Audacity abiatzea nahi duzu?"
 
 #: src/AudacityApp.cpp
@@ -949,24 +1009,91 @@ msgid "Error Locking Temporary Folder"
 msgstr "Akatsa Aldibaterako Agiritegia Lotzerakoan"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Sistemak Audacity-ren beste kopia bat ekinean dagoela atzeman du.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Erabili Berria edo Ireki aginduak orain abiarazitako Audacity-n\n"
 "egitasmo anitz aldiberean irekitzeko.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity jadanik lanean dago"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+"Ezin da semafororik erosi.\n"
+"\n"
+"Hori, ziurrenik, baliabide-eskasia dela eta gertatu da.\n"
+"Eta baliteke berriz hasi behar izatea."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity Abiarazte Hutsegitea"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+"Ezin da semafororik sortu.\n"
+"\n"
+"Hori, ziurrenik, baliabide-eskasia dela eta gertatu da.\n"
+"Eta baliteke berriz hasi behar izatea."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+"Ezin da semafororik erosi.\n"
+"\n"
+"Hori, ziurrenik, baliabide-eskasia dela eta gertatu da.\n"
+"Eta baliteke berriz hasi behar izatea."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+"Ezin da semafororik erosi.\n"
+"\n"
+"Hori, ziurrenik, baliabide-eskasia dela eta gertatu da.\n"
+"Eta baliteke berriz hasi behar izatea."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+"Ezin da semafororik sortu.\n"
+"\n"
+"Hori, ziurrenik, baliabide-eskasia dela eta gertatu da.\n"
+"Eta baliteke berriz hasi behar izatea."
 
 #: src/AudacityApp.cpp
 msgid "An unrecoverable error has occurred during startup"
@@ -990,7 +1117,8 @@ msgstr "ekin bere igarpenak"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "erakutsi Audacity bertsioa"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1000,9 +1128,10 @@ msgid "audio or project file name"
 msgstr "audio edo egitasmo agiria"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1015,24 +1144,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity Egitasmoko Agiriak"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Mezua"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "DarkAudacity Norberetzea"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Laguntza"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Utzi Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity-ren Oharra"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1044,7 +1197,8 @@ msgstr "G&orde..."
 msgid "Cl&ear"
 msgstr "G&arbitu"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "It&xi"
 
@@ -1099,7 +1253,8 @@ msgid "Error Initializing Midi"
 msgstr "Akatsa Midi Abirazterakoan"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity Audioa"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1114,37 +1269,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Ez dago oroimenik!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Ezin izan da gehiago hobetu. Handiegia oraindik."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapenak bolumena %2f-ra gutxitu du."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Ezin da gehiago hobetu. Apalegia oraindik."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapenak bolumena %2f-ra gehitu du."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Azterketa zenbatekoa guztira gainditu da bolumen onargarri bat aurkitu gabe. Handiegia oraindik."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Azterketa zenbatekoa guztira gainditu da bolumen onargarri bat aurkitu gabe. Apalegia oraindik."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. %.2f bolumen onargarri bezala ikusten da."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1247,43 +1371,6 @@ msgstr "Ez da irakurketa gailurik aurkitu honentzat: '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Ezinezkoa elkar laginketa neurriak egiaztatzea bi gailuak gabe.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "%d jaso d gailuak irekitzean\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Ezinezkoa Ataka-Nahastzailea irekitzea\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Nahasgailu eskuragarriak:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Grabaketa iturburu eskuragarriak:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Irakurketa Bolumen eskuragarriak:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Grabaketa Bolumena antzeratua da\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Grabaketa Bolumena jatorrizkoa da\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Irakurketa bolumena emulatua da\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Irakurketa bolumena jatorrizkoa da\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1326,8 +1413,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Berezgaitasunezko Matxura Berreskurapena"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1340,12 +1428,14 @@ msgid "Recoverable &projects"
 msgstr "Egitasmo berreskuragarriak"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Hautatu"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Izena"
 
@@ -1356,6 +1446,11 @@ msgstr " Hautatuta"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Ezer ez Hautatuta"
+
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Skip"
+msgstr "&Saltatu"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1430,6 +1525,11 @@ msgstr "Eragina"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menu Aginduak (Parametroekin)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1575,7 +1675,8 @@ msgstr "Le&heneratu"
 msgid "I&mport..."
 msgstr "I&nportatu..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&sportatu..."
 
@@ -1616,7 +1717,8 @@ msgstr "Mugitu &Gora"
 msgid "Move &Down"
 msgstr "Mugitu &Behera"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Gorde"
 
@@ -1663,6 +1765,11 @@ msgstr "Izenek ezin dute izan '%c' eta '%c'"
 msgid "Are you sure you want to delete %s?"
 msgstr "Zihur zaude %s ezabatzea nahi duzula?"
 
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+msgid "Benchmark"
+msgstr "Benchmark"
+
 #: src/Benchmark.cpp
 msgid "Disk Block Size (KB):"
 msgstr "Diska Bloke Neurria (KB):"
@@ -1694,9 +1801,16 @@ msgid "Run"
 msgstr "Ekin"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Itxi"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "benchmark.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1834,11 +1948,6 @@ msgid "No revision identifier was provided"
 msgstr "Ez da berrikusketa ezagutarazlerik eman"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Amaiera Eguna eta Ordua"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Garbiketa eraiketa (garbiketa maila %d)"
@@ -1947,10 +2056,25 @@ msgstr "Oraingo Egitasmoa"
 msgid "Checkpointing %s"
 msgstr "%s inportatzen"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr "Honek segundo batzuk behar izan ditzake"
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Ezin da agirian idatzi: %s\n"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Diskoa beteta dago.\n"
+"%s\n"
+"Espazioa askatzeko aholkuak lortzeko, egin klik laguntza-botoian."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1971,6 +2095,10 @@ msgid ""
 msgstr ""
 "Hutsegitea erregistratzerakoan:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr "Datu-basearen errorea. Barkatu, baina ez dugu xehetasun gehiago."
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -2068,6 +2196,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopiatu Izenak Gakora"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Ez dago"
 
@@ -2076,10 +2209,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Jarraitzen baduzu, zure egitasmoa ez da diskan gordeko. Hori da nahi duzuna?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2093,7 +2227,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Elkartoki Egiaztapena"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Bat ere ez"
 
@@ -2101,7 +2238,7 @@ msgstr "Bat ere ez"
 msgid "Rectangle"
 msgstr "Laukiluzea"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Hirukia"
 
@@ -2115,17 +2252,59 @@ msgstr "Laukiluzea"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, ezer ez"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Galesera"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg sostengua ez dago bilduta"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2147,8 +2326,8 @@ msgid "Locate FFmpeg"
 msgstr "Kokatu FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity-k '%s' agiria behar du audioa FFmpeg bidez inportatzeko eta esportatzeko."
 
 #: src/FFmpeg.cpp
@@ -2161,7 +2340,8 @@ msgstr "'%s'-ren kokalekua:"
 msgid "To find '%s', click here -->"
 msgstr "'%s' bilatzeko, klikatu hemen -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Bilatu..."
 
@@ -2187,8 +2367,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg ez da aurkitu"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2218,24 +2399,24 @@ msgid "Only libavformat.so"
 msgstr "Bakarrik libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity-k huts egin du agiria %s irekitzean."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity-k huts egin du agiria %s-tik irakurtzean."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity-k ongi idatzi du agiri bat hemen: %s baina huts egin du %s bezala berrizendatzerakoan."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2272,7 +2453,9 @@ msgstr "&Ez kopiatu audiorik"
 msgid "As&k"
 msgstr "Ga&ldetu"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Agiri guztiak"
 
@@ -2297,6 +2480,10 @@ msgstr "Idazki agiriak"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML agiriak"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2338,6 +2525,14 @@ msgstr "Kuboerro Berez-elkartasuna"
 msgid "Enhanced Autocorrelation"
 msgstr "Berez-elkartasun Hobetua"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Argilitza"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2354,6 +2549,17 @@ msgstr "Maiztasun linearra"
 msgid "Log frequency"
 msgstr "Ohar maiztasuna"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Irristatu"
@@ -2361,6 +2567,15 @@ msgstr "Irristatu"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Zooma"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2421,6 +2636,24 @@ msgstr "Audio gehiegi hautatu dira. Audioaren lehen %.1f segundoak bakarrik azte
 msgid "Not enough data selected."
 msgstr "Ez dira nahikoa datu hautatu."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "s"
+msgstr "sm"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f seg (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f seg (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2443,7 +2676,8 @@ msgstr "argilitza.txt"
 msgid "Export Spectral Data As:"
 msgstr "Esportatu Argilitza Datuak Honela:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Ezin da agirian idatzi: %s"
@@ -2623,6 +2857,11 @@ msgstr "Baztertu"
 msgid "&Compact"
 msgstr "&Agindua"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr "Trinkotzeak disko-espazioaren %s askatu du."
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2630,19 +2869,19 @@ msgid "&History..."
 msgstr "&Historia..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Barneko akatsa %s -> %s lerroa %d.\n"
 "Mesedez jakinarazi Audacity taldeari hemen: https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Barneko akatsa -> %s lerroa %d.\n"
 "Mesedez jakinarazi Audacity taldeari hemen: https://forum.audacityteam.org/."
@@ -2661,7 +2900,9 @@ msgid "Track"
 msgstr "Bidea"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiketa"
 
@@ -2721,7 +2962,8 @@ msgstr "Sartu bide izena"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Etiketatu Bidea"
 
@@ -2732,11 +2974,13 @@ msgstr "Gordetako etiketa bat edo gehiago ezin da irakurri."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity-ren Lehen Abiaraztea"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Hautatu Audacity-k Erabilitzeko Hizkuntza:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2746,7 +2990,8 @@ msgstr "Hautatu Audacity-k Erabilitzeko Hizkuntza:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Hautatu duzun hizkuntza, %s (%s), ez da sistemaren hizkuntza bera, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Baieztatu"
 
@@ -2764,12 +3009,13 @@ msgstr ""
 "Agiri zaharra honela gorde da: '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity Egitasmoa Irekitzen"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity Karaokea%s"
 
 #: src/LyricsWindow.cpp
@@ -2820,19 +3066,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Bide nahasketa eta aurkezpena"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity Nahastzaile Agintea%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Irabazia"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Abiadura"
 
@@ -2841,17 +3091,23 @@ msgid "Musical Instrument"
 msgstr "Musika Tresna"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panoramikoa"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Mututu"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Soloa"
 
@@ -2859,15 +3115,18 @@ msgstr "Soloa"
 msgid "Signal Level Meter"
 msgstr "Seinale Maila Neurgailua"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Irabazi irristaria mugituta"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Mugituta abiadrua irristaria"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Panel irristaria mugituta"
 
@@ -2902,9 +3161,9 @@ msgstr ""
 "Ez da gertatuko."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2938,16 +3197,19 @@ msgstr ""
 "\n"
 "Erabili iturburu fidagarrietako moduloak bakarrik"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Bai"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ez"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacity Modulo Gertatzailea"
 
 #: src/ModuleManager.cpp
@@ -2970,6 +3232,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Ohar Bidea"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3079,7 +3451,8 @@ msgstr "Hautatu &Denak"
 msgid "C&lear All"
 msgstr "G&arbitu Denak"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Gaitu"
 
@@ -3151,18 +3524,17 @@ msgstr ""
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "The tracks selected for recording must all have the same sampling rate"
-msgstr ""
-"Grabaketarako hautatutako bide guztiek laginketa neurri berdina izan behar "
-"dute"
+msgstr "Grabaketarako hautatutako bide guztiek laginketa neurri berdina izan behar dute"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "Mismatched Sampling Rates"
 msgstr "Laginketa Neurriak ez datoz bat"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Bide gutxiegi hautatu dira grabaketarako laginketa neurri honekin.\n"
@@ -3191,10 +3563,11 @@ msgid "Dropouts"
 msgstr "Kanporaketak"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3234,11 +3607,11 @@ msgid "Inspecting project file data"
 msgstr "Egitasmo agiri datuak aztertzen"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3281,11 +3654,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Kontuz - Agiri Izenordetua(k) Galduta"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "\"%s\" agiritegiaren egitasmo egiaztapenak\n"
@@ -3310,12 +3683,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Kontuz - Izenorde Lapurpen Agiria(k) Galduta"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3373,7 +3746,8 @@ msgstr "Kontuz - Bloke Umezurtz Agiria(k)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Garapena"
 
@@ -3398,6 +3772,11 @@ msgstr "Kontuz: Arazoak Berezgaitasunezko Berreskurapenean"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<izenburugabea>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Egitasmoa %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3439,11 +3818,96 @@ msgstr ""
 "%s"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Hutsegitea aurrezarpena kodeatzean hemendik: \"%s\""
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Audacity Egitasmo bat Gordetzea"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Ezinezkoa MP3 jarioa abiarazi"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ezinezkoa MP3 jarioa abiarazi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ezinezkoa MP3 jarioa abiarazi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ezinezkoa MP3 jarioa abiarazi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ezinezkoa MP3 jarioa abiarazi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ezinezkoa MP3 jarioa abiarazi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ezinezkoa MP3 jarioa abiarazi"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Ezinezkoa MP3 jarioa abiarazi"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3457,12 +3921,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Bloke agiri umezurtza: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Ezinezkoa jario egoera pausatuan ezartzea"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Hutsegitea kodeka bilatzerakoan"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Hutsegitea aurrezarpena kodeatzean hemendik: \"%s\""
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3473,9 +3958,9 @@ msgid "Error Writing to File"
 msgstr "Akatsa Agirira Idazterakoan"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3488,9 +3973,16 @@ msgstr "Egitasmoa &gordetzerakoan"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Egitasmoa %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3499,10 +3991,10 @@ msgstr "(Berreskuratuta)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Agiri hau Audacity %s erabiliz gorde zen .\n"
 "Audacity %s erabiltzen ari zara. Badaiteke bertsio berriago batera eguneratu behar izatea agiri hau irekitzeko."
@@ -3510,6 +4002,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Ezin da egitasmo agiria ireki"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3524,6 +4020,10 @@ msgid "Unable to parse project information."
 msgstr "Ezinezkoa aurrezarpen agiria irakurtzea."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Egitasmoa &gordetzerakoan"
 
@@ -3532,12 +4032,35 @@ msgid "Error Saving Project"
 msgstr "Akatsa Egitasmoa Gordetzerakoan"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Egitasmo &hutsa gordetzerakoan"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3546,8 +4069,25 @@ msgstr ""
 "Zorionez, hurrengo egitasmoak berezgaitasunez berreskuratu daitezke."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Egitasmo batzuk ez ziren egoki gorde Audacity azken aldiz abiarazi zenean.\n"
+"\n"
+"Zorionez, hurrengo egitasmoak berezgaitasunez berreskuratu daitezke."
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Egitasmoa Berreskuratu da"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Aldibaterako agiri zuzenbidea"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3577,6 +4117,17 @@ msgstr "Kontuz - Egitasmoa Hutsik"
 msgid "Insufficient Disk Space"
 msgstr "Diska Tokia"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3596,8 +4147,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sGorde Egitasmoa \"%s\" Honela..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Gorde Egitasmoa' Audacity egitasmo baterako da, ez audio agiri batentzat.\n"
@@ -3674,11 +4226,12 @@ msgid "Error Opening Project"
 msgstr "Akatsa Egitasmoa Irekitzerakoan"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Berezgaitasunez sortutako babeskopia agiri bat irekitzen saiatzen ari zara.\n"
 "Hau egiteak datu galera larriak eragin ditzake.\n"
@@ -3711,6 +4264,12 @@ msgid "Error Opening File or Project"
 msgstr "Akatsa Agiria edo Egitasmoa Irekitzerakoan"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Egitasmoa Berreskuratu da"
 
@@ -3736,12 +4295,33 @@ msgid "Error Importing"
 msgstr "Akatsa inportatzerakoan"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Ezarri Egitasmoa"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Ezin da egitasmo agiria ireki"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Agindua"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3752,8 +4332,8 @@ msgid "Automatic database backup failed."
 msgstr "Berezgaitasunezko Gordetzea gaituta:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Ongi etorri Audacity %s bertsiora"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3865,6 +4445,21 @@ msgstr "Ontasuna Handia"
 msgid "Best Quality (Slowest)"
 msgstr "Ontasun Hoberena (Astiroena)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+msgid "16-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+msgid "24-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
 #: src/SampleFormat.cpp
 msgid "Unknown format"
 msgstr "Heuskarri ezezaguna"
@@ -3953,7 +4548,8 @@ msgstr "Hobespen Guztiak"
 msgid "SelectionBar"
 msgstr "Hautapen-Barra"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Argilitza Hautapena"
 
@@ -3961,46 +4557,55 @@ msgstr "Argilitza Hautapena"
 msgid "Timer"
 msgstr "Denboragailua:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Tresnak"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Garraioa"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Nahastzailea"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Neurgailua"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Irakur Neurgailua"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Grabaketa Neurgailua"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Editatu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Gailua"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Irakurketa Abiaduran"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Arrast-irakurri"
 
@@ -4015,7 +4620,10 @@ msgstr "Zuzentzailea"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Bideak"
 
@@ -4125,7 +4733,8 @@ msgid "Activation level (dB):"
 msgstr "Gaitze maila (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Ongi etorri Audacity-ra!"
 
 #: src/SplashDialog.cpp
@@ -4252,10 +4861,28 @@ msgstr "Akatsa Etiketa Agiria Gordetzerakoan"
 msgid "Unsuitable"
 msgstr "Moduloa Kokatuezina"
 
-#: src/Theme.cpp
-#, c-format
+#: src/TempDirectory.cpp
+#, fuzzy
 msgid ""
-"Audacity could not write file:\n"
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Aldibaterako agiri zuzenbidea"
+
+#: src/TempDirectory.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+"Diskoa beteta dago.\n"
+"%s\n"
+"Espazioa askatzeko aholkuak lortzeko, egin klik laguntza-botoian."
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity-k ezin dut idatzi agiria:\n"
@@ -4275,9 +4902,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4286,9 +4913,9 @@ msgstr ""
 "idazteko."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity-k ezin ditu irudiak agirira idatzi:\n"
@@ -4305,9 +4932,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4317,9 +4944,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4328,8 +4955,9 @@ msgstr ""
 "png heuskarri okerra agian?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity-k ezin du berezko azalgaia irakurri.\n"
@@ -4367,9 +4995,9 @@ msgstr ""
 "jadanik badaude. Gainidatzi?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity-k ezin du agiria gorde:\n"
@@ -4408,7 +5036,11 @@ msgstr "Norberea"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Iraupena"
 
@@ -4419,7 +5051,8 @@ msgid "Time Track"
 msgstr "Denbora Bidea"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity Denboragailu Grabaketa"
 
 #: src/TimerRecordDialog.cpp
@@ -4493,7 +5126,8 @@ msgstr "Oraingo Egitasmoa"
 msgid "Recording start:"
 msgstr "Grabaketa hasiera:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Iraupena:"
 
@@ -4514,7 +5148,8 @@ msgid "Action after Timer Recording:"
 msgstr "Denboragailu Grabaketaren ondorengo ekintza:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity Denboragailu Grabaketa Garapena"
 
 #: src/TimerRecordDialog.cpp
@@ -4610,6 +5245,7 @@ msgstr "099 egun 024 ord 060 min 060 seg"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Hasiera Eguna eta Ordua"
@@ -4654,7 +5290,8 @@ msgstr "Gaitu &Berezgaitasunezko Esportatzea?"
 msgid "Export Project As:"
 msgstr "Esportatu Egitasmoa Honela:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Aukerak"
 
@@ -4667,7 +5304,8 @@ msgid "Do nothing"
 msgstr "Ez egin ezer"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Irten Audacity-tik"
 
 #: src/TimerRecordDialog.cpp
@@ -4691,7 +5329,8 @@ msgid "Scheduled to stop at:"
 msgstr "Gelditzeko egitarautua:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity Denboragailu Grabaketa - Hasteko Itxaroten"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4717,7 +5356,8 @@ msgid "Recording Exported:"
 msgstr "Grabaketa Esportatuta:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity Denboragailu Grabaketa - Itxaroten"
 
 #: src/TrackInfo.cpp
@@ -4843,6 +5483,10 @@ msgstr "Mugitu Bidea Gora"
 msgid "Move Track Down"
 msgstr "Mugitu Bidea Behera"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4909,6 +5553,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Ezartzen %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "HUTSEGITEA"
@@ -4927,13 +5581,15 @@ msgstr "%s ez da %s onartutako parametroa"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Balio baliogabea '%s'-rentzat: behar du izan %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Agindua"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Berregin %s"
@@ -5060,13 +5716,24 @@ msgstr "Ebakinak"
 msgid "Envelopes"
 msgstr "Bilkariak"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiketak"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Kutxatilak"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5076,7 +5743,8 @@ msgstr "Laburra"
 msgid "Type:"
 msgstr "Mota:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Heuskarria:"
 
@@ -5104,9 +5772,17 @@ msgstr "Aipamenak"
 msgid "Command:"
 msgstr "Agindua:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Laguntza ematen du agindu batean."
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -5136,12 +5812,17 @@ msgstr "Agiri batera esportatzen du."
 msgid "Builtin Commands"
 msgstr "Barnebildutako Aginduak"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity Taldea"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Barnebildutako eraginak hornitzen dizkio Audacity-ri"
 
 #: src/commands/LoadCommands.cpp
@@ -5192,11 +5873,22 @@ msgstr "Egitasmo bat bezala gordeten du."
 msgid "Saves a copy of current project."
 msgstr "Egitasmo bat bezala gordeten du."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Lortu Hobespena"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Izena:"
 
@@ -5244,7 +5936,8 @@ msgstr "Ikusleiho-osoa"
 msgid "Toolbars"
 msgstr "Tresnabarrak"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Eraginak"
 
@@ -5384,7 +6077,8 @@ msgstr "Ezarri"
 msgid "Add"
 msgstr "Gehitu"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Kendu"
 
@@ -5469,7 +6163,8 @@ msgid "Edited Envelope"
 msgstr "Ezarri Bilkaria"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Bilkaria"
 
@@ -5514,6 +6209,14 @@ msgid "Resize:"
 msgstr "Berneurritu:"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Zabalera:"
 
@@ -5554,10 +6257,17 @@ msgid "Gain:"
 msgstr "Irabazia:"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Ezarri Bide Ikusgarriak"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linearra"
 
@@ -5600,6 +6310,12 @@ msgstr "Erabili Argilitza Hobesp"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Argilitza Hautapena"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5655,12 +6371,18 @@ msgstr "Audiorik ez duen bide bat hautatu duzu. Berez-Uztartuk audio bideak baka
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Berez Uztartzeak aginte bide bat behar du hautaturiko bideen azpian jarri behar dena."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Uztarpen &kopurua:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segundu"
 
@@ -5684,7 +6406,8 @@ msgstr "Barne &hutsalbehera luzera:"
 msgid "Inner &fade up length:"
 msgstr "Barne h&utsalgora luzera:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Muga:"
 
@@ -5822,11 +6545,13 @@ msgstr "hona (Hz)"
 msgid "t&o"
 msgstr "ho&na"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Ehuneko Al&daketa:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Ehuneko Aldaketa"
 
@@ -5834,9 +6559,23 @@ msgstr "Ehuneko Aldaketa"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Erabili ontasun handiko indartzea (astiroa)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "e/g"
 
@@ -5864,6 +6603,7 @@ msgstr "Binilo rpm Estandarra:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "IM-kotik"
@@ -5876,6 +6616,7 @@ msgstr "&hemendik"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "IM-kora"
@@ -6018,6 +6759,12 @@ msgstr "Konprimitzailea"
 msgid "Compresses the dynamic range of audio"
 msgstr "Audioaren maila dinamikoa konprimitzen du"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6027,6 +6774,20 @@ msgstr "%.2f seg"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f seg"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6143,7 +6904,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Gain-barrentasun Aztertzailea, RMS bolumen aldeak neurtzeko hautaturiko bi audio artean."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Amaiera"
 
@@ -6203,9 +6965,32 @@ msgstr "&Aldea:"
 msgid "&Help"
 msgstr "Lag&untza"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "zehaztugabea"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6259,6 +7044,12 @@ msgstr "Oraingo aldea"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Gainalde maila neurtuta"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f seg"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6399,6 +7190,10 @@ msgstr "Ebaketa biguna-12dB, &80 egintza irabazia"
 #: src/effects/Distortion.cpp
 msgid "Fuzz Box"
 msgstr "Ilats Kutxa"
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Blues drive sustain"
@@ -6608,7 +7403,9 @@ msgstr "DTMF &sekuentzia:"
 msgid "&Amplitude (0-1):"
 msgstr "&Anplitudea (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Iraupena:"
 
@@ -6621,8 +7418,19 @@ msgid "Duty cycle:"
 msgstr "Lanaldia:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f seg"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Doinu iraupena:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.0f ms"
+msgstr "%0.f sm"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
@@ -6642,7 +7450,8 @@ msgstr "Oihartzuna"
 msgid "Repeats the selected audio again and again"
 msgstr "Hautaturiko audioa behin eta berriro berregiten du"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Eskatutako balioak oroimen gaitasuna gainditzen du."
 
@@ -6666,7 +7475,8 @@ msgstr "Aurrezarpenak"
 msgid "Export Effect Parameters"
 msgstr "Esportatu EraginParametroak"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Ezin izan da agiri hau ireki: \"%s\""
@@ -6703,6 +7513,15 @@ msgstr "Aurreikuspena gertatzen"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Aurreikusten"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist Akatsa"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7035,6 +7854,10 @@ msgid "Low rolloff for speech"
 msgstr "Ahots erortze apala"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefonoa"
 
@@ -7071,12 +7894,41 @@ msgid "Effect Unavailable"
 msgstr "Eragina Eskuraezina"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Geh dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Gutx dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7151,8 +8003,16 @@ msgid "D&efault"
 msgstr "&Berezkoa"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &Harituta"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7397,7 +8257,8 @@ msgid "Builtin Effects"
 msgstr "Barnebildutako Eraginak"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Barnebildutako eraginak hornitzen dizkio Audacity-ri"
 
 #: src/effects/LoadEffects.cpp
@@ -7407,6 +8268,10 @@ msgstr "Barne-bildutako eragin izen ezezaguna"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "atzemandako ozentasuna"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7438,6 +8303,14 @@ msgstr "&Normaldu"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Ozentasun LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7507,7 +8380,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (berezkoa)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, ezer ez"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, ezer ez"
 
 #: src/effects/NoiseReduction.cpp
@@ -7607,8 +8489,9 @@ msgid "Step 1"
 msgstr "1 Urratsa"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Hautatu zarata segundu batzuk Audacity-k zer iragazi jakin dezan,\n"
@@ -7660,13 +8543,62 @@ msgstr "L&eiho motak:"
 msgid "Window si&ze:"
 msgstr "&Leiho neurria:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (berezkoa)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Urrats leihoko:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7792,6 +8724,7 @@ msgstr "Erabili Paul-luzapena muturreko denbora-luzapen edo \"stasis\" eraginera
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "&Luzapen Ezaugarria:"
@@ -8073,6 +9006,11 @@ msgstr "Hautaturiko audioa atzekoz-aurrera jartzen du"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS Denbora / Doinuaren Indarra"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8228,6 +9166,11 @@ msgstr "Erabili Berezkoak"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Leheneratu Berezkoetara"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8387,6 +9330,10 @@ msgstr "Atzeman Isiltasuna"
 msgid "Tr&uncate to:"
 msgstr "T&runkatu hona:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "&Konprimitu hona:"
@@ -8400,7 +9347,8 @@ msgid "VST Effects"
 msgstr "VST Eraginak"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Audacity-n VST eraginak erabiltzeko gaitasuna gehitzen du."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8412,7 +9360,8 @@ msgstr "VST Shell Mihatzen"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Erregistratzen %d -> %d-tik: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Ezin da liburutegia gertatu"
 
@@ -8432,7 +9381,8 @@ msgstr "Buffer neurriak eraginari iterazio bakoitzean bidalitako lagin zenbateko
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Buffer Neurria (8 eta 1048576 lagin artean):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Atzerapen Ordaina"
 
@@ -8440,7 +9390,8 @@ msgstr "Atzerapen Ordaina"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Beren prozesapenaren atal bezala, VST eraginek audioa Audacity-ra itzultzen atzeratu daitezke. Azterapen hau konpensatzen ez denean, nabarituko duzu isiltasun txikiak txertatzen direla audioaren barnean. Aukera hau gaitzeak konpentsazio hau emango du, baina ez du lan egiten VST eragin guztiekin."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Gaitu &ordaina"
 
@@ -8474,7 +9425,8 @@ msgid "Standard VST program file"
 msgstr "VST Estandar programa agiria"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity VST aurrezarpen agiria"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8501,7 +9453,8 @@ msgstr "Akatsa VST Aurrezarpena Gertatzerakoan"
 msgid "Unable to load presets file."
 msgstr "Ezinezkoa aurrezarpen agiria gertatzea."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Eragin Ezarpenak"
 
@@ -8517,6 +9470,16 @@ msgstr "Ezinezkoa aurrezarpen agiria irakurtzea."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Parametro agiri hau %s-tik gorde zen. Jarraitu?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8548,7 +9511,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio Unitate Eraginak"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Audio Unitate Eragin sostengua hornitzen dio Audacity-ri"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8564,7 +9528,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio Unitate Eragin Aukerak"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Beren prozesapenaren atal bezala, Audio Unitate eraginek audioa Audacity-ra itzultzen atzeratu daitezke. Azterapen hau konpensatzen ez denean, nabarituko duzu isiltasun txikiak txertatzen direla audioaren barnean. Aukera hau gaitzeak konpentsazio hau emango du, baina ez du lan egiten Audio Unitate eragin guztiekin."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8708,6 +9673,7 @@ msgstr "Audio Unitatea"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA Eraginak"
@@ -8717,7 +9683,8 @@ msgid "Provides LADSPA Effects"
 msgstr "LADSPA Eraginak hornitzen ditu"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity-k ez du vst-zubia erabiltzen gehiago"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -8725,12 +9692,30 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA Eragin Aukerak"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Beren prozesapenaren atal bezala, LADSPA eraginek audioa Audacity-ra itzultzen atzeratu daitezke. Azterapen hau konpensatzen ez denean, nabarituko duzu isiltasun txikiak txertatzen direla audioaren barnean. Aukera hau gaitzeak konpentsazio hau emango du, baina ez du lan egiten LADSPA eragin guztiekin."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s hemen:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Eragin Irteera"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA Eraginak"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8742,7 +9727,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Buffer Neurria (8 eta %d) lagin artean):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Beren prozesapenaren atal bezala, LV2 eraginek audioa Audacity-ra itzultzen atzeratu daitezke. Azterapen hau konpensatzen ez denean, nabarituko duzu isiltasun txikiak txertatzen direla audioaren barnean. Aukera hau gaitzeak konpentsazio hau emango du, baina ez du lan egiten LV2 eragin guztiekin."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -8767,12 +9753,19 @@ msgstr "%s sostengatu gabeko aukera behar du %s\n"
 msgid "Generator"
 msgstr "Sortzailea"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 Eraginak"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "LV2 Eragin sostengua hornitzen dio Audacity-ri"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8780,7 +9773,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist Eraginak"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Nyquist Eragin sostengua hornitzen dio Audacity-ri"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8795,6 +9789,12 @@ msgstr "Nyquist Langilea"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Gaizki-eratutako Nyquist plug-in idazburua"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -8999,7 +9999,8 @@ msgstr "Hautatu agiri bat"
 msgid "Save file as"
 msgstr "Gorde agiriak honela"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "izenburugabea"
 
@@ -9008,7 +10009,8 @@ msgid "Vamp Effects"
 msgstr "Vamp Eraginak"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Vamp Eragin sostengua hornitzen dio Audacity-ri"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9030,6 +10032,12 @@ msgstr "Plugin Ezarpena"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9328,7 +10336,8 @@ msgstr "Audioa %s bezala esportatzen"
 msgid "Invalid sample rate"
 msgstr "Lagin neurri baliogabea"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Birlaginketa"
 
@@ -9360,7 +10369,8 @@ msgstr "Lagin Neurriak"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbs-ko"
@@ -9380,6 +10390,42 @@ msgid "%.2f kbps"
 msgstr "%.2f kbs-ko"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Bai"
 
@@ -9388,12 +10434,40 @@ msgid "Constrained"
 msgstr "Murriztua"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Audioa"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Atzerapen Apala"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9480,8 +10554,17 @@ msgid "Replace preset '%s'?"
 msgstr "Ordeztu '%s' aurrezarpena?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "L - E"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Nagusia"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9589,6 +10672,10 @@ msgstr "Hizkuntza:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bit Bildegia"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9706,6 +10793,11 @@ msgstr ""
 "geh - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Izena:"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "LPC coefficients precision\n"
 "Optional\n"
@@ -9718,6 +10810,11 @@ msgstr ""
 "0 - berez\n"
 "gutx. - 1\n"
 "geh. - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "L - E"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9898,6 +10995,16 @@ msgid "Failed to find the codec"
 msgstr "Hutsegitea kodeka bilatzerakoan"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "%s, 64 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "%s, 64 bit"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (azkarrena)"
 
@@ -9982,6 +11089,26 @@ msgid "145-185 kbps"
 msgstr "145-185 kbs-ko"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "170-210 kbs-ko"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "155-195 kbs-ko"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "80-120 kbps"
+msgstr "200-250 kbs-ko"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
+msgstr "155-195 kbs-ko"
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (Agiri txikiak)"
 
@@ -10011,7 +11138,8 @@ msgstr "Gaitza"
 msgid "Extreme"
 msgstr "Hertzekoa"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Estandarra"
 
@@ -10062,8 +11190,8 @@ msgid "Locate LAME"
 msgstr "Kokatu LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity-k %s agiria behar du MP3-ak sortzeko."
 
 #: src/export/ExportMP3.cpp
@@ -10091,10 +11219,10 @@ msgid "Where is %s?"
 msgstr "Non dago %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Lotura duzu lame_enc.dll v%d.%d-ra. Bertsio hau ez da bateragarria Audacity %d.%d.%d.-rekin\n"
 "Mesedez jeitsi  'LAME for Audacity'-ren azken bertsioa."
@@ -10394,6 +11522,15 @@ msgstr "Hautaturiko audio esportazioa Ogg Vorbis bezala"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Audioa Ogg Vorbis bezala esportatzen"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft) sinatuta 16-bit PCM"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Idazburua:"
@@ -10407,9 +11544,10 @@ msgid "Other uncompressed files"
 msgstr "Beste konprimitu gabeko agiriak"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "4GB baino handiago den WAW edo AIFF agiri bat Esportatzen saitu zara.\n"
 "Audacity-k ezin du hau egin, Esportazioa utzi egin da."
@@ -10419,8 +11557,9 @@ msgid "Error Exporting"
 msgstr "Akatsa esportatzerakoan"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Esportaturiko zure WAV agirira hautsi egin da Audacity-k ezin dituelako esportatu\n"
@@ -10460,11 +11599,11 @@ msgid "All supported files"
 msgstr "Sostengaturiko agiri guztiak"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10473,11 +11612,11 @@ msgstr ""
 "editatu dezakezu Agiria > Inportatu > MIDI klikatuz."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "MIDI agiri bat da, ez da audio agiri bat. \n"
@@ -10489,18 +11628,18 @@ msgid "Select stream(s) to import"
 msgstr "Hautatu inportatzeko jarioa(k)"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Audacity bertsio hau ez da %s sostenguarekin bildu."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" audio CD bide bat da. \n"
 "Audacity-k ezin du audio CD-rik zuzenean ireki. \n"
@@ -10509,10 +11648,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" irakur-zerrenda agiri bat da. \n"
@@ -10521,10 +11660,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Windows Media Audio agiri bat da. \n"
@@ -10533,10 +11672,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Audio Kodeaketa Aurreratuko (AAC) agiri bat da. \n"
@@ -10545,12 +11684,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" enkriptaturiko audio agiri bat da. \n"
@@ -10561,10 +11700,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" RealPlayer audio agiri bat da. \n"
@@ -10573,12 +11712,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" ohar-ohinarrik agiri bat da. \n"
 "Audacity-k ezin du honelako agiri motarik ireki. \n"
@@ -10587,10 +11726,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10603,10 +11742,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Wavpack audio agiri bat da. \n"
@@ -10615,10 +11754,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Dolby Digital audio agiri bat da. \n"
@@ -10627,10 +11766,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Ogg Speex audio agiri bat da. \n"
@@ -10639,10 +11778,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bideo agiri bat da. \n"
@@ -10656,20 +11795,31 @@ msgstr "\"%s\" agiria ez da aurkitu."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity-k ezin du '%s' agiriaren mota ezagutu.\n"
 "Saiatu FFmpeg ezartzen. Konprimitu gabeko agirientzat, saiatu ere Agiria > Inportatu > Raw Datuak."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, aztertzailea"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10678,6 +11828,11 @@ msgstr ""
 "Ustez agiri hauek sostengatzen dituzten inportatzaileak dira:\n"
 "%s,\n"
 "baina beraietako batek ere ezdu agiri heuskarri hau ulertzen."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Egitasmo datu agiriak gordetzea"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10695,8 +11850,57 @@ msgid "Import Project"
 msgstr "Inportatu Aurrezarpenak"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Barne akatsa jakinarazia lerrokapen garapenetik."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Lagin neurri baliogabea"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10704,16 +11908,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Ezinezkoa egitasmoaren datu agiritegia aurkitzea: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Egitasmoaren Hasiera"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Lagin neurri baliogabea"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Lagin neurri baliogabea"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10743,40 +12005,6 @@ msgstr "Aurkibidea[%02x] Kodeka[%s], Hizkuntza[%s], Bitneurria[%s], Bideak[%d], 
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC agiriak"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-bateragarri agiriak"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Ezinezkoa dekodeatzailea hodira gehitzea"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer Inportatzailea"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Ezinezkoa jario egoera pausatuan ezartzea."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Aurkibidea[%02d] Mota[%s], Bideak[%d], Maila[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Agiriak ez du audio jariorik."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Ezinezkoa agiria inportatze, egoera aldaketa hutsegitea."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer Akatsa: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10834,6 +12062,14 @@ msgstr "Ezin da agiria ireki: %s."
 msgid "MP3 files"
 msgstr "MP3 agiriak"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis agiriak"
@@ -10866,6 +12102,186 @@ msgstr "Barneko logika hutsegitea"
 #: src/import/ImportPCM.cpp
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, eta beste konprimitu gabeko motak"
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAVEX (Microsoft)"
+msgstr "WAV (Microsoft) sinatuta 16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 16 bit PCM"
+msgstr "AIFF (Apple) sinatuta 16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 24 bit PCM"
+msgstr "WAV (Microsoft) sinatuta 24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -10914,6 +12330,19 @@ msgstr "Inportatu Raw Datuak"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Endianness gabe"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Ertaina"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -10964,6 +12393,10 @@ msgstr "Laginketa neurria:"
 msgid "&Import"
 msgstr "I&nportatu"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -10984,6 +12417,7 @@ msgstr "%s eskuina"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11007,6 +12441,7 @@ msgstr "amaiera"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11033,7 +12468,8 @@ msgstr "Denborak ebakina eskuinera aldatzen du"
 msgid "Time shifted clips to the left"
 msgstr "Denborak ebakina ezkerrera aldatzen du"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Denbora-Aldaketa"
 
@@ -11171,7 +12607,8 @@ msgstr "Moztu hautaturiko bideak %.2f segundutik %.2f segundura"
 msgid "Trim Audio"
 msgstr "Moztu Audioa"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Banandu"
 
@@ -11296,34 +12733,6 @@ msgid "Ext&ra"
 msgstr "Es&tra"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "&Nahastzailea"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "&Zehaztu Irakurketaren Bolumena..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Igo Irakurketaren Bolumena"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Jeitsi Irakurketaren Bolumena"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Ze&haztu Grabaketaren Bolumena..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Igo &Grabaketaren Bolumena"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "J&eitsi Grabaketaren Bolumena"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "&Gailua"
 
@@ -11359,6 +12768,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Esportatu Hautaturiko Audioa"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Etiketa idazkia"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -11408,6 +12823,11 @@ msgstr "Inportatu Etiketak"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Hautatu MIDI agiri bat"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Allegro agiriak"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -11488,6 +12908,11 @@ msgid "&Labels..."
 msgstr "&Etiketak..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Esportatu MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Raw Datuak..."
 
@@ -11504,6 +12929,10 @@ msgstr "Irarkit&u..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "I&rten"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -11572,8 +13001,9 @@ msgid "&Getting Started"
 msgstr "&Hastapena"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity E&skuliburua"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Eskuliburua..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -11599,11 +13029,8 @@ msgstr "&MIDI Gailu Infoa..."
 msgid "Show &Log..."
 msgstr "Erakutsi &Oharra..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Audacity-ri buruz..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Gehitutako etiketa"
 
@@ -11851,6 +13278,10 @@ msgstr "Aldatu F&okuturiko bidea"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Kategoriagabea"
+
+#: src/menus/PluginMenus.cpp
+msgid "..."
+msgstr "…"
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12289,6 +13720,7 @@ msgstr "Kurtsore Jauzi Luz&ea Eskuinera"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Bilaketa"
@@ -12500,18 +13932,21 @@ msgid "Created new label track"
 msgstr "Etiketa bide berria sortuta"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Audacity-ren bertsio honek denbora bide bakarra ahalbidetzen du egitasmo leiho bakoitzeko."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Denbora bide berria sortuta"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Lagin neurri berria (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Sartutako balioa baliogabea da"
 
@@ -12633,6 +14068,10 @@ msgstr "&Mututu Bideak"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Desmututu Bideak"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -12764,7 +14203,9 @@ msgstr "Irakurtzen"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Grabaketa"
 
@@ -12775,6 +14216,11 @@ msgstr "ez dago etiketa biderik"
 #: src/menus/TransportMenus.cpp
 msgid "no label track at or below focused track"
 msgstr "ez dago etiketa biderik edo fokuturiko bidean"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy, c-format
+msgid "%s %d of %d"
+msgstr "%s %d -> %d ebakinetik %s"
 
 #: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
@@ -12908,10 +14354,6 @@ msgstr "&Gainsoinua (bai/ez)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "So&ftware Zehar-irakurketa (bai/ez)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "&Berezgaitasunezko Grabaketa Maila Zehaztapena (bai/ez)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13127,7 +14569,7 @@ msgstr "Hobespenak Ontasunerako"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Irten Audacity-tik"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13174,7 +14616,8 @@ msgstr "&Hostalaria:"
 msgid "Using:"
 msgstr "Erabiltzen:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Irakurketa"
 
@@ -13194,7 +14637,8 @@ msgstr "&Bideak:"
 msgid "Latency"
 msgstr "Atzerapena"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "segundumilaen"
 
@@ -13223,7 +14667,8 @@ msgid "2 (Stereo)"
 msgstr "2 (Estereoa)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Zuzenbideak"
 
@@ -13236,8 +14681,22 @@ msgid "Default directories"
 msgstr "Zuzenbideak"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Bilatu..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -13315,7 +14774,8 @@ msgid "Directory %s is not writable"
 msgstr "%s zuzenbidea ez da idazgarria"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Aldibaterako zuzenbidean eginiko aldaketek ez dute eraginik izango Audacity berrabiarazi arte"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13346,6 +14806,40 @@ msgstr "Argitaratzailez Multzokatuta"
 msgid "Grouped by Type"
 msgstr "Motaz Multzokatuta"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Nyquist Akatsa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Gaitu Eraginak"
@@ -13367,11 +14861,13 @@ msgid "Plugin Options"
 msgstr "Plugin Aukerak"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Egiaztatu plugin eguneraketak Audacity abiatzerakoan"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Bermihatu eraginak Audacity abiarazten den hurrengoan"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13551,13 +15047,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "He&utsi etiketei hautapena etiketa baten hertzera zehazten bada"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "&Nahastu sistemaren eta Audacity azalgaia"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Erabili gehienbat Ezkerretik-Eskuinera antolakuntzak RTL hizkuntzetan"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13725,7 +15226,8 @@ msgstr ""
 "   *   \"%s\"  ('%s' lastertekla erabilia delako hemen \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Hautatu Audacity-ren Lasterteklak dituen XML agiri bat..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13857,8 +15359,9 @@ msgid "Dow&nload"
 msgstr "J&eitsi"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity-k berezgaitasunez atzeman ditu baliozko FFmpeg liburutegiak.\n"
@@ -13917,8 +15420,9 @@ msgid "Preferences for Module"
 msgstr "Hobespenak Modulorako"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Hauek modulo esperimentalak dira. Bakarrik gaitu eskuliburua irakurri baduzu\n"
@@ -13926,12 +15430,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr " 'Galdetu'-k esanahi du Audacity abiarazten den bakoitzean pluginak gertatzea nahi dituzun galdetuko duela."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr " 'Hutsegitea'-k esanahi du Audacity-k uste duela plugina hautsita dagoela eta ez du abiatzen."
 
 #. i18n-hint preserve the leading spaces
@@ -13940,7 +15446,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "'Berria'-k esanahi du ez dela hautapenik egin oraindik."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Ezarpen hauetan eginiko aldaketek ez dute eraginik izango Audacity berrabiarazi arte."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14003,7 +15510,10 @@ msgstr "Ezker-Arrastatu"
 msgid "Set Selection Range"
 msgstr "Ezarri Hautapen Maila"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Aldatu-Ezker-Klikatu"
 
@@ -14090,6 +15600,15 @@ msgstr "-Ezker-Arrastatu"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Mugitu ebakina gora/behera bideen artean"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Ezker-Arrastatu"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14214,7 +15733,8 @@ msgid "Always scrub un&pinned"
 msgstr "Betik arrast-irakurri &desainguratuta"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity Hobespenak"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14228,6 +15748,11 @@ msgstr "Hobespenak:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Hobespenak Ontasunerako"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14253,6 +15778,12 @@ msgstr "Egizko-denbora Bihurketa"
 msgid "Sample Rate Con&verter:"
 msgstr "&Lagin Neurri Bihurketa:"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "&Dither:"
+msgstr "Dith&er:"
+
 #: src/prefs/QualityPrefs.cpp
 msgid "High-quality Conversion"
 msgstr "Ontasun-handiko Bihurketa"
@@ -14265,6 +15796,14 @@ msgstr "Lagin Neurri &Bihurketa:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Dith&er:"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14334,45 +15873,31 @@ msgid "System T&ime"
 msgstr "Sistemaren &Ordua"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Gaitu Berezgaitasunezko Grabaketa Maila Zehaztapena."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Xede Gailurra:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Honekin:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Azterketa Denbora:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "segundumilaen (azteketa baten denbora)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Azterketa jarrai zenbatekoa:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 amaieragabe esanahi du"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Kolpe eta Roll Grabaketa"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Zehar-&hutsalpena:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14507,6 +16032,10 @@ msgid "1024 - default"
 msgstr "1024 - berezkoa"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - banda estuagoa"
 
@@ -14604,13 +16133,14 @@ msgid "Info"
 msgstr "Argibideak"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14793,7 +16323,8 @@ msgstr "Laginak"
 msgid "4 Pixels per Sample"
 msgstr "4 Pixel Lagineko"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Geh Zooma"
 
@@ -14915,16 +16446,24 @@ msgid "Stopped"
 msgstr "Geldituta"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausatu"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Jauzi Hasierara"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Jauzi Amaierara"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausatu"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Hautatu Hasiera arte"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Hautatu Amaiera arte"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -14938,20 +16477,17 @@ msgstr "Grabatu Bide Berria"
 msgid "Append Record"
 msgstr "Erantsi Grabaketa"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Hautatu Amaiera arte"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Hautatu Hasiera arte"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s Pausatuta."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15031,11 +16567,17 @@ msgstr "Isildu hautaturiko audioa"
 msgid "Sync-Lock Tracks"
 msgstr "Aldiberetu-Lotu Bideak"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zooma Gehitu"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zooma Gutxiagotu"
 
@@ -15102,43 +16644,6 @@ msgstr "Graba&keta Neurgailu Tresnabarra"
 msgid "&Playback Meter Toolbar"
 msgstr "&Irakurketa Neurgailu Tresnabarra"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Grabaketa Bolumena"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Irakurketa Bolumena"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Grabaketa Bolumena: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Grabaketa Bolumena (Eskuraezina; erabili sistemaren nahasgailua)."
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Irakurketa Bolumena: %2f (emulatua)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Irakurketa Bolumena: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Irakurketa Bolumena (Eskuraezina; erabili sistemaren nahasgailua)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Naha&stzaile Tresnabarra"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Bilatu"
@@ -15154,6 +16659,7 @@ msgstr "Arrast-irakurtzea"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Gelditu Arrast-irakurtzea"
@@ -15161,6 +16667,7 @@ msgstr "Gelditu Arrast-irakurtzea"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Hasi Arrast-irakurtzea"
@@ -15168,6 +16675,7 @@ msgstr "Hasi Arrast-irakurtzea"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Gelditu Bilaketa"
@@ -15175,6 +16683,7 @@ msgstr "Gelditu Bilaketa"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Hasi Bilaketa"
@@ -15229,7 +16738,9 @@ msgstr "Zehaztu Hona"
 msgid "Length"
 msgstr "Luzera"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Erdia"
 
@@ -15293,8 +16804,8 @@ msgstr "&Denbora Tresnabarra"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %s Tresnabarra"
 
 #: src/toolbars/ToolBar.cpp
@@ -15321,7 +16832,8 @@ msgstr "Denbora Aldaketa Tresna"
 msgid "Zoom Tool"
 msgstr "Zoom Tresna"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Marraz Tresna"
 
@@ -15397,11 +16909,13 @@ msgstr "Arrastatu etiketa muga bat edo gehiago."
 msgid "Drag label boundary."
 msgstr "Arrastatu etiketa muga."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Etiketa Aldatuta"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Etiketa Edizioa"
 
@@ -15456,31 +16970,42 @@ msgstr "Editaturiko etiketak"
 msgid "New label"
 msgstr "Etiketa berria"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "&Igo Zortzikoa"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "&Jeitsi Zortzikoa"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klikatu zutikako zooma handitzeko, Aldatu-klik zooma gutxitzeko, Arrastatu zoom eremu bereizi bat adierazteko."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Eskuin-klikatu menurako."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zooma Berrezarri"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Aldatu-Eskuin-Klikatu"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Ezker-Klika/Ezker-Arrastatu"
 
@@ -15522,7 +17047,8 @@ msgstr "Baut"
 msgid "Expanded Cut Line"
 msgstr "Hedatuta Ebaketa Lerroa"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Hedatu"
 
@@ -15545,6 +17071,11 @@ msgstr "Mugitutako Laginak"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Lagin Edizioa"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15590,7 +17121,8 @@ msgstr "Prozesatzen: %s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' %s-ra aldatuta"
@@ -15602,6 +17134,54 @@ msgstr "Heuskarri Aldaketa"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Neurria"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15621,7 +17201,8 @@ msgstr "Neurri Aldaketa"
 msgid "Set Rate"
 msgstr "Ezarri Maila"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Ikuspegi-anitz"
 
@@ -15713,14 +17294,23 @@ msgstr "Ezker, %dHz"
 msgid "Right, %dHz"
 msgstr "Eskuin, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Ezker"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Eskuin"
@@ -15838,9 +17428,8 @@ msgstr "Interpolazio &Logaritmikoa"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klikatu eta arrastatu bide bat denboran mugitzeko"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15891,6 +17480,7 @@ msgstr "Bilkaria zehaztuta."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Ar&rast-irakurri"
@@ -15902,6 +17492,7 @@ msgstr "Bilaketa"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Arrast-irakurtze Zuzenkaria"
@@ -16097,6 +17688,12 @@ msgstr "EZ"
 msgid "R"
 msgstr "ES"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16130,9 +17727,19 @@ msgstr "Hutsik"
 msgid "Backwards"
 msgstr "Atzerantz"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Aurrerantz"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16261,6 +17868,13 @@ msgstr "Mesedez hautatu ekintza bat"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 segundu"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "ee:oo:mm:ss"
+
 #. i18n-hint: Format string for displaying time in hours, minutes and
 #. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
@@ -16339,6 +17953,7 @@ msgstr "0100 o 060 m 060 s+># lagin"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "laginak"
@@ -16504,6 +18119,25 @@ msgstr "0100000>0100 Hz"
 msgid "centihertz"
 msgstr "zentihertz"
 
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000>01000 kHz|0.001"
+msgstr "0100000>0100 Hz"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hertz"
+msgstr "zentihertz"
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
@@ -16568,6 +18202,11 @@ msgstr "(Erabili hitzinguru menua heuskarria aldatzeko)"
 msgid "centiseconds"
 msgstr "segunduehunen"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Igarotako Denbora:"
@@ -16610,6 +18249,11 @@ msgstr "Baieztatu Istea"
 msgid "Unable to write files to directory: %s."
 msgstr "Ezinezkoa aurrezarpena irakurtzea \"%s\"-tik."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -16626,6 +18270,10 @@ msgstr "Hobespenak Zuzenbideetarako"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Ez erakutsi ohar hau berriro"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -16709,15 +18357,27 @@ msgstr "Ezin da agiria ireki"
 msgid "Spectral edit multi tool"
 msgstr "Argilitza ediziorako tresna anitza"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Iragazten..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "GNU Baimen Publiko Orokorra 2-ren baldintzapean argitaratua"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aMesedez hautatu maiztasunak."
@@ -16744,7 +18404,8 @@ msgstr ""
 "                      Saiatu behe maiztasun muga handituz~%~\n"
 "                      edo gutxitu iragazkiaren 'Zabalera'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Akatsa.~%"
@@ -16805,6 +18466,25 @@ msgstr "Estudio Hutsalpen Irteera"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Hutsalpena Ezartzen..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "E&zarri Berezkotzat"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "GNU Baimen Publiko Orokorra 2-ren baldintzapean argitaratua"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16948,6 +18628,10 @@ msgstr "&Beat Aurkitzailea"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Beat-ak bilatzen..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17100,6 +18784,10 @@ msgstr "Oihartzun zenbatekoa"
 #: plug-ins/delay.ny
 msgid "Allow duration to change"
 msgstr "Ahalbidetu iraupena aldatzea"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -17268,13 +18956,38 @@ msgstr "Goi-Igaropen Iragazkia"
 msgid "Performing High-Pass Filter..."
 msgstr "Goi-Igaropen Iragazkia ezartzen..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Maiztasuna (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB zortziko bakoitzeko)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17295,10 +19008,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Etiketa Batzea"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "GNU Baimen Publiko Orokorra 2-ren baldintzapean argitaratua"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17341,12 +19050,37 @@ msgid "Point after sound"
 msgstr "Batu Estereoa"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "~aEremu luzera = ~a segundu."
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "~aEremu luzera = ~a segundu."
 
 #: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Isiltasuna bilatzen..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Isiltasuna bilatzen..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, fuzzy, lisp-format
+msgid "~ah ~am ~as"
+msgstr "~ah ~am ~as"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -17358,6 +19092,11 @@ msgstr "Hautapena %d lagin baino handiagoa izan behar da."
 #, lisp-format
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "Ez da soinurik aurkitu. Saiatu isiltasunaren~%maila eta isiltasunaren gutxienezko iraupena gutxitzen."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -17486,6 +19225,14 @@ msgstr ""
 "Ezarri kontrola honen azpitik: ~a kHz."
 
 #: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Hautapena %d lagin baino handiagoa izan behar da."
+
+#: plug-ins/noisegate.ny
 #, lisp-format
 msgid ""
 "Error.\n"
@@ -17558,7 +19305,8 @@ msgstr "Lisp agiria"
 msgid "HTML file"
 msgstr "HTML agiria"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Idazki agiria"
 
@@ -17635,6 +19383,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI balioak C notentzat: 36, 48, 60 [erdiko C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Puntada MIDI soinua"
 
@@ -17681,6 +19433,10 @@ msgstr "1 - 20 beat/neurketako"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Dilinda kopurua"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -17751,6 +19507,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI beat indartsuaren doinua"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI beat ahularen doinua"
 
@@ -17769,6 +19529,10 @@ msgstr "Danbor Hotsa"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Danbor Hotsa sortzen"
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -17871,6 +19635,11 @@ msgstr "Erakutsi mezuak"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Akatsak Bakarrik"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18139,6 +19908,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Akats.~%Bide laginketa neurria 100 Hz azpitik ez dago sostengatua."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Tremolo Ezartzen..."
 
@@ -18165,6 +19938,10 @@ msgstr "Ahots Murriztea eta Bakartzea"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Ekintza Ezartzen..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18307,8 +20084,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Plug-in honek estereo bideekin bakarrik egiten du lan."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Vocoder prozesatzen..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18350,6 +20135,208 @@ msgstr "Erradar Orratz maiztasuna (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Akatsa.~%Estereo bidea beharrezkoa."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Irten Audacity-tik"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Bidea"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Akatsa agiria dekodeatzerakoan"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Akatsa Metadatuak Gertatzerakoan."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s Tresnabarra"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Grabaketa"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Aurkezpen Id-a:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Plataforma-arteko EIG liburutegia"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Inportatu GStreamer bidez"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Ezin izan da gehiago hobetu. Handiegia oraindik."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapenak bolumena %2f-ra gutxitu du."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Ezin da gehiago hobetu. Apalegia oraindik."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapenak bolumena %2f-ra gehitu du."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Azterketa zenbatekoa guztira gainditu da bolumen onargarri bat aurkitu gabe. Handiegia oraindik."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. Azterketa zenbatekoa guztira gainditu da bolumen onargarri bat aurkitu gabe. Apalegia oraindik."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena geldituta. %.2f bolumen onargarri bezala ikusten da."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "%d jaso d gailuak irekitzean\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Ezinezkoa Ataka-Nahastzailea irekitzea\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Nahasgailu eskuragarriak:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Grabaketa iturburu eskuragarriak:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Irakurketa Bolumen eskuragarriak:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Grabaketa Bolumena antzeratua da\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Grabaketa Bolumena jatorrizkoa da\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Irakurketa bolumena emulatua da\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Irakurketa bolumena jatorrizkoa da\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Amaiera Eguna eta Ordua"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-bateragarri agiriak"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Ezinezkoa dekodeatzailea hodira gehitzea"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer Inportatzailea"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Ezinezkoa jario egoera pausatuan ezartzea."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Aurkibidea[%02d] Mota[%s], Bideak[%d], Maila[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Agiriak ez du audio jariorik."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Ezinezkoa agiria inportatze, egoera aldaketa hutsegitea."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer Akatsa: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "&Nahastzailea"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "&Zehaztu Irakurketaren Bolumena..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Igo Irakurketaren Bolumena"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Jeitsi Irakurketaren Bolumena"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Ze&haztu Grabaketaren Bolumena..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Igo &Grabaketaren Bolumena"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "J&eitsi Grabaketaren Bolumena"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity E&skuliburua"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Audacity-ri buruz..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "&Berezgaitasunezko Grabaketa Maila Zehaztapena (bai/ez)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Berezgaitasunezko Grabaketa Maila Zehaztapena"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Gaitu Berezgaitasunezko Grabaketa Maila Zehaztapena."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Xede Gailurra:"
+
+#~ msgid "Within:"
+#~ msgstr "Honekin:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Azterketa Denbora:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "segundumilaen (azteketa baten denbora)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Azterketa jarrai zenbatekoa:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 amaieragabe esanahi du"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Grabaketa Bolumena"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Irakurketa Bolumena"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Grabaketa Bolumena: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Grabaketa Bolumena (Eskuraezina; erabili sistemaren nahasgailua)."
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Irakurketa Bolumena: %2f (emulatua)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Irakurketa Bolumena: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Irakurketa Bolumena (Eskuraezina; erabili sistemaren nahasgailua)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Naha&stzaile Tresnabarra"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klikatu eta arrastatu bide bat denboran mugitzeko"
 
 #~ msgid "Program build date:"
 #~ msgstr "Programaren eraiketa eguna:"
@@ -19075,9 +21062,6 @@ msgstr "Akatsa.~%Estereo bidea beharrezkoa."
 #~ msgid "Selected:"
 #~ msgstr "Hautatuta:"
 
-#~ msgid "ms"
-#~ msgstr "sm"
-
 #~ msgid "xml files (*.xml;*.XML)|*.xml;*.XML"
 #~ msgstr "xml agiriak (*.xml;*.XML)|*.xml;*.XML"
 
@@ -19176,15 +21160,6 @@ msgstr "Akatsa.~%Estereo bidea beharrezkoa."
 
 #~ msgid "Only libmp3lame.so.0|libmp3lame.so.0|Primary Shared Object files (*.so)|*.so|Extended Libraries (*.so*)|*.so*|All Files (*)|*"
 #~ msgstr "Bakarrik libmp3lame.so|libmp3lame.so|Lehen Elkarbanatze Objetu agiriak (*.so)|*.so|Liburutegi Hedatuak (*.so*)|*.so*|Agiri Guztiak (*)|*"
-
-#~ msgid "AIFF (Apple) signed 16-bit PCM"
-#~ msgstr "AIFF (Apple) sinatuta 16-bit PCM"
-
-#~ msgid "WAV (Microsoft) signed 16-bit PCM"
-#~ msgstr "WAV (Microsoft) sinatuta 16-bit PCM"
-
-#~ msgid "WAV (Microsoft) signed 24-bit PCM"
-#~ msgstr "WAV (Microsoft) sinatuta 24-bit PCM"
 
 #~ msgid "MIDI file (*.mid)|*.mid|Allegro file (*.gro)|*.gro"
 #~ msgstr "MIDI agiria (*.mid)|*.mid|Allegro agiria (*.gro)|*.gro"
@@ -19613,9 +21588,6 @@ msgstr "Akatsa.~%Estereo bidea beharrezkoa."
 #~ msgid "L-E"
 #~ msgstr "L - A"
 
-#~ msgid "L-C"
-#~ msgstr "L - E"
-
 #~ msgid "Show start time and end time"
 #~ msgstr "Erakutsi hasiera eta amaiera denborak"
 
@@ -19823,9 +21795,6 @@ msgstr "Akatsa.~%Estereo bidea beharrezkoa."
 #~ msgid "Offset"
 #~ msgstr "Oreka"
 
-#~ msgid "Version"
-#~ msgstr "Bertsioa"
-
 #~ msgid "Heavy"
 #~ msgstr "Gogorra"
 
@@ -19859,155 +21828,22 @@ msgstr "Akatsa.~%Estereo bidea beharrezkoa."
 #~ "\n"
 #~ "'%s'"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Ezin izan zen ireki Tenacity deskargatzeko esteka."
 
-#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
-#, c-format
-msgid "Compacting actually freed %s of disk space."
-msgstr "Trinkotzeak disko-espazioaren %s askatu du."
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Eguneratze-datuak usteldu egin dira."
 
-#: src/DBConnection.cpp
-msgid "Database error.  Sorry, but we don't have more details."
-msgstr "Datu-basearen errorea. Barkatu, baina ez dugu xehetasun gehiago."
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Ezin da konektatu Tenacity eguneratzeko zerbitzariarekin."
 
-#: src/DBConnection.cpp
-#, c-format
-msgid ""
-"Disk is full.\n"
-"%s\n"
-"For tips on freeing up space, click the help button."
-msgstr ""
-"Diskoa beteta dago.\n"
-"%s\n"
-"Espazioa askatzeko aholkuak lortzeko, egin klik laguntza-botoian."
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Informazio gehiago GitHub-en"
 
-#: src/DBConnection.cpp src/ProjectFileIO.cpp
-msgid "This may take several seconds"
-msgstr "Honek segundo batzuk behar izan ditzake"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "benchmark.txt"
-
-#. i18n-hint: Benchmark means a software speed test
-#: src/Benchmark.cpp
-msgid "Benchmark"
-msgstr "Benchmark"
-
-#: src/AudacityApp.cpp
-msgid ""
-"Unable to create semaphores.\n"
-"\n"
-"This is likely due to a resource shortage\n"
-"and a reboot may be required."
-msgstr ""
-"Ezin da semafororik sortu.\n"
-"\n"
-"Hori, ziurrenik, baliabide-eskasia dela eta gertatu da.\n"
-"Eta baliteke berriz hasi behar izatea."
-
-#: src/AudacityApp.cpp
-msgid ""
-"Unable to acquire semaphores.\n"
-"\n"
-"This is likely due to a resource shortage\n"
-"and a reboot may be required."
-msgstr ""
-"Ezin da semafororik erosi.\n"
-"\n"
-"Hori, ziurrenik, baliabide-eskasia dela eta gertatu da.\n"
-"Eta baliteke berriz hasi behar izatea."
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity ez dute MuseCY SM Ltd. eta Dominic m Mazzoni-k ekoizten eta "
-"bermatzen."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Audacity%s marka komertziala helburu deskribatzaile eta informatiboetarako "
-"soilik erabiltzen da software honetan."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s zergadunak"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Kontuan izan izenak alfabetoaren arabera ordenatuta daudela, ez "
-"garrantziaren arabera."
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s KB"
-msgstr "%s kB"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Ezin izan zen ireki Tenacity deskargatzeko esteka."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Eguneratze-datuak usteldu egin dira."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Ezin da konektatu Tenacity eguneratzeko zerbitzariarekin."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Informazio gehiago GitHub-en"
-
-#: src/menus/PluginMenus.cpp
-msgid "..."
-msgstr "…"
-
-#: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
-msgstr "Ezin izan zen SQLite liburutegia hasi. Tenacityk ezin du jarraitu."
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Instalatu eguneratzea"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Saltatu"
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Instalatu eguneratzea"

--- a/locale/fa.po
+++ b/locale/fa.po
@@ -12,52 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-21 19:01+0000\n"
 "Last-Translator: mzeinali <m@zmim.ir>\n"
-"Language-Team: Persian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/fa/>\n"
+"Language-Team: Persian <https://hosted.weblate.org/projects/tenacity/tenacity/fa/>\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "خروج از اوداسیتی"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "کانال"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "خطا در باز کردن پرونده"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "خطا در باز کردن پرونده"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "میله ابزار %s اوداسیتی"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "در حال ضبط"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -68,9 +32,31 @@ msgstr "نمی‌توان تعیین کرد"
 msgid "%s bytes"
 msgstr "بایت"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s کیلوبایت"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s مگابایت"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s گیگابایت"
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "در حال تقویت"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr "سیستم"
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -81,12 +67,68 @@ msgid "2nd Experimental Command"
 msgstr "انتخاب فرمان"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "در حال اعمال جلوه Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr "&بازگشت\tCtrl+Z"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Redo\tCtrl+Y"
+msgstr "&بازنشانی\tCtrl+Y"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&برش\tCtrl+X"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Copy\tCtrl+C"
+msgstr "&نسخه برداری\tCtrl+C"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
 msgstr "&چسباندن"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
+msgstr "&پاک کردن\tCtrl+L"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "انتخاب"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr "&یافتن...\tCtrl+F"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr "&رفتن به"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -101,19 +143,46 @@ msgid "Split &Horizontally"
 msgstr "استریوی افقی"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show S&cript"
+msgstr "اعلان Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Show &Output"
 msgstr "دکمهٔ لغزنده-خروجی"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "ابزار"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "توقف"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "اعلان Nyquist..."
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "اندازه‌گیر خروجی"
 
@@ -121,7 +190,20 @@ msgstr "اندازه‌گیر خروجی"
 msgid "Load Nyquist script"
 msgstr "اعلان Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "اخطار"
 
@@ -130,16 +212,58 @@ msgid "Save Nyquist script"
 msgstr "اعلان Nyquist..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "در حال اعمال جلوه Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "No matches found"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "در حال اعمال جلوه Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&جدید"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "باز کردن موارد اخیر"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -173,7 +297,8 @@ msgstr "نسخه‌برداری"
 msgid "Copy to clipboard"
 msgstr "برش و انتقال به تخته‌گیره"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "برش"
 
@@ -181,7 +306,8 @@ msgstr "برش"
 msgid "Cut to clipboard"
 msgstr "برش و انتقال به تخته‌گیره"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "چسباندن"
 
@@ -206,7 +332,8 @@ msgstr "انتخاب"
 msgid "Select all text"
 msgstr "انتخاب"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "برگردان"
 
@@ -214,20 +341,70 @@ msgstr "برگردان"
 msgid "Undo last change"
 msgstr "تغییر قالب"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&دوباره"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "تغییر قالب"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Match"
 msgstr "دسته‌ای"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "برچسبی برای صدور نیست."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "ابزار قبلی"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "جابه‌جایی تمرکز به شیار قبلی"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "ابزار بعدی"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "آغاز"
 
@@ -235,7 +412,8 @@ msgstr "آغاز"
 msgid "Start script"
 msgstr "اعلان Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "توقف"
 
@@ -243,27 +421,139 @@ msgstr "توقف"
 msgid "Stop script"
 msgstr "اعلان Nyquist..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "تأیید"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "روشن"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "خاموش"
 
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "برعکس کردن"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr "نوع نوفه:"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "پوشهٔ تنظیمات: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "پوشهٔ تنظیمات: "
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Sample rate conversion"
 msgstr "مبدل نرخ نمونه‌"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "خطا در وارد کردن"
+
+#: src/AboutDialog.cpp
+msgid "Ogg Vorbis Import and Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FLAC import and export"
+msgstr "برپاسازی صدور FLAC"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "برپاسازی صدور MP2"
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export"
+msgstr "خطای LOF"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "متصل‌شونده‌های %Ii تا %Ii"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "GPL License"
+msgstr ""
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -286,6 +576,18 @@ msgstr "پاکت"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "پاکت"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "پاکت"
 
@@ -297,9 +599,51 @@ msgstr "پاکت"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "پاکت"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "پاکت"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "پاکت"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "اکولایزر گرافیکی"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "پاکت"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "پاکت"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -320,8 +664,26 @@ msgid "%s, graphics"
 msgstr "اکولایزر گرافیکی"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "دست‌اندرکاران"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -339,6 +701,11 @@ msgstr "مشارکت‌کنندگان دیگر"
 msgid "Tenacity Special thanks:"
 msgstr "تشکر ویژه:"
 
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "شاخه‌ها"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
@@ -352,14 +719,23 @@ msgid "%s Team Members"
 msgstr "اعضای دیگر تیم امیریتوس"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "مشارکت‌کنندگان دیگر"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -384,6 +760,26 @@ msgstr "تشکر ویژه:"
 msgid "%s website: "
 msgstr "اولین اجرای اوداسیتی"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "مشارکت‌کنندگان دیگر"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "برای تنظیم اندازهٔ نسبی قطعات استریو کلیک کنید و در حالی که کلید را پایین نگاه داشته‌اید موشی را حرکت دهید."
@@ -394,9 +790,15 @@ msgstr "برای تنظیم اندازهٔ نسبی قطعات استریو کل
 msgid "Record/Play head"
 msgstr "در حال ضبط"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "متصل‌شونده‌های ۱ تا %Ii"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "برای ویرایش نمونه‌ها کلیک کنید و بکشید"
@@ -404,12 +806,57 @@ msgstr "برای ویرایش نمونه‌ها کلیک کنید و بکشید"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "برای تغییر اندازهٔ شیار کلیک کنید و در حالی که دکمه را نگاه داشته‌اید موشی را حرکت دهید."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "جابه‌جایی تمرکز به شیار بعدی"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "پایین بردن شیار"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "بستن شیار مورد تمرکز"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr " (از کار افتاده)"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr " (از کار افتاده)"
 
 #: src/AdornedRulerPanel.cpp
@@ -417,14 +864,42 @@ msgid "Timeline Options"
 msgstr "متصل‌شونده‌های ۱ تا %Ii"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "اضافه کردن برچسب در قسمت انتخاب شده"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "در حال ضبط"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "خطا"
 
@@ -434,8 +909,36 @@ msgid "Failed to remove %s"
 msgstr "حذف «‎%s» ممکن نیست"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "ترجیحات اوداسیتی"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -454,6 +957,11 @@ msgstr "&باز کردن..."
 
 #: src/AudacityApp.cpp
 #, fuzzy
+msgid "Open &Recent..."
+msgstr "باز کردن موارد اخیر"
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
+#, fuzzy
 msgid "&About Tenacity..."
 msgstr "&دربارهٔ اوداسیتی..."
 
@@ -466,29 +974,33 @@ msgid "&File"
 msgstr "&پرونده"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "اوداسیتی جایی برای ذخیرهٔ پروندهٔ موقت پیدا نکرد.\n"
 "لطفاً در پنجرهٔ ترجیحات یک شاخهٔ مناسب وارد کنید."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "اوداسیتی جایی برای ذخیرهٔ پروندهٔ موقت پیدا نکرد.\n"
 "لطفاً در پنجرهٔ ترجیحات یک شاخهٔ مناسب وارد کنید."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "در حال خارج شدن از اوداسیتی. برای استفاده از شاخهٔ موقت جدید لطفاً اوداسیتی را دوباره راه‌اندازی کنید."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -497,40 +1009,113 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "اوداسیتی نتوانست شاخهٔ پرونده‌های موقت را قفل کند.\n"
 "ممکن است یک نسخهٔ دیگر اوداسیتی در حال استفاده از این پوشه باشد.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "آیا با وجود این می‌خواهید اوداسیتی را آغاز کنید؟"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "خطا در باز کردن پرونده"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "سیستم یک نسخهٔ دیگر اوداسیتی را در حال اجرا یافته است.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "برای اینکه چندین پروژه را هم‌زمان باز کنید\n"
 "از فرمان جدید یا بازکردن در اوداسیتی در حال اجرا استفاده کنید\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "اوداسیتی از قبل در حال اجرا است"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "پرونده‌های پروژهٔ اوداسیتی"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
+
+#. i18n-hint: This displays a list of available options
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "this help message"
+msgstr "روشن"
+
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+msgid "run self diagnostics"
+msgstr ""
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "به اوداسیتی نسخهٔ %s خوش آمدید"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -540,9 +1125,10 @@ msgid "audio or project file name"
 msgstr "نمی‌توان پروندهٔ پروژه را باز کرد"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -554,25 +1140,74 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "پرونده‌های پروژهٔ اوداسیتی"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "نم&ونه‌برداری مجدد..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "مدت زمان صوت:"
 
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Help"
+msgstr "را&هنما"
+
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "خروج از اوداسیتی"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "میله ابزار %s اوداسیتی"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "&ذخیره کردن..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "بس&تن"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "ذخیره به نام..."
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -601,7 +1236,26 @@ msgid "Error Initializing Audio"
 msgstr "خطا در راه‌اندازی صدا"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"قادر به پخش یا ضبط صدا نخواهید بود.\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "خطا در راه‌اندازی صدا"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "میله ابزار %s اوداسیتی"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -611,10 +1265,27 @@ msgid ""
 "Error code: %s"
 msgstr "خطا در هنگام باز کردن دستگاه صدا. "
 
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
+
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "دستگاه ورودی\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "دستگاه ورودی\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -652,8 +1323,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "در حال ضبط\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "در حال ضبط\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "در حال ضبط\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "در حال ضبط\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -667,37 +1348,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "دستگاه ورودی\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "دستگاه ورودی\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "سرعت پخش\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "صدور ممکن نیست\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "سرعت پخش\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "در حال ضبط\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "‏«‎%s» وارد شد\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "پخش\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "در حال ضبط\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "در حال ضبط\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "پخش\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "پخش\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -705,8 +1389,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "دستگاه ورودی\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "دستگاه ورودی\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "سرعت پخش\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "سرعت پخش\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -714,8 +1408,9 @@ msgid "Automatic Crash Recovery"
 msgstr "بازیابی خودکار پس از فروپاشی"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -727,12 +1422,14 @@ msgid "Recoverable &projects"
 msgstr "پروژه‌های قابل بازیابی"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "انتخاب"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "نام"
 
@@ -745,8 +1442,20 @@ msgid "&Recover Selected"
 msgstr "انتخاب"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Skip"
+msgstr "&گذشتن"
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "زنجیره‌ای انتخاب نشده"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -761,12 +1470,25 @@ msgid "&Edit Parameters"
 msgstr "&ویرایش پارامترها"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Use Preset"
+msgstr "تنظیمات جلوه"
+
+#: src/BatchCommandDialog.cpp
 msgid "&Parameters"
 msgstr "&پارامترها"
 
 #: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "ان&تخاب فرمان"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -775,6 +1497,11 @@ msgstr "آشکار شدن تدریجی"
 #: src/BatchCommands.cpp
 msgid "Import Macro"
 msgstr "وارد کردن MIDI"
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Export Macro"
@@ -787,6 +1514,27 @@ msgstr "ج&لوه"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&ویرایش پارامترها"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&ویرایش پارامترها"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Your batch command of %s was not recognized."
+msgstr ""
 
 #. i18n-hint: active verb in past tense
 #: src/BatchCommands.cpp
@@ -808,11 +1556,47 @@ msgstr "جلوه‌های اعمال‌شده: %s"
 msgid "Apply '%s'"
 msgstr "در حال اِعمال..."
 
+#: src/BatchCommands.cpp
+#, c-format
+msgid ""
+"Apply %s with parameter(s)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Test Mode"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Apply %s"
+msgstr "در حال اِعمال..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "انتخاب"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&برچسب‌ها..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "اِعمال زنجیره"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -868,13 +1652,43 @@ msgstr "ان&صراف"
 msgid "Remo&ve"
 msgstr "&حذف"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "نم&ونه‌برداری مجدد..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "&وارد کردن..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "&صدور..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "&ویرایش پارامترها"
 
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "&فرمان"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#, fuzzy
+msgid "Parameters"
+msgstr "&پارامترها"
 
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp
 msgid "&Insert"
@@ -896,9 +1710,15 @@ msgstr "&بالاتر"
 msgid "Move &Down"
 msgstr "&پایین‌تر"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&ذخیره کردن..."
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -944,11 +1764,38 @@ msgid "Benchmark"
 msgstr "&اجرای آزمایش محک..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "تعداد دفعات تکرار: "
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "بستن"
 
@@ -963,9 +1810,51 @@ msgid "Export Benchmark Data as:"
 msgstr "صدور داده‌های طیفی به صورت:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Preparing...\n"
+msgstr "طول"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 #, c-format
 msgid "Performing %d edits...\n"
 msgstr "در حال تکرار کردن\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -973,13 +1862,90 @@ msgid "Paste: %lld\n"
 msgstr "چسباندن\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "مدت زمان صوت:\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "تاریخ و زمان پایان"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
 
 #: src/BuildInfo.h
 #, fuzzy
@@ -995,9 +1961,58 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "باید اول یک شیار انتخاب کنید."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "زنجیره‌ای انتخاب نشده"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr "باید اول یک شیار انتخاب کنید."
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr "باید اول یک شیار انتخاب کنید."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1014,9 +2029,28 @@ msgid "Checkpointing project"
 msgstr "اِعمال بر پر&وژهٔ فعلی"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "اِعمال بر پر&وژهٔ فعلی"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "نمی‌توان در پرونده نوشت: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"اوداسیتی نتوانست این پرونده را بنویسد:\n"
+"  %s."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1034,6 +2068,10 @@ msgid ""
 "%s"
 msgstr "حذف «‎%s» ممکن نیست"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "در حال حذف وابستگی‌ها"
@@ -1041,6 +2079,25 @@ msgstr "در حال حذف وابستگی‌ها"
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "در حال نسخه‌برداری از اطلاعات صوتی در پروژه..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "در هنگام ذخیره‌سازی پروژه‌ای که به پرونده‌های صوتی دیگر وابستگی دارد"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1055,8 +2112,26 @@ msgid "Disk Space"
 msgstr "فضای دیسک"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "انتخاب"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "صرف نظر از ذخیره‌سازی"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "برچسب"
+
+#: src/Dependencies.cpp
+msgid "Do Not Copy"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1068,9 +2143,32 @@ msgstr "وقتی پروژه‌ای به پرونده‌های دیگر وابس�
 msgid "Ask me"
 msgstr "پرسش از شما"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "برش و انتقال به تخته‌گیره"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1081,10 +2179,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "اگر ادامه دهید پروژهٔ شما در دیسک ذخیره نخواهد شد. آیا منظورتان همین است؟"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "بررسی وابستگی"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "هیچ"
 
@@ -1092,7 +2202,7 @@ msgstr "هیچ"
 msgid "Rectangle"
 msgstr "مستطیل"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "مثلث"
 
@@ -1104,24 +2214,167 @@ msgstr "شکل‌یافته"
 msgid "Rectangular"
 msgstr "مستطیلی"
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
 msgstr ""
-"اوداسیتی نتوانست این پرونده را بنویسد:\n"
-"  %s."
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
 msgstr ""
-"اوداسیتی نتوانست این پرونده را بنویسد:\n"
-"  %s."
 
-#: src/FileException.cpp
-#, c-format
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
 msgid ""
-"Audacity failed to write to a file.\n"
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "کُنش"
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "To find '%s', click here -->"
+msgstr ""
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Browse..."
+msgstr "انتخاب..."
+
+#: src/FFmpeg.cpp
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
+msgstr ""
+
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "%s کجاست؟"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "این اخطار دیگر نشان داده نشود"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"اوداسیتی نتوانست این پرونده را بنویسد:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+"اوداسیتی نتوانست این پرونده را بنویسد:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1139,10 +2392,29 @@ msgid "Error (file may not have been written): %s"
 msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %hs"
 
 #: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr "در حال نسخه‌برداری از اطلاعات صوتی در پروژه..."
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
 msgstr "در حال نسخه‌برداری از اطلاعات صوتی در پروژه..."
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "همهٔ پرونده‌ها (*)|*"
 
@@ -1153,6 +2425,14 @@ msgid "AUP3 project files"
 msgstr "در حال ذخیره کردن پرونده‌های دادهٔ پروژه"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "پرونده‌های نام:"
 
@@ -1160,12 +2440,24 @@ msgstr "پرونده‌های نام:"
 msgid "XML files"
 msgstr "بار کردن پرونده‌ها"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "پرونده‌های نام:"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -1192,6 +2484,14 @@ msgstr "خودهمبستگی ریشهٔ چهارم"
 msgid "Enhanced Autocorrelation"
 msgstr "خودهمبستگی بهبودیافته"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "طیف"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1210,9 +2510,18 @@ msgstr "بسامد لگاریتمی"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "دسی‌بل"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
 
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
@@ -1221,7 +2530,9 @@ msgstr "زوم"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "هرتز"
 
@@ -1240,6 +2551,14 @@ msgid "Cursor:"
 msgstr "مکان‌نما به چپ"
 
 #: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Algorithm:"
 msgstr "الگوریتم:"
 
@@ -1254,6 +2573,10 @@ msgstr "&صدور..."
 #: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "کُنش"
+
+#: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Replot..."
@@ -1277,11 +2600,43 @@ msgstr "اندازهٔ داده‌های انتخاب‌شده کافی نیست
 msgid "s"
 msgstr "ثانیه"
 
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "طیف"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "صدور داده‌های طیفی به صورت:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "نمی‌توان در پرونده نوشت: "
@@ -1298,6 +2653,22 @@ msgstr "تأخیر (ثانیه)\tفرکانس (هرتز)\tسطح"
 msgid "Plot Spectrum..."
 msgstr "&رسم طیف..."
 
+#: src/HelpText.cpp
+msgid "Welcome!"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "پخش"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording Audio"
+msgstr "صدای ضبط‌شده"
+
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
 msgid "Recording - Choosing the Recording Device"
@@ -1312,6 +2683,95 @@ msgstr "در حال ضبط"
 #: src/HelpText.cpp
 msgid "Recording - Setting the Recording Level"
 msgstr "در حال ضبط"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "صدور چندتایی"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "در حال باز کردن پروژهٔ اوداسیتی"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1330,6 +2790,10 @@ msgid "Used Space"
 msgstr "فضای دیسک"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "ت&عداد مراحل برگردان موجود"
 
@@ -1343,6 +2807,10 @@ msgid "&Discard"
 msgstr "&دور انداختن"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&دور انداختن"
 
@@ -1350,11 +2818,40 @@ msgstr "&دور انداختن"
 msgid "&Compact"
 msgstr "&فرمان"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&تاریخچه"
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.h
+#, fuzzy
+msgid "Internal Error"
+msgstr "خطای LOF"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "برچسب‌ها ویرایش شدند"
 
 #. i18n-hint: (noun).  A track contains waves, audio etc.
 #: src/LabelDialog.cpp
@@ -1362,7 +2859,9 @@ msgid "Track"
 msgstr "شیار"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "برچسب"
 
@@ -1419,19 +2918,47 @@ msgstr "شیار برچسب جدید"
 msgid "Enter track name"
 msgstr "نام شیار را وارد کنید"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "&شیار برچسب"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "اولین اجرای اوداسیتی"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "زبان اوداسیتی را انتخاب کنید"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "تأیید"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "نمی‌توان در پرونده نوشت: "
 
 #: src/Legacy.cpp
 #, c-format
@@ -1443,8 +2970,19 @@ msgstr ""
 "پروندهٔ قدیمی به نام «‎%s» ذخیره شد"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "در حال باز کردن پروژهٔ اوداسیتی"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "تشکر ویژه:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "انتخاب..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1464,6 +3002,17 @@ msgstr "انجام &دوبارهٔ %s"
 msgid "&Redo"
 msgstr "&دوباره"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "خاموش"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
@@ -1477,34 +3026,76 @@ msgstr "&میکس و رندر"
 msgid "Mixing and rendering tracks"
 msgstr "میکس و رندر شیارها"
 
+#: src/MixerBoard.cpp
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr "ضبط زمان‌بندی شدهٔ اوداسیتی"
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "بهره"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "حرکت افقی"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "بی‌صدا"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "تک"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "دکمهٔ لغزندهٔ بهره، حرکت داده شده"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "دکمهٔ لغزندهٔ بهره، حرکت داده شده"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "دکمهٔ لغزندهٔ حرکت افقی، حرکت داده شده"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "نوار ابزار میکسر"
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1514,13 +3105,73 @@ msgid ""
 "Error: %s"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "روشن"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "هیچ"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "میله ابزار %s اوداسیتی"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1530,18 +3181,126 @@ msgstr "شیار نُت"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "گیگابایت"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "دسی‌بل"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "رونویسی پرونده‌های موجود"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -1563,9 +3322,29 @@ msgstr[1] "به کار انداختن اندازه‌گیر\n"
 msgid "Enable new plug-ins"
 msgstr "به کار انداختن اندازه‌گیر"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "در حال اعمال جلوه Nyquist..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "به کار انداختن اندازه‌گیر"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "روشن"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -1592,6 +3371,25 @@ msgstr "روشن"
 msgid "E&nabled"
 msgstr "روشن"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "روشن"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "انتخاب"
@@ -1600,7 +3398,8 @@ msgstr "انتخاب"
 msgid "C&lear All"
 msgstr "&پاک کردن"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "روشن"
 
@@ -1639,6 +3438,14 @@ msgstr "هنگام چاپ مشکلی پیش آمد."
 msgid "Print"
 msgstr "چاپ"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgid "Actual Rate: %d"
@@ -1654,6 +3461,21 @@ msgstr "خطا در هنگام باز کردن دستگاه صدا. لطفاً �
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "برای رسم طیف، همهٔ شیارهای انتخاب‌شده باید نرخ نمونه‌برداری یکسان داشته باشند."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "صدای ضبط‌شده"
@@ -1662,9 +3484,99 @@ msgstr "صدای ضبط‌شده"
 msgid "Record"
 msgstr "ضبط"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "همین حالا پروژه بدون هیچ تغییری بسته شود"
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "نمی‌توان پروندهٔ پروژه را باز کرد"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Treat missing audio as silence (this session only)"
+msgstr "پر کردن داده‌های نمایشی مفقود با سکوت [فقط برای این نشست]"
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Fill in silence for missing display data (this session only)"
@@ -1674,11 +3586,87 @@ msgstr "پر کردن داده‌های نمایشی مفقود با سکوت [�
 msgid "Close project immediately with no further changes"
 msgstr "همین حالا پروژه بدون هیچ تغییر دیگری بسته شود"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "پیشرفت"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "در حال پاک‌سازی شاخه‌های حافظهٔ نهان"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "جادادن پروژه"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1717,11 +3705,96 @@ msgid ""
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "حذف «‎%s» ممکن نیست"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1730,12 +3803,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "تغییر نام «‎%s» به «‎%s» ممکن نیست"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "حذف «‎%s» ممکن نیست"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1746,9 +3845,9 @@ msgid "Error Writing to File"
 msgstr "نمی‌توان در پرونده نوشت: "
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1759,8 +3858,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "پروژهٔ جدید ایجاد شد"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "میله ابزار %s اوداسیتی"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -1768,9 +3876,21 @@ msgstr "میله ابزار %s اوداسیتی"
 msgid "(Recovered)"
 msgstr "(بازیابی شده)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "نمی‌توان پروندهٔ پروژه را باز کرد"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -1785,14 +3905,62 @@ msgid "Unable to parse project information."
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&ذخیرهٔ پروژه"
 
-#: src/ProjectFileManager.cpp
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "اعمال جلوه: %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "&ذخیرهٔ پروژه"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
+msgstr ""
+"دفعهٔ قبلی که اوداسیتی اجرا شده، بعضی پروژه‌ها درست ذخیره نشده‌اند.\n"
+"خوشبختانه پروژه‌های زیر را می‌توان به طور خودکار بازیابی کرد:"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
 msgstr ""
 "دفعهٔ قبلی که اوداسیتی اجرا شده، بعضی پروژه‌ها درست ذخیره نشده‌اند.\n"
 "خوشبختانه پروژه‌های زیر را می‌توان به طور خودکار بازیابی کرد:"
@@ -1801,9 +3969,42 @@ msgstr ""
 msgid "Project Recovered"
 msgstr "پروژه بازیابی شد"
 
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "شاخهٔ پرونده‌های موقت"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "&ذخیرهٔ پروژه"
+
 #: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "فضای دیسک"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -1811,9 +4012,34 @@ msgid "Saved %s"
 msgstr "‏‎%s ذخیره شد"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "ذخیرهٔ پروژه به &نام..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -1821,9 +4047,21 @@ msgid "Overwrite Project Warning"
 msgstr "رونویسی پرونده‌های موجود"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "ذخیرهٔ پروژه به &نام..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -1846,6 +4084,23 @@ msgstr "یک یا چند پروندهٔ صوتی انتخاب کنید..."
 msgid "%s is already open in another window."
 msgstr "‏%s از قبل در پنجرهٔ دیگری باز است."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "خطا در باز کردن پرونده"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "خطا در باز کردن پرونده"
@@ -1862,6 +4117,17 @@ msgid ""
 msgstr ""
 "ممکن است پرونده نامعتبر یا خراب باشد: \n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "خطا در باز کردن پرونده"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -1889,12 +4155,33 @@ msgid "Error Importing"
 msgstr "خطا در وارد کردن"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&ذخیرهٔ پروژه"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "نمی‌توان پروندهٔ پروژه را باز کرد"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&فرمان"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -1905,8 +4192,8 @@ msgid "Automatic database backup failed."
 msgstr "بازیابی خودکار پس از فروپاشی"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "به اوداسیتی نسخهٔ %s خوش آمدید"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -1920,9 +4207,23 @@ msgid "Save project before closing?"
 msgstr "آیا پیش از بستن، تغییرات ذخیره شود؟"
 
 #: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "Disk space remaining for recording: %s"
 msgstr "دیسک به اندازهٔ ضبط %Id دقیقه فضای خالی دارد."
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -1937,6 +4238,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -1953,6 +4266,26 @@ msgstr "استریوی افقی"
 msgid "Vertical Scrollbar"
 msgstr "استریوی عمودی"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "کیفیت "
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "کیفیت "
@@ -1961,9 +4294,107 @@ msgstr "کیفیت "
 msgid "High Quality"
 msgstr "کیفیت "
 
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "۱۶ بیتی"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "۱۶ بیتی"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "مکانی برای ذخیره‌سازی پرونده‌های صادرشده انتخاب کنید"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "تغییرات ذخیره شود؟"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "انتخاب..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "اندازه"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "اندازه"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "White Bkgnd"
+msgstr "سفید"
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr " پنجره‌ای"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "نوع پنجره:"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "اِعمال بر پر&وژهٔ فعلی"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "ابزار"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -1977,7 +4408,13 @@ msgstr "همهٔ پرونده‌ها (*)|*"
 msgid "All Preferences"
 msgstr "ترجیحات..."
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "انتخاب"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "انتخاب"
 
@@ -1985,47 +4422,153 @@ msgstr "انتخاب"
 msgid "Timer"
 msgstr "زمان پایان"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "ابزارها"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "آوانویسی"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "میکسر"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "اندازه‌گیر"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "اندازه‌گیر پخش"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "اندازه‌گیر ضبط"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&ویرایش"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "دستگاه"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "پخش در سرعت خاص"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "نوار ابزار ویرایش"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
 msgstr "تابلوی شیار"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "شیارها"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "&شیار‌ها"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "شیار جدید"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "پخش یک ثانیه"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "&شیار‌ها"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "&شیار‌ها"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "شیارها"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "مکانی برای ذخیره‌سازی پرونده‌های صادرشده انتخاب کنید"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "روشن"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
@@ -2043,9 +4586,55 @@ msgstr "تنظیمات جلوه"
 msgid "Debu&g"
 msgstr "&اشکال‌زدایی"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Nearest"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Sound Activated Record"
+msgstr "ضبط زمان‌بندی شدهٔ اوداسیتی"
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "میزان تقویت (دسی‌بل):"
+
+#: src/SplashDialog.cpp
+#, fuzzy
+msgid "Welcome to Tenacity!"
+msgstr "به اوداسیتی نسخهٔ %s خوش آمدید"
+
+#: src/SplashDialog.cpp
+#, fuzzy
+msgid "Don't show this again at start up"
+msgstr "این اخطار دیگر نشان داده نشود"
+
 #: src/SqliteSampleBlock.cpp
 msgid "Connection to project file is null"
 msgstr "نمی‌توان پروندهٔ پروژه را باز کرد"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Artist Name"
+msgstr "مرتب‌سازی بر مبنای نام"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Track Title"
+msgstr "نمای شیار"
+
+#: src/Tags.cpp
+msgid "Album Title"
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Track Number"
@@ -2064,12 +4653,40 @@ msgid "Comments"
 msgstr "توضیحات"
 
 #: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "شکل موج (دسی‌بل)"
+
+#: src/Tags.cpp
 msgid "&Add"
 msgstr "ا&ضافه"
 
 #: src/Tags.cpp
 msgid "&Remove"
 msgstr "&حذف"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genres"
+msgstr "ژانر"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&ویرایش"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "زوم به خارج"
 
 #: src/Tags.cpp
 msgid "Template"
@@ -2080,26 +4697,100 @@ msgid "&Load..."
 msgstr "&بار کردن..."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "پی&ش‌فرض‌ها"
+
+#: src/Tags.cpp
 msgid "Don't show this when exporting audio"
 msgstr "این اخطار دیگر نشان داده نشود"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Edit Genres"
+msgstr "&ویرایش پارامترها"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to save genre file."
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/Tags.cpp
+msgid "Reset Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Are you sure you want to reset the genre list to defaults?"
+msgstr "آیا مطمئن هستید که می‌خواهید پرونده را با ذخیره کنید با نام \"\n"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to open genre file."
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/Tags.cpp
+msgid "Load Metadata As:"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "خطا در باز کردن پرونده"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Save Metadata As:"
+msgstr "ذخیرهٔ پروژه به &نام..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "خطا در باز کردن پرونده"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "روشن"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "شاخهٔ پرونده‌های موقت"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "اوداسیتی نتوانست این پرونده را بنویسد:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2107,18 +4798,26 @@ msgstr ""
 "  %s"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "اوداسیتی نتوانست تصاویر را در این پرونده بنویسد:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -2128,9 +4827,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -2139,8 +4838,9 @@ msgstr ""
 "شاید پروندهٔ PNG اشکال دارد؟"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "اوداسیتی نتوانست تم پیش‌فرضش را بخواند.\n"
@@ -2178,18 +4878,40 @@ msgstr ""
 "از قبل موجود هستند."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "اوداسیتی نتوانست این پرونده را ذخیره کند:\n"
 "  %s"
 
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "سبک"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "نام شیار"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2198,16 +4920,85 @@ msgstr "سبک"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "مدت زمان"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "شیار &زمان"
+
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "ضبط زمان‌بندی شدهٔ اوداسیتی"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
+msgstr "در حال ضبط"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "اعمال جلوه: %s"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "مدت زمان صوت:"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "بازیابی خودکار پس از فروپاشی"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Save"
+msgstr "بازیابی خودکار پس از فروپاشی"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "بازیابی خودکار پس از فروپاشی"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "بازیابی خودکار پس از فروپاشی"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
 msgstr "در حال ضبط"
 
 #: src/TimerRecordDialog.cpp
@@ -2217,6 +5008,12 @@ msgstr "اِعمال بر پر&وژهٔ فعلی"
 #: src/TimerRecordDialog.cpp
 msgid "Recording start:"
 msgstr "اندازه‌گیر ضبط"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "مدت زمان"
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
@@ -2232,6 +5029,11 @@ msgstr "بازیابی خودکار پس از فروپاشی"
 
 #: src/TimerRecordDialog.cpp
 msgid "Action after Timer Recording:"
+msgstr "ضبط زمان‌بندی شدهٔ اوداسیتی"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "ضبط زمان‌بندی شدهٔ اوداسیتی"
 
 #: src/TimerRecordDialog.cpp
@@ -2251,12 +5053,44 @@ msgid ""
 msgstr "اندازه‌گیر ضبط"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "در حال ضبط"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
 "\n"
 "Recording exported: %s"
 msgstr "اندازه‌گیر ضبط"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "در حال ضبط"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
@@ -2277,16 +5111,32 @@ msgstr "0100 روز 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "تاریخ و زمان آغاز"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "&زمان آغاز"
 
 #: src/TimerRecordDialog.cpp
 msgid "End Date and Time"
 msgstr "تاریخ و زمان پایان"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date"
+msgstr "تاریخ و زمان پایان"
+
+#: src/TimerRecordDialog.cpp
 msgid "Automatic Save"
+msgstr "بازیابی خودکار پس از فروپاشی"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
 msgstr "بازیابی خودکار پس از فروپاشی"
 
 #: src/TimerRecordDialog.cpp
@@ -2309,7 +5159,8 @@ msgstr "صدور ممکن نیست"
 msgid "Export Project As:"
 msgstr "صدور برچسب‌ها به صورت:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "تنظیمات جلوه"
 
@@ -2318,8 +5169,25 @@ msgid "After Recording completes:"
 msgstr "اندازه‌گیر ضبط"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "خروج از اوداسیتی"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -2329,11 +5197,24 @@ msgstr "مدت زمان صوت:"
 msgid "Scheduled to stop at:"
 msgstr "انتخاب تا آغاز"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr "ضبط زمان‌بندی شدهٔ اوداسیتی"
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "اندازه‌گیر ضبط"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -2344,8 +5225,19 @@ msgid "Recording Exported:"
 msgstr "اندازه‌گیر ضبط"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "ضبط زمان‌بندی شدهٔ اوداسیتی"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "استریو، "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -2375,6 +5267,15 @@ msgstr "تک"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "انتخاب"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "انتخاب صدا"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -2453,6 +5354,10 @@ msgstr "بالا بردن شیار"
 msgid "Move Track Down"
 msgstr "پایین بردن شیار"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -2498,21 +5403,80 @@ msgstr "برای چسباندن انتخاب به اندازهٔ کافی جا �
 msgid "There is not enough room available to expand the cut line"
 msgstr "برای گسترش خط برشْ به اندازهٔ کافی جا نیست"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "در حال اِعمال..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "انتخاب فرمان"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "&فرمان"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "تکرار %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -2522,6 +5486,15 @@ msgstr "نسخه‌برداری از برچسب‌ها"
 msgid "Threshold:"
 msgstr "آستانه:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "ایجاد شیار صوتی جدید"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "زمان تأخیر (ثانیه):"
@@ -2529,6 +5502,10 @@ msgstr "زمان تأخیر (ثانیه):"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "عامل میرایی:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -2550,9 +5527,38 @@ msgstr "شیار"
 msgid "Track 1"
 msgstr "شیار"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "نوع پنجره:"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -2570,21 +5576,86 @@ msgstr "همهٔ پرونده‌ها (*)|*"
 msgid "Preferences"
 msgstr "ترجیحات..."
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "ابزار بعدی"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "پاکت"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "برچسب‌ها"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "اندازه‌گیر"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "تغییر قالب"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "پایین بردن شیار"
 
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "اندازه‌گیر"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "توضیحات"
+
+#: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command:"
+msgstr "&فرمان"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -2603,6 +5674,11 @@ msgid "Number of Channels:"
 msgstr "تعداد دفعات تکرار: "
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "صدور چندتایی"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "صدور چندتایی"
 
@@ -2610,9 +5686,31 @@ msgstr "صدور چندتایی"
 msgid "Builtin Commands"
 msgstr "انتخاب فرمان"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "تیم پشتیبانی اوداسیتی %s"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "تاریخ و زمان پایان"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "روشن"
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Open Project2"
@@ -2650,17 +5748,50 @@ msgstr "&ذخیرهٔ پروژه"
 msgid "Saves a copy of current project."
 msgstr "&ذخیرهٔ پروژه"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "ترجیحات..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "نام"
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "ترجیحات..."
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "شکل موج (دسی‌بل)"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "&چاپ..."
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Window"
@@ -2675,8 +5806,23 @@ msgid "Window Plus"
 msgstr "نوع پنجره:"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "ابزار"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "ج&لوه"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "همهٔ پرونده‌ها (*)|*"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -2714,6 +5860,10 @@ msgstr "شیارها"
 msgid "All Tracks Plus"
 msgstr "تابلوی شیار"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -2721,9 +5871,30 @@ msgid "White"
 msgstr "سفید"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "نمی‌توان در پرونده نوشت: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&چاپ..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -2766,6 +5937,14 @@ msgid "Select Frequencies"
 msgstr "بسامد (هرتز)"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&شیار‌ها"
 
@@ -2777,6 +5956,12 @@ msgstr "انتخاب"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "ا&ضافه"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&حذف"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -2795,6 +5980,11 @@ msgid "Selects a time range."
 msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "ایجاد شیار صوتی جدید"
 
@@ -2806,9 +5996,37 @@ msgstr "مدت زمان سکوت:"
 msgid "Set Clip"
 msgstr "ابزار بعدی"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "آغاز"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -2827,9 +6045,14 @@ msgid "Edited Envelope"
 msgstr "پاکت"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "پاکت"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -2839,6 +6062,10 @@ msgstr "تفکیک برچسب‌ها"
 msgid "Label Index"
 msgstr "ویرایش برچسب"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "انتخاب"
@@ -2846,6 +6073,10 @@ msgstr "انتخاب"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "برچسب‌ها ویرایش شدند"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -2859,9 +6090,26 @@ msgstr "تنظیم نرخ"
 msgid "Resize:"
 msgstr "اندازه"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "سبک"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&ذخیرهٔ پروژه"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -2876,6 +6124,10 @@ msgid "Set Track Status"
 msgstr "به آغاز شیار"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "مکث"
 
@@ -2888,10 +6140,17 @@ msgid "Gain:"
 msgstr "بهره"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&شیار‌ها"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "خطی..."
 
@@ -2900,8 +6159,21 @@ msgid "Reset"
 msgstr "زوم به خارج"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "زمان پایان"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
 msgstr "نمایش"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -2923,16 +6195,36 @@ msgstr "تنظیمات جلوه"
 msgid "Spectral Select"
 msgstr "انتخاب"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "شیار جدید"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "ایجاد شیار صوتی جدید"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "تقویت"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "میزان تقویت (دسی‌بل):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "میزان تقویت (دسی‌بل):"
 
 #: src/effects/Amplify.cpp
@@ -2946,6 +6238,10 @@ msgstr "اجازهٔ برش"
 #: src/effects/AutoDuck.cpp
 msgid "Auto Duck"
 msgstr "مخفی‌سازی خودکار"
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
 
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
@@ -2961,12 +6257,18 @@ msgstr "شما شیاری را انتخاب کرده‌اید که حاوی صو
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "مخفی‌سازی خودکار به یک شیار کنترلی نیاز دارد که باید زیر شیار انتخاب‌شده قرار داده شود."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "مقدار مخفی‌سازی:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "ثانیه"
 
@@ -2990,7 +6292,8 @@ msgstr "طول داخلی کم شدن تدریجی صدا:"
 msgid "Inner &fade up length:"
 msgstr "طول داخلی بلند شدن تدریجی صدا:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "آستانه:"
 
@@ -2999,8 +6302,17 @@ msgid "Preview not available"
 msgstr "پیش‌نمایش موجود نیست"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "انقباض از چپ انتخاب"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "آستانه:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3011,8 +6323,31 @@ msgid "Ba&ss (dB):"
 msgstr "تقویت (دسی‌بل):"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "شکل موج (دسی‌بل)"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "ویرایش برچسب"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Volume (dB):"
+msgstr "شکل موج (دسی‌بل)"
+
+#: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "ابزار ترازبندی"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -3023,13 +6358,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "تغییر کوک بدون عوض شدن ضرباهنگ"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "کیفیت "
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "تغییر کوک بدون عوض شدن ضرباهنگ"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "کوک (EAC)"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -3063,17 +6420,54 @@ msgstr "نیم‌پرده:"
 msgid "Frequency"
 msgstr "بسامد (هرتز)"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "تا"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "تغییر درصد:"
 
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "تغییر درصد:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "مربوط نیست"
 
@@ -3092,6 +6486,32 @@ msgstr "تغییر سرعت، که روی ضرباهنگ و کوک تأثیر م
 #: src/effects/ChangeSpeed.cpp
 msgid "&Speed Multiplier:"
 msgstr "صدور چندتایی"
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -3113,6 +6533,12 @@ msgstr ""
 msgid "Current length of selection."
 msgstr "کوتاه‌کردن پرونده بنابر انتخاب"
 
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
+
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
 msgstr "طول"
@@ -3132,8 +6558,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "تغییر ضرباهنگ بدون تغییر کردن کوک"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "کیفیت "
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "تغییر ضرباهنگ بدون تغییر کردن کوک"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -3148,6 +6599,12 @@ msgstr "طول (به ثانیه)"
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
 msgid "t&o"
 msgstr "تا"
 
@@ -3157,15 +6614,106 @@ msgid "Length in seconds from %s, to"
 msgstr "طول (به ثانیه)"
 
 #: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "حذف تق‌ها..."
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "نام نمی‌تواند خالی باشد"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "آستانه برای نوفه: "
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "آستانه:"
 
 #: src/effects/ClickRemoval.cpp
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "آستانه برای نوفه: "
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "فشرده‌ساز..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "زمان حمله: %I.1f ثانیه"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "نوع نوفه:"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "نوع نوفه:"
+
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "مدت زمان"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "مدت زمان"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -3176,16 +6724,48 @@ msgid "&Attack Time:"
 msgstr "زمان حمله: "
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "زمان حمله: "
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "زمان حمله: %I.1f ثانیه"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "زمان حمله: %I.1f ثانیه"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "آستانه: %Id دسی‌بل"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -3198,29 +6778,301 @@ msgid "Release Time %.1f secs"
 msgstr "زمان حمله: %I.1f ثانیه"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "ایجاد شیار صوتی جدید"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "ایجاد شیار صوتی جدید"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "ایجاد شیار صوتی جدید"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "پایان"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "انتخاب سکوت"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "تاریخ و زمان پایان"
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "انتخاب سکوت"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "زوم به خارج"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "ترجیحات..."
 
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "را&هنما"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "نمی‌توان تعیین کرد"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr ""
+"این شاخه ایجاد نشد:\n"
+"  %s"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "صدور برچسب‌ها به صورت:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "نام «%s» به «%s» تغییر کرد"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "تکرار"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "&پیش‌فرض‌ها"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "قلم..."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Clipping"
+msgstr "اجازهٔ برش"
+
 #: src/effects/Distortion.cpp
 msgid "Soft Clipping"
 msgstr "اجازهٔ برش"
+
+#: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Expand and Compress"
@@ -3229,6 +7081,98 @@ msgstr "فشرده‌ساز با دامنهٔ پویا"
 #: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "ابزار ترازبندی"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "مدت زمان"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "اجازهٔ برش"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -3251,8 +7195,16 @@ msgid "Distortion"
 msgstr "مدت زمان"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "درون‌یابی همگامی سریع"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -3267,8 +7219,26 @@ msgid "Clipping level"
 msgstr "در حال ترازبندی..."
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "اِعمال زنجیره"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "آستانه:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "مدت زمان"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -3279,12 +7249,69 @@ msgid "Repeat processing"
 msgstr "در حال پردازش مخفی‌سازی خودکار..."
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "درجهٔ ترازبندی"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "اجازهٔ برش"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "سرعت پخش"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "سرعت پخش"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "صوت‌های& DTMF"
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -3294,7 +7321,9 @@ msgstr "دنبالهٔ DTMF"
 msgid "&Amplitude (0-1):"
 msgstr "دامنه (۰-۱)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "مدت زمان"
 
@@ -3307,12 +7336,29 @@ msgid "Duty cycle:"
 msgstr "دورهٔ کار:"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "مدت زمان صوت:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "مدت زمان سکوت:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -3321,6 +7367,11 @@ msgstr "پژواک"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "صدور صوت انتخاب‌شده در قالب اُگ وربیس"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -3331,6 +7382,10 @@ msgid "D&ecay factor:"
 msgstr "عامل میرایی:"
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "فشار دهید"
 
@@ -3338,7 +7393,8 @@ msgstr "فشار دهید"
 msgid "Export Effect Parameters"
 msgstr "&ویرایش پارامترها"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "باز کردن پروندهٔ «%s» مممکن نیست"
@@ -3362,6 +7418,31 @@ msgstr "&ویرایش پارامترها"
 msgid "%s: is not a valid presets file.\n"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Preparing preview"
+msgstr "اندازه‌گیر ضبط"
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Previewing"
+msgstr "پی&ش‌نمایش"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
+
 #: src/effects/EffectManager.cpp
 #, c-format
 msgid "Applied effect: %s"
@@ -3384,6 +7465,11 @@ msgstr "فشار دهید"
 msgid "User Presets"
 msgstr "تنظیمات جلوه"
 
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "&پیش‌فرض‌ها"
+
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
 msgstr "تنظیمات جلوه"
@@ -3392,13 +7478,68 @@ msgstr "تنظیمات جلوه"
 msgid "Factory Defaults"
 msgstr "&پیش‌فرض‌ها"
 
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "انتخاب تا پایان"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
+
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
 msgstr "ج&لوه"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Apply"
+msgstr "اِعمال زنجیره"
+
+#: src/effects/EffectUI.cpp
 msgid "Latency: 0"
 msgstr "نهفتگی"
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "ردیف شد"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Move Up"
@@ -3417,6 +7558,24 @@ msgid "Move effect down in the rack"
 msgstr "بریده‌های منتقل‌شده به شیاری دیگر"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "بریده‌های منتقل‌شده به شیاری دیگر"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "نام زنجیر جدید را وارد کنید"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "نهفتگی"
@@ -3424,6 +7583,20 @@ msgstr "نهفتگی"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "انتخاب فرمان"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "مدیریت تاریخچه"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "پخش"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3438,6 +7611,16 @@ msgstr "پی&ش‌نمایش"
 #: src/effects/EffectUI.cpp
 msgid "&Preview effect"
 msgstr "پی&ش‌نمایش"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "پرش به آغاز"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "پرش به آغاز"
 
 #: src/effects/EffectUI.cpp
 msgid "Skip forward"
@@ -3455,6 +7638,11 @@ msgstr "روشن"
 msgid "Save Preset..."
 msgstr "ذخیره به نام..."
 
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "انتخاب"
+
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
 msgstr "&پیش‌فرض‌ها"
@@ -3467,10 +7655,30 @@ msgstr "&وارد کردن..."
 msgid "Export..."
 msgstr "&صدور..."
 
+#: src/effects/EffectUI.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Options..."
+msgstr "تنظیمات جلوه"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "اندازه‌گیر"
+
 #: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "نام"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "برعکس کردن"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "خطا: "
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -3478,9 +7686,18 @@ msgid "Description: %s"
 msgstr "آوانویسی"
 
 #: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "آیا مطمئنید که می‌خواهید %s را حذف کنید؟"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "ذخیره به نام..."
 
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
@@ -3489,6 +7706,13 @@ msgstr "نام پروندهٔ اول:"
 #: src/effects/EffectUI.cpp
 msgid "You must specify a name"
 msgstr "باید اول یک شیار انتخاب کنید."
+
+#: src/effects/EffectUI.cpp
+msgid ""
+"Preset already exists.\n"
+"\n"
+"Replace?"
+msgstr ""
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3526,12 +7750,56 @@ msgid "Graphic EQ"
 msgstr "اکولایزر گرافیکی"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "تقویت بسامدهای بم"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "تقویت بسامدهای بم"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "ویرایش برچسب"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "ویرایش برچسب"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -3546,16 +7814,55 @@ msgid "Effect Unavailable"
 msgstr "پیش‌نمایش موجود نیست"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "حداکثر قدرت صدا (دسی‌بل)"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "حداقل قدرت صدا (دسی‌بل)"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "اندازه‌گیر"
+
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "رسم منحنی"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "ابزار رسم"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -3566,8 +7873,54 @@ msgid "Interpolation type"
 msgstr "درون‌یابی همگامی سریع"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "بسامد خطی"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "بسامد خطی"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "در حال ترازبندی..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "در حال ترازبندی..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "انتخاب"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "انتخاب"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "معکوس کردن"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Processing: "
@@ -3578,8 +7931,106 @@ msgid "D&efault"
 msgstr "&پیش‌فرض‌ها"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&اجرای آزمایش محک..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "اعمال جلوه: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "در حال اِعمال اکولایزر"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "مدیریت تاریخچه"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "رسم منحنی"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "مکان‌نما به چپ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "نام"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "حذف"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "انتخاب..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "پی&ش‌فرض‌ها"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3587,14 +8038,42 @@ msgid "Rename '%s' to..."
 msgstr "نام «%s» به «%s» تغییر کرد"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "نم&ونه‌برداری مجدد..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "نام «%s» به «%s» تغییر کرد"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "ت&غییر نام"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr "رونویسی پرونده‌های موجود"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "&پایین‌تر"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "صدور صوت به %s ممکن نیست"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3611,8 +8090,51 @@ msgid "Delete %d items?"
 msgstr "حذف برچسب‌ها"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "پروندهٔ ذخیرهٔ خودکار حذف نشد"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "صدور &برچسب‌ها..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "صدور صوت به %s ممکن نیست"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "اندازه‌گیر ضبط"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "برچسبی برای صدور نیست."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -3626,13 +8148,76 @@ msgstr "محو شدن تدریجی"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "برای انتخاب صوت کلیک کنید و بکشید"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "برای انتخاب صوت کلیک کنید و بکشید"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "اجازهٔ برش"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "اجازهٔ برش"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "آستانه: %Id دسی‌بل"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "آستانه: %Id دسی‌بل"
+
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "برای چسباندن انتخاب به اندازهٔ کافی جا نیست"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "معکوس کردن"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "در حال اعمال جلوه Nyquist..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "نرمال‌سازی حداکثر دامنه تا"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -3651,6 +8236,31 @@ msgstr "در حال پردازش مخفی‌سازی خودکار..."
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "نرمال‌سازی"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -3676,6 +8286,10 @@ msgid "Noise"
 msgstr "نوع نوفه:"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "نوع نوفه:"
 
@@ -3688,16 +8302,73 @@ msgid "Second greatest"
 msgstr "ثانیه"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "۲۵۶ ‐ پیش‌فرض"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "۲۵۶ ‐ پیش‌فرض"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "کاهش نوفه (دسی‌بل):"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "برای رسم طیف، همهٔ شیارهای انتخاب‌شده باید نرخ نمونه‌برداری یکسان داشته باشند."
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -3705,6 +8376,11 @@ msgstr "محدودهٔ انتخاب‌شده برای استفاده از کلی
 
 #: src/effects/NoiseReduction.cpp
 msgid "&Noise reduction (dB):"
+msgstr "کاهش نوفه (دسی‌بل):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
 msgstr "کاهش نوفه (دسی‌بل):"
 
 #: src/effects/NoiseReduction.cpp
@@ -3735,6 +8411,11 @@ msgstr "‏%Id بار تکرار شد"
 msgid "&Frequency smoothing (bands):"
 msgstr "هموارسازی بسامد (هرتز):"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "هموارسازی بسامد (هرتز):"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "حساسیت"
@@ -3748,8 +8429,9 @@ msgid "Step 1"
 msgstr "مرحلهٔ ۱"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "چند ثانیه از نوفه‌ها را انتخاب کنید تا اوداسیتی بداند چه چیزی را صافی کند،\n"
@@ -3771,6 +8453,27 @@ msgstr ""
 "تمام صدایی که می‌خواهید صافی کنید را انتخاب نمایید، مشخص کنید که چه مقدار نوفه را می‌خواهید\n"
 "با استفاده از صافی حذف کنید، سپس روی «تأیید» کلیک کنید تا نوفه حذف گردد.\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "نوع نوفه:"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "ح&ذف شیار‌ها"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "اندازه"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "گزینه‌های پیشرفتهٔ میکس"
@@ -3783,17 +8486,78 @@ msgstr "نوع پنجره:"
 msgid "Window si&ze:"
 msgstr "نوع پنجره:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "۲۵۶ ‐ پیش‌فرض"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "۲۵۶ ‐ پیش‌فرض"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "حذف نوفه"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -3808,6 +8572,11 @@ msgid "Noise re&duction (dB):"
 msgstr "کاهش نوفه (دسی‌بل):"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "حساسیت"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr "هموارسازی بسامد (هرتز):"
 
@@ -3815,13 +8584,70 @@ msgstr "هموارسازی بسامد (هرتز):"
 msgid "Attac&k/decay time (secs):"
 msgstr "زمان حمله/میرایی (ثانیه):"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "زمان حمله/میرایی (ثانیه):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&حذف"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "نرمال‌سازی"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "در حال حذف نوفه\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "در حال حذف نوفه\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "در حال حذف نوفه\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -3831,9 +8657,23 @@ msgstr "نرمال‌سازی حداکثر دامنه تا"
 msgid "Peak amplitude dB"
 msgstr "بیشینه دامنهٔ جدید (دسی‌بل) :"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "عامل میرایی:"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "عامل میرایی:"
@@ -3842,29 +8682,94 @@ msgstr "عامل میرایی:"
 msgid "&Time Resolution (seconds):"
 msgstr "زمان تأخیر (ثانیه):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "فاز"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "مراحل:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "مراحل:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "فرکانس LFO (هرتز):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "فرکانس LFO (هرتز):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "فاز شروع LFO (درجه):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "فاز شروع LFO (درجه):"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "عمق:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "بازخورد (٪):"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "&Output gain (dB):"
@@ -3879,6 +8784,10 @@ msgid "Repair"
 msgstr "تعمیر"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -3888,9 +8797,22 @@ msgstr ""
 "\n"
 "با استفاده از زوم کردن به داخل، کسر کوچکی از ثانیه را برای تعمیر انتخاب کنید."
 
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "تکرار"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -3914,9 +8836,65 @@ msgstr "طول انتخاب جدید: "
 msgid "New selection length: %s"
 msgstr "طول انتخاب جدید: "
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "حذف شیار"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "متوسط"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "برعکس"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "اندازه"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "زمان حمله/میرایی (ثانیه):"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -3925,6 +8903,34 @@ msgstr "بازخورد (٪):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "عمق (٪):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "عمق (٪):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "کانال‌های خروجی: %I2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "کانال‌های خروجی: %I2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "استریو، "
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -3939,13 +8945,98 @@ msgstr "برعکس"
 msgid "Reverses the selected audio"
 msgstr "صدور صوت انتخاب‌شده بعنوان FLAC"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "بارگ&ذاری پرونده..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "برای رسم طیف، همهٔ شیارهای انتخاب‌شده باید نرخ نمونه‌برداری یکسان داشته باشند."
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "اندازه‌گیر"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "ردیف کردن پایان با پایان انتخاب"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "مدت زمان"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "مدت زمان"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -3954,6 +9045,14 @@ msgstr "نوع پنجره:"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "نوع پنجره:"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -3969,6 +9068,15 @@ msgstr "آستانه:"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "مرتب‌سازی بر مبنای مدت"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "مرتب‌سازی بر مبنای مدت"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -4007,15 +9115,28 @@ msgstr "&پیش‌فرض‌ها"
 msgid "Restore Defaults"
 msgstr "&پیش‌فرض‌ها"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "سکوت"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "ا&ستریو به مونو"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -4032,6 +9153,43 @@ msgstr "اعمال استریو به مونو"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "عامل میرایی:"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "درون‌یابی همگامی سریع"
 
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
@@ -4050,12 +9208,48 @@ msgid "Square, no alias"
 msgstr "مربعی، بدون پراکندگی"
 
 #: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "شکل موج:"
 
 #: src/effects/ToneGen.cpp
 msgid "&Frequency (Hz):"
 msgstr "بسامد (هرتز):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "بسامد (هرتز)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "بسامد (هرتز)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "دامنه (۰-۱)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "دامنه (۰-۱)"
 
 #: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
@@ -4066,14 +9260,62 @@ msgid "Truncate Detected Silence"
 msgstr "حذف سکوت..."
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "حذف سکوت..."
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "انتخاب سکوت"
+
+#: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "فشرده‌ساز..."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "ج&لوه"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "نمی‌توان کتاب‌خانهٔ رمزگذاری MP3 را باز کرد!"
 
@@ -4081,8 +9323,32 @@ msgstr "نمی‌توان کتاب‌خانهٔ رمزگذاری MP3 را باز
 msgid "VST Effect Options"
 msgstr "تنظیمات جلوه"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "طول"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
+msgstr "ترکیب کلید‌ها"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
 msgstr "ترکیب کلید‌ها"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -4090,32 +9356,96 @@ msgid "Graphical Mode"
 msgstr "اکولایزر گرافیکی"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "ذخیرهٔ گفتار با نام:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "صدور چندتایی"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "صدور چندتایی"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "پرونده‌های پروژهٔ اوداسیتی"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "اعمال جلوه: %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "بار کردن پرونده‌ها"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "اعمال جلوه: %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "تنظیمات جلوه"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "واو‐واو"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -4126,8 +9456,29 @@ msgid "Reso&nance:"
 msgstr "طنین:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "طنین:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "اُفست فرکانس واو (٪):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "اُفست فرکانس واو (٪):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "تنظیمات جلوه"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "تنظیمات جلوه"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -4142,16 +9493,47 @@ msgid "Audio Unit Effect Options"
 msgstr "تنظیمات جلوه"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "واسط"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "انقباض از چپ انتخاب"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr " پنجره‌ای"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&تولید"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "صدور چندتایی"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "فشار دهید"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
@@ -4219,19 +9601,74 @@ msgid "Failed to retrieve preset content"
 msgstr "حذف «‎%s» ممکن نیست"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "مبدل نرخ نمونه‌"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "حذف «‎%s» ممکن نیست"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "حذف «‎%s» ممکن نیست"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "حذف «‎%s» ممکن نیست"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "پروندهٔ صوتی"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "ج&لوه"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "ج&لوه"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "تنظیمات جلوه"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -4239,6 +9676,7 @@ msgstr "تنظیمات جلوه"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "ج&لوه"
@@ -4247,13 +9685,59 @@ msgstr "ج&لوه"
 msgid "LV2 Effect Settings"
 msgstr "تنظیمات جلوه"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&تولید"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "ج&لوه"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "در حال اعمال جلوه Nyquist..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -4269,6 +9753,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "خروجی Nyquist: "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "هم‌ردیف با پایان انتخاب"
 
@@ -4281,12 +9783,36 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "متاسفانه نمی‌توان جلوه را بر روی شیارهای استریو که با هم همخوانی ندارند، اعمال نمود."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "خروجی Nyquist: "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "در حال پردازش مخفی‌سازی خودکار..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -4323,6 +9849,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist صوت بازنگرداند.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "این نسخه از اوداسیتی از %s پشتیبانی نمی‌کند."
@@ -4331,10 +9861,37 @@ msgstr "این نسخه از اوداسیتی از %s پشتیبانی نمی‌
 msgid "Could not open file"
 msgstr "پرونده باز نمی‌شود: "
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "پرونده باز نمی‌شود: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -4355,6 +9912,21 @@ msgid "Lisp scripts"
 msgstr "اعلان Nyquist..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "پرونده باز نمی‌شود: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -4373,17 +9945,72 @@ msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
 msgid "Save file as"
 msgstr "دخیرهٔ پرونده‌ها"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "ج&لوه"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "متاسفانه نمی‌توان جلوه را بر روی شیارهای استریو که با هم همخوانی ندارند، اعمال نمود."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "متصل‌شونده‌های ۱ تا %Ii"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "طیف‌نما"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "تنظیمات جلوه"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
 msgstr "صدور چندتایی"
 
+#: src/export/Export.cpp src/export/ExportMultiple.cpp src/menus/EditMenus.cpp
+msgid "Edit Metadata Tags"
+msgstr ""
+
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "‏«‎%s» وارد شد"
+
+#: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -4391,8 +10018,23 @@ msgid "Are you sure you want to export the file as \"%s\"?\n"
 msgstr "آیا مطمئن هستید که می‌خواهید پرونده را با ذخیره کنید با نام \"\n"
 
 #: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
 msgstr "ببخشید، نام‌مسیرهای بلندتر از ۲۵۶ نویسه پشتیبانی نمی‌شود."
+
+#: src/export/Export.cpp
+#, c-format
+msgid "A file named \"%s\" already exists. Replace?"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Your tracks will be mixed down and exported as one mono file."
@@ -4437,16 +10079,55 @@ msgid "Output Channels: %2d"
 msgstr "کانال‌های خروجی: %I2d"
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "تابلوی شیار"
+
+#: src/export/Export.cpp
 #, c-format
 msgid ""
 "Unable to export.\n"
 "Error %s"
 msgstr "صدور ممکن نیست"
 
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Show output"
+msgstr "دکمهٔ لغزنده-خروجی"
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "انتخاب فرمان"
+
+#: src/export/ExportCL.cpp
+msgid "(external program)"
+msgstr ""
+
 #: src/export/ExportCL.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Cannot export audio to %s"
 msgstr "صدور صوت به %s ممکن نیست"
+
+#: src/export/ExportCL.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export"
+msgstr "&صدور..."
 
 #: src/export/ExportCL.cpp
 msgid "Exporting the selected audio using command-line encoder"
@@ -4457,21 +10138,182 @@ msgid "Exporting the audio using command-line encoder"
 msgstr "صدور صوت انتخاب‌شده با استفاده از رمزگذار خط فرمان"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "&فرمان"
+
+#: src/export/ExportCL.cpp
 msgid "&OK"
 msgstr "&تأیید"
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "خطای LOF"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Exporting the audio as %s"
 msgstr "صدور صوت انتخاب‌شده بعنوان FLAC"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "نرخ نمونه‌برداری:"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "نمونه‌برداری مجدد"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "نرخ نمونه‌برداری:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -4481,9 +10323,59 @@ msgstr "نرخ بیت:"
 msgid "Quality (kbps):"
 msgstr "کیفیت "
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "&باز کردن..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Constrained"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -4494,8 +10386,44 @@ msgid "Low Delay"
 msgstr "نوع کلید"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "متوسط"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -4518,6 +10446,14 @@ msgid "Application:"
 msgstr "اِعمال زنجیره"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "اِعمال بر پر&وژهٔ فعلی"
 
@@ -4526,17 +10462,434 @@ msgid "Current Codec:"
 msgstr "اِعمال بر پر&وژهٔ فعلی"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "اعمال جلوه: %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "رونویسی پرونده‌های موجود"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "تأیید"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "ایجاد شیار صوتی جدید"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "شاخهٔ %s وجود ندارد. آیا ساخته شود؟"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "نام «%s» به «%s» تغییر کرد"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "چ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "میکس اصلی"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "خطای LOF"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "ابزار ترازبندی"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "ابزار ترازبندی"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "ابزار ترازبندی"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "فشار دهید"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "بار کردن پرونده‌ها"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "صدور برچسب‌ها به صورت:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "صدور برچسب‌ها به صورت:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "اِعمال بر پر&وژهٔ فعلی"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "متصل‌شونده‌های ۱ تا %Ii"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "زبان:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Quality:"
+msgstr "کیفیت "
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "نرخ نمونه‌برداری:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "همهٔ پرونده‌ها (*)|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "تنظیمات جلوه"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "فشرده‌ساز..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "نام"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "انتخاب تا پایان"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "تنظیم نرخ"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "نمای شیار"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "نام «%s» به «%s» تغییر کرد"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "برچسبی برای صدور نیست."
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "پرونده(های) لازم برای پردازش دسته‌ای را انتخاب کنید..."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -4547,8 +10900,38 @@ msgid "24 bit"
 msgstr "۲۴ بیتی"
 
 #: src/export/ExportFLAC.cpp
+msgid "0 (fastest)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "8 (best)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Level:"
+msgstr "ابزار ترازبندی"
+
+#: src/export/ExportFLAC.cpp
 msgid "Bit depth:"
 msgstr "عمق بیت:"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "FLAC Files"
+msgstr "بار کردن پرونده‌ها"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "باز کردن پروندهٔ «%s» مممکن نیست"
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
@@ -4557,6 +10940,11 @@ msgstr "صدور صوت انتخاب‌شده بعنوان FLAC"
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the audio as FLAC"
 msgstr "صدور صوت انتخاب‌شده بعنوان FLAC"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy
+msgid "MP2 Files"
+msgstr "بار کردن پرونده‌ها"
 
 #: src/export/ExportMP2.cpp
 msgid "Cannot export MP2 with this sample rate and bit rate"
@@ -4577,13 +10965,148 @@ msgid "Exporting the audio at %ld kbps"
 msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
 
 #: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "متوسط"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "پیش‌نمایش موجود نیست"
+
+#: src/export/ExportMP3.cpp
+msgid "Average"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Constant"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "۲ (استریو)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "۲ (استریو)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "نرخ بیت:"
 
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "کیفیت "
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "کانال: %I2d"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "خط برش حذف‌شده"
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Tenacity needs the file %s to create MP3s."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr "کُنش"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "To find %s, click here -->"
+msgstr ""
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+msgid "To get a free copy of LAME, click here -->"
+msgstr ""
 
 #. i18n-hint: It's asking for the location of a file, for
 #. * example, "Where is lame_enc.dll?" - you could translate
@@ -4592,6 +11115,43 @@ msgstr "کیفیت "
 #, c-format
 msgid "Where is %s?"
 msgstr "%s کجاست؟"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "در حال ذخیره کردن پرونده‌های دادهٔ پروژه"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "بار کردن پرونده‌ها"
 
 #: src/export/ExportMP3.cpp
 msgid "Could not open MP3 encoding library!"
@@ -4606,8 +11166,23 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "کتاب‌خانهٔ رمزگذاری MP3 معتبری نیست!"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
+msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
 msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
 
 #: src/export/ExportMP3.cpp
@@ -4616,9 +11191,41 @@ msgid "Exporting the audio with VBR quality %s"
 msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "صدور صوت انتخاب‌شده با سرعت %ld کیلوبیت در ثانیه"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
@@ -4629,8 +11236,22 @@ msgid "Cannot Export Multiple"
 msgstr "صدور چندتایی"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "محل صدور:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Create"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Options:"
@@ -4649,6 +11270,11 @@ msgid "First file name:"
 msgstr "نام پروندهٔ اول:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "نام پروندهٔ اول:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "پرونده‌های نام:"
 
@@ -4657,7 +11283,22 @@ msgid "Using Label/Track Name"
 msgstr "استفاده از برچسب/نام شیار"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "استفاده از برچسب/نام شیار"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "پیشوند نام پرونده:"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "پیشوند نام پرونده:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "پیشوند نام پرونده:"
 
 #: src/export/ExportMultiple.cpp
@@ -4665,16 +11306,105 @@ msgid "Overwrite existing files"
 msgstr "رونویسی پرونده‌های موجود"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Choose a location to save the exported files"
 msgstr "مکانی برای ذخیره‌سازی پرونده‌های صادرشده انتخاب کنید"
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "ذخیره به نام..."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis Files"
+msgstr "یک پروندهٔ اُگ وربیس نیست"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -4688,17 +11418,69 @@ msgstr "صدور صوت انتخاب‌شده در قالب اُگ وربیس"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "صدور صوت انتخاب‌شده در قالب اُگ وربیس"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "Header:"
+msgstr ""
+
 #: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
 msgid "Encoding:"
 msgstr "کدگذاری: "
+
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "یک پروندهٔ صوتی نافشرده انتخاب کنید..."
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "خطا در وارد کردن"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
 msgstr "صدور صوت در این قالب ممکن نیست."
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "صدور صوت انتخاب‌شده بعنوان FLAC"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -4706,8 +11488,184 @@ msgstr "‏«‎%s» وارد شد"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "انتخاب تا پایان"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "این نسخه از اوداسیتی از %s پشتیبانی نمی‌کند."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "در حال ذخیره کردن پرونده‌های دادهٔ پروژه"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -4722,13 +11680,123 @@ msgid "Import Project"
 msgstr "صدور برچسب‌ها به صورت:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "پوشهٔ داده‌های پروژه پیدا نمی‌شود: «%s»"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "نرخ پروژه (هرتز):"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -4745,17 +11813,20 @@ msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نی
 msgid "Unable to read %lld samples from %s"
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "تغییر نام «‎%s» به «‎%s» ممکن نیست"
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "همهٔ پرونده‌ها (*)|*"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -4809,6 +11880,29 @@ msgstr "پرونده باز نمی‌شود: "
 msgid "Could not open file %s."
 msgstr "باز کردن پروندهٔ «%s» مممکن نیست"
 
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "بار کردن پرونده‌ها"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis files"
+msgstr "یک پروندهٔ اُگ وربیس نیست"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
 msgstr "خطا در خواندن رسانه"
@@ -4830,6 +11924,165 @@ msgid "Internal logic fault"
 msgstr "نقص در منطق درونی"
 
 #: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 16 bit PCM"
+msgstr "۱۶ بیتی"
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 24 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "۱۶ بیتی"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "۱۶ بیتی"
 
@@ -4838,8 +12091,64 @@ msgid "24 bit DWVW"
 msgstr "۲۴ بیتی"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "۱۶ بیتی"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "۱۶ بیتی"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "‏«‎%s» وارد شد"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "پرونده‌های نام:"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "نمی‌توان تعیین کرد"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "حذف «‎%s» ممکن نیست"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "ورود دادهٔ خام"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -4850,6 +12159,19 @@ msgstr "ورود دادهٔ خام"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "بدون endianness"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "متوسط"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -4870,6 +12192,15 @@ msgstr "۲ کاناله (استریو)"
 msgid "%d Channels"
 msgstr "%Id کاناله"
 
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "کانال"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
@@ -4887,6 +12218,15 @@ msgstr "مقداری که باید وارد شود:"
 #: src/import/ImportRaw.cpp
 msgid "Sample rate:"
 msgstr "نرخ نمونه‌برداری:"
+
+#: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Import"
+msgstr "وارد کردن"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -4908,6 +12248,7 @@ msgstr "راست"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -4931,6 +12272,7 @@ msgstr "پایان"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -4950,12 +12292,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "بریده‌ها/شیارهای  %s که زمان آنها به اندازهٔ %I.02f ثانیه به جابه‌جا شده است"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "بریده‌ها/شیارهای  %s که زمان آنها به اندازهٔ %I.02f ثانیه به جابه‌جا شده است"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "جابه‌جایی زمانی"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "به آغاز انتخاب"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -4972,6 +12337,26 @@ msgstr "ابزار بعدی"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "ابزار بعدی"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "ابزار قبلی"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "اِعمال بر پر&وژهٔ فعلی"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "ابزار بعدی"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "به آغاز انتخاب"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -5005,6 +12390,11 @@ msgstr "برش و انتقال به تخته‌گیره"
 #, c-format
 msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "%I.2f ثانیه در زمان %I.2f حذف شد"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasting one type of track into another is not allowed."
+msgstr "نسخه‌برداری از صوت استریو در شیار مونو مجاز نیست."
 
 #: src/menus/EditMenus.cpp
 msgid "Copying stereo audio into a mono track is not allowed."
@@ -5051,7 +12441,13 @@ msgstr "سکوت"
 msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
 msgstr "شیار‌های انتخاب شده برای %I.2f ثانیه از %I.2f ساکت شدند"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "آ&رایش"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "تفکیک"
 
@@ -5071,6 +12467,20 @@ msgstr "%I.2f ثانیه در زمان %I.2f پیوسته شد"
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "پیوستن"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "%I.2f ثانیه در زمان %I.2f حذف شد"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Metadata Tags"
+msgstr "ویرایش &زنجیرها"
 
 #: src/menus/EditMenus.cpp
 msgid "&Edit"
@@ -5100,6 +12510,11 @@ msgstr "&چسباندن"
 msgid "Duplic&ate"
 msgstr "تک&ثیر"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "ح&ذف شیار‌ها"
+
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
 msgid "Spl&it Cut"
@@ -5109,6 +12524,12 @@ msgstr "تفکی&ک و برش"
 #: src/menus/EditMenus.cpp
 msgid "Split D&elete"
 msgstr "تفکیک و ح&ذف"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "ناحیه‌های برچسب‌دار سکوت"
 
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
@@ -5129,9 +12550,19 @@ msgstr "تفکیک ج&دید"
 msgid "&Join"
 msgstr "&پیوستن"
 
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "انتخاب سکوت"
+
 #: src/menus/EditMenus.cpp
 msgid "&Metadata..."
 msgstr "ویرایش &زنجیرها"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "ترجی&حات..."
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -5142,32 +12573,8 @@ msgid "Delete Key&2"
 msgstr "حذف کلید ۲"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "نوار ابزار میکسر"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "پخش"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "پخش"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "پخش"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "در حال ضبط"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "در حال ضبط"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "در حال ضبط"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -5189,9 +12596,26 @@ msgstr "بار کردن صدا در حافظهٔ نهانی"
 msgid "Change Recording Cha&nnels..."
 msgstr "تغییر کوک"
 
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "صدور صوت انتخاب‌شده با سرعت %Id کیلوبیت در ثانیه"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "ویرایش برچسب"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -5206,12 +12630,28 @@ msgid "Please select a Note Track."
 msgstr "ایجاد شیار صوتی جدید"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "&صدور..."
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "همهٔ پرونده‌ها (*)|*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "&صدور..."
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -5225,6 +12665,11 @@ msgstr "وارد کردن برچسب"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "همهٔ پرونده‌ها (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -5242,6 +12687,12 @@ msgstr "ذخیره به نام..."
 #: src/menus/FileMenus.cpp
 msgid "Open Recent"
 msgstr "باز کردن موارد اخیر"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "دخیرهٔ پرونده‌ها"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -5322,6 +12773,10 @@ msgid "E&xit"
 msgstr "&خروج"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "صدور برچسب‌ها به صورت:"
 
@@ -5344,8 +12799,17 @@ msgid "Fix"
 msgstr "میکس"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "را&هنما"
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "چیزی برای برگرداندن نیست"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -5360,6 +12824,18 @@ msgid "Recording stops and starts"
 msgstr "اندازه‌گیر ضبط"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "را&هنما"
 
@@ -5368,7 +12844,8 @@ msgid "&Getting Started"
 msgstr "آغاز انتخاب:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "میله ابزار %s اوداسیتی"
 
 #: src/menus/HelpMenus.cpp
@@ -5376,12 +12853,34 @@ msgid "&Quick Help..."
 msgstr "را&هنما"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&دربارهٔ اوداسیتی..."
+msgid "&Manual..."
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "&Diagnostics"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "برچسب اضافه شد"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "جابه‌جایی تمرکز به شیار بعدی"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -5497,6 +12996,15 @@ msgid "Add Label at &Playback Position"
 msgstr "اضافه کردن برچسب در مکان پخش"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "جابه‌جایی تمرکز به شیار بعدی"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "صدای ضبط‌شده"
 
@@ -5531,6 +13039,11 @@ msgid "Label Split Delete"
 msgstr "تفکیک و حذف"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "ناحیه‌های برچسب‌دار سکوت"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "سکوت"
 
@@ -5555,6 +13068,23 @@ msgstr "ویرایش برچسب"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "ویرایش برچسب"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "جابه‌جایی تمرکز به شیار بعدی"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -5593,8 +13123,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "تغییر وضعیت تمرکز شیار"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "جدید..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -5611,6 +13149,10 @@ msgid "&Generate"
 msgstr "&تولید"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
 msgstr "تولیدکنندهٔ صوت"
 
@@ -5619,8 +13161,18 @@ msgid "Effe&ct"
 msgstr "ج&لوه"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "تولیدکنندهٔ صوت"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "تحلی&ل"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "تولیدکنندهٔ صوت"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -5658,6 +13210,10 @@ msgstr "&اجرای آزمایش محک..."
 msgid "Simulate Recording Errors"
 msgstr "در حال ضبط"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -5678,6 +13234,16 @@ msgstr "انتخاب"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "به آغاز شیار"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "مدت زمان سکوت:"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&شیار‌ها"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -5703,9 +13269,20 @@ msgstr "&ویرایش برچسب‌ها"
 msgid "Set Project..."
 msgstr "ذخیرهٔ پروژه به &نام..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "همهٔ پرونده‌ها (*)|*"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "&شیار‌ها"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "اطلاعات"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -5731,6 +13308,33 @@ msgstr "انتخاب..."
 msgid "Compare Audio..."
 msgstr "فشرده‌ساز..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "&چاپ..."
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "تنظیم نقطهٔ انتخاب"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "مکان صوت:"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "تنظیم نقطهٔ انتخاب"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "انتخاب"
+
 #: src/menus/SelectMenus.cpp
 msgid "&None"
 msgstr "&ذخیره"
@@ -5744,8 +13348,21 @@ msgid "&Tracks"
 msgstr "&شیار‌ها"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "شیارها"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Sync-Locked"
 msgstr "انتخاب صدا"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
@@ -5764,8 +13381,18 @@ msgid "Set Selection Right at Play Position"
 msgstr "سمت راست مکان  پخش"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "انتخاب تا آغاز"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "انتخاب تا آغاز"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "نام شیار"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -5804,8 +13431,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "بسامد خطی"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "انتخاب تا آغاز"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "مکان صوت:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -5818,6 +13454,18 @@ msgstr "یافتن تقاطع‌های &صفر"
 #: src/menus/SelectMenus.cpp
 msgid "&Selection"
 msgstr "انتخاب"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Off"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Nearest"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection to &Start"
@@ -5930,6 +13578,40 @@ msgstr "مکان‌نما به چپ"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "مکان‌نما به راست"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "ابزار"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
@@ -6081,6 +13763,15 @@ msgid "Align Together"
 msgstr "هم‌ردیف کردن شیار‌ها"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "ردیف کردن پایان با پایان انتخاب"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
 msgstr "بهره تنظیم شد"
 
@@ -6105,10 +13796,21 @@ msgid "Created new label track"
 msgstr "شیار برچسب جدید ایجاد شد"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "شیار زمان جدید ایجاد شد"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "نرخ نمونه‌برداری:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "مقدار واردشده نامعتبر است"
 
@@ -6128,6 +13830,25 @@ msgstr "نمونه‌برداری مجدد شیار"
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "ایجاد شیار صوتی جدید"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "ردیف کردن پایان با پایان انتخاب"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -6150,6 +13871,11 @@ msgid "Can't delete track with active audio"
 msgstr "شیار با صوت فعال را نمی‌توان حذف کرد"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&جدید"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "جابه‌جایی شیار"
 
@@ -6166,8 +13892,18 @@ msgid "&Time Track"
 msgstr "شیار &زمان"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "نوار ابزار میکسر"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "اعمال استریو به مونو"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x and Render"
+msgstr "&میکس و رندر"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix and Render to Ne&w Track"
@@ -6186,6 +13922,11 @@ msgid "M&ute/Unmute"
 msgstr "بدون صدا/با صدا کردن شیار مورد تمرکز"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "پ&هن کردن همهٔ قطعات"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
 msgstr "پ&هن کردن همهٔ قطعات"
 
@@ -6196,6 +13937,10 @@ msgstr "&شیار‌ها"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "پ&هن کردن همهٔ قطعات"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -6220,6 +13965,11 @@ msgstr "مرکز"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Center"
 msgstr "مرکز"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "شیارها"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
@@ -6248,6 +13998,11 @@ msgstr "&زمان آغاز"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "نام"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "بریده‌های منتقل‌شده به شیاری دیگر"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -6319,7 +14074,9 @@ msgstr "پخش"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "در حال ضبط"
 
@@ -6332,8 +14089,27 @@ msgid "no label track at or below focused track"
 msgstr "حرکت افقی به چپ بر روی شیار مورد تمرکز"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "شیار برچسب جدید ایجاد شد"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -6368,8 +14144,28 @@ msgid "Pl&ay/Stop"
 msgstr "پخش/توقف"
 
 #: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "پخش در سرعت خاص"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "مکث"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "در حال ضبط"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "ضبط"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -6380,13 +14176,70 @@ msgid "Record &New Track"
 msgstr "ح&ذف شیار‌ها"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "در حال ضبط"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "اندازه‌گیر ضبط"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
+msgstr "آوانویسی"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "در حال ضبط"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
 msgstr "آوانویسی"
 
 #. i18n-hint: (verb) Start playing audio
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "پخش/توقف"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -6504,6 +14357,11 @@ msgid "&Fit to Width"
 msgstr "&جا دادن در پنجره"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&جا دادن در پنجره"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&جمع کردن همهٔ قطعات"
 
@@ -6528,12 +14386,57 @@ msgid "Skip to Selection End"
 msgstr "به پایان انتخاب"
 
 #: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
 msgstr "اجازهٔ برش"
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "ج&لوه"
 
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr " پنجره‌ای"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "اندازه‌گیر ضبط"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -6541,7 +14444,7 @@ msgstr "ترجیحات..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "خروج از اوداسیتی"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -6561,6 +14464,15 @@ msgstr "ترجیحات..."
 msgid "Behaviors"
 msgstr "رفتارها"
 
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "دستگاه"
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
 msgstr "ترجیحات..."
@@ -6571,11 +14483,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "واسط"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "با استفاده از:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "پخش"
 
@@ -6595,7 +14513,8 @@ msgstr "کانال"
 msgid "Latency"
 msgstr "نهفتگی"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "میلی‌ثانیه"
 
@@ -6608,6 +14527,15 @@ msgid "&Latency compensation:"
 msgstr "ترکیب کلید‌ها"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "شیار(های) صوتی حذف‌شده"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "۱ (مونو)"
 
@@ -6616,17 +14544,37 @@ msgid "2 (Stereo)"
 msgstr "۲ (استریو)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "شاخه‌ها"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "بازیابی پروژه‌ها"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "شاخه‌ها"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "انتخاب..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -6649,8 +14597,17 @@ msgid "Bro&wse..."
 msgstr "انتخاب..."
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "&Macro output:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory"
 msgstr "شاخهٔ پرونده‌های موقت"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "کُنش"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory cannot be on a FAT drive."
@@ -6669,8 +14626,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "محلی برای قرار دادن شاخهٔ موقت انتخاب کنید"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "ان&تخاب فرمان"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -6687,8 +14653,14 @@ msgid "Directory %s is not writable"
 msgstr "شاخهٔ %s قابل نوشتن نیست"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "تغییرات در شاخهٔ موقت تا زمانی که اوداسیتی راه‌اندازی مجدد نشود، اعمال نخواهند شد"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "شاخهٔ موقت جدید"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -6698,11 +14670,36 @@ msgstr "ترجیحات..."
 msgid "Sorted by Effect Name"
 msgstr "مرتب‌سازی بر مبنای نام"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "مرتب‌سازی بر مبنای نام"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "مرتب‌سازی بر مبنای نام"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "ج&لوه"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -6712,17 +14709,141 @@ msgstr "ج&لوه"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "ج&لوه"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "تنظیمات جلوه"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "متصل‌شونده‌های ۱ تا %Ii"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "درون‌یابی همگامی سریع"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "وارد کردن"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "ترجیحات..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "نوع نوفه:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "صدور برچسب‌ها به صورت:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "&بالاتر"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "&پایین‌تر"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "&بالاتر"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "&پایین‌تر"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "ناحیه‌های برچسب‌دار حذف شد"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "محل صدور:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "انتخاب"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "آیا مطمئنید که می‌خواهید %s را حذف کنید؟"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "مدت زمان صوت:"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -6747,6 +14868,11 @@ msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "۴۸- دسی‌بلد (محدودهٔ PCM نمونه‌های ۸ بیت)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "۹۶- دسی‌بل (محدودهٔ PCM نمونه‌های ۱۶ بیت)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
 msgstr "۹۶- دسی‌بل (محدودهٔ PCM نمونه‌های ۱۶ بیت)"
 
@@ -6766,9 +14892,99 @@ msgstr "۱۲۰- دسی‌بل (حد تقریبی شنوایی انسان)"
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "۱۴۵- دسی‌بل (محدودهٔ PCM نمونه‌های ۲۴ بیت)"
 
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "کُنش"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
 #: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
 msgid "Display"
 msgstr "نمایش"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "زبان:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Location of &Manual:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "شکل موج (دسی‌بل)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "روشن"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "متصل‌شونده‌های ۱ تا %Ii"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "به کار انداختن اندازه‌گیر"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "صدور برچسب‌ها به صورت:"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "ترجیحات..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -6779,6 +14995,14 @@ msgid "&Use Advanced Mixing Options"
 msgstr "گزینه‌های پیشرفتهٔ میکس"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
 msgstr "ثانیه"
 
@@ -6787,8 +15011,29 @@ msgid "&Beats"
 msgstr "تکرار"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "صدور برچسب‌ها به صورت:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -6800,6 +15045,18 @@ msgid "Preferences for KeyConfig"
 msgstr "ترجیحات..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "مقیدسازی کلیدها"
 
@@ -6808,12 +15065,49 @@ msgid "View by:"
 msgstr "ن&ما"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "نام"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "ن&ما"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "ن&ما"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "ن&ما"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
 msgstr "مقیدسازی کلیدها"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "تنظیمات جلوه"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -6828,7 +15122,15 @@ msgid "&Defaults"
 msgstr "&پیش‌فرض‌ها"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "یک پروندهٔ XML که میان‌بُرهای صفحه‌کلید اوداسیتی در آن باشد را انتخاب کنید..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -6837,8 +15139,21 @@ msgstr "صدور میان‌بُرهای صفحه‌کلید با نام:"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "‏%Id میانبُر صفحه‌کلیدی بار شد\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -6852,6 +15167,38 @@ msgstr "صدور میان‌بُرهای صفحه‌کلید با نام:"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "صدور میان‌بُرهای صفحه‌کلید با نام:"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "ترکیب کلید‌ها"
@@ -6861,12 +15208,72 @@ msgid "Preferences for Library"
 msgstr "ترجیحات..."
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "نسخهٔ کتاب‌خانهٔ MP3"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "نسخهٔ کتاب‌خانهٔ MP3"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "خطای LOF"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "&ذخیره کردن..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
 
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "ترجیحات..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "واسط"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -6874,17 +15281,77 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "واسط"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "فرکانس حداقل باید یک عدد صحیح باشد"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "ترجیحات..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "تغییرات در شاخهٔ موقت تا زمانی که اوداسیتی راه‌اندازی مجدد نشود، اعمال نخواهند شد"
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "پرسش از شما"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -6926,13 +15393,26 @@ msgstr "کشیدن به چپ"
 msgid "Set Selection Range"
 msgstr "تنظیم محدودهٔ انتخاب"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "کلیک چپ با تبدیل"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Extend Selection Range"
 msgstr "گسترش محدودهٔ انتخاب"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "کلیک چپ با دگرساز"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "انتخاب تا پایان"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
@@ -6971,6 +15451,26 @@ msgid "same as left-drag"
 msgstr "مانند چپ و کشیدن"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "تبدیل و چپ و کشیدن"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom out on a Range"
+msgstr "زوم به داخل بر روی محدوده"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "کلیک چپ"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom default"
+msgstr "&پیش‌فرض‌ها"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Move clip left/right or between tracks"
 msgstr "تغییر محل بریده بین شیارها (بالا/پایین)"
 
@@ -6989,6 +15489,15 @@ msgstr "کشیدن به چپ"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "تغییر محل بریده بین شیارها (بالا/پایین)"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "کشیدن به چپ"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -7040,6 +15549,11 @@ msgid "Scroll tracks up or down"
 msgstr "لغزش به بالا یا پایین"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Wheel-Rotate"
+msgstr "چرخاندن چرخ موشی"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Scroll waveform"
 msgstr "شکل موج"
 
@@ -7076,9 +15590,46 @@ msgstr "طول"
 msgid "Cut Preview"
 msgstr "پیش‌نمایش برش"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "ترجیحات اوداسیتی"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -7087,6 +15638,11 @@ msgstr "ترجیحات..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "ترجیحات..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -7105,20 +15661,70 @@ msgid "Default Sample &Format:"
 msgstr "قالب نمونهٔ پیش‌فرض:"
 
 #: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "مبدل نرخ نمونه‌"
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Con&verter:"
 msgstr "مبدل نرخ نمونه‌"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "درون‌یابی همگامی با کیفیت بالا"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "مبدل نرخ نمونه‌"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
 msgstr "ترجیحات..."
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "شیار جدید"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "در حال ضبط"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -7129,9 +15735,19 @@ msgstr "شکل موج (دسی‌بل)"
 msgid "Name newly recorded tracks"
 msgstr "میکس و رندر شیارها"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "نام شیار"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "ویرایش برچسب"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -7141,11 +15757,69 @@ msgstr "صدای ضبط‌شده"
 msgid "&Track Number"
 msgstr "شمارهٔ شیار"
 
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "System &Date"
+msgstr "سیستم"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "System T&ime"
+msgstr "سیستم"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "ترجیحات..."
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "شیار نُت"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "۲۵۶ ‐ پیش‌فرض"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "۲۵۶ ‐ پیش‌فرض"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "خطی..."
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -7157,14 +15831,42 @@ msgstr "خطی..."
 msgid "Frequencies"
 msgstr "بسامد (هرتز)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "کوک (EAC)"
 
 #: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "فرکانس حداقل باید دست کم ۰ هرتز باشد"
+
+#: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "فرکانس حداقل باید دست کم ۰ هرتز باشد"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "فرکانس حداقل باید دست کم ۰ هرتز باشد"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "فرکانس حداقل باید دست کم ۰ هرتز باشد"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -7183,6 +15885,10 @@ msgstr "ترجیحات..."
 msgid "&Use Preferences"
 msgstr "ترجیحات..."
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "فرکانس حداقل (هرتز):"
@@ -7190,6 +15896,24 @@ msgstr "فرکانس حداقل (هرتز):"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "فرکانس حداکثر (هرتز):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "کانال‌های خروجی: %I2d"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "تقویت (دسی‌بل):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -7212,12 +15936,52 @@ msgid "1024 - default"
 msgstr "۲۵۶ ‐ پیش‌فرض"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "32768 - most narrowband"
+msgstr "۸ ‐ بیشترین پهنای باند"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "نوع پنجره:"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "عامل میرایی:"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "انتخاب"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "بیشینه دامنهٔ جدید (دسی‌بل) :"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -7235,6 +15999,36 @@ msgstr "فرکانس حداکثر باید یک عدد صحیح باشد"
 msgid "The minimum frequency must be an integer"
 msgstr "فرکانس حداقل باید یک عدد صحیح باشد"
 
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "فرکانس حداکثر باید یک عدد صحیح باشد"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "فرکانس حداکثر باید یک عدد صحیح باشد"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "فرکانس حداکثر باید یک عدد صحیح باشد"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "فرکانس حداقل باید یک عدد صحیح باشد"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "فرکانس حداکثر باید یک عدد صحیح باشد"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "فرکانس حداکثر باید یک عدد صحیح باشد"
+
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
 #. such as those on button controls.  Audacity can load and save alternative
@@ -7250,6 +16044,25 @@ msgstr "ترجیحات..."
 #: src/prefs/ThemePrefs.cpp
 msgid "Info"
 msgstr "اطلاعات"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
 #. * so keep it as is
@@ -7287,6 +16100,11 @@ msgid "Preferences for TracksBehaviors"
 msgstr "رفتارها"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "نمونه‌ها"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
 msgstr "چند"
 
@@ -7304,8 +16122,33 @@ msgid "Enable &dragging selection edges"
 msgstr "اضافه کردن برچسب در قسمت انتخاب شده"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "گزینه‌های پیشرفتهٔ میکس"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "دکمه"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -7319,6 +16162,14 @@ msgstr "شکل موج"
 msgid "Spectrogram"
 msgstr "طیف‌نما"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "&جا دادن در پنجره"
@@ -7330,6 +16181,10 @@ msgstr "&زوم به اندازهٔ انتخاب"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "&پیش‌فرض‌ها"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -7352,6 +16207,16 @@ msgid "50ths of Seconds"
 msgstr "ثانیه"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "ثانیه"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "ثانیه"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "میلی‌ثانیه"
 
@@ -7359,7 +16224,12 @@ msgstr "میلی‌ثانیه"
 msgid "Samples"
 msgstr "نمونه‌ها"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "زوم"
 
@@ -7368,12 +16238,42 @@ msgid "Preferences for Tracks"
 msgstr "ترجیحات..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "در حال ضبط"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "نرخ نمونه‌برداری پیش‌فرض:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "قالب نمونهٔ پیش‌فرض:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "نمونه‌ها"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -7396,9 +16296,46 @@ msgstr "فشار دهید"
 msgid "Preset 2:"
 msgstr "فشار دهید"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "اخطار"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "ترجیحات..."
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&ذخیرهٔ پروژه"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&ذخیرهٔ پروژه"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "اعمال استریو به مونو"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "اعمال استریو به مونو"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -7421,16 +16358,24 @@ msgid "Stopped"
 msgstr "توقف"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "مکث"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "پرش به آغاز"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "پرش به انتها"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "مکث"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "انتخاب تا آغاز"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "انتخاب تا پایان"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -7444,20 +16389,24 @@ msgstr "شیار جدید"
 msgid "Append Record"
 msgstr "ضبط"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "انتخاب تا پایان"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "انتخاب تا آغاز"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "مکث"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "ابزار آوانویسی"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -7468,6 +16417,11 @@ msgstr "سرعت پخش"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "اندازه‌گیر ضبط"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "مکان صوت:"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -7490,8 +16444,18 @@ msgid "Select Playback Device"
 msgstr "سرعت پخش"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "مدت زمان سکوت:"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "کانال راست"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "پیش‌نمایش موجود نیست\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -7515,11 +16479,22 @@ msgstr "آرایش بخش بیرون از انتخاب"
 msgid "Silence audio selection"
 msgstr "انتخاب سکوت"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "&شیار‌ها"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "زوم به داخل"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "زوم به خارج"
 
@@ -7530,6 +16505,11 @@ msgstr "جادادن انتخاب در پنجره"
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "جادادن پروژه در پنجره"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "ج&لوه"
 
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
@@ -7582,38 +16562,24 @@ msgstr "نوار ابزار اندازه‌گیر"
 msgid "&Playback Meter Toolbar"
 msgstr "اندازه‌گیر پخش"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "در حال ضبط"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "پخش"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "به کار انداختن اندازه‌گیر"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "در حال ضبط"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "پخش"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "پخش"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "نوار ابزار میکسر"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "اعلان Nyquist..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "اعلان Nyquist..."
@@ -7621,6 +16587,7 @@ msgstr "اعلان Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "اعلان Nyquist..."
@@ -7628,9 +16595,24 @@ msgstr "اعلان Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "شروع پایشگر"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "شروع پایشگر"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "از کار انداختن اندازه‌گیر"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -7641,6 +16623,10 @@ msgstr "نوار ابزار ویرایش"
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "نرخ پروژه (هرتز):"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap-To"
+msgstr ""
 
 #: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
 msgid "Audio Position"
@@ -7662,13 +16648,36 @@ msgstr "به پایان انتخاب"
 msgid "Length and Center of Selection"
 msgstr "کوتاه‌کردن پرونده بنابر انتخاب"
 
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap To"
+msgstr ""
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Length"
 msgstr "طول"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "مرکز"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -7695,6 +16704,10 @@ msgstr "در حال تقویت بسامدهای بم"
 msgid "Center Frequency"
 msgstr "بسامد خطی"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -7713,8 +16726,8 @@ msgstr "نوار ابزار دستگاه"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "میله ابزار %s اوداسیتی"
 
 #: src/toolbars/ToolBar.cpp
@@ -7741,7 +16754,8 @@ msgstr "ابزار جابه‌جایی زمانی"
 msgid "Zoom Tool"
 msgstr "ابزار زوم"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "ابزار رسم"
 
@@ -7817,11 +16831,13 @@ msgstr "محدودهٔ یک یا چند اسم شیار را بردارید"
 msgid "Drag label boundary."
 msgstr "محدودهٔ اسم شیار را بردارید"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "برچسب تغییریافته"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "ویرایش برچسب"
 
@@ -7841,6 +16857,12 @@ msgstr "قلم برچسب شیار"
 #. i18n-hint: (noun) The name of the typeface
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Face name"
+msgstr "ت&غییر نام"
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
 msgstr "ت&غییر نام"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -7871,31 +16893,42 @@ msgstr "برچسب‌ها ویرایش شدند"
 msgid "New label"
 msgstr "برچسب اضافه شد"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "اُکتاو بالا"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "اُکتاو پایین"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "برای زوم به داخل عمودی کلیک، برای زوم به خارج تبدیل-کلیک کنید و برای ایجاد محدودهٔ زوم خاص کلید موشی را نگه دارید و موشی را حرکت دهید."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "کلیک راست"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "زوم به خارج"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "کلیک چپ با تبدیل"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "کلیک چپ با تبدیل"
 
@@ -7918,10 +16951,28 @@ msgid "Stretch"
 msgstr "عامل میرایی:"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "اجازهٔ برش"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Expanded Cut Line"
 msgstr "خط برش گسترش‌یافته"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "گسترش"
 
@@ -7934,12 +16985,21 @@ msgid "Click and drag to edit the samples"
 msgstr "برای ویرایش نمونه‌ها کلیک کنید و بکشید"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "نمونه جابه‌جا شد"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "ویرایش نمونه"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -7948,6 +17008,16 @@ msgstr "زوم به داخل بر روی نقطه"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "طیف‌نما"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -7973,7 +17043,8 @@ msgstr "در حال پردازش مخفی‌سازی خودکار..."
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "«%s» به «%s» تغییر کرد"
@@ -7987,7 +17058,60 @@ msgid "Rat&e"
 msgstr "تنظیم نرخ"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 h 060 m 060>0100 s"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -8008,7 +17132,8 @@ msgstr "تغییر نرخ"
 msgid "Set Rate"
 msgstr "تنظیم نرخ"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "چند"
 
@@ -8100,6 +17225,27 @@ msgstr "چپ، "
 msgid "Right, %dHz"
 msgstr "راست، "
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "راست"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "برای تنظیم اندازهٔ نسبی قطعات استریو کلیک کنید و در حالی که کلید را پایین نگاه داشته‌اید موشی را حرکت دهید."
@@ -8107,6 +17253,15 @@ msgstr "برای تنظیم اندازهٔ نسبی قطعات استریو کل
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "برای جابه‌جایی یک شیار در زمان کلیک کنید و بکشید"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "برای جابه‌جایی یک شیار در زمان کلیک کنید و بکشید"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -8116,6 +17271,10 @@ msgstr "زوم به داخل"
 msgid "Zoom x2"
 msgstr "زوم"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "شکل موج"
@@ -8123,6 +17282,11 @@ msgstr "شکل موج"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "شکل موج"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -8155,16 +17319,37 @@ msgid "Set Range"
 msgstr "تنظیم ناحیه"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "نمایش"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "درون‌یابی همگامی سریع"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "خطی..."
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "درون‌یابی همگامی سریع"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -8176,9 +17361,8 @@ msgstr "درون‌یابی همگامی سریع"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "برای جابه‌جایی یک شیار در زمان کلیک کنید و بکشید"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -8229,6 +17413,21 @@ msgstr "پاکت تنظیم‌شده."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "نوار ابزار ویرایش"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "شروع پایشگر"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "به کار انداختن اندازه‌گیر"
@@ -8244,6 +17443,16 @@ msgstr "بستن شیار مورد تمرکز"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "پایین بردن شیار"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "اعلان Nyquist..."
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "پرش به آغاز"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -8296,6 +17505,11 @@ msgstr "برای انتخاب صوت کلیک کنید و بکشید"
 msgid "Click and drag to select audio"
 msgstr "برای انتخاب صوت کلیک کنید و بکشید"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "برای جابه‌جایی یک شیار در زمان کلیک کنید و بکشید"
@@ -8317,6 +17531,10 @@ msgstr "شیار‌های انتخاب شده برای %I.2f ثانیه از %I.
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "شیار‌های انتخاب شده برای %I.2f ثانیه از %I.2f ساکت شدند"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -8343,6 +17561,12 @@ msgstr "&فرمان"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "کلیک چپ"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "ایجاد شیار صوتی جدید"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -8401,6 +17625,17 @@ msgstr "چ"
 msgid "R"
 msgstr "ر"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
 msgstr " لطفاً یک کُنش انتخاب کنید "
@@ -8424,6 +17659,34 @@ msgstr "گیره"
 #: src/widgets/Grid.cpp
 msgid "Empty"
 msgstr "خالی"
+
+#: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "پرش به آغاز"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "همهٔ پرونده‌ها (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -8462,6 +17725,13 @@ msgid "Refresh Rate"
 msgstr "تنظیم نرخ"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "آهنگ نوسازی اندازه‌گیر بر ثانیه [۱ تا۱۰۰]: "
 
@@ -8474,12 +17744,21 @@ msgid "Meter Style"
 msgstr "اندازه‌گیر"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "اندازه‌گیر"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "مدت زمان"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "بازیابی خودکار پس از فروپاشی"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -8493,12 +17772,62 @@ msgstr "خط‌کش عمودی"
 msgid " Monitoring "
 msgstr "توقف پایشگر"
 
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "ایجاد شیار صوتی جدید"
+
 #. i18n-hint: Format string for displaying time in seconds. Change the comma
 #. * in the middle to the 1000s separator for your locale, and the 'seconds'
 #. * on the end to the word for seconds. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000,01000 seconds"
 msgstr "01000,01000 ثانیه‌های "
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + نمونه‌ها"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -8510,10 +17839,41 @@ msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 روز 024 h 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "hh:mm:ss + نمونه‌ها"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + میلی‌ثانیه"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -8535,6 +17895,7 @@ msgstr "0100 h 060 m 060 s+># نمونه"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "نمونه‌ها"
@@ -8696,6 +18057,10 @@ msgstr "01000,01000 فریم|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 h 060 m 060>0100 s"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows frequency in kilohertz
 #: src/widgets/NumericTextCtrl.cpp
 msgid "kHz"
@@ -8708,6 +18073,10 @@ msgstr "کیلوهرتز"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 h 060 m 060>0100 s"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -8723,15 +18092,76 @@ msgstr "اُکتاو پایین"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 فریم|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 فریم|24"
 
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "برای تغییر قالب دکمهٔ راست موشی یا دکمهٔ زمینه را بزنید"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "ثانیه"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "زمان حمله: %I.1f ثانیه"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "زمان پایان"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Cancel"
+msgstr "ان&صراف"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to cancel?"
@@ -8763,6 +18193,11 @@ msgstr "تأیید"
 msgid "Unable to write files to directory: %s."
 msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -8780,14 +18215,44 @@ msgstr "بازیابی پروژه‌ها"
 msgid "Don't show this warning again"
 msgstr "این اخطار دیگر نشان داده نشود"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
 #: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "خالی"
 
 #: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "ضبط"
+
+#: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "زوم به داخل بر روی محدوده"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "خطای LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -8805,12 +18270,31 @@ msgid "Value must not be greater than %s"
 msgstr "نام نمی‌تواند خالی باشد"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "پروژهٔ جدید ایجاد شد"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
 msgstr "شاخه‌ها"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "شاخه‌ها"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "خطا: "
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Could not load file: \"%s\""
+msgstr "باز کردن پروندهٔ «%s» مممکن نیست"
 
 #: src/xml/XMLFileReader.cpp
 msgid "Could not parse XML"
@@ -8820,16 +18304,49 @@ msgstr "پرونده باز نمی‌شود: "
 msgid "Spectral edit multi tool"
 msgstr "انتخاب"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "طول"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "بسامد (هرتز)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "خطا"
@@ -8844,8 +18361,34 @@ msgstr "کانال‌های خروجی: %I2d"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "فرکانس حداقل باید دست کم ۰ هرتز باشد"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -8858,6 +18401,28 @@ msgstr "محو شدن تدریجی"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "در حال اِعمال..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -8884,8 +18449,16 @@ msgid "S-Curve Down"
 msgstr "&پایین‌تر"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "آغاز"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -8894,6 +18467,14 @@ msgstr "بهره"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "آغاز"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -8906,6 +18487,14 @@ msgstr "خطی..."
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "خطی..."
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -8944,6 +18533,24 @@ msgstr "&پایین‌تر"
 msgid "Error~%~%"
 msgstr "خطا"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "تکرار"
@@ -8951,6 +18558,10 @@ msgstr "تکرار"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "در حال حذف سکوت..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "میله ابزار %s اوداسیتی"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -8964,6 +18575,23 @@ msgstr "مکان‌نما به راست"
 msgid "Reconstructing clips..."
 msgstr "در حال حذف تق و توق..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "آستانه: %Id دسی‌بل"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "شیار نُت"
@@ -8972,6 +18600,21 @@ msgstr "شیار نُت"
 msgid "Crossfading..."
 msgstr "شیار نُت"
 
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
 msgstr "شیار نُت"
@@ -8979,6 +18622,18 @@ msgstr "شیار نُت"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade type"
 msgstr "نوع نوفه:"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Gain"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 1"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 2"
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Custom Curve"
@@ -8991,6 +18646,19 @@ msgstr "نام شیار"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade direction"
 msgstr "انتخاب"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Delay"
@@ -9009,6 +18677,19 @@ msgid "Regular"
 msgstr "مستطیلی"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "کاهش نوفه (دسی‌بل):"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "زمان تأخیر (ثانیه):"
 
@@ -9021,12 +18702,24 @@ msgid "Pitch/Tempo"
 msgstr "کوک (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
 msgstr "پی&ش‌نمایش"
 
 #: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "تعداد دفعات تکرار: "
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -9041,18 +18734,40 @@ msgid "XML file"
 msgstr "بار کردن پرونده‌ها"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "ضبط"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "خطا در باز کردن پرونده"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %hs"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %hs"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -9083,18 +18798,67 @@ msgstr "طول (به ثانیه)"
 msgid "Length of label region (seconds)"
 msgstr "طول (به ثانیه)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "ویرایش برچسب"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "ترکیب کلید‌ها"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "اخطار"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -9104,6 +18868,17 @@ msgstr "پیوستن برچسب‌ها"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "پیوستن برچسب‌ها"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -9117,13 +18892,46 @@ msgstr "در حال اِعمال اکولایزر"
 msgid "Dominic Mazzoni"
 msgstr "حذف نوفه نوشتهٔ دومینیک مازونی"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "بسامد (هرتز)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "فرکانس حداقل باید دست کم ۰ هرتز باشد"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -9143,6 +18951,16 @@ msgid "Peak level"
 msgstr "سرعت پخش"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "سرعت پخش"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "سرعت پخش"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "مدت زمان سکوت:"
 
@@ -9155,14 +18973,64 @@ msgid "Label type"
 msgstr "ویرایش برچسب"
 
 #: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Point after sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "در حال حذف سکوت..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "در حال حذف سکوت..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "نام نمی‌تواند خالی باشد"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -9190,8 +19058,25 @@ msgid "Hard Clip"
 msgstr "اجازهٔ برش"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "کانال راست"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "شکل موج (دسی‌بل)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -9214,7 +19099,24 @@ msgid "Select Function"
 msgstr "انتخاب"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Stereo Linking"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
+msgstr "ساخت شیار استریو"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
 msgstr "ساخت شیار استریو"
 
 #: plug-ins/noisegate.ny
@@ -9237,6 +19139,44 @@ msgstr "زمان حمله/میرایی (ثانیه):"
 msgid "Decay (ms)"
 msgstr "زمان حمله/میرایی (ثانیه):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "نام نمی‌تواند خالی باشد"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "در حال ترازبندی..."
@@ -9244,6 +19184,22 @@ msgstr "در حال ترازبندی..."
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "در حال ترازبندی..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -9266,7 +19222,8 @@ msgstr "پرونده‌های نام:"
 msgid "HTML file"
 msgstr "بار کردن پرونده‌ها"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "پرونده‌های نام:"
 
@@ -9283,9 +19240,24 @@ msgid "Disallow"
 msgstr "خاموش"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "خاموش"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "حذف «‎%s» ممکن نیست"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -9296,16 +19268,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "محل صدور:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "در حال تولید صوت"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "نوع نوفه:"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -9320,8 +19334,40 @@ msgid "Generating Rhythm..."
 msgstr "در حال تولید جیرجیر"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "تعداد دفعات تکرار: "
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -9344,12 +19390,54 @@ msgid "Beat sound"
 msgstr "تکرار"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "در حال حذف نوفه"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "نوع نوفه:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -9360,12 +19448,25 @@ msgid "Generating Risset Drum..."
 msgstr "در حال تولید نوفه"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "زمان تأخیر (ثانیه):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "بسامد خطی"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "بسامد (هرتز)"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -9378,6 +19479,10 @@ msgstr "صدور ممکن نیست"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "در حال اِعمال..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -9396,6 +19501,10 @@ msgid "HTML files"
 msgstr "بار کردن پرونده‌ها"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "ویرایش نمونه"
 
@@ -9404,8 +19513,34 @@ msgid "Time Indexed"
 msgstr "ویرایش برچسب"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "&همه"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -9420,6 +19555,11 @@ msgstr "روشن"
 msgid "Errors Only"
 msgstr "خطا: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -9432,6 +19572,46 @@ msgstr "کانال راست"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "نمونه‌ها"
 
@@ -9439,6 +19619,43 @@ msgstr "نمونه‌ها"
 #, lisp-format
 msgid "~a seconds."
 msgstr "ثانیه"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -9457,6 +19674,10 @@ msgid "Value (dB)"
 msgstr "شکل موج (دسی‌بل)"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "خطی..."
 
@@ -9473,6 +19694,14 @@ msgid "Right (dB)"
 msgstr "راست، "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "خطی..."
 
@@ -9483,6 +19712,40 @@ msgstr "۲ کاناله (استریو)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "۱ کاناله (مونو)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "خطا (ممکن است در پرونده نوشته شده باشد) : %hs"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -9497,8 +19760,40 @@ msgid "Select file"
 msgstr "یک یا چند پروندهٔ MIDI انتخاب کنید..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "خطا"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -9508,6 +19803,15 @@ msgstr "خطا در باز کردن پرونده"
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "انتخاب"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -9525,9 +19829,21 @@ msgstr "دندان‌اره‌ای"
 msgid "Starting phase (degrees)"
 msgstr "فاز شروع LFO (درجه):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "در حال اِعمال..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -9569,9 +19885,96 @@ msgstr "تحلی&ل"
 msgid "Strength"
 msgstr "طول"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "در حال پردازش مخفی‌سازی خودکار..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -9605,6 +20008,101 @@ msgstr "بسامد (هرتز)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "بسامد (هرتز)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "خروج از اوداسیتی"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "کانال"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "میله ابزار %s اوداسیتی"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "در حال ضبط"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "صدور ممکن نیست\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "در حال ضبط\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "پخش\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "در حال ضبط\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "در حال ضبط\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "پخش\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "پخش\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "تغییر نام «‎%s» به «‎%s» ممکن نیست"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "پخش"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "پخش"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "پخش"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "در حال ضبط"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "در حال ضبط"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "در حال ضبط"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&دربارهٔ اوداسیتی..."
+
+#~ msgid "Recording Volume"
+#~ msgstr "در حال ضبط"
+
+#~ msgid "Playback Volume"
+#~ msgstr "پخش"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "در حال ضبط"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "پخش"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "پخش"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "برای جابه‌جایی یک شیار در زمان کلیک کنید و بکشید"
+
 #~ msgid "Program build date:"
 #~ msgstr "تاریخ ساخت نسخهٔ اجرایی برنامه: "
 
@@ -9615,14 +20113,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "s"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
-
-#, fuzzy
-#~ msgid "available"
-#~ msgstr "پیش‌نمایش موجود نیست"
 
 #, fuzzy
 #~ msgid "Audacity Support Data"
@@ -9642,14 +20132,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Failed to copy tags"
 #~ msgstr "حذف «‎%s» ممکن نیست"
-
-#, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "یک پروندهٔ صوتی نافشرده انتخاب کنید..."
-
-#, fuzzy
-#~ msgid "decode an autosave file"
-#~ msgstr "پروندهٔ ذخیرهٔ خودکار حذف نشد"
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -9701,10 +20183,6 @@ msgstr "بسامد (هرتز)"
 #~ "/%s/%s.%s"
 #~ msgstr "در حال ضبط"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "در حال ضبط"
-
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
 #~ msgstr "در این نسخه از اوداسیتی اُگ وربیس را پشتیبانی نمی‌کند"
 
@@ -9718,9 +20196,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "در حال پاک‌سازی پرونده‌های موقت"
-
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "در حال پاک‌سازی شاخه‌های حافظهٔ نهان"
 
 #~ msgid "Renamed file: %s\n"
 #~ msgstr "پرونده با نام تغییر یافته: ‎%s\n"
@@ -9750,10 +20225,6 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "پروندهٔ ذخیرهٔ خودکار حذف نشد"
 
 #, fuzzy
-#~ msgid "Compress"
-#~ msgstr "فشرده‌ساز..."
-
-#, fuzzy
 #~ msgid ""
 #~ "MP3 Decoding Failed:\n"
 #~ "\n"
@@ -9777,9 +20248,6 @@ msgstr "بسامد (هرتز)"
 
 #~ msgid "Audio cache"
 #~ msgstr "حافظهٔ نهان صوتی"
-
-#~ msgid "When saving a project that depends on other audio files"
-#~ msgstr "در هنگام ذخیره‌سازی پروژه‌ای که به پرونده‌های صوتی دیگر وابستگی دارد"
 
 #, fuzzy
 #~ msgid "Silence Finder"
@@ -9812,10 +20280,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Audacity Team Members"
 #~ msgstr "تیم برنامه‌سازی اوداسیتی %s"
-
-#, fuzzy
-#~ msgid "Unable to open/create test file."
-#~ msgstr "باز کردن/ایجاد پروندهٔ آزمایشی مممکن نیست"
 
 #~ msgid "Unable to remove '%s'."
 #~ msgstr "حذف «‎%s» ممکن نیست"
@@ -9875,10 +20339,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Disable dragging selection"
 #~ msgstr "انتخاب سکوت"
-
-#, fuzzy
-#~ msgid "Disable Scrub Ruler"
-#~ msgstr "از کار انداختن اندازه‌گیر"
 
 #, fuzzy
 #~ msgid "Enable Scrub Ruler"
@@ -9946,10 +20406,6 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "نمی‌توان پروندهٔ ذخیره‌سازی خودکار را ایجاد کرد: "
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "حذف شیار"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "در حال حذف تق و توق..."
 
@@ -9980,18 +20436,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Current settings returned the original audio."
 #~ msgstr "."
-
-#, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "پروندهٔ صوتی"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "در حال اعمال جلوه Nyquist..."
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "نمی‌توان تعیین کرد"
 
 #, fuzzy
 #~ msgid "Unable to save MIDI device info"
@@ -10048,10 +20492,6 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "ویرایش &زنجیرها"
 
 #, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "ابزار آوانویسی"
-
-#, fuzzy
 #~ msgid "&Tools"
 #~ msgstr "ابزارها"
 
@@ -10073,10 +20513,6 @@ msgstr "بسامد (هرتز)"
 #~ "Error opening sound device.\n"
 #~ "Try changing the audio host, recording device and the project sample rate."
 #~ msgstr "خطا در هنگام باز کردن دستگاه صدا. لطفاً تنظیمات خروجی دستگاه و نرخ نمونه‌برداری پروژه را بررسی کنید."
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "در حال ضبط"
 
 #, fuzzy
 #~ msgid "Slider Playback"
@@ -10110,10 +20546,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "آوانویسی"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "نوار ابزار ویرایش"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -10178,10 +20610,6 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "طول"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "انتخاب تا پایان"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "به پایان انتخاب"
 
@@ -10240,10 +20668,6 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "تغییر درصد:"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "زمان حمله: "
-
-#, fuzzy
 #~ msgid "Repeats"
 #~ msgstr "تکرار"
 
@@ -10254,14 +20678,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Duty Cycle"
 #~ msgstr "دورهٔ کار:"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "دامنه (۰-۱)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "نام"
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -10313,10 +20729,6 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "بازخورد (٪):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "اندازه"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "بازخورد (٪):"
 
@@ -10331,14 +20743,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "بهره"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "استریو، "
-
-#, fuzzy
-#~ msgid "FilterType"
-#~ msgstr "اندازه‌گیر"
 
 #, fuzzy
 #~ msgid "RatePercentChangeStart"
@@ -10363,10 +20767,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "StartAmp"
 #~ msgstr "آغاز"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "برعکس کردن"
 
 #~ msgid ""
 #~ "The keyboard shortcut '%s' is already assigned to:\n"
@@ -10466,10 +20866,6 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "کانال راست"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "تقویت (دسی‌بل):"
-
-#, fuzzy
 #~ msgid "&Enable level control"
 #~ msgstr "به کار انداختن اندازه‌گیر"
 
@@ -10480,10 +20876,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "-Left-Click"
 #~ msgstr "کلیک چپ"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "کلیک چپ با دگرساز"
 
 #~ msgid "Time shift clip or move up/down between tracks"
 #~ msgstr "تغییر محل زمانی بریده در شیار یا حرکت بالا/پایین بین شیارها"
@@ -10522,12 +20914,6 @@ msgstr "بسامد (هرتز)"
 #~ "  %s"
 
 #, fuzzy
-#~ msgid "Current directory:"
-#~ msgstr ""
-#~ "این شاخه ایجاد نشد:\n"
-#~ "  %s"
-
-#, fuzzy
 #~ msgid "Directory doesn't exist."
 #~ msgstr "شاخهٔ %s وجود ندارد. آیا ساخته شود؟"
 
@@ -10554,12 +20940,6 @@ msgstr "بسامد (هرتز)"
 #, fuzzy
 #~ msgid "Plug-ins %i to %i"
 #~ msgstr "متصل‌شونده‌های %Ii تا %Ii"
-
-#~ msgid "FLAC Export Setup"
-#~ msgstr "برپاسازی صدور FLAC"
-
-#~ msgid "MP2 Export Setup"
-#~ msgstr "برپاسازی صدور MP2"
 
 #~ msgid "MP3 Export Setup"
 #~ msgstr "برپاسازی صدور MP3"
@@ -10598,9 +20978,6 @@ msgstr "بسامد (هرتز)"
 
 #~ msgid "&Audio Track"
 #~ msgstr "شیار &صوتی"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "درون‌یابی همگامی با کیفیت بالا"
 
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "درون‌یابی همگامی سریع"
@@ -10652,9 +21029,6 @@ msgstr "بسامد (هرتز)"
 #~ msgid "Change Tempo..."
 #~ msgstr "تغییر ضرباهنگ..."
 
-#~ msgid "Click Removal..."
-#~ msgstr "حذف تق‌ها..."
-
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "اعمال فشرده‌سازی با دامنهٔ پویا..."
 
@@ -10682,9 +21056,6 @@ msgstr "بسامد (هرتز)"
 
 #~ msgid "Equalization..."
 #~ msgstr "اِعمال اکولایزر..."
-
-#~ msgid "Performing Equalization"
-#~ msgstr "در حال اِعمال اکولایزر"
 
 #~ msgid "Fading In"
 #~ msgstr "در حال آشکار شدن تدریجی"
@@ -10735,20 +21106,8 @@ msgstr "بسامد (هرتز)"
 #~ msgstr "ت&غییر نام"
 
 #, fuzzy
-#~ msgid "Load preset:"
-#~ msgstr "بار کردن پرونده‌ها"
-
-#, fuzzy
 #~ msgid "Change name to:"
 #~ msgstr "تغییر نام شیار به:"
-
-#, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "برعکس"
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "بارگ&ذاری پرونده..."
 
 #, fuzzy
 #~ msgid "Silence..."
@@ -10765,9 +21124,6 @@ msgstr "بسامد (هرتز)"
 
 #~ msgid "Chirp Generator"
 #~ msgstr "تولیدکنندهٔ جیرجیر"
-
-#~ msgid "Truncate Silence..."
-#~ msgstr "حذف سکوت..."
 
 #, fuzzy
 #~ msgid "Buffer Delay Compensation"
@@ -11050,85 +21406,22 @@ msgstr "بسامد (هرتز)"
 #~ msgid "Calibrate"
 #~ msgstr "میزان کردن"
 
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "&Go to"
-msgstr "&رفتن به"
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "باز کردن لینک دانلود تناسیتی ممکن نیست."
 
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "&Find...\tCtrl+F"
-msgstr "&یافتن...\tCtrl+F"
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "داده‌های به روز شده مشکل دارد."
 
-#: modules/mod-nyq-bench/NyqBench.cpp
-#, fuzzy
-msgid "Cle&ar\tCtrl+L"
-msgstr "&پاک کردن\tCtrl+L"
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "دسترسی به سرور به روز رسانی تناسیتی ممکن نیست."
 
-#: modules/mod-nyq-bench/NyqBench.cpp
-#, fuzzy
-msgid "&Copy\tCtrl+C"
-msgstr "&نسخه برداری\tCtrl+C"
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "در گیتهاب بیشتر بخوانید"
 
-#: modules/mod-nyq-bench/NyqBench.cpp
-#, fuzzy
-msgid "Cu&t\tCtrl+X"
-msgstr "&برش\tCtrl+X"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "&Redo\tCtrl+Y"
-msgstr "&بازنشانی\tCtrl+Y"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "&Undo\tCtrl+Z"
-msgstr "&بازگشت\tCtrl+Z"
-
-#: libraries/lib-strings/Languages.cpp
-msgid "System"
-msgstr "سیستم"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s گیگابایت"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s مگابایت"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s KB"
-msgstr "%s کیلوبایت"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "باز کردن لینک دانلود تناسیتی ممکن نیست."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "داده‌های به روز شده مشکل دارد."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "دسترسی به سرور به روز رسانی تناسیتی ممکن نیست."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "در گیتهاب بیشتر بخوانید"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&نصب به روز رسانی‌ها"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&گذشتن"
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&نصب به روز رسانی‌ها"

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -5,82 +5,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-27 11:11+0000\n"
 "Last-Translator: Tommi Nieminen <translator@legisign.org>\n"
-"Language-Team: Finnish <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/fi/>\n"
+"Language-Team: Finnish <https://hosted.weblate.org/projects/tenacity/tenacity/fi/>\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Päivitä Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Ohita"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Asenna päivitys"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Muokkausloki"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Lue lisää GitHubissa"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Päivitysten tarkistus epäonnistui"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Ei voitu yhdistää Tenacity-päivityspalvelimeen."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Päivitystieto on virheellistä."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Päivityksen lataus epäonnistui."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Tenacityn latauslinkkiä ei voitu avata."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s on saatavilla!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Tietue"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -234,7 +168,8 @@ msgid "Script"
 msgstr "Skripti"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Tuloste"
 
@@ -250,7 +185,12 @@ msgstr "Nyquist-skriptit (*.ny)|*.ny|Lisp-skriptit (*.lsp)|*.lsp|Kaikki tiedosto
 msgid "Script was not saved."
 msgstr "Skriptiä ei ole tallennettu."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Varoitus"
 
@@ -263,18 +203,25 @@ msgid "Find dialog"
 msgstr "Hakuikkuna"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr "Harvey Lubin (logo)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango Icon Gallery (työkalurivin kuvakkeet)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Luscius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "© 2009 Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
-msgstr ""
-"Ulkoinen Tenacity-moduuli, joka tarjoaa yksinkertaisen kehitysympäristön "
-"tehosteiden luomiseen."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr "Ulkoinen Tenacity-moduuli, joka tarjoaa yksinkertaisen kehitysympäristön tehosteiden luomiseen."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -296,7 +243,8 @@ msgstr "Nimetön"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist-tehostetyöpöytä - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Uusi"
 
@@ -336,7 +284,8 @@ msgstr "Kopioi"
 msgid "Copy to clipboard"
 msgstr "Kopioi leikepöydälle"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Leikkaa"
 
@@ -344,7 +293,8 @@ msgstr "Leikkaa"
 msgid "Cut to clipboard"
 msgstr "Leikkaa leikepöydälle"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Liitä"
 
@@ -369,7 +319,8 @@ msgstr "Valitse kaikki"
 msgid "Select all text"
 msgstr "Valitse kaikki teksti"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Kumoa"
 
@@ -377,7 +328,8 @@ msgstr "Kumoa"
 msgid "Undo last change"
 msgstr "Kumoa viimeinen muutos"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Tee uudelleen"
 
@@ -434,7 +386,8 @@ msgid "Go to next S-expr"
 msgstr "Siirry seuraavaan S-lausekkeeseen"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Alku"
 
@@ -442,7 +395,8 @@ msgstr "Alku"
 msgid "Start script"
 msgstr "Aloita skripti"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Pysäytä"
 
@@ -456,15 +410,23 @@ msgstr "Pysäytä skripiti"
 msgid "About %s"
 msgstr "Tietoa: %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "OK"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Koosteen tiedot"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Ei käytössä"
 
@@ -474,8 +436,9 @@ msgid "The Build"
 msgstr "Koontiversio"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Koontitunnus:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versio"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -485,22 +448,28 @@ msgstr "Koostetyyppi:"
 msgid "Compiler:"
 msgstr "Kääntäjä:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Asennuksen etuliite:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Asetuskansio:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Asetuskansio:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Tiedostomuototuki"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Alustariippumaton käyttöliittymäkirjasto"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -514,7 +483,6 @@ msgstr "Näytteenottotaajuuden muutos"
 msgid "MP3 Importing"
 msgstr "MP3-tuonti"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis -tuonti ja -vienti"
@@ -523,7 +491,6 @@ msgstr "Ogg Vorbis -tuonti ja -vienti"
 msgid "ID3 tag support"
 msgstr "ID3-tunnistetuki"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC-vienti ja -tuonti"
@@ -541,14 +508,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg-tuonti/vienti"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Tuo GStreamerin avulla"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Ominaisuudet"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Liitännäistuki"
 
@@ -563,6 +522,10 @@ msgstr "Sävelkorkeus- ja tempomuutostuki"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Äärimmäisen sävelkorkeuden ja tempon muutoksen tuki"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Ominaisuudet"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -681,16 +644,22 @@ msgstr "%s, Audacityn grafiikka"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (sisältää %s, %s, %s, %s ja %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Ilmainen, avoimen lähdekoodin, monialustainen ohjelmisto äänien "
-"tallentamiseen ja muokkaamiseen."
+msgstr "Ilmainen, avoimen lähdekoodin, monialustainen ohjelmisto äänien tallentamiseen ja muokkaamiseen."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Tekijät"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Huomaa, että nimet on lajiteltu aakkos-, ei tärkeysjärjestykseen."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -723,6 +692,10 @@ msgid "%s Team Members"
 msgstr "%s-tiimijäsenet"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr "Audacity-emeritus:"
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Audacityn avustajat"
 
@@ -735,11 +708,10 @@ msgstr "Audacity-sivusto ja -grafiikka"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
-msgstr ""
-"Suomennos: Petri Vuorio, Elias Julkunen, Tomi Toivio & Ilkka Mäkelä, Heino "
-"Keränen, upd 05-2020 VeikkoM, Sampo Hippeläinen, Tommi Nieminen"
+msgstr "Suomennos: Petri Vuorio, Elias Julkunen, Tomi Toivio & Ilkka Mäkelä, Heino Keränen, upd 05-2020 VeikkoM, Sampo Hippeläinen, Tommi Nieminen"
 
 #: src/AboutDialog.cpp
 msgid "Translators"
@@ -754,6 +726,22 @@ msgstr "Erityiskiitokset Audacitystä:"
 #, c-format
 msgid "%s website: "
 msgstr "%s-verkkosivusto: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999–%s %s avustajat"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Audacity%s-tuotemerkkiä käytetään tässä ohjelmistossa vain kuvailu- ja tiedotustarkoituksiin."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "MuseCY SM Ltd. tai Dominic M. Mazzoni eivät tue tai kannata Tenacityä."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -776,6 +764,7 @@ msgstr "Aikajana"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Napsautus tai veto aloittaa kelauksen"
@@ -783,6 +772,7 @@ msgstr "Napsautus tai veto aloittaa kelauksen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Napsautus tai veto aloittaa hankauksen"
@@ -790,14 +780,15 @@ msgstr "Napsautus tai veto aloittaa hankauksen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
-msgstr ""
-"Hankaa napsauttamalla ja liikuttamalla, kelaa napsauttamalla ja vetämällä."
+msgstr "Hankaa napsauttamalla ja liikuttamalla, kelaa napsauttamalla ja vetämällä."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Kelaa liikuttamalla"
@@ -805,6 +796,7 @@ msgstr "Kelaa liikuttamalla"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Hankaa liikuttamalla"
@@ -861,7 +853,17 @@ msgstr ""
 "Et voi lukita aluetta projektin\n"
 "lopun jälkeen."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Virhe"
 
@@ -885,7 +887,8 @@ msgstr ""
 "Tämä on kertaluonteinen kysymys 'asennuksen' jälkeen, jossa pyysit oletusasetusten palauttamista."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Palauta Tenacityn asetukset"
 
 #: src/AudacityApp.cpp
@@ -900,7 +903,8 @@ msgstr ""
 "Se poistettiin äskettäisten tiedostojen luettelosta."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite-kirjastoa ei voitu alustaa.  Tenacity ei voi jatkaa."
 
 #: src/AudacityApp.cpp
@@ -925,7 +929,7 @@ msgstr "&Avaa..."
 msgid "Open &Recent..."
 msgstr "Avaa &viimeisin..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&Tietoa Tenacitystä…"
 
@@ -938,34 +942,35 @@ msgid "&File"
 msgstr "&Tiedosto"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity ei löytänyt väliaikaistiedostoille\n"
 "turvallista paikkaa.\n"
-"Tenacity tarvitsee paikan, josta automaattiset puhdistusohjelmat eivät "
-"poista väliaikaistiedostoja.\n"
+"Tenacity tarvitsee paikan, josta automaattiset puhdistusohjelmat eivät poista väliaikaistiedostoja.\n"
 "Aseta sopiva kansio asetusikkunassa."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity ei löytänyt paikkaa väliaikaistiedostoille.\n"
 "Anna kelvollinen kansio asetusikkunassa."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"Tenacity sulkeutuu. Ota uusi väliaikaiskansio käyttöön käynnistämällä "
-"Tenacity uudelleen."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "Tenacity sulkeutuu. Ota uusi väliaikaiskansio käyttöön käynnistämällä Tenacity uudelleen."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -974,15 +979,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity ei voinut lukita väliaikaistiedostojen kansiota.\n"
 "Se saattaa olla toisen Tenacity-kopion käytössä.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Haluatko silti käynnistää Tenacityn?"
 
 #: src/AudacityApp.cpp
@@ -990,19 +997,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Virhe lukittaessa väliaikaiskansiota"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Järjestelmä on havainnut toisen Tenacityn olevan käynnissä.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Käytä käynnissä olevan Tenacityn Uusi- tai Avaa-komentoja\n"
 "useamman projektin avaamiseksi samanaikaisesti.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity on jo käynnissä"
 
 #: src/AudacityApp.cpp
@@ -1018,7 +1028,8 @@ msgstr ""
 "ja uudelleenkäynnistys voi olla tarpeen."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Tenacity-käynnistysvirhe"
 
 #: src/AudacityApp.cpp
@@ -1058,8 +1069,9 @@ msgstr ""
 "ja uudelleenkäynnistys voi olla tarpeen."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1091,7 +1103,8 @@ msgstr "suorita itsediagnostiikka"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "näytä Tenacityn versio"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1101,9 +1114,10 @@ msgid "audio or project file name"
 msgstr "ääni- tai projektitiedoston nimi"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1116,16 +1130,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tenacityn projektitiedostot"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Viesti"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Audacityn määritysvirhe"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1135,27 +1151,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Seuraavaa määritystiedostoa ei voitu avata:\n"
 "\n"
 "\t%s\n"
 "\n"
-"Tämä voi johtua monesta syystä, mutta todennäköisimmin levy on täynnä tai "
-"tiedostoon ei ole kirjoitusoikeuksia. Alla olevasta ohjepainiketta "
-"napsauttamalla saa lisätietoa.\n"
+"Tämä voi johtua monesta syystä, mutta todennäköisimmin levy on täynnä tai tiedostoon ei ole kirjoitusoikeuksia. Alla olevasta ohjepainiketta napsauttamalla saa lisätietoa.\n"
 "\n"
 "Voit yrittää korjata ongelman ja jatkaa painamalla ”Yritä uudelleen”.\n"
 "\n"
-"Jos päätät sulkea Tenacityn, projekti saattaa jäädä keskeneräiseen tilaan ja "
-"Tenacityn pitää palauttaa se ensi kerralla."
+"Jos päätät sulkea Tenacityn, projekti saattaa jäädä keskeneräiseen tilaan ja Tenacityn pitää palauttaa se ensi kerralla."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Ohje"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Lopeta Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1163,7 +1179,8 @@ msgid "&Retry"
 msgstr "Yritä &uudelleen"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacityn loki"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1175,9 +1192,14 @@ msgstr "&Tallenna…"
 msgid "Cl&ear"
 msgstr "Ty&hjennä"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Sulje"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr "log.txt"
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1226,7 +1248,8 @@ msgid "Error Initializing Midi"
 msgstr "Virhe alustettaessa MIDIä"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity-ääni"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1241,39 +1264,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Muisti loppu!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr ""
-"Automaattinen äänitystason säätö on pysähtynyt. Enempi optimointi ei ollut "
-"mahdollista. On yhä liian suuri."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automaattinen äänitystason säätö laski voimakkuuden arvoon %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automaattinen äänitystason säätö on pysähtynyt. Sitä ei ollut mahdollista optimoida enempää, on edelleen liian matala."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automaattinen äänitystason säätö nosti voimakkuuden arvoon %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automaattinen äänitystason säätö on pysähtynyt. Analyysien kokonaismäärä on ylitetty löytämättä hyväksyttävää äänenvoimakkuutta, on edelleen liian korkea."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automaattinen äänitystason säätö on pysähtynyt. Analyysien kokonaismäärä on ylitetty löytämättä hyväksyttävää äänenvoimakkuutta, on edelleen liian matala."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automaattinen äänitystason säätö on pysähtynyt. %.2f tuntuu hyväksyttävältä arvolta."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1372,43 +1362,6 @@ msgstr "Kohteelle ”%s” ei löytynyt toistolaitetta.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Vastavuoroisia näytteenottotaajuuksia ei voida tarkistaa ilman molempia laitteita.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Vastaanotettiin virhe %d avattaessa laitteita\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Portmixeriä ei voi avata\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Käytettävissä olevat mikserit:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Käytettävissä olevat tallennuslähteet:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Käytettävissä olevat toistovoimakkuudet:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Äänitysvoimakkuus on emuloitu\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Äänitysvoimakkuus on alkuperäinen\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Toiston voimakkuus on emuloitu\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Toiston voimakkuus on alkuperäinen\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1451,28 +1404,29 @@ msgid "Automatic Crash Recovery"
 msgstr "Automaattinen palautuminen kaatumisesta"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
-"Joitakin projekteja ei tallennettu oikein Tenacityn viime käyttökerran "
-"aikana, mutta ne voidaan palauttaa automaattisesti.\n"
+"Joitakin projekteja ei tallennettu oikein Tenacityn viime käyttökerran aikana, mutta ne voidaan palauttaa automaattisesti.\n"
 "\n"
-"Palautuksen jälkeen projektit tulee tallentaa, jotta muutokset "
-"kirjoitettaisiin levylle."
+"Palautuksen jälkeen projektit tulee tallentaa, jotta muutokset kirjoitettaisiin levylle."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "Palautettavissa olevat pro&jektit"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Valitse"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nimi"
 
@@ -1558,6 +1512,11 @@ msgstr "Tehoste"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Valikkokomento (parametreineen)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1703,7 +1662,8 @@ msgstr "Pa&lauta"
 msgid "I&mport..."
 msgstr "&Tuo…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Vie…"
 
@@ -1744,7 +1704,8 @@ msgstr "Siirrä &ylemmäs"
 msgid "Move &Down"
 msgstr "Siirrä &alemmas"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Tallenna"
 
@@ -1827,9 +1788,16 @@ msgid "Run"
 msgstr "Suorita"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Sulje"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "nopeustesti.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1967,10 +1935,6 @@ msgid "No revision identifier was provided"
 msgstr "Versiotunnusta ei annettu"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Tuntematon päiväys ja aika"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Virheenkorjausversio (taso %d)"
@@ -2000,17 +1964,13 @@ msgstr ""
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
-msgstr ""
-"Valitse toiminnolle %s käytettävä ääni (esim. Komento+A valitsee kaiken) ja "
-"yritä uudelleen."
+msgstr "Valitse toiminnolle %s käytettävä ääni (esim. Komento+A valitsee kaiken) ja yritä uudelleen."
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
-msgstr ""
-"Valitse toiminnolle %s käytettävä ääni (esim. Ctrl+A valitsee kaiken) ja "
-"yritä uudelleen."
+msgstr "Valitse toiminnolle %s käytettävä ääni (esim. Ctrl+A valitsee kaiken) ja yritä uudelleen."
 
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
@@ -2029,8 +1989,7 @@ msgid ""
 msgstr ""
 "Valitse toiminnolle %s käytettävä ääni.\n"
 "\n"
-"1. Valitse kohinaa edustavaa ääntä ja käytä toimintoa %s saadaksesi "
-"”kohinaprofiilin”.\n"
+"1. Valitse kohinaa edustavaa ääntä ja käytä toimintoa %s saadaksesi ”kohinaprofiilin”.\n"
 "\n"
 "2. Saatuasi kohinaprofiilin valitse ääni, jonka haluat muuttaa,\n"
 "ja käytä toimintoa %s äänen muuttamiseen."
@@ -2058,6 +2017,11 @@ msgid ""
 msgstr ""
 "Ensin on valittava jotakin ääntä tätä toimintoa varten.\n"
 "(Muun tyyppiset raidat eivät kelpaa.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2153,8 +2117,7 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Puuttuviksi merkittyjä tiedostoja on siirretty tai poistettu, eikä niitä voi "
-"kopioida.\n"
+"Puuttuviksi merkittyjä tiedostoja on siirretty tai poistettu, eikä niitä voi kopioida.\n"
 "Palauta ne alkuperäiseen paikkaansa, jotta ne voidaan kopioida projektiin."
 
 #: src/Dependencies.cpp
@@ -2221,6 +2184,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopioi nimet leikepöydälle"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Puuttuu"
 
@@ -2229,10 +2197,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Jos jatkat, projektia ei tallenneta levylle. Tätäkö haluat?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2246,7 +2215,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Riippuvuustarkistus"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ei mitään"
 
@@ -2254,7 +2226,7 @@ msgstr "Ei mitään"
 msgid "Rectangle"
 msgstr "Kantti"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Kolmio"
 
@@ -2266,14 +2238,60 @@ msgstr "Muotoiltu"
 msgid "Rectangular"
 msgstr "Suorakulma"
 
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman–Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr "Gauss (a = 2,5)"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr "Gauss (a = 3,5)"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr "Gauss (a = 4,5)"
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg-tukea ei ole käännetty mukaan"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2295,8 +2313,8 @@ msgid "Locate FFmpeg"
 msgstr "Etsi FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity vaatii äänen tuontiin ja vientiin FFmpegillä tiedoston ”%s”."
 
 #: src/FFmpeg.cpp
@@ -2309,7 +2327,8 @@ msgstr "Tiedoston ”%s” sijainti:"
 msgid "To find '%s', click here -->"
 msgstr "Etsi ”%s” napsauttamalla tästä →"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Selaa…"
 
@@ -2335,8 +2354,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpegiä ei löytynyt"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2366,26 +2386,24 @@ msgid "Only libavformat.so"
 msgstr "Vain libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity ei voinut avata tiedostoa kansiossa %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity ei voinut lukea tiedostoa kansiossa %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
-msgstr ""
-"Tenacity onnistui kirjoittamaan tiedoston kansioon %s, mutta sen nimeksi ei "
-"onnistuttu muuttamaan %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr "Tenacity onnistui kirjoittamaan tiedoston kansioon %s, mutta sen nimeksi ei onnistuttu muuttamaan %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2423,7 +2441,9 @@ msgstr "Älä kopioi mitään ääntä"
 msgid "As&k"
 msgstr "&Kysy"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
@@ -2448,6 +2468,10 @@ msgstr "Tekstitiedostot"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML-tiedostot"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ", "
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2512,6 +2536,17 @@ msgstr "Lineaarinen taajuus"
 msgid "Log frequency"
 msgstr "Logaritminen taajuus"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Vieritys"
@@ -2519,6 +2554,15 @@ msgstr "Vieritys"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Suurennus"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
@@ -2566,9 +2610,7 @@ msgstr "&Päivitä..."
 
 #: src/FreqWindow.cpp
 msgid "To plot the spectrum, all selected tracks must be the same sample rate."
-msgstr ""
-"Spektrin piirtämiseksi kaikilla valituilla raidoilla on oltava sama "
-"näytteenottotaajuus."
+msgstr "Spektrin piirtämiseksi kaikilla valituilla raidoilla on oltava sama näytteenottotaajuus."
 
 #: src/FreqWindow.cpp
 #, c-format
@@ -2578,6 +2620,23 @@ msgstr "Liikaa ääntä valittu. Analysoidaan vain ensimmäiset %.1f sekuntia."
 #: src/FreqWindow.cpp
 msgid "Not enough data selected."
 msgstr "Dataa ei ole valittu riittävästi."
+
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
 
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
@@ -2601,7 +2660,8 @@ msgstr "spektri.txt"
 msgid "Export Spectral Data As:"
 msgstr "Vie spektridata nimellä:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Tiedostoon ei voitu kirjoittaa: %s"
@@ -2686,15 +2746,11 @@ msgstr "<br><br>Käyttämäsi Tenacityn versio on <b>beetatestiversio.</b>."
 
 #: src/HelpText.cpp
 msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
-msgstr ""
-"Suosittelemme käyttämään uusinta vakaata julkaistua versiota, jolle on täysi "
-"ohjeistus ja tuki.<br><br>"
+msgstr "Suosittelemme käyttämään uusinta vakaata julkaistua versiota, jolle on täysi ohjeistus ja tuki.<br><br>"
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"Voit auttaa saattamaan Tenacityn julkaisuvalmiiksi liittymällä "
-"[[https://tenacityaudio.org/|yhteisöön]].<hr><br><br>"
+msgstr "Voit auttaa saattamaan Tenacityn julkaisuvalmiiksi liittymällä [[https://tenacityaudio.org/|yhteisöön]].<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2707,16 +2763,12 @@ msgstr "Tukimuotomme ovat:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[help:Quick_Help|Pikaohje]] – ellei ole asennettu paikallisesti, on "
-"[[https://manual.audacityteam.org/quick_help.html|saatavilla verkosta]]"
+msgstr "[[help:Quick_Help|Pikaohje]] – ellei ole asennettu paikallisesti, on [[https://manual.audacityteam.org/quick_help.html|saatavilla verkosta]]"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
-msgstr ""
-" [[help:Main_Page|Käyttöohje]] – ellei ole asennettu paikallisesti, on "
-"[[https://manual.audacityteam.org/|saatavilla verkosta]]"
+msgstr " [[help:Main_Page|Käyttöohje]] – ellei ole asennettu paikallisesti, on [[https://manual.audacityteam.org/|saatavilla verkosta]]"
 
 #: src/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
@@ -2724,36 +2776,23 @@ msgstr " Keskustelualue – kysy suoraan verkossa."
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"Lisää:</b> Vinkkejä, vihjeitä, oppaita ja tehosteliitännäisiä löytyy wikistä."
+msgstr "Lisää:</b> Vinkkejä, vihjeitä, oppaita ja tehosteliitännäisiä löytyy wikistä."
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"Tenacity voi tuoda suojaamattomia tiedostoja monista muista "
-"tiedostomuodoista (kuten M4A ja WMA, kannettavien tallenninten pakatut WAV-"
-"tiedostot sekä videotiedostojen ääni), kun lataat ja asennat koneelle "
-"valinnaisen FFmpeg-kirjaston."
+msgstr "Tenacity voi tuoda suojaamattomia tiedostoja monista muista tiedostomuodoista (kuten M4A ja WMA, kannettavien tallenninten pakatut WAV-tiedostot sekä videotiedostojen ääni), kun lataat ja asennat koneelle valinnaisen FFmpeg-kirjaston."
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"Voit myös lukea ohjeemme MIDI-tiedostojen ja -raitojen tuomiseksi ääni-"
-"CD:iltä."
+msgstr "Voit myös lukea ohjeemme MIDI-tiedostojen ja -raitojen tuomiseksi ääni-CD:iltä."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Käyttöohjetta ei näytä olevan asennettu. [[*URL*|Lue sitä verkosta]]. Jos "
-"haluat lukea sen aina verkosta, vaihda käyttöliittymän asetuksissa "
-"käyttöohjeen sijainniksi ”Verkosta”."
+msgstr "Käyttöohjetta ei näytä olevan asennettu. [[*URL*|Lue sitä verkosta]]. Jos haluat lukea sen aina verkosta, vaihda käyttöliittymän asetuksissa käyttöohjeen sijainniksi ”Verkosta”."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Käyttöohjetta ei näy olevan asennettu. [[*URL*|Lue sitä verkosta]] tai lataa "
-"käyttöohje.<br><br>Lukeaksesi käyttöohjetta aina verskosta vaihda "
-"käyttöliittymän asetuksissa käyttöohjeen sijainniksi ”Verkosta”."
+msgstr "Käyttöohjetta ei näy olevan asennettu. [[*URL*|Lue sitä verkosta]] tai lataa käyttöohje.<br><br>Lukeaksesi käyttöohjetta aina verskosta vaihda käyttöliittymän asetuksissa käyttöohjeen sijainniksi ”Verkosta”."
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2812,19 +2851,19 @@ msgid "&History..."
 msgstr "&Historia…"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Sisäinen virhe kohdassa %s tiedoston %s rivillä %d.\n"
 "Ilmoitathan Tenacity-tiimille: https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Sisäinen virhe kohdassa %s tiedoston %s rivillä %d.\n"
 "Ilmoita asiasta Tenacity-tiimille: https://tenacityaudio.org/."
@@ -2843,7 +2882,9 @@ msgid "Track"
 msgstr "Raita"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Merkki"
 
@@ -2903,7 +2944,8 @@ msgstr "Kirjoita raidan nimi"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Merkkiraita"
 
@@ -2914,11 +2956,13 @@ msgstr "Vähintään yhtä tallennettua merkkiä ei voitu lukea."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Tenacityn ensikäynnistys"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Valitse Tenacityssä käytettävä kieli:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2928,7 +2972,8 @@ msgstr "Valitse Tenacityssä käytettävä kieli:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Valitsemasi kieli %s (%s) ei ole sama kuin järjestelmän kieli, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Vahvista"
 
@@ -2946,13 +2991,18 @@ msgstr ""
 "Vanha tiedosto on tallennettu nimellä '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Avataan Tenacity-projektia"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Tenacityn karaoke%s"
+
+#: src/LyricsWindow.cpp
+msgid "&Karaoke..."
+msgstr "Ka&raoke…"
 
 #: src/Menus.cpp
 #, c-format
@@ -2998,19 +3048,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Miksataan ja hahmonnetaan raitoja"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacityn miksauspöytä%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Vahvistus"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Nopeus"
 
@@ -3019,17 +3073,23 @@ msgid "Musical Instrument"
 msgstr "Musiikkisoitin"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panorointi"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Mykistä"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Soolo"
 
@@ -3037,15 +3097,18 @@ msgstr "Soolo"
 msgid "Signal Level Meter"
 msgstr "Signaalin tason mittari"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Siirretty vahvistussäädintä"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Siirretty nopeussäädintä"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Siirretty panorointisäädintä"
 
@@ -3080,9 +3143,9 @@ msgstr ""
 "Sitä ei ladata."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3116,16 +3179,19 @@ msgstr ""
 "\n"
 "Käytä vain luotetuista lähteistä saatuja moduuleja"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Kyllä"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ei"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity-moduulilataaja"
 
 #: src/ModuleManager.cpp
@@ -3148,6 +3214,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Nuottiraita"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "C"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "C♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "D"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "D♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "E"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "F"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "F♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "G"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "G♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "A"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "A♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "B"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "D♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "E♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "G♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "A♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "B♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "C♯/D♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "D♯/E♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "F♯/G♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "G♯/A♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "A♯/B♭"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3257,7 +3433,8 @@ msgstr "Valit&se kaikki"
 msgid "C&lear All"
 msgstr "T&yhjennä kaikki"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Ota käyttöön"
 
@@ -3337,9 +3514,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Näytteenottotaajuudet eivät täsmää"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Raitoja ei ole valittu tarpeeksi tällä näytteenottotaajuudella\n"
@@ -3368,10 +3546,11 @@ msgid "Dropouts"
 msgstr "Katkokset"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3400,10 +3579,7 @@ msgstr "Sulje projekti välittömästi muutoksitta"
 
 #: src/ProjectFSCK.cpp
 msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
-msgstr ""
-"Jatka lokissa todettuja korjauksia ja tarkista, löytyykö muita virheitä. "
-"Tallentaa projektin nykytilassaan paitsi jos valitset tulevissa "
-"virheilmoituksissa ”Sulje projekti välittömästi”."
+msgstr "Jatka lokissa todettuja korjauksia ja tarkista, löytyykö muita virheitä. Tallentaa projektin nykytilassaan paitsi jos valitset tulevissa virheilmoituksissa ”Sulje projekti välittömästi”."
 
 #: src/ProjectFSCK.cpp
 msgid "Warning - Problems Reading Sequence Tags"
@@ -3414,11 +3590,11 @@ msgid "Inspecting project file data"
 msgstr "Tarkistetaan projektitiedoston tietoja"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3461,11 +3637,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Varoitus – aliastiedostoja puuttuu"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Projektin tarkistus havaitsi kansiossa ”%s” \n"
@@ -3490,12 +3666,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Varoitus – aliasyhteenvetotiedostoja puuttuu"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3553,7 +3729,8 @@ msgstr "Varoitus – orpoja lohkotiedostoja"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Edistyminen"
 
@@ -3567,8 +3744,7 @@ msgid ""
 "\n"
 "Select 'Help > Diagnostics > Show Log...' to see details."
 msgstr ""
-"Projektin tarkistus löysi automaattipalautuksessa "
-"tiedostoepäjohdonmukaisuuksia.\n"
+"Projektin tarkistus löysi automaattipalautuksessa tiedostoepäjohdonmukaisuuksia.\n"
 "\n"
 "Lisätietoa saa kohdasta Ohje → Diagnostiikka → Näytä loki…"
 
@@ -3579,6 +3755,11 @@ msgstr "Varoitus – ongelmia automaattisessa palautuksessa"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<nimetön projekti>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projekti %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3648,12 +3829,14 @@ msgstr ""
 "(Väliaikaistiedostoja ei voi luoda)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Tämä ei ole Audacity-projektitiedosto"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3785,9 +3968,9 @@ msgid "Error Writing to File"
 msgstr "Virhe tiedoston kirjoituksessa"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3801,9 +3984,16 @@ msgstr "Tiivistetään projektia"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekti %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3812,10 +4002,10 @@ msgstr "(Palautettu)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Tämän tiedoston on tallentanut Audacity %s.\n"
 "Käytät Audacityn versiota %s. Sinun tulee päivittää uudempi versio tiedoston avaamiseksi."
@@ -3887,8 +4077,9 @@ msgid "Backing up project"
 msgstr "Varmuuskopioidaan projektia"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3897,8 +4088,9 @@ msgstr ""
 "Se on palautettu viimeisimpään vedokseen."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3977,8 +4169,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sTallenna projekti \"%s\" nimellä..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Tallenna projekti' tallentaa Audacity-projektin, ei äänitiedostoa.\n"
@@ -4055,11 +4248,12 @@ msgid "Error Opening Project"
 msgstr "Virhe projektia avatessa"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Yrität avata automaattisesti luotua varmuuskopiota.\n"
 "Tämä voi aiheuttaa vakavaa tietojen häviämistä.\n"
@@ -4168,8 +4362,8 @@ msgid "Automatic database backup failed."
 msgstr "Tietokannan automaattinen varmuuskopiointi epäonnistui."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Tervetuloa käyttämään Audacityn versiota %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4384,7 +4578,8 @@ msgstr "Kaikki asetukset"
 msgid "SelectionBar"
 msgstr "Valintapalkki"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektrivalinta"
 
@@ -4392,46 +4587,55 @@ msgstr "Spektrivalinta"
 msgid "Timer"
 msgstr "Ajastin"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Työkalut"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Siirto"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mikseri"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Mittari"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Tasomittari"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Äänitystasomittari"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Muokkaus"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Laite"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Toisto nopeudella"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Hankaus"
 
@@ -4446,7 +4650,10 @@ msgstr "Viivain"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Raidat"
 
@@ -4556,7 +4763,8 @@ msgid "Activation level (dB):"
 msgstr "Aktivointitaso (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Tervetuloa käyttämään Audacityä!"
 
 #: src/SplashDialog.cpp
@@ -4703,9 +4911,9 @@ msgstr ""
 "Ohjenapista voi löytyä vihjeitä joillekin asemille."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity ei voinut kirjoittaa tiedostoa:\n"
@@ -4725,9 +4933,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4736,9 +4944,9 @@ msgstr ""
 "kirjoitusta varten."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity ei voinut kirjoittaa kuvia tiedostoon:\n"
@@ -4755,9 +4963,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4767,9 +4975,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4778,8 +4986,9 @@ msgstr ""
 "Ehkä virheellinen png-muoto?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity ei voinut lukea sen oletusteemaa.\n"
@@ -4817,9 +5026,9 @@ msgstr ""
 "olivat jo mukana. Korvataanko?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity ei voinut tallentaa tiedostoa:\n"
@@ -4858,7 +5067,11 @@ msgstr "Mukautettu"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Kesto"
 
@@ -4869,7 +5082,8 @@ msgid "Time Track"
 msgstr "Aikaraita"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacityn ajastettu äänitys"
 
 #: src/TimerRecordDialog.cpp
@@ -4943,7 +5157,8 @@ msgstr "Nykyinen projekti"
 msgid "Recording start:"
 msgstr "Äänityksen alku:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Kesto:"
 
@@ -4964,7 +5179,8 @@ msgid "Action after Timer Recording:"
 msgstr "Toiminto ajastetun tallennuksen jälkeen:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacityn ajastettu äänitys käynnissä"
 
 #: src/TimerRecordDialog.cpp
@@ -5045,6 +5261,11 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Ajastettu äänitys"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr "099 t 060 min 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -5055,6 +5276,7 @@ msgstr "099 päivää 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Alkupäivämäärä ja -aika"
@@ -5099,7 +5321,8 @@ msgstr "Otetaanko automaattinen vi&enti käyttöön?"
 msgid "Export Project As:"
 msgstr "Vie projekti nimellä:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Asetukset"
 
@@ -5112,7 +5335,8 @@ msgid "Do nothing"
 msgstr "Älä tee mitään"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Poistu Audacitystä"
 
 #: src/TimerRecordDialog.cpp
@@ -5136,7 +5360,8 @@ msgid "Scheduled to stop at:"
 msgstr "Ajoitettu pysähtymään:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacityn ajastettu äänitys - odottaa aloitusta"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5162,8 +5387,13 @@ msgid "Recording Exported:"
 msgstr "Äänite viety:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity ajoitettu äänitys - Odotetaan"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, 999999 Hz"
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5354,6 +5584,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s kesken..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "EPÄONN"
@@ -5372,13 +5612,15 @@ msgstr "%s ei ole parametri jonka %s hyväksyisi"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Parametrin '%s' arvo ei kelpaa: pitäisi olla %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Komento"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Toista - %s"
@@ -5411,6 +5653,10 @@ msgstr "Kynnysarvo:"
 #: src/commands/CompareAudioCommand.h
 msgid "Compares a range on two tracks."
 msgstr "Vertaa kahden raidan aluetta."
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr "Demo"
 
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
@@ -5501,13 +5747,24 @@ msgstr "Leikkeet"
 msgid "Envelopes"
 msgstr "Verhokäyrät"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Merkit"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Laatikot"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr "JSON"
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr "Lisp"
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5517,7 +5774,8 @@ msgstr "Lyhyt"
 msgid "Type:"
 msgstr "Tyyppi:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Muoto:"
 
@@ -5544,6 +5802,10 @@ msgstr "Kommentti"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Komento:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr "_"
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5581,12 +5843,17 @@ msgstr "Vie tiedostoon."
 msgid "Builtin Commands"
 msgstr "Sisäänrakennetut komennot"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity-tiimi"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Tarjoaa sisäänrakennettuja komentoja Audacitylle"
 
 #: src/commands/LoadCommands.cpp
@@ -5649,7 +5916,10 @@ msgstr "Tyhjentää lokin sisällön."
 msgid "Get Preference"
 msgstr "Hae asetus"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nimi:"
 
@@ -5697,7 +5967,8 @@ msgstr "Koko näyttö"
 msgid "Toolbars"
 msgstr "Työkalupalkit"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Tehosteet"
 
@@ -5837,7 +6108,8 @@ msgstr "Aseta"
 msgid "Add"
 msgstr "Lisää"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Poista"
 
@@ -5922,7 +6194,8 @@ msgid "Edited Envelope"
 msgstr "Muokattu verhokäyrä"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Verhokäyrä"
 
@@ -5965,6 +6238,14 @@ msgstr "Taajuus:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Muuta kokoa:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr "X:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr "Y:"
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -6014,7 +6295,10 @@ msgstr "Panorointi:"
 msgid "Set Track Visuals"
 msgstr "Määritä raidan visualisoinnit"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineaarinen"
 
@@ -6127,7 +6411,9 @@ msgid "Duck &amount:"
 msgstr "Vähennysmäärä:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekuntia"
 
@@ -6151,7 +6437,8 @@ msgstr "&Sisemmän häivytyksen pituus:"
 msgid "Inner &fade up length:"
 msgstr "Sisemmän n&oston pituus:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Kynnysarvo:"
 
@@ -6289,11 +6576,13 @@ msgstr "uusi (Hz)"
 msgid "t&o"
 msgstr "-->"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Muutosprosentti:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Muutosprosentti"
 
@@ -6301,9 +6590,23 @@ msgstr "Muutosprosentti"
 msgid "&Use high quality stretching (slow)"
 msgstr "Käytä korkealaat&uista venytystä (hidas)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr "33⅓"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr "45"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr "78"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "--"
 
@@ -6331,6 +6634,7 @@ msgstr "Vinyylinopeus:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Nopeudesta"
@@ -6343,6 +6647,7 @@ msgstr "&vanha"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Nopeuteen"
@@ -6485,6 +6790,12 @@ msgstr "Kompressori"
 msgid "Compresses the dynamic range of audio"
 msgstr "Kompressoi äänen dynaamista aluetta"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6494,6 +6805,20 @@ msgstr "%.2f sek"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f sek"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr "%.1f:1"
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6610,7 +6935,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Kontrastianalysaattori RMS-äänenvoimakkuuden erojen mittaamiseksi kahden äänivalinnan välillä."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Loppu"
 
@@ -6670,6 +6996,18 @@ msgstr "&Erotus:"
 msgid "&Help"
 msgstr "&Ohje"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr "RMS = %s."
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr "%s dB"
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nolla"
@@ -6677,6 +7015,13 @@ msgstr "nolla"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "määrittelemätön"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB RMS"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6730,6 +7075,12 @@ msgstr "Nykyinen erotus"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Mitattu edustataso"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -7083,7 +7434,9 @@ msgstr "DTMF-&sarja:"
 msgid "&Amplitude (0-1):"
 msgstr "&Amplitudi (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Kesto:"
 
@@ -7096,12 +7449,29 @@ msgid "Duty cycle:"
 msgstr "Pulssisuhde:"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr "%.1f %%"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Äänen kesto:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Hiljaisuuden kesto:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr "%0.f ms"
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7111,7 +7481,8 @@ msgstr "Kaiku"
 msgid "Repeats the selected audio again and again"
 msgstr "Toistaa valittua ääntä uudestaan ja uudestaan"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Pyydetty arvo ylittää muistikapasiteetin."
 
@@ -7135,7 +7506,8 @@ msgstr "Esiasetukset"
 msgid "Export Effect Parameters"
 msgstr "Vie tehosteen parametrit"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Ei voitu avata tiedostoa: \"%s\""
@@ -7172,6 +7544,14 @@ msgstr "Valmistellaan esikatselua"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Esikatsellaan"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7504,6 +7884,10 @@ msgid "Low rolloff for speech"
 msgstr "Alhainen jyrkkyys puheelle"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr "RIAA"
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Puhelin"
 
@@ -7529,9 +7913,7 @@ msgstr "Käyrätaajuuskorjain tarvitsee eri nimen"
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
-msgstr ""
-"Taajuuskorjaus vaatii, että kaikilla valituilla raidoilla on sama "
-"näytteenottotaajuus."
+msgstr "Taajuuskorjaus vaatii, että kaikilla valituilla raidoilla on sama näytteenottotaajuus."
 
 #: src/effects/Equalization.cpp
 msgid "Track sample rate is too low for this effect."
@@ -7542,12 +7924,41 @@ msgid "Effect Unavailable"
 msgstr "Tehoste ei ole käytettävissä"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr "+ dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Maksimi-dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr "%d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Minimi-dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr "– dB"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr "%g kHz"
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr "%g k"
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7622,8 +8033,16 @@ msgid "D&efault"
 msgstr "Ol&etus"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr "&SSE"
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE, &säikeistetty"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr "AV&X"
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7868,7 +8287,8 @@ msgid "Builtin Effects"
 msgstr "Sisäänrakennetut tehosteet"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Huolehtii Audacityn sisäänrakennetuista tehosteista"
 
 #: src/effects/LoadEffects.cpp
@@ -7878,6 +8298,10 @@ msgstr "Tuntematon sisäänrakennettu tehostenimi"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "koettu äänekkyys"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr "RMS"
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7909,6 +8333,14 @@ msgstr "Normalisoi"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Äänekkyys (LUFS)"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr "LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr "RMS dB"
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7978,8 +8410,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (oletus)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr "Blackman–Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
 msgstr "Hamming, ei mitään"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr "Hamming–Hann"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Hamming, Reciprocal Hamming"
@@ -8078,8 +8518,9 @@ msgid "Step 1"
 msgstr "Vaihe 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Valitse muutama sekunti pelkkää kohinaa, jotta Audacity tietää, mitä pitää\n"
@@ -8131,13 +8572,62 @@ msgstr "&Ikkunatyypit:"
 msgid "Window si&ze:"
 msgstr "Ikkunan &koko:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr "16"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr "32"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr "64"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr "128"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr "256"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr "512"
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr "1024"
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (oletus)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr "4096"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr "8192"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr "16 384"
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Askeleita ikkunassa:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8253,12 +8743,17 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&ormalisoi stereokanavat itsenäisesti"
 
 #: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr "Paulstretch"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch on vain äärimmäiselle aikavenytykselle tai pysäytystehosteelle"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Venytyskerroin:"
@@ -8540,6 +9035,21 @@ msgstr "Kääntää valitun äänen toisinpäin"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS-ajan/sävelkorkeuden venytys"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr "Butterworth"
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr "Tšebyšov, tyyppi I"
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr "Tšebyšov, tyyppi II"
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Alipäästö"
@@ -8685,6 +9195,11 @@ msgstr "Käytä oletuksia"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Palauta oletukset"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr "%.3f"
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8844,6 +9359,10 @@ msgstr "Tunnista hiljaisuus"
 msgid "Tr&uncate to:"
 msgstr "Ly&hennä:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr "%"
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "&Pakkaa:"
@@ -8857,7 +9376,8 @@ msgid "VST Effects"
 msgstr "VST-tehosteet"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Mahdollistaa VST-tehosteiden käytön Audacityssä."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8869,7 +9389,8 @@ msgstr "Haetaan Shell VST:iä"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Rekisteröidään %d / %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Kirjaston lataaminen ei onnistunut"
 
@@ -8889,7 +9410,8 @@ msgstr "Puskurin koko määrittää kuhunkin iterointiin lähetettyjen näytteid
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Puskurin koko (8 -> 1048576 näytettä):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Viiveenkorjaus"
 
@@ -8897,7 +9419,8 @@ msgstr "Viiveenkorjaus"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Joidenkin VST-tehosteiden pitää käsittelyn takia viivästää äänen palauttamista Audacityyn. Jos tätä viivettä ei korjaa, äänen väliin voi tulla lyhyitä hiljaisia kohtia. Tämän vaihtoehdon käyttäminen pyrkii korjaamaan viiveet, mutta se ei välttämättä toimi kaikille VST-tehosteille."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Käytä &korjausta"
 
@@ -8931,7 +9454,8 @@ msgid "Standard VST program file"
 msgstr "Tavallinen VST-ohjelmatiedosto"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacityn VST-esiasetustiedosto"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8958,7 +9482,8 @@ msgstr "VST-esiasetuksen latausvirhe"
 msgid "Unable to load presets file."
 msgstr "Esiasetustiedostoa ei voida ladata."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Tehosteasetukset"
 
@@ -8974,6 +9499,12 @@ msgstr "Esiasetustiedostoa ei voida lukea."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Tämä parametritiedosto tallennettiin kohteesta %s. Jatketaanko?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr "VST"
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -9009,7 +9540,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio Units -tehosteet"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Huolehtii Audacityn Audio Units -tehostetuesta"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9025,7 +9557,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio Units -tehostevalinnat"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Joidenkin Audio Units -tehosteiden pitää käsittelyn takia viivästää äänen palauttamista Audacityyn. Jos tätä viivettä ei korjaa, äänen väliin voi tulla lyhyitä hiljaisia kohtia. Tämän vaihtoehdon käyttäminen pyrkii korjaamaan viiveet, mutta se ei välttämättä toimi kaikille Audio Units -tehosteille."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9169,6 +9702,7 @@ msgstr "Audio Units"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA-tehosteet"
@@ -9178,7 +9712,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Huolehtii LADSPA-tehosteista"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity ei käytä enää vst-bridgeä"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9186,12 +9721,29 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA-tehostevalinnat"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Joidenkin LADSPA-tehosteiden pitää käsittelyn takia viivästää äänen palauttamista Audacityyn. Jos tätä viivettä ei korjaa, äänen väliin voi tulla lyhyitä hiljaisia kohtia. Tämän vaihtoehdon käyttäminen pyrkii korjaamaan viiveet, mutta se ei välttämättä toimi kaikille LADSPA-tehosteille."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr "%s:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Tehostelähtö"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9203,7 +9755,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Puskurin koko (8 – %d) näytettä):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Joidenkin LV2-tehosteiden pitää käsittelyn takia viivästää äänen palauttamista Audacityyn. Jos tätä viivettä ei korjaa, äänen väliin voi tulla lyhyitä hiljaisia kohtia. Tämän vaihtoehdon käyttäminen pyrkii korjaamaan viiveet, mutta se ei välttämättä toimi kaikille LV2-tehosteille."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9228,12 +9781,19 @@ msgstr "%s edellyttää asetusta %s, jota ei tueta\n"
 msgid "Generator"
 msgstr "Generaattori"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-tehosteet"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Huolehtii Audacityn LV2-tehostetuesta"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9241,7 +9801,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist-tehosteet"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Huolehtii Audacityn Nyquist-tehostetuesta"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9469,7 +10030,8 @@ msgstr "Valitse tiedosto"
 msgid "Save file as"
 msgstr "Tallenna tiedosto nimellä"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "nimetön"
 
@@ -9478,7 +10040,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-tehosteet"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Huolehtii Audacityn Vamp-tehostetuesta"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9500,6 +10063,12 @@ msgstr "Laajennusasetukset"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Sovellus"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9541,8 +10110,7 @@ msgid ""
 msgstr ""
 "Olet viemässä tiedostoa %s nimellä \"%s\".\n"
 "\n"
-"Normaalisti nämä tiedostot käyttävät päätettä \".%s\" Jotkin ohjelmat eivät "
-"avaa tiedostoja, jos niillä on väärä tiedostopääte.\n"
+"Normaalisti nämä tiedostot käyttävät päätettä \".%s\" Jotkin ohjelmat eivät avaa tiedostoja, jos niillä on väärä tiedostopääte.\n"
 "\n"
 "Haluatko varmasti viedä tiedoston tällä nimellä?"
 
@@ -9657,6 +10225,10 @@ msgstr "Viedään ääntä komentorivienkooderilla"
 #: src/export/ExportCL.cpp
 msgid "Command Output"
 msgstr "Komennon tuloste"
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr "&OK"
 
 #: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
@@ -9797,7 +10369,8 @@ msgstr "Viedään ääni muodossa %s"
 msgid "Invalid sample rate"
 msgstr "Virheellinen näytteenottotaajuus"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Muuta näytteenottotaajuutta"
 
@@ -9816,8 +10389,7 @@ msgid ""
 "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the current output file format. "
 msgstr ""
-"Projektin näytteenottotaajuuden (%d) ja bittinopeuden (%d kbit/s) "
-"yhdistelmää\n"
+"Projektin näytteenottotaajuuden (%d) ja bittinopeuden (%d kbit/s) yhdistelmää\n"
 "ei nykyisessä kohdetiedostomuodossa tueta. "
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
@@ -9828,6 +10400,14 @@ msgstr "Voit ottaa näytteen johonkin alla olevista."
 msgid "Sample Rates"
 msgstr "Näytteenottotaajuudet"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr "%d kbit/s"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Bittinopeus:"
@@ -9835,6 +10415,48 @@ msgstr "Bittinopeus:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Laatu (kbit/s):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr "%.2f kbit/s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr "0"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr "3"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr "5"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr "6"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr "9"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr "10"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9845,12 +10467,40 @@ msgid "Constrained"
 msgstr "Rajoitettu"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr "VOIP"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Ääni"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Pieni viive"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr "5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr "10 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr "20 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr "40 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr "60 ms"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9937,8 +10587,16 @@ msgid "Replace preset '%s'?"
 msgstr "Korvaa esiasetus '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Pää"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr "LTP"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10046,6 +10704,10 @@ msgstr "Kieli:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bittisäilö"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr "VBL"
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10181,6 +10843,10 @@ msgstr ""
 "max - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr "LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -10211,6 +10877,10 @@ msgstr ""
 "max - 32 (LPC) tai 4 (ilman LPC)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr "Min. PDO"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal prediction order\n"
 "Optional\n"
@@ -10223,6 +10893,10 @@ msgstr ""
 "-1 - oletus\n"
 "min - 0\n"
 "max - 32 (LPC) tai 4 (ilman LPC)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr "Maks. PDO"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10239,6 +10913,10 @@ msgstr ""
 "maksimi - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr "Min. PtO"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal partition order\n"
 "Optional\n"
@@ -10251,6 +10929,10 @@ msgstr ""
 "-1 - oletus\n"
 "min - 0\n"
 "max - 8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr "Maks. PtO"
 
 #. i18n-hint:  Abbreviates "Linear Predictive Coding",
 #. but this text needs to be kept very short
@@ -10398,8 +11080,7 @@ msgstr "MP2-tiedostot"
 
 #: src/export/ExportMP2.cpp
 msgid "Cannot export MP2 with this sample rate and bit rate"
-msgstr ""
-"MP2-tiedostoa ei voi viedä tällä näytteenottotaajuudella ja bittinopeudella"
+msgstr "MP2-tiedostoa ei voi viedä tällä näytteenottotaajuudella ja bittinopeudella"
 
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
@@ -10418,6 +11099,38 @@ msgstr "Viedään ääntä nopeudella %ld kbps"
 #: src/export/ExportMP3.cpp
 msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (paras laatu)"
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr "200–250 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr "170–210 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr "155–195 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr "145–185 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr "110–150 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr "95–135 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr "80–120 kbit/s"
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr "65–105 kbit/s"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -10449,7 +11162,8 @@ msgstr "Maksimi"
 msgid "Extreme"
 msgstr "Äärimmäinen"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Vakio"
 
@@ -10474,6 +11188,10 @@ msgid "Joint Stereo"
 msgstr "Yhdistetty stereo"
 
 #: src/export/ExportMP3.cpp
+msgid "Stereo"
+msgstr "Stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Bittinopeustila:"
 
@@ -10496,8 +11214,8 @@ msgid "Locate LAME"
 msgstr "Etsi LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity tarvitsee %s -tiedostoa MP3:n luomiseen."
 
 #: src/export/ExportMP3.cpp
@@ -10525,10 +11243,10 @@ msgid "Where is %s?"
 msgstr "Missä on %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Olet linkittämässä kohteeseen lame_enc.dll v%d.%d. Tämä versio ei ole yhteensopiva Audacityn %d.%d.%d kanssa.\n"
 "Lataa uusin versio \"LAME for Audacity\"."
@@ -10833,6 +11551,14 @@ msgstr "Viedään äänivalintaa Ogg Vorbis -muodossa"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Viedään ääntä Ogg Vorbis -muodossa"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr "AIFF (Apple/SGI)"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft)"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Otsikko:"
@@ -10846,9 +11572,10 @@ msgid "Other uncompressed files"
 msgstr "Muut pakkaamattomat tiedostot"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Yritit viedä WAV- tai AIFF-tiedoston, joka olisi suurempi kuin 4 Gt.\n"
 "Audacity ei pysty tähän, joten vienti hylättiin."
@@ -10858,8 +11585,9 @@ msgid "Error Exporting"
 msgstr "Virhe vietäessä"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Viety WAV-tiedosto on katkaistu, koska Audacity ei voi viedä\n"
@@ -10899,11 +11627,11 @@ msgid "All supported files"
 msgstr "Kaikki tuetut tiedostot"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10912,11 +11640,11 @@ msgstr ""
 "muokata sitä valitsemalla Tiedosto > Tuo > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "ei ole äänitiedosto. \n"
@@ -10927,18 +11655,18 @@ msgid "Select stream(s) to import"
 msgstr "Valitse tuotavat virrat"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Tähän Audacityn versioon ei ole käännetty tukea muodolle %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on ääni-CD-raita. \n"
 "Audacity ei voi avata CD:tä suoraan. \n"
@@ -10947,10 +11675,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" on soittolistatiedosto. \n"
@@ -10959,10 +11687,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on Windows Media Audio -tiedosto. \n"
@@ -10971,10 +11699,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on Advanced Audio Coding t-iedosto. \n"
@@ -10983,12 +11711,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" on salattu äänitiedosto. \n"
@@ -10999,10 +11727,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on RealPlayer-mediatiedosto. \n"
@@ -11011,12 +11739,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" on nuottipohjainen tiedosto, ei äänitiedosto. \n"
 "Audacity ei voi avata tällaista tiedostoa. \n"
@@ -11025,10 +11753,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11041,10 +11769,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on Wavpack-äänitiedosto. \n"
@@ -11053,10 +11781,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on Dolby Digital -äänitiedosto. \n"
@@ -11065,10 +11793,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on Ogg Speex -äänitiedosto. \n"
@@ -11077,10 +11805,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" on videotiedosto. \n"
@@ -11094,9 +11822,9 @@ msgstr "Tiedostoa %s ei löydy."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11112,11 +11840,16 @@ msgstr ""
 "Kokeile asentaa FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr "%s, %s"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11146,12 +11879,13 @@ msgid "Import Project"
 msgstr "Tuo projekti"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Projekti tallennettiin Audacityn versiolla 1.0 tai vanhemmalla.\n"
 "Koska tiedostomuoto on muuttunut, tämä versio ei voi tuoda sitä.\n"
@@ -11202,7 +11936,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Projektin datakansiota \"%s\" ei löytynyt"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Projektitiedostossa on MIDI-raitoja, mutta tämä koontiversio Audacitysta ei tue niitä, joten ne ohitetaan."
 
 #: src/import/ImportAUP.cpp
@@ -11307,40 +12042,6 @@ msgstr "Indeksi[%02x] Koodekki[%s], Kieli[%s], Bittinopeus[%s], Kanavat[%d], Kes
 msgid "FLAC files"
 msgstr "FLAC-tiedostot"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-yhteensopivat tiedostot"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Dekooderia ei voi lisätä putkeen"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer-tuonti"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Virran tilaa ei voi asettaa tauotetuksi."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indeksi[%02d], Tyyppi[%s], Kanavat[%d], Nopeus[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Tiedosto ei sisällä äänivirtoja."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Tiedoston tuonti epäonnistui, tilanmuutos epäonnistui."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer-virhe: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Lista tiedostoista perustekstimuodossa"
@@ -11442,18 +12143,98 @@ msgstr "Sisäinen logiikkavirhe"
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, ja muut pakkaamattomat tyypit"
 
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr "AU (Sun/NeXT)"
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr "AVR (Audio Visual Research)"
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr "CAF (Apple Core Audio File)"
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/import/ImportPCM.cpp
 msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (FLAC, häviötön äänikoodekki)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr "HTK (HMM Tool Kit)"
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr "IFF (Amiga IFF/SVX8/SV16)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr "MPC (Akai MPC 2k)"
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG-säiliömuoto)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr "PAF (Ensoniq PARIS)"
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr "PVF (Portable Voice Format)"
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (otsikoton)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr "RF64 (RIFF 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr "SD2 (Sound Designer II)"
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr "SDS (MIDI-näytevedosstandardi)"
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr "SF (Berkeley/IRCAM/CARL)"
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr "VOC (Creative Labs)"
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr "W64 (SoundFoundry WAVE 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr "WAV (NIST Sphere)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr "WAVEX (Microsoft)"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr "WVE (Psion Series 3)"
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr "XI (FastTracker 2)"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11484,6 +12265,34 @@ msgid "64 bit float"
 msgstr "64-bittinen liukuluku"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr "U-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr "A-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr "IMA ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr "Microsoft ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr "GSM 6.10"
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr "32 kbit/s G721 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr "24 kbit/s G723 ADPCM"
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12-bittinen DWVW"
 
@@ -11496,12 +12305,20 @@ msgid "24 bit DWVW"
 msgstr "24-bittinen DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr "VOX ADPCM"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bittinen DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8-bittinen DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr "Vorbis"
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11636,6 +12453,7 @@ msgstr "%s oikea"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11659,6 +12477,7 @@ msgstr "loppu"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11685,7 +12504,8 @@ msgstr "Leikkeet siirretty ajassa oikealle"
 msgid "Time shifted clips to the left"
 msgstr "Leikkeet siirretty ajassa vasemmalle"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Aikasiirros"
 
@@ -11823,7 +12643,8 @@ msgstr "Rajattiin valitut ääniraidat %.2f sekunnista %.2f sekunniksi"
 msgid "Trim Audio"
 msgstr "Rajaa ääni"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Halkaisu"
 
@@ -11948,34 +12769,6 @@ msgid "Ext&ra"
 msgstr "E&kstrat"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mi&kseri"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Sää&dä toiston voimakkuutta..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Nosta toiston äänenvoimakkuutta"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Laske toiston äänenvoimakkuutta"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Sää&dä äänitysvoimakkuutta..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Nosta ää&nitysvoimakkuutta"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "L&aske äänitysvoimakkuutta"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "Lai&tteet"
 
@@ -12011,6 +12804,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Vie valittu ääni"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Merkin teksti"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -12144,6 +12943,10 @@ msgid "&Labels..."
 msgstr "&Merkkejä..."
 
 #: src/menus/FileMenus.cpp
+msgid "&MIDI..."
+msgstr "MI&DI…"
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Raakadata..."
 
@@ -12232,8 +13035,9 @@ msgid "&Getting Started"
 msgstr "&Aloitusopas"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacityn &käyttöohje"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Käyttöohje..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12259,11 +13063,8 @@ msgstr "&MIDI-laitteen tiedot..."
 msgid "Show &Log..."
 msgstr "Näytä &loki..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Tietoja Audacitystä..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Lisättiin merkki"
 
@@ -12511,6 +13312,10 @@ msgstr "Vaihda raidan koh&distuksen tilaa (on/ei)"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Luokittelematon"
+
+#: src/menus/PluginMenus.cpp
+msgid "..."
+msgstr "…"
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12949,6 +13754,7 @@ msgstr "Kohdistimen pitkä h&yppy oikealle"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Kelaa"
@@ -13160,18 +13966,21 @@ msgid "Created new label track"
 msgstr "Luotiin uusi merkkiraita"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Tämä Audacityn versio sallii vain yhden aikaraidan kussakin projekti-ikkunassa."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Luotiin uusi aikaraita"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Uusi näytteenottotaajuus (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Annettu arvo on virheellinen"
 
@@ -13428,7 +14237,9 @@ msgstr "Toistetaan"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Äänitetään"
 
@@ -13577,10 +14388,6 @@ msgstr "&Jälkiäänitys/dubbaus (päällä/pois)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Toisto ohjelman läpi (päällä/pois)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Automatisoitu äänitystason säätö (päällä/pois)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13795,7 +14602,8 @@ msgid "Preferences for Application"
 msgstr "Laatuasetukset"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Päivitä Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13841,7 +14649,8 @@ msgstr "&Rajapinta:"
 msgid "Using:"
 msgstr "Käyttää:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Toisto"
 
@@ -13861,7 +14670,8 @@ msgstr "Ka&navat:"
 msgid "Latency"
 msgstr "Viive"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "millisekuntia"
 
@@ -13890,7 +14700,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Hakemistot"
 
@@ -13998,7 +14809,8 @@ msgid "Directory %s is not writable"
 msgstr "Hakemisto %s ei ole kirjoitettava"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Väliaikaiskansion muutos tulee voimaan vasta, kun Audacity käynnistetään uudelleen"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14029,6 +14841,39 @@ msgstr "Ryhmittely julkaisijan mukaan"
 msgid "Grouped by Type"
 msgstr "Ryhmittely tyypin mukaan"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr "LA&DSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr "LV&2"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr "Ny&quist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr "&Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr "V&ST"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Salli tehosteet"
@@ -14050,11 +14895,13 @@ msgid "Plugin Options"
 msgstr "Laajennusvalinnat"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Tarkista päivitetyt liitännäiset Audacityn käynnistyessä"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Tarkista laajennukset uudelleen kun Audacity käynnistetään seuraavan kerran"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14234,7 +15081,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Pidä merkki vaikka valinta tarraisi siihen"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Sulauta järjestelmän ja Audacityn teemaa"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14412,7 +15260,8 @@ msgstr ""
 "   *   \"%s\"  (koska pikanäppäin '%s' on annettu toiminnolle \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Valitse Audacityn pikanäppäimet sisältävä XML-tiedosto..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14545,8 +15394,9 @@ msgid "Dow&nload"
 msgstr "Lataa"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity on tunnistanut automaattisesti kelvolliset FFmpeg-kirjastot.\n"
@@ -14591,6 +15441,10 @@ msgstr "MIDI-syntetisaattori&viive (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "MIDI-syntetisaattorin viive tulee olla kokonaisluku"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr "MIDI I/O"
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -14601,8 +15455,9 @@ msgid "Preferences for Module"
 msgstr "Moduulin asetukset"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Nämä ovat kokeellisia moduuleja. Ota ne käyttöön vain, jos olet lukenut Audacity-käyttöohjeet\n"
@@ -14610,12 +15465,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'Kysy' tarkoittaa: Audacity kysyy, haluatko ladata moduulin joka kerta ohjelman käynnistyessä."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'Virhe' tarkoittaa: Audacity arvelee moduulin olevan rikki eikä käytä sitä."
 
 #. i18n-hint preserve the leading spaces
@@ -14624,7 +15481,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Uusi' tarkoittaa: Valintaa ei ole vielä tehty."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Muutos tulee voimaan vasta, kun Audacity käynnistetään uudelleen."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14642,6 +15500,10 @@ msgstr "Moduuleita ei löytynyt"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Moduuli"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr "Ctrl"
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14683,7 +15545,10 @@ msgstr "Vasen raahaus"
 msgid "Set Selection Range"
 msgstr "Aseta valinta-alue"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Vaihto + vasen napsautus"
 
@@ -14770,6 +15635,15 @@ msgstr "-vasen raahaus"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Siirrä leikettä ylös/alas raitojen välillä"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-vasen raahaus"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14894,7 +15768,8 @@ msgid "Always scrub un&pinned"
 msgstr "&Hankaus jättää toistopään kiinnityksen huomiotta"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacityn asetukset"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14908,6 +15783,11 @@ msgstr "Asetukset:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Laatuasetukset"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr "%i Hz"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -15027,39 +15907,6 @@ msgid "System T&ime"
 msgstr "Järjestelmän a&ika"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automaattinen äänitystason säätö"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Käytä automaattista äänitystason säätöä."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Kohdehuippu:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Aikana:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Analysointiaika:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "millisekuntia (yhden analyysin aika)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Peräkkäisten analyysien määrä:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 tarkoittaa rajatonta"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Korjaaminen lennossa"
 
@@ -15070,6 +15917,21 @@ msgstr "Esike&laus:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Risti&häivytys:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr "Mel"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr "Bark"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr "ERB"
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15204,6 +16066,10 @@ msgid "1024 - default"
 msgstr "1024 - oletus"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr "2048"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - kapein kaista"
 
@@ -15301,13 +16167,14 @@ msgid "Info"
 msgstr "Tiedot"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15490,7 +16357,8 @@ msgstr "Näytteet"
 msgid "4 Pixels per Sample"
 msgstr "4 pikseliä näytettä kohden"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Enimmäissuurennus"
 
@@ -15612,16 +16480,24 @@ msgid "Stopped"
 msgstr "Pysäytetty"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Tauko"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Hyppää alkuun"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Hyppää loppuun"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Tauko"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Valitse alkuun"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Valitse loppuun"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15635,20 +16511,17 @@ msgstr "Äänitä uusi raita"
 msgid "Append Record"
 msgstr "Äänitä loppuun"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Valitse loppuun"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Valitse alkuun"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s keskeytetty."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr "%s."
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15728,11 +16601,17 @@ msgstr "Hiljennä valittu ääni"
 msgid "Sync-Lock Tracks"
 msgstr "Synkrolukitse raitoja"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Lähennä"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Loitonna"
 
@@ -15799,43 +16678,6 @@ msgstr "Äänityksen &mittaripalkki"
 msgid "&Playback Meter Toolbar"
 msgstr "&Toiston mittaripalkki"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Äänitysvoimakkuus"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Toistovoimakkuus"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Äänitysvoimakkuus: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Äänitysvoimakkuus (ei käytössä; käytä järjestelmän mikseriä.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Toistovoimakkuus: %.2f (emuloitu)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Toistovoimakkuus: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Toistovoimakkuus (ei käytössä, käytä järjestelmän mikseriä.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Mikserityökalut"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Kelaus"
@@ -15851,6 +16693,7 @@ msgstr "Hankaus"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Lopeta hankaus"
@@ -15858,6 +16701,7 @@ msgstr "Lopeta hankaus"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Aloita hankaus"
@@ -15865,6 +16709,7 @@ msgstr "Aloita hankaus"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Lopeta kelaus"
@@ -15872,6 +16717,7 @@ msgstr "Lopeta kelaus"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Aloita kelaus"
@@ -15926,7 +16772,9 @@ msgstr "Tarraa"
 msgid "Length"
 msgstr "Pituus"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Keskellä"
 
@@ -15990,8 +16838,8 @@ msgstr "Aika&työkalupalkki"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacityn %s-palkki"
 
 #: src/toolbars/ToolBar.cpp
@@ -16018,7 +16866,8 @@ msgstr "Aikasiirtotyökalu"
 msgid "Zoom Tool"
 msgstr "Suurennustyökalu"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Piirtotyökalu"
 
@@ -16094,11 +16943,13 @@ msgstr "Raahaa yhtä tai useampaa merkin rajaa."
 msgid "Drag label boundary."
 msgstr "Raahaa merkin rajaa."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Muokattu merkki"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Merkin muokkaus"
 
@@ -16153,31 +17004,42 @@ msgstr "Muokattiin merkkejä"
 msgid "New label"
 msgstr "Uusi otsikko"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Oktaavi &ylös"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Oktaa&vi alas"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Napsautus lähentää pystysuunnassa. Vaihto + napsautus loitontaa. Raahaaminen määrittää suurennusalueen."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Oikeanapsautus avaa valikon."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Nollaa suurennus"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Vaihto + oikea napsautus"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Vasen napsautus tai raahaus"
 
@@ -16219,7 +17081,8 @@ msgstr "Yhdistä"
 msgid "Expanded Cut Line"
 msgstr "Laajennettiin leikeviiva"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Laajenna"
 
@@ -16242,6 +17105,11 @@ msgstr "Siirrettiin näytteitä"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Näytteen muokkaus"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr "k"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16287,7 +17155,8 @@ msgstr "Käsitellään...  %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Muutettu '%s' -> %s"
@@ -16299,6 +17168,54 @@ msgstr "Muuta muotoa"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Taajuus"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr "8000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr "11 025 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr "16 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr "22 050 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr "44 100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr "48 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr "88 200 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr "96 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr "176 400 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr "192 000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr "352 800 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr "384 000 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16318,7 +17235,8 @@ msgstr "Näytteenottotaajuuden muutos"
 msgid "Set Rate"
 msgstr "Aseta näytteenottotaajuus"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Moninäkymä"
 
@@ -16337,6 +17255,10 @@ msgstr "Erota stereora&ita"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Erota stereo mo&noksi"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16388,6 +17310,16 @@ msgstr "Erota monoksi"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
+msgid "Stereo, %dHz"
+msgstr "Stereo, %d Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Mono, %dHz"
+msgstr "Mono, %d Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
 msgid "Left, %dHz"
 msgstr "Vasen, %dHz"
 
@@ -16396,14 +17328,23 @@ msgstr "Vasen, %dHz"
 msgid "Right, %dHz"
 msgstr "Oikea, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr "%+.1f dB"
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% vasen"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% oikea"
@@ -16521,8 +17462,8 @@ msgstr "Logaritminen &interpolointi"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Napsautus ja raahaus siirtää raitaa aikajanalla"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16573,6 +17514,7 @@ msgstr "Muokattu verhokäyrä."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Hankaa"
@@ -16584,6 +17526,7 @@ msgstr "Kelaus"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Hankaus&viivain"
@@ -16779,6 +17722,12 @@ msgstr "V"
 msgid "R"
 msgstr "O"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr "%.2f×"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16812,9 +17761,19 @@ msgstr "Tyhjä"
 msgid "Backwards"
 msgstr "Taaksepäin"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr "<"
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Eteenpäin"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ">"
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16949,6 +17908,15 @@ msgstr "01000,01000 sekuntia"
 msgid "hh:mm:ss"
 msgstr "tt:mm:ss"
 
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr "0100 t 060 min 060 s"
+
 #. i18n-hint: Name of time display format that shows time in days, hours,
 #. * minutes and seconds
 #: src/widgets/NumericTextCtrl.cpp
@@ -16970,11 +17938,33 @@ msgstr "0100 päivää 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "tt:mm:ss + sadannekset"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 t 060 min 060>0100 s"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "tt:mm:ss + millisekunnit"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 t 060 min 060>01000 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16996,6 +17986,7 @@ msgstr "0100 h 060 m 060 s+># näytettä"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "näytteet"
@@ -17149,9 +18140,30 @@ msgstr "CDDA-sektorit (75/sek)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 sektoria|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr "010,01000<0100 Hz"
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centihertz"
 msgstr "senttihertsi"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr "kHz"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr "01000<01000 kHz|0,001"
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hertz"
@@ -17221,6 +18233,11 @@ msgstr "(Käytä pikavalikkoa tiedon muodon muuttamiseen.)"
 msgid "centiseconds"
 msgstr "senttisekuntia"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Kulunut aika:"
@@ -17263,6 +18280,11 @@ msgstr "Vahvista sulkeminen"
 msgid "Unable to write files to directory: %s."
 msgstr "Projektitiedoston alustaminen ei onnistu"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr "Varmista, että kansio on olemassa, sen käyttöoikeudet ovat oikein eikä levy ole täynnä."
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17277,6 +18299,10 @@ msgstr "Hakemistojen asetukset"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Älä näytä tätä varoitusta uudelleen"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr "NaN"
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17360,15 +18386,27 @@ msgstr "XML:ää ei voitu jäsentää"
 msgid "Spectral edit multi tool"
 msgstr "Spektrimuokkauksen monitoimityökalu"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Suodatus..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr "Paul Licameli"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Julkaistu GNU General Public License -version 2 ehtojen mukaisesti"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aValitse taajuudet."
@@ -17395,7 +18433,8 @@ msgstr ""
 "                      Yritä kasvattaa taajuuden alarajaa~%~\n"
 "                      tai laskea suodattimen \"leveyttä\"."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Virhe.~%"
@@ -17456,6 +18495,24 @@ msgstr "Studiohäivytys (ulos)"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Häivytetään..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr "Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Julkaistu GNU General Public License -version 2 tai uudemman ehtojen mukaisesti."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17599,6 +18656,10 @@ msgstr "Tahtihaku"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Etsitään tahteja..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17923,13 +18984,38 @@ msgstr "Ylipäästösuodatin"
 msgid "Performing High-Pass Filter..."
 msgstr "Suoritetaan ylipäästösuodatinta..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr "Dominic Mazzoni"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Taajuus (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Jyrkkyys (dB/oktaavi)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr "6 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr "12 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr "24 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr "36 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr "48 dB"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17950,10 +19036,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Merkitse äänet"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Julkaistu GNU General Public License -version 2 tai uudemman ehtojen mukaisesti."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18014,6 +19096,12 @@ msgstr "Loppuhiljaisuuden enimmäispituus"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Ääni ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr "~a t ~a min ~a s"
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -18193,6 +19281,12 @@ msgstr ""
 "Huippu perustuu ensimmäisiin ~a sekuntiin ~a dB~%\n"
 "Ehdotettu kynnysasetus ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr "~a t ~a min"
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Kaistanestosuodatin"
@@ -18241,7 +19335,8 @@ msgstr "Lisp-tiedosto"
 msgid "HTML file"
 msgstr "HTML-tiedosto"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Tekstitiedosto"
 
@@ -18318,6 +19413,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI-arvot C-nuoteille: 36, 48, 60 [keski C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr "David R. Sky"
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "MIDI-sävelkorkeus"
 
@@ -18346,6 +19445,10 @@ msgid "Generating Rhythm..."
 msgstr "Luodaan rytmiä..."
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr "Tempo (BPM)"
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 iskua/minuutti"
 
@@ -18360,6 +19463,10 @@ msgstr "1 - 20 iskua/mittaus"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Heilumismäärä"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr "+/– 1"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18430,6 +19537,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI-sävelkorkeus (vahva isku)"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr "18–116"
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI-sävelkorkeus (heikko isku)"
 
@@ -18448,6 +19559,10 @@ msgstr "Risset'n rumpu"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Luodaan Risset'n rumpua..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr "Steven Jones"
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18701,8 +19816,7 @@ msgid ""
 "<a href=\"~a\">Audacity</a> by Steve\n"
 "Daulton"
 msgstr ""
-"Tuotettu <span>Sample Data Export</span> -ohjelmalla seuraaviin "
-"tarkoituksiin\n"
+"Tuotettu <span>Sample Data Export</span> -ohjelmalla seuraaviin tarkoituksiin\n"
 "<a href=\"~a\">Tenacity</a> by Steve\n"
 "Daulton"
 
@@ -18824,6 +19938,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Virhe.~%Raidan näytteenottotaajuutta alle 100 Hz ei tueta."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr "Tremolo"
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Käytetään tremoloa..."
 
@@ -18850,6 +19968,10 @@ msgstr "Laulun vähentäminen ja eristäminen"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Käytetään toimintoa..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr "Robert Haenggi"
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -19000,6 +20122,10 @@ msgid "Processing Vocoder..."
 msgstr "Käsitellään vokooderia..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr "Edgar-RFT"
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "Etäisyys: (1-120, oletus = 20)"
 
@@ -19039,6 +20165,229 @@ msgstr "Ryöppytaajuus (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Virhe.~%Stereoraita vaaditaan."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Päivitä Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Ohita"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Asenna päivitys"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Muokkausloki"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Lue lisää GitHubissa"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Päivitysten tarkistus epäonnistui"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Ei voitu yhdistää Tenacity-päivityspalvelimeen."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Päivitystieto on virheellistä."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Päivityksen lataus epäonnistui."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Tenacityn latauslinkkiä ei voitu avata."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s on saatavilla!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Tietue"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Koontitunnus:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Alustariippumaton käyttöliittymäkirjasto"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Tuo GStreamerin avulla"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automaattinen äänitystason säätö on pysähtynyt. Enempi optimointi ei ollut mahdollista. On yhä liian suuri."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automaattinen äänitystason säätö laski voimakkuuden arvoon %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automaattinen äänitystason säätö on pysähtynyt. Sitä ei ollut mahdollista optimoida enempää, on edelleen liian matala."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automaattinen äänitystason säätö nosti voimakkuuden arvoon %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automaattinen äänitystason säätö on pysähtynyt. Analyysien kokonaismäärä on ylitetty löytämättä hyväksyttävää äänenvoimakkuutta, on edelleen liian korkea."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automaattinen äänitystason säätö on pysähtynyt. Analyysien kokonaismäärä on ylitetty löytämättä hyväksyttävää äänenvoimakkuutta, on edelleen liian matala."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automaattinen äänitystason säätö on pysähtynyt. %.2f tuntuu hyväksyttävältä arvolta."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Vastaanotettiin virhe %d avattaessa laitteita\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Portmixeriä ei voi avata\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Käytettävissä olevat mikserit:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Käytettävissä olevat tallennuslähteet:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Käytettävissä olevat toistovoimakkuudet:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Äänitysvoimakkuus on emuloitu\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Äänitysvoimakkuus on alkuperäinen\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Toiston voimakkuus on emuloitu\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Toiston voimakkuus on alkuperäinen\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Tuntematon päiväys ja aika"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-yhteensopivat tiedostot"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Dekooderia ei voi lisätä putkeen"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer-tuonti"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Virran tilaa ei voi asettaa tauotetuksi."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indeksi[%02d], Tyyppi[%s], Kanavat[%d], Nopeus[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Tiedosto ei sisällä äänivirtoja."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Tiedoston tuonti epäonnistui, tilanmuutos epäonnistui."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer-virhe: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mi&kseri"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Sää&dä toiston voimakkuutta..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Nosta toiston äänenvoimakkuutta"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Laske toiston äänenvoimakkuutta"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Sää&dä äänitysvoimakkuutta..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Nosta ää&nitysvoimakkuutta"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "L&aske äänitysvoimakkuutta"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacityn &käyttöohje"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Tietoja Audacitystä..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Automatisoitu äänitystason säätö (päällä/pois)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automaattinen äänitystason säätö"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Käytä automaattista äänitystason säätöä."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Kohdehuippu:"
+
+#~ msgid "Within:"
+#~ msgstr "Aikana:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Analysointiaika:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "millisekuntia (yhden analyysin aika)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Peräkkäisten analyysien määrä:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 tarkoittaa rajatonta"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Äänitysvoimakkuus"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Toistovoimakkuus"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Äänitysvoimakkuus: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Äänitysvoimakkuus (ei käytössä; käytä järjestelmän mikseriä.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Toistovoimakkuus: %.2f (emuloitu)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Toistovoimakkuus: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Toistovoimakkuus (ei käytössä, käytä järjestelmän mikseriä.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Mikserityökalut"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Napsautus ja raahaus siirtää raitaa aikajanalla"
 
 #~ msgid "Program build date:"
 #~ msgstr "Ohjelman koontipäivä:"
@@ -20349,9 +21698,6 @@ msgstr "Virhe.~%Stereoraita vaaditaan."
 #~ msgid "Truncate"
 #~ msgstr "Lyhennä arvoon"
 
-#~ msgid "Version"
-#~ msgstr "Versio"
-
 #~ msgid "C&ategory:"
 #~ msgstr "&Luokka:"
 
@@ -21007,1156 +22353,6 @@ msgstr "Virhe.~%Stereoraita vaaditaan."
 #~ msgid "true"
 #~ msgstr "totta"
 
-#: src/Dependencies.cpp
 #, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d – %s\n"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr "MuseCY SM Ltd. tai Dominic M. Mazzoni eivät tue tai kannata Tenacityä."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Audacity%s-tuotemerkkiä käytetään tässä ohjelmistossa vain kuvailu- ja "
-"tiedotustarkoituksiin."
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr "Huomaa, että nimet on lajiteltu aakkos-, ei tärkeysjärjestykseen."
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/AudacityLogger.cpp
-msgid "log.txt"
-msgstr "log.txt"
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999–%s %s avustajat"
-
-#: src/AboutDialog.cpp
-msgid "Emeritus:"
-msgstr "Audacity-emeritus:"
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "OK"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Luscius"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Harvey Lubin (logo)"
-msgstr "Harvey Lubin (logo)"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=4.5)"
-msgstr "Gauss (a = 4,5)"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=3.5)"
-msgstr "Gauss (a = 3,5)"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=2.5)"
-msgstr "Gauss (a = 2,5)"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman–Harris"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Projekti %02i] "
-
-#: src/LyricsWindow.cpp
-msgid "&Karaoke..."
-msgstr "Ka&raoke…"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#: src/FileNames.cpp
-msgid ", "
-msgstr ", "
-
-#: plug-ins/rhythmtrack.ny
-msgid "18 - 116"
-msgstr "18–116"
-
-#: plug-ins/rhythmtrack.ny
-msgid "+/- 1"
-msgstr "+/– 1"
-
-#: plug-ins/rhythmtrack.ny
-msgid "Tempo (bpm)"
-msgstr "Tempo (BPM)"
-
-#: plug-ins/pluck.ny
-msgid "David R.Sky"
-msgstr "David R. Sky"
-
-#. i18n-hint: hours and minutes. Do not translate "~a".
-#: plug-ins/noisegate.ny
-#, lisp-format
-msgid "~ah ~am"
-msgstr "~a t ~a min"
-
-#. i18n-hint: hours minutes and seconds. Do not translate "~a".
-#: plug-ins/label-sounds.ny
-#, lisp-format
-msgid "~ah ~am ~as"
-msgstr "~a t ~a min ~a s"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "48 dB"
-msgstr "48 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "36 dB"
-msgstr "36 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "24 dB"
-msgstr "24 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "12 dB"
-msgstr "12 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "6 dB"
-msgstr "6 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
-msgid "Dominic Mazzoni"
-msgstr "Dominic Mazzoni"
-
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
-msgid "Steve Daulton"
-msgstr "Steve Daulton"
-
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
-msgid "Paul Licameli"
-msgstr "Paul Licameli"
-
-#: src/widgets/numformatter.cpp
-msgid "NaN"
-msgstr "NaN"
-
-#. i18n-hint: This message describes the error in the Error dialog.
-#: src/widgets/UnwritableLocationErrorDialog.cpp
-msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
-msgstr ""
-"Varmista, että kansio on olemassa, sen käyttöoikeudet ovat oikein eikä levy "
-"ole täynnä."
-
-#: src/widgets/PopupMenuTable.h
-#, c-format
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. i18n-hint: Format string for displaying frequency in kilohertz. Change
-#. * the decimal point for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
-#. * to '>' if your language uses a '.'.
-#: src/widgets/NumericTextCtrl.cpp
-msgid "01000>01000 kHz|0.001"
-msgstr "01000<01000 kHz|0,001"
-
-#. i18n-hint: Name of display format that shows frequency in kilohertz
-#: src/widgets/NumericTextCtrl.cpp
-msgid "kHz"
-msgstr "kHz"
-
-#. i18n-hint: Format string for displaying frequency in hertz. Change
-#. * the decimal point for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
-#. * to '>' if your language uses a '.'.
-#: src/widgets/NumericTextCtrl.cpp
-msgid "010,01000>0100 Hz"
-msgstr "010,01000<0100 Hz"
-
-#. i18n-hint: Format string for displaying time in hours, minutes, seconds
-#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
-#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
-#. * milliseconds are shown as decimal seconds) . Don't change the numbers
-#. * unless there aren't 60 minutes in an hour in your locale.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
-#. * to '>' if your language uses a '.'.
-#: src/widgets/NumericTextCtrl.cpp
-msgid "0100 h 060 m 060>01000 s"
-msgstr "0100 t 060 min 060>01000 s"
-
-#. i18n-hint: Format string for displaying time in hours, minutes, seconds
-#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
-#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
-#. * (the hundredths are shown as decimal seconds). Don't change the numbers
-#. * unless there aren't 60 minutes in an hour in your locale.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
-#. * to '>' if your language uses a '.'.
-#: src/widgets/NumericTextCtrl.cpp
-msgid "0100 h 060 m 060>0100 s"
-msgstr "0100 t 060 min 060>0100 s"
-
-#. i18n-hint: Format string for displaying time in hours, minutes and
-#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
-#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
-#. * change the numbers unless there aren't 60 seconds in a minute in your
-#. * locale
-#: src/widgets/NumericTextCtrl.cpp
-msgid "0100 h 060 m 060 s"
-msgstr "0100 t 060 min 060 s"
-
-#. i18n-hint arrowhead meaning forward movement
-#: src/widgets/HelpSystem.cpp
-msgid ">"
-msgstr ">"
-
-#. i18n-hint arrowhead meaning backward movement
-#: src/widgets/HelpSystem.cpp
-msgid "<"
-msgstr "<"
-
-#. i18n-hint: "x" suggests a multiplicative factor
-#: src/widgets/ASlider.cpp
-#, c-format
-msgid "%.2fx"
-msgstr "%.2f×"
-
-#. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%+.1f dB"
-msgstr "%+.1f dB"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-#, c-format
-msgid "Mono, %dHz"
-msgstr "Mono, %d Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-#, c-format
-msgid "Stereo, %dHz"
-msgstr "Stereo, %d Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "Mono"
-msgstr "Mono"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "384000 Hz"
-msgstr "384 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "352800 Hz"
-msgstr "352 800 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "192000 Hz"
-msgstr "192 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "176400 Hz"
-msgstr "176 400 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "96000 Hz"
-msgstr "96 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "88200 Hz"
-msgstr "88 200 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "48000 Hz"
-msgstr "48 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "44100 Hz"
-msgstr "44 100 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "22050 Hz"
-msgstr "22 050 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "16000 Hz"
-msgstr "16 000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "11025 Hz"
-msgstr "11 025 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "8000 Hz"
-msgstr "8000 Hz"
-
-#. i18n-hint k abbreviating kilo meaning thousands
-#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
-msgid "k"
-msgstr "k"
-
-#: src/toolbars/ControlToolBar.cpp
-#, c-format
-msgid "%s."
-msgstr "%s."
-
-#: src/prefs/SpectrumPrefs.cpp
-msgid "2048"
-msgstr "2048"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
-#: src/prefs/SpectrogramSettings.cpp
-msgid "ERB"
-msgstr "ERB"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Bark"
-msgstr "Bark"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Mel"
-msgstr "Mel"
-
-#: src/prefs/QualityPrefs.cpp
-#, c-format
-msgid "%i Hz"
-msgstr "%i Hz"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Ctrl"
-msgstr "Ctrl"
-
-#: src/prefs/MidiIOPrefs.h
-msgid "Midi IO"
-msgstr "MIDI I/O"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/prefs/EffectsPrefs.cpp
-msgid "V&ST"
-msgstr "V&ST"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/prefs/EffectsPrefs.cpp
-msgid "&Vamp"
-msgstr "&Vamp"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/prefs/EffectsPrefs.cpp
-msgid "N&yquist"
-msgstr "Ny&quist"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/prefs/EffectsPrefs.cpp
-msgid "LV&2"
-msgstr "LV&2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/prefs/EffectsPrefs.cpp
-msgid "&LADSPA"
-msgstr "LA&DSPA"
-
-#: src/menus/PluginMenus.cpp
-msgid "..."
-msgstr "…"
-
-#: src/menus/FileMenus.cpp
-msgid "&MIDI..."
-msgstr "MI&DI…"
-
-#: src/import/ImportPCM.cpp
-msgid "Vorbis"
-msgstr "Vorbis"
-
-#: src/import/ImportPCM.cpp
-msgid "VOX ADPCM"
-msgstr "VOX ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "24kbs G723 ADPCM"
-msgstr "24 kbit/s G723 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "32kbs G721 ADPCM"
-msgstr "32 kbit/s G721 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "GSM 6.10"
-msgstr "GSM 6.10"
-
-#: src/import/ImportPCM.cpp
-msgid "Microsoft ADPCM"
-msgstr "Microsoft ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "IMA ADPCM"
-msgstr "IMA ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "A-Law"
-msgstr "A-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "U-Law"
-msgstr "U-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "XI (FastTracker 2)"
-msgstr "XI (FastTracker 2)"
-
-#: src/import/ImportPCM.cpp
-msgid "WVE (Psion Series 3)"
-msgstr "WVE (Psion Series 3)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAVEX (Microsoft)"
-msgstr "WAVEX (Microsoft)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAV (NIST Sphere)"
-msgstr "WAV (NIST Sphere)"
-
-#: src/import/ImportPCM.cpp
-msgid "W64 (SoundFoundry WAVE 64)"
-msgstr "W64 (SoundFoundry WAVE 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "VOC (Creative Labs)"
-msgstr "VOC (Creative Labs)"
-
-#: src/import/ImportPCM.cpp
-msgid "SF (Berkeley/IRCAM/CARL)"
-msgstr "SF (Berkeley/IRCAM/CARL)"
-
-#: src/import/ImportPCM.cpp
-msgid "SDS (Midi Sample Dump Standard)"
-msgstr "SDS (MIDI-näytevedosstandardi)"
-
-#: src/import/ImportPCM.cpp
-msgid "SD2 (Sound Designer II)"
-msgstr "SD2 (Sound Designer II)"
-
-#: src/import/ImportPCM.cpp
-msgid "RF64 (RIFF 64)"
-msgstr "RF64 (RIFF 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "PVF (Portable Voice Format)"
-msgstr "PVF (Portable Voice Format)"
-
-#: src/import/ImportPCM.cpp
-msgid "PAF (Ensoniq PARIS)"
-msgstr "PAF (Ensoniq PARIS)"
-
-#: src/import/ImportPCM.cpp
-msgid "MPC (Akai MPC 2k)"
-msgstr "MPC (Akai MPC 2k)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-
-#: src/import/ImportPCM.cpp
-msgid "IFF (Amiga IFF/SVX8/SV16)"
-msgstr "IFF (Amiga IFF/SVX8/SV16)"
-
-#: src/import/ImportPCM.cpp
-msgid "HTK (HMM Tool Kit)"
-msgstr "HTK (HMM Tool Kit)"
-
-#: src/import/ImportPCM.cpp
-msgid "CAF (Apple Core Audio File)"
-msgstr "CAF (Apple Core Audio File)"
-
-#: src/import/ImportPCM.cpp
-msgid "AVR (Audio Visual Research)"
-msgstr "AVR (Audio Visual Research)"
-
-#: src/import/ImportPCM.cpp
-msgid "AU (Sun/NeXT)"
-msgstr "AU (Sun/NeXT)"
-
-#: src/import/Import.cpp src/menus/ClipMenus.cpp
-#, c-format
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "WAV (Microsoft)"
-msgstr "WAV (Microsoft)"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "AIFF (Apple/SGI)"
-msgstr "AIFF (Apple/SGI)"
-
-#: src/export/ExportMP3.cpp
-msgid "Stereo"
-msgstr "Stereo"
-
-#: src/export/ExportMP3.cpp
-msgid "65-105 kbps"
-msgstr "65–105 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "80-120 kbps"
-msgstr "80–120 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "95-135 kbps"
-msgstr "95–135 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "110-150 kbps"
-msgstr "110–150 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "145-185 kbps"
-msgstr "145–185 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "155-195 kbps"
-msgstr "155–195 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "170-210 kbps"
-msgstr "170–210 kbit/s"
-
-#: src/export/ExportMP3.cpp
-msgid "200-250 kbps"
-msgstr "200–250 kbit/s"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Max. PtO"
-msgstr "Maks. PtO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Min. PtO"
-msgstr "Min. PtO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Max. PdO"
-msgstr "Maks. PDO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Min. PdO"
-msgstr "Min. PDO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LPC"
-msgstr "LPC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VBL"
-msgstr "VBL"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LTP"
-msgstr "LTP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LC"
-msgstr "LC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "60 ms"
-msgstr "60 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "40 ms"
-msgstr "40 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "20 ms"
-msgstr "20 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10 ms"
-msgstr "10 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "5 ms"
-msgstr "5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "2.5 ms"
-msgstr "2,5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VOIP"
-msgstr "VOIP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10"
-msgstr "10"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "9"
-msgstr "9"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "7"
-msgstr "7"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "6"
-msgstr "6"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "5"
-msgstr "5"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "4"
-msgstr "4"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "3"
-msgstr "3"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "1"
-msgstr "1"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "0"
-msgstr "0"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#: src/export/ExportFFmpegDialogs.cpp
-#, c-format
-msgid "%.2f kbps"
-msgstr "%.2f kbit/s"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
-#, c-format
-msgid "%d kbps"
-msgstr "%d kbit/s"
-
-#: src/export/ExportCL.cpp
-msgid "&OK"
-msgstr "&OK"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/effects/vamp/VampEffect.h
-msgid "Vamp"
-msgstr "Vamp"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/effects/lv2/LV2Effect.h
-msgid "LV2"
-msgstr "LV2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/effects/ladspa/LadspaEffect.h
-msgid "LADSPA"
-msgstr "LADSPA"
-
-#. i18n-hint: An item name introducing a value, which is not part of the string but
-#. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
-#, c-format
-msgid "%s:"
-msgstr "%s:"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/effects/VST/VSTEffect.h
-msgid "VST"
-msgstr "VST"
-
-#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
-msgid "%"
-msgstr "%"
-
-#: src/effects/ScoreAlignDialog.cpp
-#, c-format
-msgid "%.3f"
-msgstr "%.3f"
-
-#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
-#: src/effects/ScienFilter.cpp
-msgid "Chebyshev Type II"
-msgstr "Tšebyšov, tyyppi II"
-
-#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
-#: src/effects/ScienFilter.cpp
-msgid "Chebyshev Type I"
-msgstr "Tšebyšov, tyyppi I"
-
-#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
-#: src/effects/ScienFilter.cpp
-msgid "Butterworth"
-msgstr "Butterworth"
-
-#: src/effects/Paulstretch.cpp
-msgid "Paulstretch"
-msgstr "Paulstretch"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "2"
-msgstr "2"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16384"
-msgstr "16 384"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "8192"
-msgstr "8192"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "4096"
-msgstr "4096"
-
-#: src/effects/NoiseReduction.cpp
-msgid "1024"
-msgstr "1024"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "512"
-msgstr "512"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "256"
-msgstr "256"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "128"
-msgstr "128"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "64"
-msgstr "64"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "32"
-msgstr "32"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16"
-msgstr "16"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
-msgid "8"
-msgstr "8"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Hamming, Hann"
-msgstr "Hamming–Hann"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Blackman, Hann"
-msgstr "Blackman–Hann"
-
-#: src/effects/Loudness.cpp
-msgid "RMS dB"
-msgstr "RMS dB"
-
-#: src/effects/Loudness.cpp
-msgid "LUFS"
-msgstr "LUFS"
-
-#: src/effects/Loudness.cpp src/widgets/Meter.cpp
-msgid "RMS"
-msgstr "RMS"
-
-#: src/effects/Equalization.cpp
-msgid "A&VX"
-msgstr "AV&X"
-
-#: src/effects/Equalization.cpp
-msgid "&SSE"
-msgstr "&SSE"
-
-#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%gk"
-msgstr "%g k"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%g kHz"
-msgstr "%g kHz"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "- dB"
-msgstr "– dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-#, c-format
-msgid "%d dB"
-msgstr "%d dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "+ dB"
-msgstr "+ dB"
-
-#: src/effects/Equalization.cpp
-msgid "RIAA"
-msgstr "RIAA"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/effects/Effect.h
-msgid "Nyquist"
-msgstr "Nyquist"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%0.f ms"
-msgstr "%0.f ms"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.0f ms"
-msgstr "%.0f ms"
-
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.1f %%"
-msgstr "%.1f %%"
-
-#. i18n-hint: short form of 'decibels'
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB"
-msgstr "%.2f dB"
-
-#. i18n-hint: dB abbreviates decibels
-#. * RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB RMS"
-msgstr "%.2f dB RMS"
-
-#. i18n-hint: dB abbreviates decibels
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%s dB"
-msgstr "%s dB"
-
-#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "RMS = %s."
-msgstr "RMS = %s."
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.1f:1"
-msgstr "%.1f:1"
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.0f:1"
-msgstr "%.0f:1"
-
-#. i18n-hint: usually leave this as is as dB doesn't get translated
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%3d dB"
-msgstr "%3d dB"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "78"
-msgstr "78"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "45"
-msgstr "45"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "33⅓"
-msgstr "33⅓"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "Y:"
-msgstr "Y:"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "X:"
-msgstr "X:"
-
-#: src/commands/HelpCommand.cpp
-msgid "_"
-msgstr "_"
-
-#. i18n-hint name of a computer programming language
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "LISP"
-msgstr "Lisp"
-
-#. i18n-hint JavaScript Object Notation
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "JSON"
-msgstr "JSON"
-
-#: src/commands/Demo.cpp
-msgid "Demo"
-msgstr "Demo"
-
-#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%s: %s"
-msgstr "%s: %s"
-
-#: src/TrackInfo.cpp
-msgid "Stereo, 999999Hz"
-msgstr "Stereo, 999999 Hz"
-
-#. i18n-hint a format string for hours, minutes, and seconds
-#: src/TimerRecordDialog.cpp
-msgid "099 h 060 m 060 s"
-msgstr "099 t 060 min 060 s"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "A♯/B♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "G♯/A♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "F♯/G♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "D♯/E♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "C♯/D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "B♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "A♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "G♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "B"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "A♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "A"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "G♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "G"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "F♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "F"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "E"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "D♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "D"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "C♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "C"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "nopeustesti.txt"
-
-#: plug-ins/vocoder.ny
-msgid "Edgar-RFT"
-msgstr "Edgar-RFT"
-
-#: plug-ins/vocalrediso.ny
-msgid "Robert Haenggi"
-msgstr "Robert Haenggi"
-
-#: plug-ins/tremolo.ny
-msgid "Tremolo"
-msgstr "Tremolo"
-
-#: plug-ins/rissetdrum.ny
-msgid "Steven Jones"
-msgstr "Steven Jones"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d – %s\n"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -24,82 +24,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-02 18:11+0000\n"
 "Last-Translator: J. Lavoie <j.lavoie@net-c.ca>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"fr/>\n"
+"Language-Team: French <https://hosted.weblate.org/projects/tenacity/tenacity/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Mettre Tenacity à jour"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Sauter"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Installer la mise à jour"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Journal des modifications"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "En lire davantage sur GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Erreur de vérification de mise à jour"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Impossible de se connecter au serveur de mise à jour de Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Les données de mise à jour ont été corrompues."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Erreur de téléchargement de la mise à jour."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Impossible d’ouvrir le lien de téléchargement de Tenacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s est disponible !"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Enregistrement"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -265,9 +199,14 @@ msgstr "&Arrêt\tF6"
 msgid "&About"
 msgstr "À propos (&a)"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script"
+msgstr "Script"
+
 # trebmuh to check (voir dans un contexte graphique)
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Sortie"
 
@@ -283,7 +222,12 @@ msgstr "Scripts Nyquist (*.ny)|*.ny|scripts Lisp (*.lsp)|*.lsp|Tous les fichiers
 msgid "Script was not saved."
 msgstr "Le script n’a pas été sauvegardé."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Attention"
 
@@ -296,15 +240,24 @@ msgid "Find dialog"
 msgstr "Dialogue de recherche"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr "Harvey Lubin (logo)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galerie d’icône Tango (icônes de barre d’outils)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 par Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Module Tenacity externe qui fournit un IDE simple pour l’écriture d’effets."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -327,7 +280,8 @@ msgstr "Sans titre"
 msgid "Nyquist Effect Workbench - "
 msgstr "Panoplie d’effet Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nouveau"
 
@@ -367,7 +321,8 @@ msgstr "Copier"
 msgid "Copy to clipboard"
 msgstr "Copier vers le presse-papier"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Couper et raccorder"
 
@@ -375,7 +330,8 @@ msgstr "Couper et raccorder"
 msgid "Cut to clipboard"
 msgstr "Couper vers le presse-papier"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Coller"
 
@@ -400,7 +356,8 @@ msgstr "Tout sélectionner"
 msgid "Select all text"
 msgstr "Sélectionner tout le texte"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Annuler"
 
@@ -408,7 +365,8 @@ msgstr "Annuler"
 msgid "Undo last change"
 msgstr "Annuler la dernière modification"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Refaire"
 
@@ -467,7 +425,8 @@ msgid "Go to next S-expr"
 msgstr "Aller au S-expr suivant"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Démarrer"
 
@@ -475,7 +434,8 @@ msgstr "Démarrer"
 msgid "Start script"
 msgstr "Démarrer le script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Arrêter"
 
@@ -490,7 +450,8 @@ msgid "About %s"
 msgstr "À propos d’%s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Valider"
 
@@ -498,11 +459,13 @@ msgstr "Valider"
 msgid "Build Information"
 msgstr "Informations de version"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Activé"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Désactivé"
 
@@ -511,10 +474,10 @@ msgstr "Désactivé"
 msgid "The Build"
 msgstr "Informations de compilation"
 
-# trebmuh to check (vérifier dans un contexte graphique)
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Identifiant de commit :"
+#, fuzzy
+msgid "Version:"
+msgstr "Version : %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -524,22 +487,28 @@ msgstr "Type de version :"
 msgid "Compiler:"
 msgstr "Compilateur :"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Préfixe d’intallation :"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Répertoire de paramètres :"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Répertoire de paramètres :"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Prise en charge de format de fichier"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Bibliothèque graphique multiplateforme"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -553,7 +522,6 @@ msgstr "Conversion de taux d’échantillonnage"
 msgid "MP3 Importing"
 msgstr "Importation de MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Import et export Ogg Vorbis"
@@ -562,7 +530,6 @@ msgstr "Import et export Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Support des balises ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Import et export FLAC"
@@ -580,14 +547,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Import/export FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importer via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Fonctionnalités"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Prise en charge de greffons"
 
@@ -602,6 +561,10 @@ msgstr "Prise en charge du changement de hauteur et de tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Prise en charge du changement extrême de hauteur et de tempo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Fonctionnalités"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -720,16 +683,22 @@ msgstr "%s, graphiques"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (incorporaant %s, %s, %s, %s et %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"%s est un logiciel libre, à source ouverte, multiplateformes pour l’"
-"enregistrement et l’édition de sons."
+msgstr "%s est un logiciel libre, à source ouverte, multiplateformes pour l’enregistrement et l’édition de sons."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Crédits"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Veuillez noter que les noms sont classés par ordre alphabétique et non par ordre d'importance."
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -781,6 +750,7 @@ msgstr "Site web et graphiques"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -813,6 +783,16 @@ msgstr "Site web de %s : "
 msgid "%s %s 1999-%s %s contributors"
 msgstr "%s %s 1999-%s %s contributeurs"
 
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "La marque Audacity%s est utilisée dans ce logiciel à des fins descriptives et informatives uniquement."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity n'est pas produit ni approuvé par MuseCY SM Ltd. ou Dominic M Mazzoni."
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "Actions dans la ligne du temps désactivées pendant l’enregistrement"
@@ -835,6 +815,7 @@ msgstr "Ligne temporelle"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Cliquer ou glisser pour démarrer la recherche"
@@ -843,6 +824,7 @@ msgstr "Cliquer ou glisser pour démarrer la recherche"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Cliquer ou glisser pour démarrer le frottement"
@@ -850,6 +832,7 @@ msgstr "Cliquer ou glisser pour démarrer le frottement"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Cliquez et déplacez pour le frottement. Cliquez et glissez-tirez pour la recherche."
@@ -858,6 +841,7 @@ msgstr "Cliquez et déplacez pour le frottement. Cliquez et glissez-tirez pour l
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Déplacer vers la recherche"
@@ -865,6 +849,7 @@ msgstr "Déplacer vers la recherche"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Déplacer pour le frottement"
@@ -922,7 +907,17 @@ msgstr ""
 "Ne peut pas verrouiller la région\n"
 "au delà de la fin du projet."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Erreur"
 
@@ -946,7 +941,8 @@ msgstr ""
 "Il s’agit d’une question ponctuelle faisant suite à une installation où vous avez demandé la réinitialisation des préférences."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Réinitialiser les préférences de Tenacity"
 
 #: src/AudacityApp.cpp
@@ -961,7 +957,8 @@ msgstr ""
 "Il a été retiré de la liste des fichiers récents."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Échec de l’initialisation de la bibliothèque SQLite.  Tenacity ne peut pas continuer."
 
 #: src/AudacityApp.cpp
@@ -987,7 +984,7 @@ msgstr "&Ouvrir…"
 msgid "Open &Recent..."
 msgstr "Ouvrir un fichier &récent…"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "À propos d’&Audacity…"
@@ -1001,9 +998,10 @@ msgid "&File"
 msgstr "&Fichier"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity n’a pas pu trouver de place sûre pour stocker les fichiers temporaires.\n"
@@ -1011,20 +1009,23 @@ msgstr ""
 "Veuillez entrer un répertoire approprié dans la boîte de dialogue des préférences."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity n’a pas pu trouver de place pour stocker les fichiers temporaires.\n"
 "Veuillez entrer un répertoire approprié dans la boîte de dialogue des préférences."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Tenacity va maintenant se fermer. Veuillez relancer Tenacity pour utiliser le nouveau répertoire temporaire."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -1033,15 +1034,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity n’a pas pu verrouiller le répertoire de fichiers temporaires.\n"
 "Ce répertoire est peut être déjà utilisé par une autre session de Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Voulez-vous toujours démarrer Tenacity ?"
 
 #: src/AudacityApp.cpp
@@ -1049,19 +1052,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Erreur de verrouillage du répertoire temporaire"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Le système a détecté qu’une autre session de Tenacity était lancée.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "À partir de la session actuellement lancée de Tenacity, utilisez Nouveau ou\n"
 "Ouvrir pour démarrer plusieurs projets simultanément.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity est déjà lancé"
 
 #: src/AudacityApp.cpp
@@ -1077,7 +1083,8 @@ msgstr ""
 "et un redémarrage peut être nécessaire."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Échec du démarrage de Tenacity"
 
 #: src/AudacityApp.cpp
@@ -1117,8 +1124,9 @@ msgstr ""
 "et un redémarrage peut être nécessaire."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1150,7 +1158,8 @@ msgstr "exécute les auto-diagnostiques"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "affiche la version de Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1160,9 +1169,10 @@ msgid "audio or project file name"
 msgstr "nom du fichier audio ou du projet"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1175,12 +1185,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Fichiers projet Tenacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+msgid "Message"
+msgstr "Message"
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Erreur de configuration de Tenacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1190,7 +1206,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Le fichier de configuration suivant n’a pas pu être consulté :\n"
 "\n"
@@ -1202,12 +1218,15 @@ msgstr ""
 "\n"
 "Si vous choisissez de « Quitter Tenacity », votre projet peut être laissé dans un état non sauvegardé qui sera récupéré la prochaine fois que vous l’ouvrirez."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Aide"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Quitter Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1215,7 +1234,8 @@ msgid "&Retry"
 msgstr "&Réessayer"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Journal de Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1228,9 +1248,14 @@ msgid "Cl&ear"
 msgstr "&Effacer"
 
 # trebmuh to check (accélérateur)
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "F&ermer"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr "journal.txt"
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1279,7 +1304,8 @@ msgid "Error Initializing Midi"
 msgstr "Erreur d’initialisation MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audio Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1294,37 +1320,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Mémoire disponible insuffisante !"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Impossible de l’optimiser davantage. Toujours trop haut."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "L’ajustement automatique du niveau d’enregistrement a réduit le volume à %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Impossible de l’optimiser davantage. Toujours trop bas."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "L’ajustement automatique du niveau d’enregistrement a augmenté le volume à %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Le nombre total d’analyses a été dépassé sans pouvoir trouver un volume acceptable. Toujours trop haut."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Le nombre total d’analyses a été dépassé sans pouvoir trouver un volume acceptable. Toujours trop bas."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. %.2f semble être un volume acceptable."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1424,43 +1419,6 @@ msgstr "Aucun périphérique de lecture trouvé pour '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Impossible de vérifier les taux d’échantillonnage mutuels sans les deux périphériques.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Reçu %d lors de l’ouverture des périphériques\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Impossible d’ouvrir Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Mixeurs disponibles : \n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Sources d’enregistrement disponibles :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volumes de lecture disponibles :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Le volume d’enregistrement est émulé\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Le vlume d’enregistrement est natif\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Le volume de lecture est émulé\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Le volume de lecture est natif\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1503,8 +1461,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Récupération automatique de plantage"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1517,12 +1476,14 @@ msgid "Recoverable &projects"
 msgstr "&Projets récupérables"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Sélection"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nom"
 
@@ -1609,6 +1570,11 @@ msgstr "Effet"
 msgid "Menu Command (With Parameters)"
 msgstr "Menu de commandes (avec paramètres)"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
+
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
 msgstr "Menu de commandes (sans paramètres)"
@@ -1680,6 +1646,11 @@ msgstr "Gérer les macros"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Sélectionner une macro"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+msgid "Macro"
+msgstr "Macro"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
@@ -1753,7 +1724,8 @@ msgstr "Re&staurer"
 msgid "I&mport..."
 msgstr "I&mporter…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xporter…"
 
@@ -1797,7 +1769,8 @@ msgstr "&Monter"
 msgid "Move &Down"
 msgstr "&Descendre"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Sauvegarder"
 
@@ -1883,7 +1856,8 @@ msgid "Run"
 msgstr "Lancer"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Fermer"
 
@@ -2041,11 +2015,6 @@ msgstr "Test de performance terminé avec succès.\n"
 #: src/BuildInfo.h
 msgid "No revision identifier was provided"
 msgstr "Aucun identifiant de révision n’a été fourni"
-
-#: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Date et heure de fin"
 
 #: src/BuildInfo.h
 #, c-format
@@ -2313,10 +2282,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Si vous le faites, votre projet ne sera pas enregistré sur le disque. Le souhaitez-vous ?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2331,13 +2301,20 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Vérification des dépendances"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Aucun"
 
 #: src/Dither.cpp
 msgid "Rectangle"
 msgstr "Rectangulaire"
+
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Triangle"
+msgstr "Triangle"
 
 #: src/Dither.cpp
 msgid "Shaped"
@@ -2346,6 +2323,36 @@ msgstr "Onde"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Rectangulaire"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2367,9 +2374,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Le support FFmpeg n’est pas compilé"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2392,8 +2400,8 @@ msgid "Locate FFmpeg"
 msgstr "Localiser FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity nécessite le fichier '%s' pour importer et exporter de l’audio via FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2406,7 +2414,8 @@ msgstr "Localisation de '%s' :"
 msgid "To find '%s', click here -->"
 msgstr "Pour trouver '%s', cliquer ici -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Parcourir…"
 
@@ -2432,8 +2441,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg absent"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2462,24 +2472,24 @@ msgid "Only libavformat.so"
 msgstr "Seulement libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity a échoué à ouvrir un fichier dans %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity a échoué à lire un fichier dans %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Tenacity a réussi à écrire un fichier dans %s mais a échoué à le renommer en %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2521,7 +2531,9 @@ msgstr "&Ne pas copier d’audio"
 msgid "As&k"
 msgstr "Demander à l’utilisateur (&k)"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Tous les fichiers"
 
@@ -2546,6 +2558,10 @@ msgstr "Fichiers texte"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Fichiers XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ", "
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2610,10 +2626,34 @@ msgstr "Fréquence linéaire"
 msgid "Log frequency"
 msgstr "Fréquence logarithmique"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 # trebmuh to check (vérifier dans un contexte graphique)
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Défilement"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+msgid "Zoom"
+msgstr "Zoom"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2676,6 +2716,23 @@ msgstr "Trop d’audio a été sélectionné. Seules les %.1f premières seconde
 msgid "Not enough data selected."
 msgstr "Pas assez de données sélectionnées."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2698,7 +2755,8 @@ msgstr "spectre.txt"
 msgid "Export Spectral Data As:"
 msgstr "Exporter les données spectrales sous :"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Impossible de sauvegarder le fichier : %s"
@@ -2800,10 +2858,7 @@ msgstr "Voici nos différentes méthodes d’assistance :"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[help:Quick_Help|Aide rapide (en anglais)]] - si non installé localement, "
-"[[https://manual.audacityteam.org/quick_help.html|voir en ligne (en anglais "
-"également)]]"
+msgstr "[[help:Quick_Help|Aide rapide (en anglais)]] - si non installé localement, [[https://manual.audacityteam.org/quick_help.html|voir en ligne (en anglais également)]]"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
@@ -2842,6 +2897,10 @@ msgstr "Historique"
 #: src/HistoryWindow.cpp
 msgid "&Manage History"
 msgstr "&Gérer l’historique"
+
+#: src/HistoryWindow.cpp src/effects/TruncSilence.cpp plug-ins/vocalrediso.ny
+msgid "Action"
+msgstr "Action"
 
 #: src/HistoryWindow.cpp
 msgid "Used Space"
@@ -2894,19 +2953,19 @@ msgstr "&Historique…"
 #  trebmuh to check (vérifier le remplacement des %s dans un contexte
 # graphique)
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Erreur interne dans %s à %s ligne %d.\n"
 "Veuillez en informer l’équipe de Tenacity à https://forum.audacityteam.org/ (en anglais)."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Erreur interne à %s ligne %d.\n"
 "Veuillez en informer l’équipe de Tenacity à https://forum.audacityteam.org/ (en anglais)."
@@ -2925,7 +2984,9 @@ msgid "Track"
 msgstr "Piste"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Marqueur"
 
@@ -2985,7 +3046,8 @@ msgstr "Entrer le nom de la piste"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Piste de marqueur"
 
@@ -2996,11 +3058,13 @@ msgstr "Un ou plusieurs marqueur(s) enregistré(s) ne peuvent être lu(s)."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Premier démarrage de Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Choisir la langue que Tenacity utilisera :"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -3010,7 +3074,8 @@ msgstr "Choisir la langue que Tenacity utilisera :"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "La langue choisie, %s (%s), n’est pas la même que celle du système, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirmer"
 
@@ -3028,12 +3093,13 @@ msgstr ""
 "L’ancien fichier a été sauvegardé sous '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Ouverture d’un projet Tenacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoké%s Tenacity"
 
 #: src/LyricsWindow.cpp
@@ -3085,13 +3151,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mixer et rendre les pistes"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Table de mixage %s de Tenacity"
+
+#. i18n-hint: title of the Gain slider, used to adjust the volume
+#. i18n-hint: Title of the Gain slider, used to adjust the volume
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+msgid "Gain"
+msgstr "Gain"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Vélocité"
 
@@ -3100,28 +3176,42 @@ msgid "Musical Instrument"
 msgstr "Instrument de musique"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panoramique"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Silencer"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "VU-mètre du signal"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Curseur de niveau déplacé"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Curseur de vitesse déplacé"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Curseur de panoramique déplacé"
 
@@ -3156,9 +3246,9 @@ msgstr ""
 "Il ne sera pas chargé."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3192,16 +3282,19 @@ msgstr ""
 "\n"
 "N’utilisez que les modules provenant de sources fiables"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Oui"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Non"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Chargeur de module de Tenacity"
 
 #: src/ModuleManager.cpp
@@ -3450,7 +3543,8 @@ msgstr "Nettoyer tout (&l)"
 
 # trebmuh to check (accélérateur)
 # trebmuh to check : "activé" ou "activer" ?
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "activé (&e)"
 
@@ -3530,9 +3624,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Taux d’échantillonnage inadéquat"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Trop peu de pistes sont sélectionnées pour l’enregistrement à\n"
@@ -3561,10 +3656,11 @@ msgid "Dropouts"
 msgstr "Désynchros"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3605,11 +3701,11 @@ msgid "Inspecting project file data"
 msgstr "Inspection des données du fichier-projet"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3651,11 +3747,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Attention - Fichier(s) alias manquant(s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "La vérification du projet du dossier « %s » \n"
@@ -3680,12 +3776,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Attention - Fichier(s)-alias de sommaire manquant(s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3743,7 +3839,8 @@ msgstr "Attention - Bloc(s) de fichier orphelin(s)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progression"
 
@@ -3768,6 +3865,11 @@ msgstr "Attention : problèmes lors de la récupération automatique"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sans titre>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projet %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3836,12 +3938,14 @@ msgstr ""
 "(Impossible de créer les fichiers temporaires requis)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Ceci n’est pas un fichier de projet Tenacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3971,9 +4075,9 @@ msgid "Error Writing to File"
 msgstr "Erreur lors de l’écriture du fichier"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3988,9 +4092,16 @@ msgstr "Compactage du projet"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projet %02i] Tenacity « %s »"
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3999,10 +4110,10 @@ msgstr "(Récupéré)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Ce fichier a été enregistré avec Tenacity %s.\n"
 "Vous utilisez Tenacity %s. Vous devez mettre votre version à jour pour ouvrir ce fichier."
@@ -4074,8 +4185,9 @@ msgid "Backing up project"
 msgstr "Sauvegarde du projet"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -4084,8 +4196,9 @@ msgstr ""
 "Il a été récupéré au dernier cliché."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4164,8 +4277,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sSauvegarder le projet \"%s\" sous…"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "« Sauvegarder le projet » concerne la sauvegarde d’un projet Tenacity, pas d’un fichier audio.\n"
@@ -4243,11 +4357,12 @@ msgid "Error Opening Project"
 msgstr "Erreur d’ouverture du projet"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Vous essayez d’ouvrir un fichier de sauvegarde créé automatiquement.\n"
 "Le faire peut causer des pertes sévères de données.\n"
@@ -4356,8 +4471,8 @@ msgid "Automatic database backup failed."
 msgstr "Échec de la sauvegarde automatique de la base de données."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Bienvenue dans Tenacity version %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4572,7 +4687,8 @@ msgstr "Toutes les préférences"
 msgid "SelectionBar"
 msgstr "Barre de sélection"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Sélection spectrale"
 
@@ -4580,43 +4696,56 @@ msgstr "Sélection spectrale"
 msgid "Timer"
 msgstr "Chronomètre"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Outils"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+msgid "Transport"
+msgstr "Transport"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mixage"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "VU-mètre"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "VU-mètre de lecture"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "VU-mètre d’enregistrement"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Édition"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Périphérique"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Lecture-à-la-vitesse"
 
 # trebmuh to check (trouver une meilleure traduction que frottement ?)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Frottement"
 
@@ -4631,7 +4760,10 @@ msgstr "Règle"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Pistes"
 
@@ -4743,7 +4875,8 @@ msgid "Activation level (dB):"
 msgstr "Niveau d’activation (dB) :"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Bienvenue dans Tenacity !"
 
 #: src/SplashDialog.cpp
@@ -4774,6 +4907,10 @@ msgstr "Numéro de piste"
 msgid "Year"
 msgstr "Année"
 
+#: src/Tags.cpp
+msgid "Genre"
+msgstr "Genre"
+
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Commentaires"
@@ -4797,6 +4934,10 @@ msgstr "&Ajouter"
 #: src/Tags.cpp
 msgid "&Remove"
 msgstr "&Retirer"
+
+#: src/Tags.cpp
+msgid "Genres"
+msgstr "Genres"
 
 #: src/Tags.cpp
 msgid "E&dit..."
@@ -4882,9 +5023,9 @@ msgstr ""
 "Pour obtenir des conseils sur les lecteurs appropriés, cliquez sur le bouton d’aide."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity ne parvient pas à écrire le fichier :\n"
@@ -4904,9 +5045,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4915,9 +5056,9 @@ msgstr ""
 "en écriture."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity n’arrive pas à sauvegarder les images dans le fichier :\n"
@@ -4934,9 +5075,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4946,9 +5087,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4957,8 +5098,9 @@ msgstr ""
 "Peut-être un mauvais format png ?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity ne peut pas lire son thème par défaut.\n"
@@ -4996,9 +5138,9 @@ msgstr ""
 "étaient déjà présents. Les écraser ?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity n’a pas pu sauvegarder le fichier :\n"
@@ -5037,7 +5179,11 @@ msgstr "Personnalisé"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Durée"
 
@@ -5048,7 +5194,8 @@ msgid "Time Track"
 msgstr "Piste de tempo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Enregistrement programmé de Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5122,7 +5269,8 @@ msgstr "Projet actuel"
 msgid "Recording start:"
 msgstr "Début de l’enregistrement :"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Durée :"
 
@@ -5143,7 +5291,8 @@ msgid "Action after Timer Recording:"
 msgstr "Action après l’enregistrement programmé :"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Progression de l’enregistrement programmé de Tenacity"
 
 # trebmuh to check
@@ -5225,6 +5374,12 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Enregistrement programmé"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 jours 024 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -5235,6 +5390,7 @@ msgstr "099 jours 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Date et heure de début"
@@ -5279,6 +5435,11 @@ msgstr "Activer l’&export automatique ?"
 msgid "Export Project As:"
 msgstr "Exporter le projet sous :"
 
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
+msgid "Options"
+msgstr "Options"
+
 #: src/TimerRecordDialog.cpp
 msgid "After Recording completes:"
 msgstr "Après que l’enregistrement soit effectué :"
@@ -5288,7 +5449,8 @@ msgid "Do nothing"
 msgstr "Ne rien faire"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Quitter Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5312,7 +5474,8 @@ msgid "Scheduled to stop at:"
 msgstr "Programmé pour s’arrêter à :"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Enregistrement programmé de Tenacity – en attente de démarrage"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5338,7 +5501,8 @@ msgid "Recording Exported:"
 msgstr "Enregistrement exporté :"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Enregistrement programmé de Tenacity – en attente"
 
 #: src/TrackInfo.cpp
@@ -5537,7 +5701,11 @@ msgid "Applying %s..."
 msgstr "Application de %s…"
 
 #. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%s: %s"
 msgstr "%s : %s"
@@ -5560,13 +5728,15 @@ msgstr "%s n’est pas un paramètre accepté par %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Valeur invalide pour le paramètre '%s' : devrait être %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Commande"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Répéter %s"
@@ -5624,6 +5794,11 @@ msgstr "Glisser"
 msgid "Panel"
 msgstr "Panneau"
 
+#: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
+#, fuzzy
+msgid "Application"
+msgstr "Application :"
+
 #: src/commands/DragCommand.cpp
 msgid "Track 0"
 msgstr "Piste 0"
@@ -5673,21 +5848,41 @@ msgstr "Obtenir des infos"
 msgid "Commands"
 msgstr "Commandes"
 
+#: src/commands/GetInfoCommand.cpp
+msgid "Menus"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp src/commands/ScreenshotCommand.cpp
 msgid "Preferences"
 msgstr "Préférences"
+
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Paramètre le clip"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Outils de niveau (enveloppes)"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Marqueurs"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Boîtes"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5697,7 +5892,8 @@ msgstr "Bref"
 msgid "Type:"
 msgstr "Type :"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Format :"
 
@@ -5724,6 +5920,10 @@ msgstr "Commentaire"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Commande :"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5762,12 +5962,17 @@ msgstr "Exporte dans un fichier"
 msgid "Builtin Commands"
 msgstr "Commandes embarquées"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "L’équipe d’Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Fournit des commandes intégrées à Audacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5830,7 +6035,10 @@ msgstr "Efface le contenu du journal."
 msgid "Get Preference"
 msgstr "Obtenir les préférences"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nom :"
 
@@ -5878,9 +6086,15 @@ msgstr "Plein écran"
 msgid "Toolbars"
 msgstr "Barres d’outils"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effets"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "tous les scriptables"
 
 # trebmuh : à vérifier
 #: src/commands/ScreenshotCommand.cpp
@@ -6018,7 +6232,8 @@ msgstr "Attribuer"
 msgid "Add"
 msgstr "Ajouter"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Retirer"
 
@@ -6104,7 +6319,8 @@ msgid "Edited Envelope"
 msgstr "Enveloppe éditée"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Outil de niveau (enveloppe)"
 
@@ -6206,7 +6422,10 @@ msgstr "Pan :"
 msgid "Set Track Visuals"
 msgstr "Paramètre les visuels de la piste"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linéaire"
 
@@ -6277,6 +6496,11 @@ msgid "&Amplification (dB):"
 msgstr "&Amplification (dB) :"
 
 #: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
+msgstr "&Amplification (dB) :"
+
+#: src/effects/Amplify.cpp
 msgid "&New Peak Amplitude (dB):"
 msgstr "&Nouvelle amplitude de crête (dB) :"
 
@@ -6284,6 +6508,10 @@ msgstr "&Nouvelle amplitude de crête (dB) :"
 #: src/effects/Amplify.cpp
 msgid "Allo&w clipping"
 msgstr "Autoriser la saturation (&w)"
+
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
 
 #: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
@@ -6303,13 +6531,19 @@ msgstr "Vous avez sélectionné une piste ne contenant pas d’audio. AutoDuck n
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck nécessite une piste de contrôle placée sous la (les) piste(s) sélectionnée(s)."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 # trebmuh to check
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Mont&ant de Duck :"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "secondes"
 
@@ -6334,7 +6568,8 @@ msgid "Inner &fade up length:"
 msgstr "Longueur de &fondu interne à l’ouverture :"
 
 # trebmuh to check (accélérateur)
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Seuil (&t) :"
 
@@ -6481,11 +6716,13 @@ msgid "t&o"
 msgstr "vers (&o)"
 
 # trebmuh to check (accélérateur)
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Pourcentage de modification (&h) :"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Pourcentage de modification"
 
@@ -6493,9 +6730,23 @@ msgstr "Pourcentage de modification"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Utilise un étirement de haute-qualité (lent)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "s.o."
 
@@ -6523,6 +6774,7 @@ msgstr "rpm vinyle standard :"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Depuis rpm"
@@ -6536,6 +6788,7 @@ msgstr "depuis (&f)"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Vers rpm"
@@ -6684,6 +6937,36 @@ msgstr "Compresseur"
 msgid "Compresses the dynamic range of audio"
 msgstr "Compresse la plage dynamique de l’audio"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "Temps d’attaque %.2f secs"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
@@ -6704,6 +6987,11 @@ msgstr "Niveau de bruit"
 
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "&Ratio :"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "&Ratio :"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -6796,9 +7084,16 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analyseur de contraste, pour mesurer les différences de volume RMS entre deux sélections d’audio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Fin"
+
+# trebmuh to check (accélérateur)
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "&Aiguë (dB) :"
 
 # trebmuh to check (accélérateur)
 #: src/effects/Contrast.cpp
@@ -6854,6 +7149,18 @@ msgstr "&Différence :"
 msgid "&Help"
 msgstr "A&ide"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "zéro"
@@ -6861,6 +7168,13 @@ msgstr "zéro"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "indéterminer"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6914,6 +7228,12 @@ msgstr "Différence actuelle"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Niveau mesuré d’avant-plan"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr " Crête %2.f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -7187,6 +7507,10 @@ msgstr "Contrôles de paramètre"
 msgid "Clipping level"
 msgstr "Niveau de saturation (clipping)"
 
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
 # trebmuh to check (vérifier dans le contexte graphique)
 #: src/effects/Distortion.cpp
 msgid "Make-up Gain"
@@ -7287,7 +7611,9 @@ msgstr "&Séquence DTMF :"
 msgid "&Amplitude (0-1):"
 msgstr "&Amplitude (0-1) :"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Durée :"
 
@@ -7300,12 +7626,29 @@ msgid "Duty cycle:"
 msgstr "Cycle d’activité :"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Durée de son :"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Durée du silence :"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7315,7 +7658,8 @@ msgstr "Écho"
 msgid "Repeats the selected audio again and again"
 msgstr "Répète l’audio sélectionné encore et encore"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "La valeur demandée excède la capacité mémoire."
 
@@ -7339,7 +7683,8 @@ msgstr "Préréglages"
 msgid "Export Effect Parameters"
 msgstr "Exporter les paramètres de l’effet"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Impossible d’ouvrir le fichier : \"%s\""
@@ -7376,6 +7721,15 @@ msgstr "Préparation de la prélecture"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Prélecture"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Erreur Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7668,6 +8022,11 @@ msgstr "Arrêter la lecture (&p)"
 msgid "Play"
 msgstr "Lecture"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
@@ -7713,6 +8072,10 @@ msgid "Low rolloff for speech"
 msgstr "Petit dérapage pour les discours"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Téléphone"
 
@@ -7748,6 +8111,43 @@ msgstr "Le taux d’échantillonnage de la piste est trop bas pour cet effet."
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Effet indisponible"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7824,8 +8224,16 @@ msgid "D&efault"
 msgstr "Par &défaut"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE Mul&titâches"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -8072,7 +8480,8 @@ msgid "Builtin Effects"
 msgstr "Effets intégrés"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Fournit des effets intégrés à Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -8082,6 +8491,10 @@ msgstr "Nom d’effet intégré inconnu"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "sonie perçue"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -8115,12 +8528,24 @@ msgid "Loudness LUFS"
 msgstr "Sonie LUFS"
 
 #: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Normaliser des canaux &stéréo indépendamment"
 
 #: src/effects/Loudness.cpp
 msgid "&Treat mono as dual-mono (recommended)"
 msgstr "&Traiter le mono comme du double mono (recommandé)"
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -8179,7 +8604,17 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (défaut)"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "Blackman"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, aucun"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, aucun"
 
 #: src/effects/NoiseReduction.cpp
@@ -8284,8 +8719,9 @@ msgid "Step 1"
 msgstr "Étape 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Choisir quelques secondes de bruit seul\n"
@@ -8340,13 +8776,62 @@ msgstr "Types de fenêtre (&w)"
 msgid "Window si&ze:"
 msgstr "Taille de la fenêtre (&z) :"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (défaut)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "É&tapes par fenêtre :"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8467,6 +8952,11 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&ormaliser les canaux stéréo indépendamment"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Étirer"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch ne s’utilise que pour un étirement temporel extrême ou pour un effet de \"stase\""
 
@@ -8474,6 +8964,7 @@ msgstr "Paulstretch ne s’utilise que pour un étirement temporel extrême ou p
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Facteur d’étirement (&s) :"
@@ -8523,6 +9014,10 @@ msgstr ""
 "\n"
 "Essayez d’augmenter la sélection audio pour au moins %.1f secondes,\n"
 "ou de réduire la 'résolution temporelle' à moins de %.1f secondes."
+
+#: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
@@ -8755,6 +9250,21 @@ msgstr "Renverse l’audio sélectionné"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Temps SBMS / étirement de hauteur"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Passe-bas"
@@ -8902,6 +9412,18 @@ msgstr "Utiliser les réglages par défaut"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Restaurer les réglages par défaut"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
+#. i18n-hint: noun
+#: src/effects/Silence.cpp
+#, fuzzy
+msgctxt "generator"
+msgid "Silence"
+msgstr "Silencer"
 
 #: src/effects/Silence.cpp
 msgid "Creates audio of zero amplitude"
@@ -9059,6 +9581,10 @@ msgstr "Détecter le silence"
 msgid "Tr&uncate to:"
 msgstr "Tronquer à (&u) :"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "C&ompresser à :"
@@ -9072,7 +9598,8 @@ msgid "VST Effects"
 msgstr "Effets VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Ajoute la possibilité d’utiliser des effets VST dans Audacity."
 
 # trebmuh to check (à vérifier : "shell" dans ce contexte)
@@ -9085,7 +9612,8 @@ msgstr "Scan des VST 'Shell'"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Inscription %d de %d : %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Impossible de charger la bibliothèque"
 
@@ -9106,7 +9634,8 @@ msgstr "La taille du tampon contrôle le nombre d’échantillons envoyés à l�
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Taille du tampon (8 à 1048576 échantillons) (&b) :"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Compensation de latence"
 
@@ -9114,7 +9643,8 @@ msgstr "Compensation de latence"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Dans le cadre de leur traitement, certains effets VST doivent retarder le retour audio à Audacity. Lorsque vous ne compensez pas ce retard, vous remarquerez que de petits silences ont été insérés dans l’audio. En activant cette option, vous obtiendrez cette compensation, mais il se peut qu’elle ne fonctionne pas pour tous les effets VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Activer la &compensation"
 
@@ -9148,7 +9678,8 @@ msgid "Standard VST program file"
 msgstr "Fichier de programme VST standard"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Fichier de préréglage VST Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9175,7 +9706,8 @@ msgstr "Erreur lors du chargement des préréglages VST"
 msgid "Unable to load presets file."
 msgstr "Incapable de charger le fichier de préréglages."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Réglages de l’effet"
 
@@ -9191,6 +9723,16 @@ msgstr "Incapable de lire le fichier de préréglages."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Ce fichier de paramètre a été sauvegardé à partir de %s. Continuer ?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -9225,7 +9767,8 @@ msgid "Audio Unit Effects"
 msgstr "Effets Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Fournit le support des effets Audio Unit à Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9241,7 +9784,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Options d’effet Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Dans le cadre de leur traitement, certains effets Audio Unit doivent retarder le retour audio à Audacity. Lorsque vous ne compensez pas ce retard, vous remarquerez que de petits silences ont été insérés dans l’audio. En activant cette option, vous obtiendrez cette compensation, mais il se peut qu’elle ne fonctionne pas pour tous les effets Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9377,8 +9921,16 @@ msgstr "Échec de la création d’une liste de propriétés pour le préréglag
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "Impossible de définir les informations de classe pour le préréglage \"%s\""
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Effets Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Effets LADSPA"
@@ -9388,7 +9940,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Fournit des effets LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity n’utilise plus le pont-vst"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9396,12 +9949,15 @@ msgid "LADSPA Effect Options"
 msgstr "Options d’effet LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Dans le cadre de leur traitement, certains effets LADSPA doivent retarder le retour audio à Audacity. Lorsque vous ne compensez pas ce retard, vous remarquerez que de petits silences ont été insérés dans l’audio. En activant cette option, vous obtiendrez cette compensation, mais il se peut qu’elle ne fonctionne pas pour tous les effets LADSPA."
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s :"
@@ -9409,6 +9965,14 @@ msgstr "%s :"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Sortie d’effet"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Effets LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9421,7 +9985,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Taille du tampon (8 à %d) échantillons (&b) :"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Dans le cadre de leur traitement, certains effets LV2 doivent retarder le retour audio à Audacity. Lorsque vous ne compensez pas ce retard, vous remarquerez que de petits silences ont été insérés dans l’audio. En activant cette option, vous obtiendrez cette compensation, mais il se peut qu’elle ne fonctionne pas pour tous les effets LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9446,12 +10011,19 @@ msgstr "%s nécessite une option non-supportée %s\n"
 msgid "Generator"
 msgstr "Générateur"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Effets LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Fournit le support des effets LV2 à Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9459,7 +10031,8 @@ msgid "Nyquist Effects"
 msgstr "Effets Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Fournit le support des effets Nyquist à Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9690,7 +10263,8 @@ msgstr "Choisir un fichier"
 msgid "Save file as"
 msgstr "Sauvegarder le fichier sous"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "sans titre"
 
@@ -9699,7 +10273,8 @@ msgid "Vamp Effects"
 msgstr "Effets Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Fournit le support des effets Vamp à Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9721,6 +10296,12 @@ msgstr "Réglages du greffon"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programme"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -10022,7 +10603,8 @@ msgstr "Exporter l’audio sous %s"
 msgid "Invalid sample rate"
 msgstr "Taux d’échantillonnage invalide"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Rééchantillonner"
 
@@ -10032,8 +10614,7 @@ msgid ""
 "The project sample rate (%d) is not supported by the current output\n"
 "file format. "
 msgstr ""
-"Le taux d’échantillonnage du projet (%d) n’est pas pris en charge par le "
-"format\n"
+"Le taux d’échantillonnage du projet (%d) n’est pas pris en charge par le format\n"
 "de fichier de sortie actuel. "
 
 #: src/export/ExportFFmpeg.cpp
@@ -10051,6 +10632,14 @@ msgstr "Vous devez rééchantillonner à un des taux ci-dessous."
 msgid "Sample Rates"
 msgstr "Taux d’échantillonnage"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Débit binaire :"
@@ -10058,6 +10647,48 @@ msgstr "Débit binaire :"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualité (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "80-120 kb/s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -10068,12 +10699,42 @@ msgid "Constrained"
 msgstr "Contraint"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Audio"
+msgstr "&Audio…"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Délai faible"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -10094,6 +10755,11 @@ msgstr "Bande super large"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
 msgstr "Bande complète"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression"
+msgstr "Compression :"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Frame Duration:"
@@ -10156,8 +10822,17 @@ msgid "Replace preset '%s'?"
 msgstr "Remplacer le préréglage '%s' ?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Do"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principal"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10262,6 +10937,14 @@ msgstr ""
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Langue :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10396,6 +11079,11 @@ msgstr ""
 "0 - défaut\n"
 "min - 1\n"
 "max - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Utilise LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10714,13 +11402,28 @@ msgstr "Délirant"
 msgid "Extreme"
 msgstr "Extrême"
 
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
+
 #: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "Moyen"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "disponible"
+
+#: src/export/ExportMP3.cpp
 msgid "Average"
 msgstr "Moyenne"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Constant"
+msgstr "Gain constant"
 
 #: src/export/ExportMP3.cpp
 msgid "Joint Stereo"
@@ -10753,8 +11456,8 @@ msgid "Locate LAME"
 msgstr "Localiser LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity requiert le fichier %s pour pouvoir créer des MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10782,10 +11485,10 @@ msgid "Where is %s?"
 msgstr "Où se trouve %s ?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Vous liez vers lame_enc.dll v%d.%d. Cette version n’est pas compatible avec Audacity %d.%d.%d.\n"
 "Veuillez télécharger la dernière version 'LAME pour Audacity'."
@@ -11094,6 +11797,14 @@ msgstr "Exportation de la sélection audio en Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Exportation de l’audio en Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Entête :"
@@ -11107,9 +11818,10 @@ msgid "Other uncompressed files"
 msgstr "Autres formats non-compressés"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Vous avez tenté d’exporter un fichier WAV ou AIFF de plus de 4 Go.\n"
 "Audacity ne peut pas faire cela, l’exportation a été abandonnée."
@@ -11119,8 +11831,9 @@ msgid "Error Exporting"
 msgstr "Erreur d’exportation"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Votre fichier WAV exporté a été tronqué car Audacity ne peut pas exporter\n"
@@ -11160,11 +11873,11 @@ msgid "All supported files"
 msgstr "Tous les fichiers supportés"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -11173,11 +11886,11 @@ msgstr ""
 "pouvez l’éditer en cliquant sur Fichier > Importer > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "n’est pas un fichier audio. \n"
@@ -11188,18 +11901,18 @@ msgid "Select stream(s) to import"
 msgstr "Sélectionner le(s) flux à importer"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Cette version d’Audacity n’a pas été compilée avec le support %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est une piste de CD audio. \n"
 "Audacity ne peut pas ouvrir de CD audio directement. \n"
@@ -11208,10 +11921,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" est une liste de lecture. \n"
@@ -11220,10 +11933,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier Windows Media Audio. \n"
@@ -11232,10 +11945,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier Advanced Audio Coding.\n"
@@ -11244,12 +11957,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier audio crypté, de ceux distribués par les boutiques de musique en ligne. \n"
@@ -11259,10 +11972,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier média RealPlayer. \n"
@@ -11271,12 +11984,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" est un fichier de notes, pas un fichier audio. \n"
 "Audacity ne peut pas ouvrir ce type de fichier. \n"
@@ -11285,10 +11998,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11301,10 +12014,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier audio Wavpack. \n"
@@ -11313,10 +12026,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier audio Dolby Digital. \n"
@@ -11325,10 +12038,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier audio Ogg Speex. \n"
@@ -11337,10 +12050,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" est un fichier vidéo. \n"
@@ -11354,9 +12067,9 @@ msgstr "Fichier \"%s\"» non trouvé."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11372,11 +12085,16 @@ msgstr ""
 "Essayez d’installer FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, testeur"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11406,12 +12124,13 @@ msgid "Import Project"
 msgstr "Importer le projet"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Ce projet a été sauvegardé par Audacity version 1.0 ou antérieure. Le format\n"
 "a changé et cette version d’Audacity est incapable d’importer le projet.\n"
@@ -11462,7 +12181,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Impossible de trouver le répertoire de données du projet : \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Les pistes MIDI trouvées dans le fichier du projet, mais cette construction d’Audacity n’inclut pas la prise en charge du MIDI, court-circuitage de la piste."
 
 #: src/import/ImportAUP.cpp
@@ -11567,40 +12287,6 @@ msgstr "Index[%02x] Codec[%s], Langue[%s], Débit binaire[%s], Canaux[%d], Duré
 msgid "FLAC files"
 msgstr "Fichiers FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Fichiers compatibles GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Incapable d’ajouter le décodeur au tuyau"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Assistant d’importation GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Incapable de paramétrer l’état du flux à mettre en pause."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index[%02d], Type[%s], Canaux[%d], Taux[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Le fichier ne contient aucun flux audio."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Impossible d’importer le fichier, le changement d’état a échoué."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Erreur GStreamer : %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Liste des fichiers en format texte"
@@ -11703,6 +12389,99 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, et autres formats non-compressés"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
 msgstr "8 bits PCM signé"
 
@@ -11729,6 +12508,66 @@ msgstr "32 bits flottant"
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "64 bits flottant"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DWVW"
+msgstr "16 bits"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "24 bit DWVW"
+msgstr "24 bits"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DPCM"
+msgstr "16 bits PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "16 bits PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11863,6 +12702,7 @@ msgstr "%s droite"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11886,6 +12726,7 @@ msgstr "fin"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11912,7 +12753,8 @@ msgstr "Déplacer les clips étirés temporellement vers la droite"
 msgid "Time shifted clips to the left"
 msgstr "Décalage les pistes étirés temporellement vers la gauche"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Glissement temporel"
 
@@ -12059,7 +12901,8 @@ msgstr "Rogner la piste audio sélectionné de %.2f secondes à %.2f secondes"
 msgid "Trim Audio"
 msgstr "Rognage audio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Séparer"
 
@@ -12191,35 +13034,9 @@ msgstr "Touche &de suppression"
 msgid "Delete Key&2"
 msgstr "Touche de suppression&2"
 
-# trebmuh to check ("barre de" nécessaire ?)
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Barre de mi&xeur"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "A&juster le volume de lecture…"
-
-# trebmuh to check (accélérateur)
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Augmenter le volume de lecture (&i)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Ré&duire le volume de lecture"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Aj&uster le volume d’enregistrement…"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Augme&nter le volume d’enregistrement"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Réduir&e le volume d’enregistrement"
+msgid "Ext&ra"
+msgstr ""
 
 # trebmuh to check (accélérateur)
 #: src/menus/ExtraMenus.cpp
@@ -12497,8 +13314,9 @@ msgid "&Getting Started"
 msgstr "Prêt à démarrer (&g)"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manuel d’Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manuel…"
 
 # trebmuh to check (accélérateur)
 #: src/menus/HelpMenus.cpp
@@ -12508,6 +13326,11 @@ msgstr "Aide rapide (&Q)…"
 #: src/menus/HelpMenus.cpp
 msgid "&Manual..."
 msgstr "&Manuel…"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Diagnostics"
+msgstr "exécute les auto-diagnostiques"
 
 #: src/menus/HelpMenus.cpp
 msgid "Au&dio Device Info..."
@@ -12521,11 +13344,8 @@ msgstr "Informations sur les périphériques &MIDI…"
 msgid "Show &Log..."
 msgstr "Afficher le journal des &bogues…"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "À propos d’&Audacity…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Marqueur ajouté"
 
@@ -12737,6 +13557,10 @@ msgstr "Mettre en arrière de la fenêtre active"
 msgid "Move Forward Through Active Windows"
 msgstr "Mettre en avant de la fenêtre active"
 
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
 # trebmuh to check
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -12871,6 +13695,12 @@ msgstr "Simuler des erreurs d’enregistrement"
 msgid "Detect Upstream Dropouts"
 msgstr "Détecter les désynchronisations amonts"
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Script&ables I"
+msgstr "tous les scriptables"
+
 #: src/menus/PluginMenus.cpp
 msgid "Select Time..."
 msgstr "Sélectionner le temps…"
@@ -12919,6 +13749,12 @@ msgstr "Paramétrer le marqueur…"
 msgid "Set Project..."
 msgstr "Paramétrer le projet…"
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "tous les scriptables"
+
 # trebmuh to check (accélérateur)
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -12961,6 +13797,11 @@ msgstr "Capture d’écran (format court)…"
 #: src/menus/SelectMenus.cpp
 msgid "Set Left Selection Boundary"
 msgstr "Définir la limite gauche de sélection"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Position audio"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Right Selection Boundary"
@@ -13053,6 +13894,11 @@ msgstr "Stocker la &sélection"
 #: src/menus/SelectMenus.cpp
 msgid "Retrieve Selectio&n"
 msgstr "Récupérer la sélectio&n"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "S&pectral"
+msgstr "Spectre"
 
 # trebmuh to check (accélérateur)
 #: src/menus/SelectMenus.cpp
@@ -13227,6 +14073,7 @@ msgstr "Grand saut de curseur à droite (&m)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Chercher (&k)"
@@ -13441,18 +14288,21 @@ msgid "Created new label track"
 msgstr "Nouvelle piste de marqueurs créée"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Cette version d’Audacity n’autorise qu’une seule piste de tempo par projet."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Nouvelle piste de tempo créée"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nouveau taux d’échantillonnage (Hz) :"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "La valeur entrée est invalide"
 
@@ -13530,6 +14380,12 @@ msgstr "Piste de mar&queurs"
 #: src/menus/TrackMenus.cpp
 msgid "&Time Track"
 msgstr "Piste de &tempo"
+
+# trebmuh to check ("barre de" nécessaire ?)
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Barre de mi&xeur"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
@@ -13720,7 +14576,9 @@ msgstr "En lecture"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Enregistrement"
 
@@ -13779,6 +14637,13 @@ msgstr "Veuillez sélectionner au moins %d canaux."
 msgid "Please select a time within a clip."
 msgstr "Veuillez sélectionner un temps compris dans un clip."
 
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Tra&nsport"
+msgstr "Transport"
+
 # trebmuh to check (accélérateur)
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
@@ -13796,6 +14661,11 @@ msgstr "Lecture/arrêt et po&sitionnement du curseur"
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play"
 msgstr "Lecture en bouc&le"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "%s en pause."
 
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
@@ -13870,8 +14740,9 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "&Passage audio logiciel (marche/arrêt)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Ajustement a&utomatique du niveau d’enregistrement (marche/arrêt)"
+#, fuzzy
+msgid "T&ransport"
+msgstr "Transport"
 
 # trebmuh to check (accélérateur)
 #. i18n-hint: (verb) Start playing audio
@@ -13971,6 +14842,13 @@ msgstr "Aller au marqueur &suivant"
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Affichage"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "Zoom"
 
 # trebmuh to check (accélérateur)
 #: src/menus/ViewMenus.cpp
@@ -14100,7 +14978,7 @@ msgstr "Préférences pour la qualité"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Mettre Audacity à jour"
 
 # trebmuh to check (accélérateur)
@@ -14133,6 +15011,13 @@ msgstr "Périphériques"
 msgid "Preferences for Device"
 msgstr "Préférences pour le périphérique"
 
+#. i18n-hint Software interface to audio devices
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgctxt "device"
+msgid "Interface"
+msgstr "Interface utilisateur"
+
 #. i18n-hint: (noun)
 #: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
 msgid "&Host:"
@@ -14142,7 +15027,8 @@ msgstr "&Hôte :"
 msgid "Using:"
 msgstr "Utilisation :"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Lecture"
 
@@ -14164,7 +15050,8 @@ msgstr "Ca&naux :"
 msgid "Latency"
 msgstr "Latence"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "millisecondes"
 
@@ -14186,11 +15073,17 @@ msgid "No devices found"
 msgstr "Aucun périphérique trouvé"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Canal (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "2 (Stereo)"
 msgstr "2 (Stéréo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Répertoires"
 
@@ -14257,9 +15150,7 @@ msgstr "Emp&lacement :"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory cannot be on a FAT drive."
-msgstr ""
-"Le répertoire des fichiers temporaires ne peut pas se trouver sur un lecteur "
-"FAT."
+msgstr "Le répertoire des fichiers temporaires ne peut pas se trouver sur un lecteur FAT."
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
@@ -14301,7 +15192,8 @@ msgid "Directory %s is not writable"
 msgstr "Le répertoire %s est protégé en écriture"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Les changements de dossier temporaire ne prendront effet qu’après avoir redémarré Tenacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14332,6 +15224,40 @@ msgstr "Groupé par éditeur"
 msgid "Grouped by Type"
 msgstr "Groupé par type"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Erreur Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Activer les effets"
@@ -14353,11 +15279,13 @@ msgid "Plugin Options"
 msgstr "Options de greffon"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Vérifier les mises à jour de greffons lors du démarrage d’Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Rescanner les greffons lors du prochain lancement d’Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14447,6 +15375,13 @@ msgstr "Confirmation de suppression de règle"
 msgid "Ext Import"
 msgstr "Import ext"
 
+#. i18n-hint: refers to Audacity's user interface settings
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgctxt "GUI"
+msgid "Interface"
+msgstr "Interface utilisateur"
+
 #: src/prefs/GUIPrefs.cpp
 msgid "Preferences for GUI"
 msgstr "Préférences pour l’IGU"
@@ -14482,6 +15417,11 @@ msgstr "-120 dB (limite approximative de l’audition humaine)"
 #: src/prefs/GUIPrefs.cpp
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (amplitude PCM en échantillonnage 24 bits)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Voix I"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
@@ -14529,7 +15469,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Conserver les marqueurs si la sélec&tion s’aligne sur un marqueur"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Mé&langer les thèmes Audacity et système"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14577,6 +15518,10 @@ msgid "&Use Advanced Mixing Options"
 msgstr "&Utiliser les options de mixage avancées"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "E&xtended (with frequency ranges)"
 msgstr "Étendue (avec plages de fréquences) (&x)"
 
@@ -14611,6 +15556,10 @@ msgstr "Style de la balise exportée :"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "L’heure d’enregistrement des fichiers Allegro exportés (.gro) :"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14708,7 +15657,8 @@ msgstr ""
 "   *   \"%s\"  (car le raccourci '%s' est utilisé par \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Choisir un fichier XML contenant les raccourcis clavier d’Audacity…"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14841,8 +15791,9 @@ msgid "Dow&nload"
 msgstr "Téléchargeme&nt"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity a détecté automatiquement des bibliothèques FFmpeg valides.\n"
@@ -14869,6 +15820,13 @@ msgstr "Préférences pour MIDI ES"
 msgid "No MIDI interfaces"
 msgstr "Pas d’interface MIDI"
 
+#. i18n-hint Software interface to MIDI
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgctxt "MIDI"
+msgid "Interface"
+msgstr "Interface utilisateur"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Using: PortMidi"
 msgstr "Utilisation de PortMidi"
@@ -14885,13 +15843,19 @@ msgstr "La latence de synthétiseur MIDI doit être un nombre entier"
 msgid "Midi IO"
 msgstr "ES MIDI"
 
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "Préférences pour le module"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Ce sont des modules expérimentaux. Activez-les uniquement si vous avez lu \n"
@@ -14899,12 +15863,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'Demander' signifie qu’Audacity vous demandera si vous souhaitez charger le module à chaque fois qu’il démarre."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'Échoué' signifie qu’Audacity pense que le module est cassé et ne lancera pas."
 
 #. i18n-hint preserve the leading spaces
@@ -14914,7 +15880,8 @@ msgstr "  'Nouveau' signifie qu’aucun choix n’a encore été fait"
 
 # trebmuh to check (meilleure traduction possible peut être ?)
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Les modifications de ces paramètres ne prendront effet qu’après avoir relancé Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14928,6 +15895,14 @@ msgstr "Échec"
 #: src/prefs/ModulePrefs.cpp
 msgid "No modules were found"
 msgstr "Aucun module trouvé"
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14969,7 +15944,10 @@ msgstr "Glisser à gauche"
 msgid "Set Selection Range"
 msgstr "Régler la sélection"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Maj + clic-gauche"
 
@@ -15058,6 +16036,15 @@ msgstr "-glisser-gauche"
 msgid "Move clip up/down between tracks"
 msgstr "Déplacer les clips d’une piste à l’autre"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-glisser-gauche"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -15086,6 +16073,11 @@ msgstr "Changer plusieurs échantillons"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Changer UN seul échantillon"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Multi-outil"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -15185,7 +16177,8 @@ msgid "Always scrub un&pinned"
 msgstr "Toujours un frottement non-punaisé"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Préférences d’Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -15199,6 +16192,11 @@ msgstr "Préférences :"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Préférences pour la qualité"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -15323,39 +16321,6 @@ msgid "System T&ime"
 msgstr "Temps du système (&i)"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Ajustement automatique du niveau d’enregistrement"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Activer l’ajustement automatique du niveau d’enregistrement."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Pic cible :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Compris dans :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Durée d’analyse :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "millisecondes (durée d’une analyse)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Nombre d’analyses consécutives :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 pour illimité"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Enregistrement punch & roll"
 
@@ -15366,6 +16331,21 @@ msgstr "Pré-&lancement :"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "&Fondu-enchaîné :"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15503,6 +16483,10 @@ msgid "1024 - default"
 msgstr "1024 - par défaut"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - bande la plus étroite"
 
@@ -15598,15 +16582,21 @@ msgstr "Thème"
 msgid "Preferences for Theme"
 msgstr "Préférences pour les thèmes"
 
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Info"
+msgstr "Obtenir des infos"
+
 # trebmuh to check
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15663,6 +16653,11 @@ msgstr "Comportements des pistes"
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Preferences for TracksBehaviors"
 msgstr "Préférences pour les comportements de pistes"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "échantillons"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -15787,7 +16782,8 @@ msgstr "échantillons"
 msgid "4 Pixels per Sample"
 msgstr "4 pixels par échantillon"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom max"
 
@@ -15922,6 +16918,19 @@ msgid "Skip to End"
 msgstr "Saut à la fin"
 
 #: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Pause"
+msgstr "%s en pause."
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Sélection jusqu’au début"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Sélection jusqu’à la fin"
+
+#: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
 msgstr "Lecture en boucle"
 
@@ -15933,20 +16942,17 @@ msgstr "Enregistre une nouvelle piste"
 msgid "Append Record"
 msgstr "Poursuite de l’enregistrement"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Sélection jusqu’à la fin"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Sélection jusqu’au début"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s en pause."
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s :"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -16027,11 +17033,17 @@ msgstr "Silencier l’audio sélectionné"
 msgid "Sync-Lock Tracks"
 msgstr "Pistes synchrones"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zoom avant"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zoom arrière"
 
@@ -16099,43 +17111,6 @@ msgstr "Barre de mesure d’enregist&rement"
 msgid "&Playback Meter Toolbar"
 msgstr "Barre de mesure de lecture (&p)"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volume d’enregistrement"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volume de lecture"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volume d’enregistrement : %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volume d’enregistrement (indisponible ; utilisez le mixeur système.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volume de lecture : %.2f (émulé)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volume de lecture : %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volume de lecture (indisponible ; utiliser le mixeur système.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barre de mi&xage"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Chercher"
@@ -16154,6 +17129,7 @@ msgstr "Frottement"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Arrêter le frottement"
@@ -16162,6 +17138,7 @@ msgstr "Arrêter le frottement"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Démarrer le frottement"
@@ -16169,6 +17146,7 @@ msgstr "Démarrer le frottement"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Arrêter la recherche"
@@ -16177,6 +17155,7 @@ msgstr "Arrêter la recherche"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Chercher le début"
@@ -16234,7 +17213,9 @@ msgstr "Se coller à"
 msgid "Length"
 msgstr "Durée"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centré"
 
@@ -16300,8 +17281,8 @@ msgstr "Barre de &temps"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barre d’outils %s d’Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -16328,7 +17309,8 @@ msgstr "Outil de glissement temporel"
 msgid "Zoom Tool"
 msgstr "Outil zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Outil de retouche"
 
@@ -16405,11 +17387,13 @@ msgstr "Glisser une ou plusieurs bordures du marqueur."
 msgid "Drag label boundary."
 msgstr "Glisser une bordure du marqueur."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Marqueur modifié"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Édition de marqueur"
 
@@ -16466,31 +17450,42 @@ msgstr "Marqueurs édités"
 msgid "New label"
 msgstr "Nouveau marqueur"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Octave &supérieure"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Octave &inférieure"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Cliquer pour zoom vertical. Maj + clic pour zoom arrière. Glisser pour zoomer sur une région."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clic-droit pour le menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Réinitialiser le zoom"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Maj + clic-droit"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Clic-gauche/déplacé-gauche"
 
@@ -16532,7 +17527,8 @@ msgstr "Mélanger"
 msgid "Expanded Cut Line"
 msgstr "Étendre la ligne de coupe"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Étendre"
 
@@ -16555,6 +17551,11 @@ msgstr "Échantillons déplacés"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Édition d’échantillon"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16581,6 +17582,11 @@ msgid "S&pectrogram Settings..."
 msgstr "&Paramètres du spectrogramme…"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Format :"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Modification du taux d’échantillonnage"
 
@@ -16596,7 +17602,8 @@ msgstr "Traitement…   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "« %s » changé en %s"
@@ -16609,6 +17616,54 @@ msgstr "Modification du format"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Taux (&e)"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 # trebmuh to check (accélérateur)
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -16629,7 +17684,8 @@ msgstr "Changement de taux"
 msgid "Set Rate"
 msgstr "Fréquence d’échantillonnage"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Multi-vue"
 
@@ -16648,6 +17704,10 @@ msgstr "Sc&inder la piste stéréo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Séparer la stéréo vers des mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16703,6 +17763,11 @@ msgid "Stereo, %dHz"
 msgstr "Stéréo, %dHz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Stéréo, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Gauche, %dHz"
@@ -16712,14 +17777,23 @@ msgstr "Gauche, %dHz"
 msgid "Right, %dHz"
 msgstr "Droit, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% gauche"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% droite"
@@ -16741,6 +17815,16 @@ msgid "Close sub-view"
 msgstr "Fermer les vues secondaires"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Zoom avant"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Zoom"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
 msgstr "Demi onde"
 
@@ -16752,6 +17836,11 @@ msgstr "Forme d’o&nde"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Couleur d’onde (&w)"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Instrument de musique"
 
 # trebmuh to check (vérifier dans un contexte graphique)
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -16828,9 +17917,8 @@ msgstr "&Interpolation logarithmique"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Cliquer et glisser pour glisser temporellement une piste"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16884,6 +17972,7 @@ msgstr "Enveloppe ajustée."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Frottement (&s)"
@@ -16896,6 +17985,7 @@ msgstr "En recherche"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Règle de frottement"
@@ -17104,6 +18194,12 @@ msgstr "G"
 msgid "R"
 msgstr "D"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -17137,13 +18233,28 @@ msgstr "Vide"
 msgid "Backwards"
 msgstr "En arrière"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "En avant"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Aide sur Internet"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Arbre de menu"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -17212,9 +18323,25 @@ msgstr "Pente"
 msgid "Meter Type"
 msgstr "Type des mesureurs"
 
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Orientation"
+msgstr "Durée"
+
 #: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
 msgid "Automatic"
 msgstr "Automatique"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Horizontal"
+msgstr "Horizontal"
+
+# trebmuh to check ("split" à traduire ou pas ?)
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "&Vertical"
 
 # trebmuh to check (on laisse "monitoring" ou on met "surveillance" ?)
 #: src/widgets/Meter.cpp
@@ -17255,6 +18382,23 @@ msgstr "Veuillez sélectionner une action"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 secondes"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "jj:hh:mm:ss"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 jours 024 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in days, hours,
 #. * minutes and seconds
 #: src/widgets/NumericTextCtrl.cpp
@@ -17276,11 +18420,35 @@ msgstr "0100 jours 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + centièmes"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 images|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + millisecondes"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 images|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -17302,6 +18470,7 @@ msgstr "0100 h 060 m 060 s+># échantillons"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "échantillons"
@@ -17463,6 +18632,16 @@ msgstr "01000,01000 échantillons|75"
 msgid "010,01000>0100 Hz"
 msgstr "010,01000<0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "kHz"
+msgstr "Hz"
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -17470,6 +18649,17 @@ msgstr "010,01000<0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0.001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in octaves
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "octaves"
+msgstr "à l’octave"
 
 #. i18n-hint: Format string for displaying log of frequency in octaves.
 #. * Change the decimal points for your locale. Don't change the numbers.
@@ -17529,6 +18719,11 @@ msgstr "(Utiliser le menu contextuel pour modifier le format.)"
 msgid "centiseconds"
 msgstr "centièmes de seconde"
 
+#: src/widgets/PopupMenuTable.h
+#, fuzzy, c-format
+msgid "%s (%s)"
+msgstr "(%s)"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Temps écoulé :"
@@ -17573,6 +18768,11 @@ msgstr "Confirmer la fermeture"
 msgid "Unable to write files to directory: %s."
 msgstr "Incapable de lire le préréglages depuis \"%s\""
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17587,6 +18787,10 @@ msgstr "Préférences pour les répertoires"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Ne plus montrer cet avertissement"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17671,15 +18875,27 @@ msgid "Spectral edit multi tool"
 msgstr "Multi-outils d’édition spectrale"
 
 # trebmuh to check (vérifier dans un contexte graphique)
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrage…"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Fourni sous les termes de la licence public générale GNU version 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aVeuillez sélectionner les fréquences."
@@ -17706,7 +18922,8 @@ msgstr ""
 "                      Essayez d’augmenter la limite de fréquence basse~%~\n"
 "                      ou de réduire le filtre de largeur 'Width'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Erreur.~%"
@@ -17714,6 +18931,11 @@ msgstr "Erreur.~%"
 #: plug-ins/SpectralEditParametricEQ.ny
 msgid "Spectral edit parametric EQ"
 msgstr "Égalisation paramétrique de l’édition spectrale"
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Gain (dB)"
+msgstr "&Gain (dB) :"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
@@ -17763,6 +18985,25 @@ msgstr "Fondu en fermeture du studio"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Application du fondu…"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Réglages par dé&faut"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Fourni sous licence publique générale GNU version 2 ou suivante."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17910,6 +19151,10 @@ msgstr "Trouveur de pulsation"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Recherche de pulsations…"
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18238,7 +19483,12 @@ msgstr "Filtre passe-haut"
 msgid "Performing High-Pass Filter..."
 msgstr "Exécution du filtre passe-haut…"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Fréquence (Hz)"
 
@@ -18246,6 +19496,26 @@ msgstr "Fréquence (Hz)"
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB par octave)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -18266,10 +19536,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Marquer les sons"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Fourni sous licence publique générale GNU version 2 ou suivante."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18367,6 +19633,11 @@ msgstr "Limiteur"
 #: plug-ins/limiter.ny
 msgid "Limiting..."
 msgstr "Limitation…"
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Type"
+msgstr "Type :"
 
 # trebmuh to check (vérifier dans un contexte graphique)
 #: plug-ins/limiter.ny
@@ -18572,7 +19843,8 @@ msgstr "Fichier Lisp"
 msgid "HTML file"
 msgstr "Fichier HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Fichier texte"
 
@@ -18637,6 +19909,10 @@ msgstr "Ne peut pas être écrit dans le dossier des greffons :"
 msgid "Error.~%No file selected."
 msgstr "Erreur.~%Aucun fichier sélectionné."
 
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
 # trebmuh : à vérifier
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
@@ -18645,6 +19921,10 @@ msgstr "Génération de son pluck…"
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Valeurs MIDI pour les notes Do : 36, 48, 60 [Do du milieu], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
 
 # trebmuh : à vérifier
 #: plug-ins/pluck.ny
@@ -18676,6 +19956,10 @@ msgid "Generating Rhythm..."
 msgstr "Génération de rythme…"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 pulsations/minute"
 
@@ -18690,6 +19974,10 @@ msgstr "1 - 20 pulsations/minute"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Quantité de swing"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18732,6 +20020,11 @@ msgid "Ping (short)"
 msgstr "Ping (court)"
 
 #: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Ping (long)"
+msgstr "Goutte (long)"
+
+#: plug-ins/rhythmtrack.ny
 msgid "Cowbell"
 msgstr "Cloche de vache"
 
@@ -18756,6 +20049,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Hauteur MIDI de la pulsation forte"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Hauteur MIDI de la pulsation faible"
 
@@ -18777,6 +20074,10 @@ msgid "Generating Risset Drum..."
 msgstr "Génération d’une batterie Risset…"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Délai (secondes)"
 
@@ -18791,6 +20092,11 @@ msgstr "Largeur de la bande de bruit (Hz)"
 #: plug-ins/rissetdrum.ny
 msgid "Amount of noise in mix (percent)"
 msgstr "Quantité de bruit dans le mix (pourcentage)"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amplitude (0 - 1)"
+msgstr "&Amplitude (0-1) :"
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
@@ -18837,6 +20143,11 @@ msgid "Include header information"
 msgstr "Inclut les entêtes d’informations"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Minimal"
+msgstr "&Minimiser"
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Tout"
 
@@ -18869,6 +20180,11 @@ msgstr "Afficher les messages"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Erreurs seulement"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -19170,6 +20486,10 @@ msgid "Applying Action..."
 msgstr "Application de l’action…"
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "Suppression des voix: vers mono"
 
@@ -19318,6 +20638,10 @@ msgid "Processing Vocoder..."
 msgstr "Traitement vocodeur…"
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "Distance : (1 à 120, défaut = 20)"
 
@@ -19357,6 +20681,230 @@ msgstr "Fréquence des aiguilles de radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Erreur.~%Piste stéréo nécessaire."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Mettre Tenacity à jour"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Sauter"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Installer la mise à jour"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Journal des modifications"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "En lire davantage sur GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Erreur de vérification de mise à jour"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Impossible de se connecter au serveur de mise à jour de Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Les données de mise à jour ont été corrompues."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Erreur de téléchargement de la mise à jour."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Impossible d’ouvrir le lien de téléchargement de Tenacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s est disponible !"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Enregistrement"
+
+# trebmuh to check (vérifier dans un contexte graphique)
+#~ msgid "Commit Id:"
+#~ msgstr "Identifiant de commit :"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Bibliothèque graphique multiplateforme"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importer via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Impossible de l’optimiser davantage. Toujours trop haut."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "L’ajustement automatique du niveau d’enregistrement a réduit le volume à %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Impossible de l’optimiser davantage. Toujours trop bas."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "L’ajustement automatique du niveau d’enregistrement a augmenté le volume à %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Le nombre total d’analyses a été dépassé sans pouvoir trouver un volume acceptable. Toujours trop haut."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. Le nombre total d’analyses a été dépassé sans pouvoir trouver un volume acceptable. Toujours trop bas."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Arrêt de l’ajustement automatique du niveau d’enregistrement. %.2f semble être un volume acceptable."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Reçu %d lors de l’ouverture des périphériques\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Impossible d’ouvrir Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Mixeurs disponibles : \n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Sources d’enregistrement disponibles :\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volumes de lecture disponibles :\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Le volume d’enregistrement est émulé\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Le vlume d’enregistrement est natif\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Le volume de lecture est émulé\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Le volume de lecture est natif\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Date et heure de fin"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Fichiers compatibles GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Incapable d’ajouter le décodeur au tuyau"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Assistant d’importation GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Incapable de paramétrer l’état du flux à mettre en pause."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index[%02d], Type[%s], Canaux[%d], Taux[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Le fichier ne contient aucun flux audio."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Impossible d’importer le fichier, le changement d’état a échoué."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Erreur GStreamer : %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "A&juster le volume de lecture…"
+
+# trebmuh to check (accélérateur)
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Augmenter le volume de lecture (&i)"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Ré&duire le volume de lecture"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Aj&uster le volume d’enregistrement…"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Augme&nter le volume d’enregistrement"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Réduir&e le volume d’enregistrement"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manuel d’Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "À propos d’&Audacity…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Ajustement a&utomatique du niveau d’enregistrement (marche/arrêt)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Ajustement automatique du niveau d’enregistrement"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Activer l’ajustement automatique du niveau d’enregistrement."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Pic cible :"
+
+#~ msgid "Within:"
+#~ msgstr "Compris dans :"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Durée d’analyse :"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "millisecondes (durée d’une analyse)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Nombre d’analyses consécutives :"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 pour illimité"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volume d’enregistrement"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volume de lecture"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volume d’enregistrement : %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume d’enregistrement (indisponible ; utilisez le mixeur système.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volume de lecture : %.2f (émulé)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volume de lecture : %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume de lecture (indisponible ; utiliser le mixeur système.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barre de mi&xage"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Cliquer et glisser pour glisser temporellement une piste"
 
 #~ msgid "Program build date:"
 #~ msgstr "Date de construction du programme :"
@@ -19404,9 +20952,6 @@ msgstr "Erreur.~%Piste stéréo nécessaire."
 #~ msgid "volunteers"
 #~ msgstr "bénévoles"
 
-#~ msgid "available"
-#~ msgstr "disponible"
-
 #~ msgid "If you find a bug or have a suggestion for us, please write, in English, to our %s. For help, view the tips and tricks on our %s or visit our %s."
 #~ msgstr "Si vous trouvez un bogue ou que vous avez une suggestion pour nous, veuillez nous écrire, en anglais, à notre %s. Pour de l’aide, consultez les trucs et astuces sur notre %s ou visitez notre %s."
 
@@ -19437,9 +20982,6 @@ msgstr "Erreur.~%Piste stéréo nécessaire."
 #~ msgid "Gray Scale"
 #~ msgstr "Échelle de gris"
 
-#~ msgid "Menu Tree"
-#~ msgstr "Arbre de menu"
-
 #~ msgid "&Generate Support Data..."
 #~ msgstr "&Générer les données de support…"
 
@@ -19453,173 +20995,6 @@ msgstr "Erreur.~%Piste stéréo nécessaire."
 #~ msgid "[Project %02i] Audacity "
 #~ msgstr "[Projet %02i] Tenacity "
 
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity n'est pas produit ni approuvé par MuseCY SM Ltd. ou Dominic M "
-"Mazzoni."
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Veuillez noter que les noms sont classés par ordre alphabétique et non par "
-"ordre d'importance."
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Harvey Lubin (logo)"
-msgstr "Harvey Lubin (logo)"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Script"
-msgstr "Script"
-
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
-msgid "Options"
-msgstr "Options"
-
-#: src/Tags.cpp
-msgid "Genres"
-msgstr "Genres"
-
-#: src/Tags.cpp
-msgid "Genre"
-msgstr "Genre"
-
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
-msgid "Transport"
-msgstr "Transport"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#: src/ProjectFileIO.cpp
 #, c-format
-msgid "[Project %02i] "
-msgstr "[Projet %02i] "
-
-#. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Solo"
-msgstr "Solo"
-
-#. i18n-hint: title of the Gain slider, used to adjust the volume
-#. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
-msgid "Gain"
-msgstr "Gain"
-
-#: src/HistoryWindow.cpp src/effects/TruncSilence.cpp plug-ins/vocalrediso.ny
-msgid "Action"
-msgstr "Action"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
-msgid "Zoom"
-msgstr "Zoom"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#: src/FileNames.cpp
-msgid ", "
-msgstr ", "
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/Dither.cpp plug-ins/tremolo.ny
-msgid "Triangle"
-msgstr "Triangle"
-
-#. i18n-hint: This is the heading for a column in the edit macros dialog
-#: src/BatchProcessDialog.cpp
-msgid "Macro"
-msgstr "Macro"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#: src/AudacityLogger.cpp
-msgid "log.txt"
-msgstr "journal.txt"
-
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
-msgid "Message"
-msgstr "Message"
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"La marque Audacity%s est utilisée dans ce logiciel à des fins descriptives "
-"et informatives uniquement."
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"

--- a/locale/ga.po
+++ b/locale/ga.po
@@ -6,79 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Irish <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"ga/>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/tenacity/tenacity/ga/>\n"
 "Language: ga\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :("
-"n>6 && n<11) ? 3 : 4;\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :(n>6 && n<11) ? 3 : 4;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Nuashonraigh Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "Léim thar &seo"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Suiteáil an nuashonrú"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Oireas na n-athruithe"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Léigh tuilleadh ar GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Earráid le linn oscailt an chomhaid"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Bhí na sonraí nuashonraithe truaillithe."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Earráid le linn oscailt an chomhaid"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Ní féidir nasc íosluchtaithe Audacity a oscailt."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Barra Uirlisí %s Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Taifeadadh á dhéanamh"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -88,6 +25,24 @@ msgstr "Ní fhéidir a aithint"
 #, c-format
 msgid "%s bytes"
 msgstr "%s bearta"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -140,6 +95,20 @@ msgstr "Roghnaigh Ui&le\tCtrl+A"
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Find...\tCtrl+F"
 msgstr "&Aimsigh... Ctrl+F"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Top S-expr\tF9"
+msgstr "&S-expr ar aghaidh\tF12"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Higher S-expr\tF10"
+msgstr "&S-expr ar aghaidh\tF12"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Previous S-expr\tF11"
@@ -197,8 +166,14 @@ msgstr "&Stad\tF6"
 msgid "&About"
 msgstr "M&aidir leis"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Taisc an script"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Aschur"
 
@@ -210,7 +185,17 @@ msgstr "Luchtaigh script Nyquist"
 msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
 msgstr "Scripteanna Nyquist (*.ny)|*.ny|scripteanna Lisp (*.lsp)|*.lsp|Gach comhad|*"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script was not saved."
+msgstr "níor bogadh an ghearrthóg"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Foláireamh"
 
@@ -227,8 +212,21 @@ msgid "Harvey Lubin (logo)"
 msgstr "Harvey Lubin (lógó)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 le Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 le Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -250,7 +248,8 @@ msgstr "Gan teideal"
 msgid "Nyquist Effect Workbench - "
 msgstr "Binse Oibre Maisiúchán Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nua"
 
@@ -290,7 +289,8 @@ msgstr "Cóipeáil"
 msgid "Copy to clipboard"
 msgstr "Cóipeáil chuig an nghearrthaisce"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Gearr"
 
@@ -298,7 +298,8 @@ msgstr "Gearr"
 msgid "Cut to clipboard"
 msgstr "Gearr agus cuir sa ghearrthaisce é"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Greamaigh"
 
@@ -323,7 +324,8 @@ msgstr "Roghnaigh Uile"
 msgid "Select all text"
 msgstr "Roghnaigh gach téacs"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Cealaigh"
 
@@ -331,7 +333,8 @@ msgstr "Cealaigh"
 msgid "Undo last change"
 msgstr "Cealaigh an t-athrú sin"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Déan arís é"
 
@@ -352,12 +355,26 @@ msgid "Match"
 msgstr "Comhoiriúnaigh"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "Go barr"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Téigh chuig an S-expr ar aghaidh"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Suas"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to higher S-expr"
+msgstr "Téigh chuig an S-expr ar aghaidh"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
@@ -376,7 +393,8 @@ msgid "Go to next S-expr"
 msgstr "Téigh chuig an S-expr ar aghaidh"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Tosaigh"
 
@@ -384,7 +402,8 @@ msgstr "Tosaigh"
 msgid "Start script"
 msgstr "Tosaigh an script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Stad"
 
@@ -399,7 +418,8 @@ msgid "About %s"
 msgstr "Maidir le %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Tá go Maith"
 
@@ -407,11 +427,13 @@ msgstr "Tá go Maith"
 msgid "Build Information"
 msgstr "Faisnéis na Tógála"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Cumasaithe"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Díchumasaithe"
 
@@ -419,6 +441,11 @@ msgstr "Díchumasaithe"
 #: src/AboutDialog.cpp
 msgid "The Build"
 msgstr "An Tógáil"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Á Aisiompú"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -429,8 +456,27 @@ msgid "Compiler:"
 msgstr "Tiomsaitheoir:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "Fillteán na socruithe:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "Fillteán na socruithe:"
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -441,12 +487,20 @@ msgstr "Athsheinm agus taifeadadh fuaime"
 msgid "Sample rate conversion"
 msgstr "Ráta samplaithe:"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "Ag tabhairt isteach %s"
+
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Tabhairt Isteach agus Amach Ogg Vorbis"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "ID3 tag support"
+msgstr "Tacaíocht do bhreiseáin"
+
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Tabhairt Isteach agus Amach FLAC"
@@ -464,12 +518,24 @@ msgid "FFmpeg Import/Export"
 msgstr "Tabhairt Isteach/Amach FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Gnéithe"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Tacaíocht do bhreiseáin"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Gnéithe"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -588,6 +654,10 @@ msgstr "%s, grafaicí"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (ag cuimsiú %s, %s, %s, %s agus %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -597,6 +667,10 @@ msgstr "%s an t-oideasra saor in aisce, foinse oscailte, tras-ardán chun fuaime
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Creidiúintí"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -621,8 +695,18 @@ msgstr "Leabharlanna"
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s includes code from the following projects:"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s Team Members"
 msgstr "Comhaltaí Foirne %s"
+
+#: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "Contributors"
@@ -637,6 +721,7 @@ msgstr "Suíomh Gréasáin agus Grafaicí"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "creidiúintí_aistritheora"
@@ -655,6 +740,26 @@ msgstr "Buíochas faoi leith:"
 msgid "%s website: "
 msgstr "Suíomh gréasáin %s: "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Rannchuiditheoirí"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Cnag is tarraing chun méad coibhneasta rianta déthónacha a ghléasadh."
@@ -672,6 +777,7 @@ msgstr "Líne Ama"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Cnag is tarraing chun na samplaí a chur in eagar"
@@ -679,6 +785,7 @@ msgstr "Cnag is tarraing chun na samplaí a chur in eagar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Cnag is tarraing chun an rian a athmhéadú."
@@ -686,8 +793,39 @@ msgstr "Cnag is tarraing chun an rian a athmhéadú."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Bog go Sciúr"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
+msgstr "Bog go Sciúr"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
 msgstr "Bog go Sciúr"
 
 #: src/AdornedRulerPanel.cpp
@@ -711,10 +849,34 @@ msgid "Enable dragging selection"
 msgstr "Cuir an Rogha ina thost"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "Taifeadadh á dhéanamh"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Earráid"
 
@@ -728,8 +890,28 @@ msgid "Failed!"
 msgstr "Theip air!"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Roghanna Audacity"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -754,7 +936,7 @@ msgstr "&Oscail..."
 msgid "Open &Recent..."
 msgstr "Oscail Le Déanaí..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Mar Gheall ar Audacity..."
@@ -768,46 +950,137 @@ msgid "&File"
 msgstr "&Comhad"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Theip ar Audacity áit a aimsiú chun comhaid shealadacha a chur i dtaisce.\n"
 "Luaigh comhadlann chuí i mbosca caidrimh na roghanna."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Theip ar Audacity áit a aimsiú chun comhaid shealadacha a chur i dtaisce.\n"
 "Luaigh comhadlann chuí i mbosca caidrimh na roghanna."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Tá Audacity ar tí scuir.  Múscail arís é chun an chomhadlann shealadach nua a úsáid."
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+msgid ""
+"Running two copies of Tenacity simultaneously may cause\n"
+"data loss or cause your system to crash.\n"
+"\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "An mian leat fós Audacity a thosú?"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Earráid le linn oscailt an chomhaid"
+
+#: src/AudacityApp.cpp
+msgid "The system has detected that another copy of Tenacity is running.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Use the New or Open commands in the currently running Tenacity\n"
+"process to open multiple projects simultaneously.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tá Audacity ar siúl cheana féin"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Teip Thosaithe Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
 
 #. i18n-hint: This displays a list of available options
 #: src/AudacityApp.cpp
 msgid "this help message"
 msgstr "an teachtaireacht chabhrach seo"
 
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "run self diagnostics"
+msgstr "&Diagnóisic"
+
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "taispeáin an leagan Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -817,9 +1090,10 @@ msgid "audio or project file name"
 msgstr "ainm an chomhaid fuaime nó an chomhaid tionscadail"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -834,24 +1108,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Comhaid Tionscadail Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Teachtaireacht"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Aga taifeadta:"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Cabhair"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Scoir ó Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Céad Mhúscailt Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -863,9 +1161,19 @@ msgstr "&Taisc..."
 msgid "Cl&ear"
 msgstr "Glan"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Dún"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "Cuir íomhánna i dtaisce i:"
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -894,18 +1202,39 @@ msgid "Error Initializing Audio"
 msgstr "Earráid le Linn Tosnú Fuaime"
 
 #: src/AudioIO.cpp
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
 msgid ""
 "You will not be able to play midi.\n"
 "\n"
 msgstr "Ní bheidh tú in ann midi a sheinm.\n"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "Earráid le Linn Tosnú Fuaime"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Fuaim Audacity"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Gan chuimhne!"
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -913,8 +1242,18 @@ msgid "Default recording device number: %d\n"
 msgstr "Taifeadadh á dhéanamh\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Taifeadadh á dhéanamh\n"
+
+#: src/AudioIOBase.cpp
 msgid "No devices found\n"
 msgstr "Níor aimsíodh aon ghléas\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Device info unavailable for: %d\n"
+msgstr "Níl réamhamharc ar fáil"
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -947,8 +1286,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Taifeadadh á dhéanamh\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Taifeadadh á dhéanamh\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Taifeadadh á dhéanamh\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Taifeadadh á dhéanamh\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -962,41 +1311,35 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Taifeadadh á dhéanamh\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Taifeadadh á dhéanamh\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Seinnt\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Ní fhéidir a aithint\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Meascthóirí ar fáil:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Taifeadadh á dhéanamh\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
 msgstr "Seinnt\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Taifeadadh á dhéanamh\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
 
+#. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Taifeadadh á dhéanamh\n"
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
 
+#. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Seinnt\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Seinnt\n"
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Luasanna a dtugtar Tacaíocht Dóibh:\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1009,21 +1352,45 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Gléas taifeadta MIDI a roghnaíodh: %d - %s\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Gléas taifeadta MIDI a roghnaíodh: %d - %s\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
 msgstr "Gléas athsheanma MIDI a roghnaíodh: %d - %s\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
+msgstr "Gléas athsheanma MIDI a roghnaíodh: %d - %s\n"
+
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "Automatic Crash Recovery"
+msgstr "Taisceadh Uathoibríoch"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
+"\n"
+"After recovery, save the projects to ensure changes are written to disk."
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "Tionscadail in-athshlánaithe"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Roghnaigh"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Ainm"
 
@@ -1036,8 +1403,20 @@ msgid "&Recover Selected"
 msgstr "Faic Roghnaithe"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Skip"
+msgstr "Léim thar &seo"
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "Níl dóthain sonraí roghnaithe."
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -1096,6 +1475,37 @@ msgid "Effect"
 msgstr "Maisiúchán"
 
 #: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (With Parameters)"
+msgstr "&Cuir na Paraiméadair in Eagar"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (No Parameters)"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Your batch command of %s was not recognized."
+msgstr ""
+
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Applied Macro"
+msgstr "Maisiúchán forchurtha: %s"
+
+#: src/BatchCommands.cpp
 msgid "Apply Macro"
 msgstr "Phaser á Fhorchur"
 
@@ -1112,8 +1522,29 @@ msgstr "Cuir '%s' i bhfeidhm"
 
 #: src/BatchCommands.cpp
 #, c-format
+msgid ""
+"Apply %s with parameter(s)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Test Mode"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
 msgid "Apply %s"
 msgstr "Cuir %s i bhfeidhm"
+
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Manage Macros"
+msgstr "Bainistigh na Cuair"
 
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
@@ -1127,8 +1558,23 @@ msgid "Macro"
 msgstr "Maicrea"
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Phaser á Fhorchur"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to project"
+msgstr "Tionscadail Audacity"
+
+#: src/BatchProcessDialog.cpp
 msgid "&Project"
 msgstr "&Tionscadal"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to files..."
+msgstr "Phaser á Fhorchur"
 
 #: src/BatchProcessDialog.cpp
 msgid "&Files..."
@@ -1142,6 +1588,21 @@ msgstr "&Fairsingigh"
 #: src/BatchProcessDialog.cpp
 msgid "No macro selected"
 msgstr "Níl dóthain sonraí roghnaithe."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "Applying '%s' to current project"
+msgstr "&Sábháil Tionscadal"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Please save and close the current project first."
+msgstr "&Sábháil Tionscadal"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Select file(s) for batch processing..."
+msgstr "Rogha go dtí an Deireadh"
 
 #: src/BatchProcessDialog.cpp
 msgid "Applying..."
@@ -1171,7 +1632,8 @@ msgstr "Cuir ar ais"
 msgid "I&mport..."
 msgstr "Tabhair isteach..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "Tabhair amach..."
 
@@ -1212,7 +1674,8 @@ msgstr "Bog S&uas"
 msgid "Move &Down"
 msgstr "Bog Síos"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Taisc"
 
@@ -1236,12 +1699,23 @@ msgid "Do you want to save the changes?"
 msgstr "An mian leat na hathruithe a choimeád?"
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Enter name of new macro"
+msgstr "Ainm an mhaicrea nua"
+
+#: src/BatchProcessDialog.cpp
 msgid "Name of new macro"
 msgstr "Ainm an mhaicrea nua"
 
 #: src/BatchProcessDialog.cpp
 msgid "Name must not be blank"
 msgstr "Ní féidir leis an ainm a bheith bán"
+
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Names may not contain '%c' and '%c'"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of a file.
 #: src/BatchProcessDialog.cpp
@@ -1255,8 +1729,16 @@ msgid "Benchmark"
 msgstr "Tagarmharc"
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Líon uaireanta le hathdhéanamh:"
+
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
 
 #. i18n-hint: A "seed" is a number that initializes a
 #. pseudorandom number generating algorithm
@@ -1265,21 +1747,59 @@ msgid "Random Seed:"
 msgstr "Síol Fánach:"
 
 #: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Run"
 msgstr "Rith é"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Dún"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "Tagarmharc"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
 msgstr "Easpórtáil Sonraí Speictreacha Mar:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Á ullmhú...\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1307,17 +1827,90 @@ msgid "Paste: %lld\n"
 msgstr "Greamaigh %ld\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Cainéal Deas\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "TEST FAILED!!!\n"
 msgstr "THEIP AR AN TÁSTÁIL!!!\n"
 
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Dáta agus Am Críochnaithe"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
 
 #: src/BuildInfo.h
 #, fuzzy
@@ -1333,9 +1926,53 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Ní foláir duit rian a roghnú i dtosach."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Níl Fuaim Roghnaithe"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr "Ní foláir duit rian a roghnú i dtosach."
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr "Ní foláir duit rian a roghnú i dtosach."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1361,10 +1998,22 @@ msgstr "An Tionscadal Reatha"
 msgid "Checkpointing %s"
 msgstr "Ag tabhairt isteach %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Níorbh fhéidir scríobh sa chomhad: %s\n"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1382,9 +2031,41 @@ msgid ""
 "%s"
 msgstr "Theip ar chlárú: %s"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Removing Dependencies"
+msgstr "Dearbháil na Spleác&hais..."
+
+#: src/Dependencies.cpp
+msgid "Copying audio data into project..."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Project Depends on Other Audio Files"
 msgstr "Brathann an Tionscadal ar Chomhaid Fuaime Eile"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Dependencies"
+msgstr "Dearbháil na Spleác&hais..."
 
 #: src/Dependencies.cpp
 msgid "Audio File"
@@ -1403,8 +2084,17 @@ msgid "Cancel Save"
 msgstr "Cealaigh an Taisceadh"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Lipéad"
+
+#: src/Dependencies.cpp
 msgid "Do Not Copy"
 msgstr "Ná Cóipeáil"
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1415,6 +2105,12 @@ msgstr "Aon uair a bhfuil tionscadal ag brath ar chomhaid eile:"
 #: src/Dependencies.cpp
 msgid "Ask me"
 msgstr "Iarr orm"
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
 
 #. i18n-hint: One of the choices of what you want Audacity to do when
 #. * Audacity finds a project depends on another file.
@@ -1432,10 +2128,35 @@ msgid "&Copy Names to Clipboard"
 msgstr "Gearr is cuir sa ghearrathaisce"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "In easnamh"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dependencies.cpp
+msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Dependency Check"
+msgstr ""
+
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Faic"
 
@@ -1443,7 +2164,7 @@ msgstr "Faic"
 msgid "Rectangle"
 msgstr "Dronnuilleog"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triantán"
 
@@ -1457,8 +2178,60 @@ msgstr "Dronnuilleogach"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Loic"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -1474,6 +2247,11 @@ msgstr "Aimsigh FFmpeg"
 
 #: src/FFmpeg.cpp
 #, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
 msgid "Location of '%s':"
 msgstr "Mar a bhfuil '%s':"
 
@@ -1482,7 +2260,8 @@ msgstr "Mar a bhfuil '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Chun '%s' a aimsiú, brúigh anseo -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Siortaigh..."
 
@@ -1508,8 +2287,21 @@ msgid "FFmpeg not found"
 msgstr "Níor aimsíodh FFmpeg"
 
 #: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
 msgid "Do not show this warning again"
 msgstr "Ná taispeáin an rabhadh seo arís"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
 
 #. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
 #: src/FFmpeg.h
@@ -1521,9 +2313,27 @@ msgid "Only libavformat.so"
 msgstr "libavformat.so amháin"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Theip ar Audacity comhad a oscailt in %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr "Theip ar Audacity comhad a oscailt in %s."
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
+"Perhaps %s is not writable or the disk is full.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
 
 #: src/FileException.h
 msgid "File Error"
@@ -1536,6 +2346,18 @@ msgid "Error (file may not have been written): %s"
 msgstr "Earráid (seans nár scríobhadh an comhad): %s"
 
 #: src/FileFormats.cpp
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy all audio into project (safest)"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "Do &not copy any audio"
 msgstr "&Ná cóipeáil aon fhuaim"
 
@@ -1543,7 +2365,9 @@ msgstr "&Ná cóipeáil aon fhuaim"
 msgid "As&k"
 msgstr "Fiafraigh"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Gach comhad"
 
@@ -1552,6 +2376,11 @@ msgstr "Gach comhad"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Comhaid Tionscadail Audacity"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Leabharlanna"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1565,12 +2394,20 @@ msgstr "Comhaid téacs"
 msgid "XML files"
 msgstr "Comhaid XML"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "%s comhaid"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
 
 #: src/FileNames.cpp
 msgid "Specify New Filename:"
@@ -1601,6 +2438,14 @@ msgstr "Uath-chomhghaolú Pr. Ciúb."
 msgid "Enhanced Autocorrelation"
 msgstr "Uath-chomhghaolú  Leasaithe"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Speictream"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1617,6 +2462,17 @@ msgstr "Minicíocht líneach"
 msgid "Log frequency"
 msgstr "Minicíocht log"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Scrollaigh"
@@ -1624,6 +2480,15 @@ msgstr "Scrollaigh"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Gluais"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1684,11 +2549,48 @@ msgstr "Roghnaíodh an iomad fuaime.  Ní dhéanfar anailís ach ar an gcéad %.
 msgid "Not enough data selected."
 msgstr "Níl dóthain sonraí roghnaithe."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Speictream"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Easpórtáil Sonraí Speictreacha Mar:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Níorbh fhéidir scríobh sa chomhad: %s"
@@ -1700,6 +2602,11 @@ msgstr "Minicíocht (Hz)\tLevel (dB)"
 #: src/FreqWindow.cpp
 msgid "Lag (seconds)\tFrequency (Hz)\tLevel"
 msgstr "Moill (soicindí)\tMinicíocht (Hz)\tLeibhéal"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Plot Spectrum..."
+msgstr "Speictream"
 
 #: src/HelpText.cpp
 msgid "Welcome!"
@@ -1732,6 +2639,23 @@ msgstr "Taifeadadh á dhéanamh"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Tabhair Fuaim Amach"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Tionscadal Audacity á Oscailt"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
 msgid "Support for Other Formats"
 msgstr "Tacaíocht i gcomhair Formáidí Eile"
 
@@ -1745,6 +2669,22 @@ msgid "No Local Help"
 msgstr "Níl Cabhair Logánta Ar Fáil"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "How to get help"
 msgstr "Conas cabhair a fháil"
 
@@ -1752,9 +2692,39 @@ msgstr "Conas cabhair a fháil"
 msgid "These are our support methods:"
 msgstr "Seo iad na modhanna tacaíochta atá againn:"
 
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
 #: src/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
 msgstr " [[https://forum.audacityteam.org/|Forum]] - cuir do cheist go díreach, ar an ngréasán."
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1801,11 +2771,30 @@ msgstr "Cuileáil"
 msgid "&Compact"
 msgstr "&Gníomh Ordaithe"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Stair..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -1821,7 +2810,9 @@ msgid "Track"
 msgstr "Rian"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Lipéad"
 
@@ -1849,6 +2840,10 @@ msgstr "Ardmhinicíocht"
 msgid "New..."
 msgstr "Nua..."
 
+#: src/LabelDialog.cpp
+msgid "Press F2 or double click to edit cell contents."
+msgstr ""
+
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Select a text file containing labels"
 msgstr "Roghnaigh comhad téacs ina bhfuil lipéid"
@@ -1857,6 +2852,11 @@ msgstr "Roghnaigh comhad téacs ina bhfuil lipéid"
 #, c-format
 msgid "Could not open file: %s"
 msgstr "Theip ar oscailt an chomhaid: %s"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "No labels to export."
+msgstr "Níl aon rianta lipéid le n-easpórtáil."
 
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Export Labels As:"
@@ -1873,18 +2873,25 @@ msgstr "Cuir isteach ainm an riain"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Cuir Lipéad ar an Rian"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Céad Mhúscailt Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Roghnaigh teanga  d'Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -1894,9 +2901,15 @@ msgstr "Roghnaigh teanga  d'Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Ní hionann an teanga ar roghnaigh tú %s (%s), agus teanga an chórais, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Deimhnigh"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "Tharla Earráid Fad Agus A Bhí an Tionscadal Á Oscailt"
 
 #: src/Legacy.cpp
 #, c-format
@@ -1908,8 +2921,19 @@ msgstr ""
 "Seanachomhad arna shábháil mar '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Tionscadal Audacity á Oscailt"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Buíochas faoi leith:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Siortaigh..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1930,6 +2954,12 @@ msgid "&Redo"
 msgstr "&Athdhéan"
 
 #: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
 msgid "Disallowed"
 msgstr "Dícheadaithe"
 
@@ -1938,15 +2968,32 @@ msgstr "Dícheadaithe"
 msgid "Mix"
 msgstr "Measc"
 
+#: src/Mix.cpp src/menus/TrackMenus.cpp
+msgid "Mix and Render"
+msgstr ""
+
+#: src/Mix.cpp
+msgid "Mixing and rendering tracks"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr ""
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Neartúchán"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Treoluas"
 
@@ -1955,27 +3002,50 @@ msgid "Musical Instrument"
 msgstr "Gléas Ceoil"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Pean"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Tost"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Aonréadach"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Maide sleamhnáin neartúcháin arna bhogadh"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Maide sleamhnáin neartúcháin arna bhogadh"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Maide sleamhnáin peanála arna bhogadh"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "&Luchtaigh..."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1991,26 +3061,182 @@ msgstr "Níl an Modúl Oiriúnach"
 
 #: src/ModuleManager.cpp
 #, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
 msgid "Module \"%s\" found."
 msgstr "Aimsíodh an modúl \"%s\"."
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ná"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Céad Mhúscailt Audacity"
 
 #: src/ModuleManager.cpp
 msgid "Try and load this module?"
 msgstr "Féach an modúl seo a luchtú?"
 
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Rian Nótaí"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2020,6 +3246,10 @@ msgstr "Scríobh thar chomhaid reatha"
 #: src/PluginManager.cpp
 msgid "Plug-in already exists"
 msgstr "Is ann don bhreiseán cheana"
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2051,6 +3281,10 @@ msgstr "Leid Nyquist"
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Bainistigh na Breiseáin"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
 
 #. i18n-hint: This is before radio buttons selecting which effects to show
 #: src/PluginRegistrationDialog.cpp
@@ -2113,7 +3347,8 @@ msgstr "&Roghnaigh Uile"
 msgid "C&lear All"
 msgstr "G&lan Uile"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Cumasaigh"
 
@@ -2137,6 +3372,13 @@ msgid ""
 "%s"
 msgstr "Maisiúchán forchurtha: %s"
 
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"Effect or Command at %s failed to register:\n"
+"%s"
+msgstr "Theip ar chlárú: %s"
+
 #: src/Printing.cpp
 msgid "There was a problem printing."
 msgstr "Deacreacht le linn priontála."
@@ -2144,6 +3386,14 @@ msgstr "Deacreacht le linn priontála."
 #: src/Printing.cpp
 msgid "Print"
 msgstr "Priontáil"
+
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
 
 #: src/ProjectAudioManager.cpp
 #, c-format
@@ -2160,6 +3410,21 @@ msgstr "Earráid le linn oscailt ghléas fuaime. Deimhnigh socruithe ghléas an 
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Chun an speictream a rianadh, ní foláir gach rian roghnaithe a bheith ag an ráta samplaithe céanna."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Fuaim Thaifeadta"
@@ -2168,23 +3433,194 @@ msgstr "Fuaim Thaifeadta"
 msgid "Record"
 msgstr "Déan Taifeadadh"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "Dún an tionscadal láithreach gan aon athrú"
 
 #: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Theip ar oscailt chomhad an tionscadail"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr "Scrios comhaid dhílleachtacha (go buan agus láithreach bonn)"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning - Missing Aliased File(s)"
+msgstr "Rabhadh - Ag Oscailt Comhad Seanthionscadail"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Close project immediately with no further changes"
+msgstr "Dún an tionscadal láithreach gan aon athrú"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr "Rabhadh - Ag Oscailt Comhad Seanthionscadail"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr "Scrios comhaid dhílleachtacha (go buan agus láithreach bonn)"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr "Rabhadh - Ag Oscailt Comhad Seanthionscadail"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
 msgid "Delete orphan files (permanent immediately)"
 msgstr "Scrios comhaid dhílleachtacha (go buan agus láithreach bonn)"
 
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning - Orphan Block File(s)"
+msgstr "Rabhadh - Ag Oscailt Comhad Seanthionscadail"
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Dul Chun Cinn"
+
+#: src/ProjectFSCK.cpp
+msgid "Cleaning up unused directories in project data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
 
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<gan teideal>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Tionscadal %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2223,11 +3659,96 @@ msgid ""
 msgstr "Ní fhéidir a aithint"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Theip ar chlárú: %s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Ní fhéidir a aithint"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Ní fhéidir a aithint"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2236,12 +3757,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Ní fhéidir a aithint"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Ní fhéidir a aithint"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Ní fhéidir a aithint"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Theip ar chlárú: %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2252,23 +3799,50 @@ msgid "Error Writing to File"
 msgstr "Theip ar scríobh sa chomhaid: "
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write file %s.\n"
+"Perhaps disk is full or not writable.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Compacting project"
 msgstr "Tionscadal nua arna cheapadh"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Tionscadal %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Treoluas"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
 msgstr "(Athshlánaithe)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Theip ar oscailt chomhad an tionscadail"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2283,16 +3857,79 @@ msgid "Unable to parse project information."
 msgstr "Ní fhéidir a aithint"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Sábháil Tionscadal"
+
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Maisiúchán á Chur i gCrích: %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Rabhadh - Tionscadal Folamh"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Athshlánaíodh an tionscadal"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Comhadlann na gcomhad sealadach"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Warning - Empty Project"
@@ -2302,15 +3939,51 @@ msgstr "Rabhadh - Tionscadal Folamh"
 msgid "Insufficient Disk Space"
 msgstr "Slí ar an nDiosca"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
 msgstr "%s sábháilte"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Sábháil Tionscadal M&ar..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2318,9 +3991,21 @@ msgid "Overwrite Project Warning"
 msgstr "Scríobh thar chomhaid reatha"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Sábháil Tionscadal M&ar..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -2348,12 +4033,42 @@ msgid "Error Opening Project"
 msgstr "Tharla Earráid Fad Agus A Bhí an Tionscadal Á Oscailt"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Earráid le linn oscailt an chomhaid"
 
 #: src/ProjectFileManager.cpp
 msgid "Error opening file"
 msgstr "Earráid le linn oscailt an chomhaid"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"File may be invalid or corrupted: \n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Tharla Earráid Fad Agus A Bhí an Tionscadal Á Oscailt"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -2381,20 +4096,45 @@ msgid "Error Importing"
 msgstr "Earráid le linn iomportála"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Socraigh Tionscadal"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Theip ar oscailt chomhad an tionscadail"
 
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Gníomh Ordaithe"
+
 #: src/ProjectHistory.cpp
 msgid "Created new project"
 msgstr "Tionscadal nua arna cheapadh"
 
+#: src/ProjectHistory.cpp
+msgid "Automatic database backup failed."
+msgstr ""
+
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Fáilte go leagan %s d'Audacity"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2406,6 +4146,21 @@ msgstr "Sábháil athruithe?"
 #: src/ProjectManager.cpp
 msgid "Save project before closing?"
 msgstr "Sábháil athruithe sara ndúntar Audacity?"
+
+#: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "Disk space remaining for recording: %s"
+msgstr ""
 
 #: src/ProjectManager.cpp
 msgid "Less than 1 minute"
@@ -2437,6 +4192,12 @@ msgstr[4] ""
 msgid "%s and %s."
 msgstr "%s agus %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -2451,6 +4212,21 @@ msgstr "Scrollbharra Cothrománach"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Scrollbharra Ingearach"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -2468,9 +4244,30 @@ msgstr "Ardcháilíocht"
 msgid "Best Quality (Slowest)"
 msgstr "An Cháilíocht Is Fearr (Is moille)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "DPCM 16-bheart"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bheart"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
 #: src/SampleFormat.cpp
 msgid "Unknown format"
 msgstr "Anaithnid"
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Choose location to save files"
@@ -2483,6 +4280,10 @@ msgstr "Cuir íomhánna i dtaisce i:"
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Roghnaigh..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Resize Small"
@@ -2505,6 +4306,34 @@ msgid "White Bkgnd"
 msgstr "Cúlra Bán"
 
 #: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr "Fuinneog Lán"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr " - fuinneog"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Screen"
+msgstr "Lánscáileán"
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "Tionscadal nua arna cheapadh"
+
+#: src/Screenshot.cpp
 msgid "All Toolbars"
 msgstr "Gach Barra Uirlisí"
 
@@ -2520,7 +4349,13 @@ msgstr "Gach ní ar féidir script a dhéanamh de"
 msgid "All Preferences"
 msgstr "Gach sainrogha"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Uirlis an Roghnaithe"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Rogha Speictreach"
 
@@ -2528,34 +4363,65 @@ msgstr "Rogha Speictreach"
 msgid "Timer"
 msgstr "Uaineadóir"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Uirlisí"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Iompar"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Meascthóir"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Méadar"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Play Meter"
+msgstr "Seinnt"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Record Meter"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Eagar"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Gléas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play-at-Speed"
+msgstr "Seinnt"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Sciúr"
+
+#: src/Screenshot.cpp src/TrackPanel.cpp
+#, fuzzy
+msgid "Track Panel"
+msgstr "Uimhir Riain:"
 
 #: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
 msgid "Ruler"
@@ -2564,7 +4430,10 @@ msgstr "Rialóir"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Rianta"
 
@@ -2605,6 +4474,11 @@ msgid "Short Tracks"
 msgstr "Rianta Gearra"
 
 #: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "Balbhaigh Rianta"
+
+#: src/Screenshot.cpp
 msgid "Tall Tracks"
 msgstr "Rianta Arda"
 
@@ -2620,8 +4494,25 @@ msgstr "Theip ar an ngabháil!"
 msgid "Long Message"
 msgstr "Teachtaireacht Fhada"
 
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+#, fuzzy
+msgid "Warning - Truncating Overlong Block File"
+msgstr "Rabhadh - Ag Oscailt Comhad Seanthionscadail"
+
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
+msgstr "&Réamhamharc"
+
+#: src/ShuttleGui.cpp
+#, fuzzy
+msgid "Dry Previe&w"
 msgstr "&Réamhamharc"
 
 #: src/ShuttleGui.cpp
@@ -2645,11 +4536,16 @@ msgid "Prior"
 msgstr "Roimh"
 
 #: src/SoundActivatedRecord.cpp
+msgid "Sound Activated Record"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
 msgid "Activation level (dB):"
 msgstr "Leibhéal gníomhachtaithe (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Fáilte go Audacity!"
 
 #: src/SplashDialog.cpp
@@ -2687,6 +4583,10 @@ msgstr "Seánra"
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Nótaí"
+
+#: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Tag"
@@ -2733,26 +4633,92 @@ msgid "Don't show this when exporting audio"
 msgstr "Ná taispeáin an foláireamh seo arís"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Edit Genres"
+msgstr "Seánraí"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to save genre file."
+msgstr "Ní fhéidir a aithint"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Reset Genres"
+msgstr "Seánraí"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Are you sure you want to reset the genre list to defaults?"
+msgstr "An bhfuil tú deimhnitheach gur mian leat an comhad a shábháil mar \"\n"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to open genre file."
+msgstr "Ní fhéidir a aithint"
+
+#: src/Tags.cpp
 msgid "Load Metadata As:"
 msgstr "Luchtaigh Meiteashonraí Mar:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Earráid le linn oscailt an chomhaid"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Save Metadata As:"
+msgstr "Luchtaigh Meiteashonraí Mar:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Earráid le linn oscailt an chomhaid"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "Níl an Modúl Oiriúnach"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Comhadlann na gcomhad sealadach"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Ní raibh Audacity in ann an comhad seo a scríobh:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2761,13 +4727,57 @@ msgstr ""
 "chun scríobh air."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Níorbh fhéidir le Audacity íomhánna a scríobh chuig an gcomhad:\n"
 "  %s."
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+"Ní raibh Audacity in ann an comhad seo a scríobh:\n"
+"  %s."
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+"Níor bhféidir le Audacity an comhad seo a oscailt:\n"
+"  %s\n"
+"chun scríobh air."
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
 
 #: src/Theme.cpp
 #, c-format
@@ -2790,13 +4800,20 @@ msgstr ""
 "ann cheana. Forscríobh orthu?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Níorbh fhéidir le hAudacity an comhad a thaisceadh:\n"
 "  %s"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+#, fuzzy
+msgid "Classic"
+msgstr "Dath (mar a bhí fadó)"
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
@@ -2825,7 +4842,11 @@ msgstr "Saincheaptha"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Aga"
 
@@ -2836,8 +4857,25 @@ msgid "Time Track"
 msgstr "Rian Ama"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
 msgstr "Taifeadadh á dhéanamh"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "Maisiúchán á Chur i gCrích: %s"
 
 #: src/TimerRecordDialog.cpp
 msgid "Duration is zero. Nothing will be recorded."
@@ -2848,6 +4886,41 @@ msgid "Error in Duration"
 msgstr "Earráid san Aga"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Taisceadh Uathoibríoch"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Save"
+msgstr "Taisceadh Uathoibríoch"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "Earráid san Aga"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/TimerRecordDialog.cpp
 msgid "Current Project"
 msgstr "An Tionscadal Reatha"
 
@@ -2855,13 +4928,34 @@ msgstr "An Tionscadal Reatha"
 msgid "Recording start:"
 msgstr "Tús an taifeadta:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Aga:"
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
 msgstr "Críoch an taifeadta:"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save enabled:"
+msgstr "Taisceadh Uathoibríoch"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export enabled:"
+msgstr "Taisceadh Uathoibríoch"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Action after Timer Recording:"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
+msgstr "Taifeadadh á dhéanamh"
 
 #: src/TimerRecordDialog.cpp
 msgid "Timer Recording stopped."
@@ -2880,12 +4974,44 @@ msgid ""
 msgstr "Taifeadadh á dhéanamh"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
 "\n"
 "Recording exported: %s"
 msgstr "Taifeadadh á dhéanamh"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
@@ -2906,6 +5032,7 @@ msgstr "099 lá 024 u 060 n 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Dáta agus Am Tosaithe"
@@ -2939,10 +5066,21 @@ msgid "Select..."
 msgstr "Roghnaigh..."
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export"
+msgstr "Uathoibríoch"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable Automatic &Export?"
+msgstr "Cumasaigh Taisceadh U&athoibríoch?"
+
+#: src/TimerRecordDialog.cpp
 msgid "Export Project As:"
 msgstr "Easpórtáil Lipéid Mar:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Roghanna"
 
@@ -2955,7 +5093,8 @@ msgid "Do nothing"
 msgstr "Ná déan faic"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Scoir ó Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -2967,12 +5106,20 @@ msgid "Shutdown system"
 msgstr "Múch an córas"
 
 #: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
 msgstr "Aga taifeadta:"
 
 #: src/TimerRecordDialog.cpp
 msgid "Scheduled to stop at:"
 msgstr "Rogha go dtí an Tosach"
+
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr ""
 
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
@@ -2996,6 +5143,11 @@ msgstr "Taifeadadh á dhéanamh"
 msgid "Recording Exported:"
 msgstr "Taifeadadh á dhéanamh"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
+msgstr "Taifeadadh á dhéanamh"
+
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "Steiréó, 999999Hz"
@@ -3004,6 +5156,11 @@ msgstr "Steiréó, 999999Hz"
 #: src/TrackPanel.cpp
 msgid "(Esc to cancel)"
 msgstr "(Esc chun cealú)"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Rian"
 
 #. i18n-hint: The %d is replaced by the number of the track.
 #. i18n-hint: compose a name identifying an unnamed track by number
@@ -3029,6 +5186,14 @@ msgstr "Curtha ina Aonair"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr " Roghnaithe"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -3107,6 +5272,19 @@ msgstr "Bog an Rian Suas"
 msgid "Move Track Down"
 msgstr "Bog an Rian Síos"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
+#. i18n-hint: Voice key is an experimental/incomplete feature that
+#. is used to navigate in vocal recordings, to move forwards and
+#. backwards by words.  So 'key' is being used in the sense of an index.
+#. This error message means that you've selected too short
+#. a region of audio to be able to use this feature.
+#: src/VoiceKey.cpp
+msgid "Selection is too small to use voice key."
+msgstr ""
+
 #: src/VoiceKey.cpp
 msgid "Calibration Results\n"
 msgstr "Torthaí na Tástála Cruinnis\n"
@@ -3118,6 +5296,16 @@ msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
 msgstr "Fuinneamh                  -- meánach: %1.4f  sd: (%1.4f)\n"
 
 #: src/VoiceKey.cpp
+#, fuzzy, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr "Fuinneamh                  -- meánach: %1.4f  sd: (%1.4f)\n"
+
+#: src/VoiceKey.cpp
+#, fuzzy, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr "Fuinneamh                  -- meánach: %1.4f  sd: (%1.4f)\n"
+
+#: src/VoiceKey.cpp
 msgid "Calibration Complete"
 msgstr "Críochnaíodh an Tástáil Cruinnis"
 
@@ -3125,10 +5313,41 @@ msgstr "Críochnaíodh an Tástáil Cruinnis"
 msgid "Resampling failed."
 msgstr "Athshampláil cosctha."
 
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to paste the selection"
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to expand the cut line"
+msgstr ""
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "%s á Fhorchur..."
+
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
 
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
@@ -3138,12 +5357,44 @@ msgstr "TEIP"
 msgid "Batch Command"
 msgstr "Gníomh Ordaithe"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "&Gníomh Ordaithe"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Athdhéan %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -3152,6 +5403,11 @@ msgstr "Cuir Fuaimeanna i gComórtas"
 #: src/commands/CompareAudioCommand.cpp
 msgid "Threshold:"
 msgstr "Tairseach:"
+
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "Rian nua fuaime arna cheapadh"
 
 #: src/commands/Demo.cpp
 msgid "Demo"
@@ -3164,6 +5420,10 @@ msgstr "Aga moille (soicindí):"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Fachtóir meatha:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -3210,6 +5470,14 @@ msgstr "Go X:"
 msgid "To Y:"
 msgstr "Go Y:"
 
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
 msgstr "Faigh Eolas"
@@ -3234,13 +5502,24 @@ msgstr "Gearrthóga"
 msgid "Envelopes"
 msgstr "Clúdaigh"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Lipéid"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Boscaí"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -3250,9 +5529,14 @@ msgstr "Gairid"
 msgid "Type:"
 msgstr "Cineál:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formáid:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -3262,9 +5546,30 @@ msgstr "Faigh Faisnéis an Riain"
 msgid "Types:"
 msgstr "Cineálacha:"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Nótaí"
+
+#: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command:"
+msgstr "&Gníomh Ordaithe"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -3283,16 +5588,44 @@ msgid "Number of Channels:"
 msgstr "Líon uaireanta le hathdhéanamh:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Easpórtáil Iomadúil"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Easpórtáil Iomadúil"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Builtin Commands"
+msgstr "Gníomh Ordaithe"
+
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Foireann Audacity"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Dáta agus Am Críochnaithe"
 
 #: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Text:"
 msgstr "Téacs:"
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "Taispeáin teachtaireachtaí"
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Open Project2"
@@ -3330,11 +5663,22 @@ msgstr "&Sábháil Tionscadal"
 msgid "Saves a copy of current project."
 msgstr "&Sábháil Tionscadal"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Faigh Sainrogha"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Ainm:"
 
@@ -3349,6 +5693,14 @@ msgstr "Luach:"
 #: src/commands/PreferenceCommands.cpp
 msgid "Reload"
 msgstr "Athluchtaigh"
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3374,9 +5726,15 @@ msgstr "Lánscáileán"
 msgid "Toolbars"
 msgstr "Barraí uirlisí"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Maisiúcháin"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Gach Comhad (*)|*"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -3510,7 +5868,8 @@ msgstr "Socraigh"
 msgid "Add"
 msgstr "Cuir leis"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Bain"
 
@@ -3595,9 +5954,14 @@ msgid "Edited Envelope"
 msgstr "Clúdach"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Clúdach"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -3619,6 +5983,11 @@ msgstr "Roghnaithe"
 msgid "Edited Label"
 msgstr "Lipéid Arna nEagrú"
 
+#: src/commands/SetLabelCommand.h
+#, fuzzy
+msgid "Sets various values for a label."
+msgstr "Socraíonn sé luachanna éagsúla i gcomhair gearrthóg."
+
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
 msgstr "Socraigh Tionscadal"
@@ -3632,12 +6001,25 @@ msgid "Resize:"
 msgstr "Athraigh an mhéid:"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Leithead:"
 
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Airde:"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "Socraíonn sé luachanna éagsúla i gcomhair gearrthóg."
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -3668,16 +6050,28 @@ msgid "Gain:"
 msgstr "Neartúchán:"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Rian Nótaí"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Líneach"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Athshocraigh é"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Am"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "HalfWave"
@@ -3721,9 +6115,18 @@ msgstr "Gúm"
 msgid "Set Track"
 msgstr "Socraigh Rian"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Socraíonn sé luachanna éagsúla i gcomhair gearrthóg."
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Aimpligh"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -3742,11 +6145,39 @@ msgid "Allo&w clipping"
 msgstr "Ceadaigh bearradh"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Cló Rian Lipéid"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "soicindí"
 
@@ -3754,7 +6185,24 @@ msgstr "soicindí"
 msgid "Ma&ximum pause:"
 msgstr "Sos uasta:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Tairseach:"
 
@@ -3769,6 +6217,11 @@ msgstr "Dord agus Tribil"
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Crapadh an Rogha ón Taobh Clé"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Tairseach:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3798,6 +6251,10 @@ msgstr "&Airde (dB):"
 msgid "Level"
 msgstr "Leibhéal"
 
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "Athraigh Airde"
@@ -3807,8 +6264,18 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Athraigh Airde gan Luas a Athrú"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Ardcháilíocht"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Athraigh Airde gan Luas a Athrú"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
@@ -3875,17 +6342,37 @@ msgstr "go (Hz)"
 msgid "t&o"
 msgstr "g&o dtí"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Céatadán an Athraithe:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Athrú Céatadáin"
 
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n/bh"
 
@@ -3905,8 +6392,15 @@ msgstr "Athraigh idir Luas is Airde"
 msgid "&Speed Multiplier:"
 msgstr "Easpórtáil Iomadúil"
 
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Ó rpm"
@@ -3919,6 +6413,7 @@ msgstr "ó"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Go rpm"
@@ -3966,14 +6461,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "Athraigh Luas; Airde gan Athrú"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "Ardcháilíocht"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "Athraigh Luas; Airde gan Athrú"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
 msgid "&from"
 msgstr "&ó"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -4002,13 +6516,53 @@ msgstr "g&o"
 msgid "Length in seconds from %s, to"
 msgstr "Fad (soicindí)"
 
+#: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Asbhaint Cnag..."
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Ní mór don luach a bheith níos mó ná %s"
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
 #: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
 msgid "Threshold"
 msgstr "Tairseach"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 msgid "Compressor"
 msgstr "Comhbhrúiteoir"
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -4019,6 +6573,20 @@ msgstr "%.2f soic"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f soic"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -4032,6 +6600,11 @@ msgstr "Ratio %.1f go 1"
 
 #: src/effects/Compressor.cpp
 msgid "&Noise Floor:"
+msgstr "Torainn:"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
 msgstr "Torainn:"
 
 #: src/effects/Compressor.cpp
@@ -4050,16 +6623,48 @@ msgid "&Attack Time:"
 msgstr "Aga Ionsaithe:"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Aga Ionsaithe:"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Aga Ionsaithe: %.1f soic"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "Aga Ionsaithe: %.1f soic"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "Tairseach %d dB"
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Noise Floor %d dB"
+msgstr "Torainn:"
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -4072,11 +6677,35 @@ msgid "Release Time %.1f secs"
 msgstr "Aga Ionsaithe: %.1f soic"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Rian nua fuaime arna cheapadh"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Roghnaigh rian fuaime."
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Rian nua fuaime arna cheapadh"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Críoch"
 
@@ -4089,6 +6718,16 @@ msgid "&Foreground:"
 msgstr "&Tulra:"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground start time"
+msgstr "Tulra"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground end time"
+msgstr "Tulra"
+
+#: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "Cuir an Rogha ina thost"
 
@@ -4097,12 +6736,26 @@ msgid "&Background:"
 msgstr "&Cúlra:"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background start time"
+msgstr "An cúlra"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "An cúlra"
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "Cuir an Rogha ina thost"
 
 #: src/effects/Contrast.cpp
 msgid "Result"
 msgstr "Toradh"
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "R&eset"
@@ -4116,6 +6769,18 @@ msgstr "&Difear:"
 msgid "&Help"
 msgstr "Cab&hair"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "náid"
@@ -4125,15 +6790,54 @@ msgid "indeterminate"
 msgstr "neamhchinntithe"
 
 #. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Infinite dB difference"
+msgstr "An difear reatha"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Difference is indeterminate."
+msgstr "neamhchinntithe"
+
+#. i18n-hint: dB abbreviates decibels
 #. RMS abbreviates root mean square, a certain averaging method
 #: src/effects/Contrast.cpp
 #, c-format
 msgid "Difference = %.2f RMS dB."
 msgstr "Difear = %.2f RMS dB."
 
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Difference = infinite RMS dB."
+msgstr "Difear = %.2f RMS dB."
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Background higher than foreground"
 msgstr "Tá an cúlra níos airde ná an tulra"
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "WCAG2 Pass"
+msgstr "Teip WCAG2"
 
 #. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
 #: src/effects/Contrast.cpp
@@ -4146,6 +6850,47 @@ msgid "Current difference"
 msgstr "An difear reatha"
 
 #: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f soic"
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground not yet measured"
+msgstr "Níorbh fhéidir an comhad a chur i dtaisce"
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Easpórtáil Lipéid Mar:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
 #, c-format
 msgid "Filename = %s."
 msgstr "Comhadainm = %s."
@@ -4155,12 +6900,30 @@ msgid "Foreground"
 msgstr "Tulra"
 
 #: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
 msgid "Background"
 msgstr "An cúlra"
 
 #: src/effects/Contrast.cpp
 msgid "Results"
 msgstr "Torthaí"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
@@ -4173,20 +6936,159 @@ msgid "%d %s %02d %02dh %02dm %02ds"
 msgstr "%d %s %02d %02du %02dn %02ds"
 
 #: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
 msgid "Contrast..."
 msgstr "Codarsnacht..."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Clipping"
+msgstr "Gearrthóg Chrua"
 
 #: src/effects/Distortion.cpp
 msgid "Soft Clipping"
 msgstr "Gearrthóg Bhog"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Soft Overdrive"
+msgstr "Deimhnigh an Forscríobh"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Medium Overdrive"
+msgstr "Deimhnigh an Forscríobh"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Forscríobh"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Comhbhrúiteoir Réimse Dhinimiciúil"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Leveller"
+msgstr "Leibhéal"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "Saobhadh"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Teorainn Chrua"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Upper Threshold"
 msgstr "Tairseach Uasta"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Paraiméadair"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Paraiméadair"
 
 #: src/effects/Distortion.cpp
 msgid "Number of repeats"
@@ -4197,12 +7099,25 @@ msgid "Distortion"
 msgstr "Saobhadh"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Cineál saofa:"
 
 #: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Threshold controls"
 msgstr "Tairseach:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter controls"
+msgstr "Paraiméadair"
 
 #: src/effects/Distortion.cpp
 msgid "Clipping level"
@@ -4213,8 +7128,21 @@ msgid "Drive"
 msgstr "Tiomántán"
 
 #: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Tairseach:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "Saobhadh"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -4225,8 +7153,34 @@ msgid "Repeat processing"
 msgstr "Athdhéan %s"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "dB Limit"
 msgstr "Teorainn dB"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Seinnt"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Seinnt"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -4249,6 +7203,20 @@ msgid "(0 to 5):"
 msgstr "(0 go 5):"
 
 #: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "&Seicheamh DTMF:"
 
@@ -4256,13 +7224,46 @@ msgstr "&Seicheamh DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Aimplitiúid (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Aga:"
 
 #: src/effects/DtmfGen.cpp
 msgid "&Tone/silence ratio:"
 msgstr "Gineadóir Ton"
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f soic"
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Tone duration:"
+msgstr "Aga taifeadta:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Silence duration:"
+msgstr "Gineadóir Ton"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -4271,6 +7272,11 @@ msgstr "Macalla"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -4292,7 +7298,8 @@ msgstr "Réamhshocruithe"
 msgid "Export Effect Parameters"
 msgstr "&Cuir na Paraiméadair in Eagar"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Theip ar oscailt an chomhaid: \"%s\""
@@ -4316,6 +7323,12 @@ msgstr "&Cuir na Paraiméadair in Eagar"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Ní fhéidir a aithint\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Réamhamharc á ullmhú"
@@ -4323,6 +7336,15 @@ msgstr "Réamhamharc á ullmhú"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Ag réamhamharc"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Earráid Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -4346,6 +7368,11 @@ msgstr "&Réamhshocrú:"
 msgid "User Presets"
 msgstr "Socruithe Maisiúcháin"
 
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "Réamhshocruithe na Monarchan"
+
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
 msgstr "Na Socruithe Reatha"
@@ -4353,6 +7380,35 @@ msgstr "Na Socruithe Reatha"
 #: src/effects/EffectManager.cpp
 msgid "Factory Defaults"
 msgstr "Réamhshocruithe na Monarchan"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "Rogha go dtí an Deireadh"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
@@ -4367,20 +7423,51 @@ msgid "Latency: 0"
 msgstr "Aga folaigh: 0"
 
 #: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr " Gníomhach "
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Show/Hide Editor"
 msgstr "Taispeáin/folaigh an tEagarthóir"
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Bog Suas"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect up in the rack"
+msgstr "Bain maisiúchán den eallóg"
+
+#: src/effects/EffectUI.cpp
 msgid "Move Down"
 msgstr "Bog Síos"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect down in the rack"
+msgstr "Bain maisiúchán den eallóg"
+
+#: src/effects/EffectUI.cpp
 msgid "Favorite"
 msgstr "Ceanán"
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Remove effect from the rack"
@@ -4400,6 +7487,10 @@ msgid "Some Command"
 msgstr "Gníomh Ordaithe"
 
 #: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "&Manage"
 msgstr "&Bainistigh"
 
@@ -4415,6 +7506,11 @@ msgstr "Tosaigh Athsheinm"
 
 #: src/effects/EffectUI.cpp
 msgid "Preview effect"
+msgstr "Réamhamharc an maisiú"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Preview effect"
 msgstr "Réamhamharc an maisiú"
 
 #: src/effects/EffectUI.cpp
@@ -4495,6 +7591,11 @@ msgstr "Maidir le"
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "An bhfuil tú cinnte gur mian leat \"%s\" a scriosadh?"
 
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "Taisc an Réamhshocrú..."
+
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
 msgstr "Ainm réamhshocraithe:"
@@ -4523,6 +7624,20 @@ msgstr "Seinnt"
 msgid "Play"
 msgstr "Seinn"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Á Chéimniú Amach"
+
+#: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Equalization"
 msgstr "Cothromú"
@@ -4530,6 +7645,15 @@ msgstr "Cothromú"
 #: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
 msgid "Filter Curve EQ"
 msgstr "Roghnaigh"
+
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Graphic EQ"
+msgstr "&Graf"
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "100Hz Rumble"
@@ -4544,12 +7668,40 @@ msgid "Bass Boost"
 msgstr "Treisiú Dúird..."
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "Treisiú Dúird..."
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Guthán"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "Eag. Lipéid"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Eag. Lipéid"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -4559,13 +7711,57 @@ msgstr "Chun an speictream a rianadh, ní foláir gach rian roghnaithe a bheith 
 msgid "Track sample rate is too low for this effect."
 msgstr "Tá na rianta ró-fhada chun an rogha a athdhéanamh."
 
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Effect Unavailable"
+msgstr "ar fáil"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "dB uasta"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "dB íosta"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "Cineál:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Draw Curves"
+msgstr "Bainistigh na Cuair"
 
 #: src/effects/Equalization.cpp
 msgid "&Draw"
@@ -4580,12 +7776,37 @@ msgid "Interpolation type"
 msgstr "Idirlonnú Sinc Thapaidh"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Minicíocht líneach"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Minicíocht líneach"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "Phaser á Fhorchur"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Phaser á Fhorchur"
+
+#: src/effects/Equalization.cpp
 msgid "&Select Curve:"
 msgstr "&Roghnaigh Cuar:"
 
 #: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Roghnaigh"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "S&ave/Manage Curves..."
+msgstr "Bainistigh na Cuair"
 
 #: src/effects/Equalization.cpp
 msgid "Fla&tten"
@@ -4604,17 +7825,72 @@ msgid "Show g&rid lines"
 msgstr "Taispeáin na línte eang&aigh"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Processing: "
+msgstr "Rian Nótaí"
+
+#: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "Réamhshocrú"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "Tagarmharc"
 
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
 msgid "unnamed"
 msgstr "gan ainm"
 
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Maisiúchán á Chur i gCrích: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Cothromú á Chur i gCrích"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Curve not found"
 msgstr "Níor aimsíodh an cuar"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Bainistigh na Cuair"
 
 #: src/effects/Equalization.cpp
 msgid "Manage Curves"
@@ -4641,6 +7917,20 @@ msgid "De&faults"
 msgstr "Na Réamhshocruithe"
 
 #: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s' to..."
 msgstr "Athainmnigh '%s' go..."
@@ -4655,6 +7945,10 @@ msgid "Rename '%s'"
 msgstr "Athainmnigh '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Same name"
 msgstr "An t-ainm céanna"
 
@@ -4666,6 +7960,15 @@ msgstr "Scríobh thar chomhaid reatha"
 #: src/effects/Equalization.cpp
 msgid "Curve exists"
 msgstr "Is ann don chuar"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Ní féidir fuaim a easpórtáil go %s"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4682,8 +7985,51 @@ msgid "Delete %d items?"
 msgstr "Scrios %d mír?"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Roghnaigh suíomh chun comhaid a chur i dtaisce ann"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Easpórtáil &Lipéid..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Ní féidir fuaim a easpórtáil go %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "Is ann don chuar"
+
+#: src/effects/Equalization.cpp
+msgid "No curves exported"
+msgstr ""
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -4697,21 +8043,74 @@ msgstr "Céimnigh Amach"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Cnag is tarraing chun fuaim a roghnú"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Cnag is tarraing chun fuaim a roghnú"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "Ag bearradh"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
 msgstr "Ag bearradh"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "Tairseach: %d dB"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "Tairseach: %d dB"
+
+#: src/effects/Generator.cpp
+msgid "There is not enough room available to generate the audio"
+msgstr ""
 
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Inbheartaigh"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Maisiúcháin Ionsuite"
 
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
+msgstr "Cuireann sé tacaíocht do Mhaisiúcháin Nyquist ar fáil do Audacity"
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normalú"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -4722,9 +8121,35 @@ msgstr "Normalú\n"
 msgid "Analyzing: %s"
 msgstr "Ag miondealú: %s"
 
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "Rian Nótaí"
+
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normalú"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -4743,9 +8168,19 @@ msgctxt "noise"
 msgid "Pink"
 msgstr "Bándearg"
 
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
 #: src/effects/Noise.cpp
 msgid "Noise"
 msgstr "Torainn"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
 
 #: src/effects/Noise.cpp
 msgid "&Noise type:"
@@ -4764,16 +8199,69 @@ msgid "Old"
 msgstr "Sean"
 
 #: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Hann, Hann (réamhshocrú)"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (réamhshocrú)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Asbhaint Fhothraim"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Chun an speictream a rianadh, ní foláir gach rian roghnaithe a bheith ag an ráta samplaithe céanna."
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -4812,12 +8300,33 @@ msgid "Release time"
 msgstr "Athdhéanta %d uair"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Frequency smoothing (bands):"
+msgstr "&Minicíocht (Hz):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Anailís ar Mhinicíocht"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "Íogaireacht (dB):"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Old Sensitivity"
+msgstr "Íogaireacht"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 1"
 msgstr "Céim 1"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid ""
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
+"then click Get Noise Profile:"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Get Noise Profile"
@@ -4826,6 +8335,12 @@ msgstr "Faigh an tImlíne Fothraim"
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 2"
 msgstr "Céim 2"
+
+#: src/effects/NoiseReduction.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Noise:"
@@ -4857,21 +8372,108 @@ msgstr "Cineálacha fuinneoga"
 msgid "Window si&ze:"
 msgstr "Méid na fuinneoige:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (réamhshocrú)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "4 (réamhshocrú)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Asbhaint Fhothraim"
 
 #: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to remove noise.\n"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise re&duction (dB):"
+msgstr "&Maolú fuaime (dB):"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "&Sensitivity (dB):"
 msgstr "&Íogaireacht (dB):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Fr&equency smoothing (Hz):"
+msgstr "&Minicíocht (Hz):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "Aga Ionsaithe: %.1f soic"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Aga Ionsaithe:"
 
 #: src/effects/NoiseRemoval.cpp
 msgid "Re&move"
@@ -4882,12 +8484,55 @@ msgid "Normalize"
 msgstr "Normalú"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Fothram á Bhaint Amach\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
+msgstr "Fothram á Bhaint Amach\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
 msgstr "Fothram á Bhaint Amach\n"
 
 #: src/effects/Normalize.cpp
 msgid "Not doing anything...\n"
 msgstr "Níl aon rud ag tarlú...\n"
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -4897,9 +8542,23 @@ msgstr "Buaicaimplitiúid Nua (dB):"
 msgid "Peak amplitude dB"
 msgstr "Buaicaimplitiúid dB"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Sín"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Fachtóir meatha:"
@@ -4907,6 +8566,45 @@ msgstr "Fachtóir meatha:"
 #: src/effects/Paulstretch.cpp
 msgid "&Time Resolution (seconds):"
 msgstr "Aga moille (soicindí):"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Phaser"
+msgstr "Phaser"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -4920,21 +8618,48 @@ msgstr "Céimeanna"
 msgid "&Dry/Wet:"
 msgstr "&Tirim/Fliuch:"
 
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
+
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
+msgstr "Minicíocht LFO (Hz):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
 msgstr "Minicíocht LFO (Hz):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
 msgstr "Pas Tosaigh LFO (céim.):"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
+msgstr "Pas Tosaigh LFO (céim.):"
+
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Doimhneach&t:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "Aiseolas (%):"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "&Output gain (dB):"
+msgstr "Neartú aschuir (dB)"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "Output gain (dB)"
@@ -4944,9 +8669,33 @@ msgstr "Neartú aschuir (dB)"
 msgid "Repair"
 msgstr "Deisigh"
 
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Athdhéan"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -4987,6 +8736,14 @@ msgid "Bathroom"
 msgstr "Seomra Folctha"
 
 #: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "Seomra Meánach"
 
@@ -5007,12 +8764,50 @@ msgid "Reverb"
 msgstr "Aisfhuaim"
 
 #: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Méad"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Meath (soicindí):"
+
+#: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
 msgstr "Aisfhotha (%):"
 
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "Doimhneacht (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Doimhneach&t (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "&Neartúchán (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "&Neartúchán (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Défh.,"
 
 #: src/effects/Reverb.cpp
 msgid "Wet O&nly"
@@ -5031,6 +8826,15 @@ msgstr "Aisiompú"
 msgid "Reverses the selected audio"
 msgstr "Ionad easportála:"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -5040,6 +8844,25 @@ msgstr "Cineál Chebyshev I"
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type II"
 msgstr "Cineál Chebyshev II"
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Highpass"
+msgstr "Ard:"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Cothromú á Chur i gCrích"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
@@ -5055,6 +8878,14 @@ msgid "O&rder:"
 msgstr "Ea&gar:"
 
 #: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
 msgstr "&Fochineál:"
 
@@ -5066,9 +8897,27 @@ msgstr "Gearradh (Hz)"
 msgid "C&utoff:"
 msgstr "Gearradh:"
 
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Ailínigh an Deireadh le Deireadh an Rogha"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Aga:"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Aga:"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -5077,6 +8926,14 @@ msgstr "Méid na Fuinneoige:"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "Méid na Fuinneoige"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -5092,6 +8949,15 @@ msgstr "Tairseach:"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "Smúdáil ag Sampla"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "Smúdáil ag Sampla"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -5130,11 +8996,20 @@ msgstr "Bain feidhm as na réamhshocruithe"
 msgid "Restore Defaults"
 msgstr "Athshocraigh na Réamhshocraithe"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Tost"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -5161,8 +9036,41 @@ msgid "Sliding Stretch"
 msgstr "Fachtóir meatha:"
 
 #: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
 msgid "(%) [-50 to 100]:"
 msgstr "(%) [-50 go 100]:"
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "Idirlonnú Sinc Thapaidh"
 
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
@@ -5177,6 +9085,26 @@ msgid "Sawtooth"
 msgstr "Sábhfhiaclach"
 
 #: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Tonnchruth:"
 
@@ -5185,8 +9113,50 @@ msgid "&Frequency (Hz):"
 msgstr "&Minicíocht (Hz):"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Minicíocht (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "Minicíocht (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Aimplitiúid (0-1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Aimplitiúid (0-1)"
+
+#: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "Idirlonnú Sinc Thapaidh"
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Detected Silence"
+msgstr "Tost á cheapadh"
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Tost"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -5196,20 +9166,37 @@ msgstr "Tost á cheapadh"
 msgid "Tr&uncate to:"
 msgstr "T&easc go:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Comhbhrúigh go:"
+
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST Effects"
 msgstr "Maisiúcháin VST"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 #, c-format
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Ag clárú %d as %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Níorbh fhéidir an leabharlann a luchtú"
 
@@ -5221,13 +9208,41 @@ msgstr "Socruithe Maisiúcháin"
 msgid "Buffer Size"
 msgstr "Méid an Mhaolaire"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Méid an Mhaolaire (8 go 1048576 sampla):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Teaglaim Cnaipí"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "Teaglaim Cnaipí"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Graphical Mode"
+msgstr "&Graf"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 #, c-format
@@ -5239,24 +9254,80 @@ msgid "Save VST Preset As:"
 msgstr "Sábháil Tionscadal M&ar..."
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Easpórtáil Iomadúil"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Easpórtáil Iomadúil"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Comhaid Tionscadail Audacity"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unrecognized file extension."
+msgstr "Iarmhíreanna comhadainm"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "Maisiúchán á Chur i gCrích: %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Luchtaigh Réamhshocrú"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Comhaid réamhshocruithe VST"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "Maisiúchán á Chur i gCrích: %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Ní fhéidir a aithint"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Socruithe Maisiúcháin"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Ní fhéidir a aithint"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Ní fhéidir a aithint"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -5274,6 +9345,22 @@ msgstr "Athshondas"
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Taobhrian Mhinicíocht Wah (%):"
 
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Taobhrian Mhinicíocht Wah (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Socruithe Maisiúcháin"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Cuireann sé tacaíocht do Mhaisiúcháin Nyquist ar fáil do Audacity"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "Níorbh fhéidir an chomhpháirt a aimsiú"
@@ -5287,8 +9374,16 @@ msgid "Audio Unit Effect Options"
 msgstr "Socruithe Maisiúcháin"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Comhéadan"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -5305,6 +9400,15 @@ msgstr "Cineálach"
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Basic"
 msgstr "Bunúsach"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Easpórtáil Iomadúil"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -5376,9 +9480,34 @@ msgid "Failed to retrieve preset content"
 msgstr "Theip ar bhaint %s"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Ní fhéidir a aithint"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Ráta samplaithe:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Theip ar chlárú: %s"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Theip ar bhaint %s"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Theip ar bhaint %s"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Ní fhéidir a aithint"
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -5388,6 +9517,7 @@ msgstr "Aonad Fuaime"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Maisiúcháin LADSPA"
@@ -5397,31 +9527,95 @@ msgid "Provides LADSPA Effects"
 msgstr "Soláthraíonn sé Maisiúcháin LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Socruithe Maisiúcháin"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s i gceann:"
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Socruithe Maisiúcháin"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Maisiúcháin LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
 msgstr "Socruithe Maisiúcháin"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, fuzzy, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr "&Méid an Mhaolaire (8 go 1048576 sampla):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Generator"
 msgstr "Gineadóir"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
 
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Maisiúcháin LV2"
+
+#: src/effects/lv2/LoadLV2.cpp
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr "Cuireann sé tacaíocht Mhaisiúcháin Réthionlacain ar fáil do Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Maisiúcháin Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Cuireann sé tacaíocht do Mhaisiúcháin Nyquist ar fáil do Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -5438,6 +9632,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Aschur Nyquist:"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Is gá fuaim a roghnú."
 
@@ -5450,8 +9662,37 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Fóiríor, ní féidir an maisiúchán a chur i gcrích ar rianta défhónacha nuair nach dtagann na rianta le chéile."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Aschur Dífhabhtaithe: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "Taifeadadh á dhéanamh"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -5488,6 +9729,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Níor sheol Nyquist fuaim thar n-ais.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Tiomsaíodh an leagan seo d'Audacity gan cumas láimhseála %s."
@@ -5495,6 +9740,21 @@ msgstr "Tiomsaíodh an leagan seo d'Audacity gan cumas láimhseála %s."
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not open file"
 msgstr "Níorbh fhéidir an comhad a oscailt"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Error in Nyquist code"
+msgstr "Earráid san Aga"
 
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
@@ -5505,6 +9765,14 @@ msgstr "Níorbh fhéidir an teanga a dhéanamh amach"
 #, c-format
 msgid "\"%s\" is not a valid file path."
 msgstr "Ní conair bhailí í \"%s\"."
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -5523,6 +9791,12 @@ msgstr "Scripteanna Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Scripteanna Lisp"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "File could not be loaded"
@@ -5553,7 +9827,8 @@ msgstr "Roghnaigh comhad"
 msgid "Save file as"
 msgstr "Cuir an comhad i dtaisce mar"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "gan teideal"
 
@@ -5562,8 +9837,22 @@ msgid "Vamp Effects"
 msgstr "Maisiúchán Réthionlacain"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Cuireann sé tacaíocht Mhaisiúcháin Réthionlacain ar fáil do Audacity"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "Fóiríor, ní féidir an maisiúchán a chur i gcrích ar rianta défhónacha nuair nach dtagann na rianta le chéile."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
@@ -5578,6 +9867,11 @@ msgstr "Ríomhchlár"
 #: src/effects/vamp/VampEffect.h
 msgid "Vamp"
 msgstr "Réthionlacan"
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Roghanna na Formáide"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -5603,6 +9897,16 @@ msgstr "Tá an fhuaim balbhaithe."
 #, c-format
 msgid "Are you sure you want to export the file as \"%s\"?\n"
 msgstr "An bhfuil tú deimhnitheach gur mian leat an comhad a shábháil mar \"\n"
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
@@ -5656,6 +9960,11 @@ msgid "Output Channels: %2d"
 msgstr "Bealaí Aschuir: %2d"
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "Meascthóir"
+
+#: src/export/Export.cpp
 #, c-format
 msgid ""
 "Unable to export.\n"
@@ -5665,6 +9974,26 @@ msgstr "Ní féidir é a thabhairt amach"
 #: src/export/ExportCL.cpp
 msgid "Show output"
 msgstr "Taispeáin an t-aschur"
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Gníomh Ordaithe"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -5688,8 +10017,21 @@ msgid "Exporting the audio using command-line encoder"
 msgstr "Fuaim roghnaithe á heaspórtáil le hionchódaitheoir an líne-orduithe"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "Gníomh Ordaithe"
+
+#: src/export/ExportCL.cpp
 msgid "&OK"
 msgstr "&Tá go maith"
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
 
 #: src/export/ExportCL.cpp
 #, c-format
@@ -5702,17 +10044,155 @@ msgid "Unable to locate \"%s\" in your path."
 msgstr "Ní féidir \"%s\" aimsiú i do chonair."
 
 #: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Earráid FFmpeg"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Exporting the audio as %s"
 msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Ráta samplaithe:"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Athshampláil"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "Ráta samplaithe:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -5722,9 +10202,60 @@ msgstr "Ráta Giotán:"
 msgid "Quality (kbps):"
 msgstr "Caighdeán (kbps):"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f soic"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Ar Siúl"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Constrained"
+msgstr "Leanúnach"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -5735,8 +10266,44 @@ msgid "Low Delay"
 msgstr "Moill Íseal"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Mórcheannach"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -5763,6 +10330,10 @@ msgid "Cutoff:"
 msgstr "Gearradh:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "An Fhormáid Reatha:"
 
@@ -5771,8 +10342,28 @@ msgid "Current Codec:"
 msgstr "An Tionscadal Reatha"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "Maisiúchán á Chur i gCrích: %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Scrios an réamhshocrú '%s'?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Confirm Overwrite"
 msgstr "Deimhnigh an Forscríobh"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "Roghnaigh am laistigh de ghearrthóg."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 #, c-format
@@ -5785,8 +10376,17 @@ msgid "Replace preset '%s'?"
 msgstr "Ionadaigh an réamhshocrú '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "C"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Príomh"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -5797,12 +10397,22 @@ msgid "AC3 Files (FFmpeg)"
 msgstr "Comhaid AC3 (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr "Comhaid WMA (leagan 2) (FFmpeg)"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Opus (OggOpus) Files (FFmpeg)"
 msgstr "Comhaid Opus (OggOpus) (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "WMA (version 2) Files (FFmpeg)"
 msgstr "Comhaid WMA (leagan 2) (FFmpeg)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "Tabhairt Isteach/Amach FFmpeg"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Estimate"
@@ -5825,6 +10435,15 @@ msgid "Full search"
 msgstr "Cuardach iomlán"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Log search"
+msgstr "Cuardach iomlán"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Preset:"
 msgstr "Réamhshocrú:"
 
@@ -5832,10 +10451,24 @@ msgstr "Réamhshocrú:"
 msgid "Load Preset"
 msgstr "Luchtaigh Réamhshocrú"
 
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Easpórtáil Lipéid Mar:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Easpórtáil Lipéid Mar:"
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Codec:"
 msgstr "Comhbhrú/dí-chomhbhrú:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Formats"
@@ -5850,32 +10483,191 @@ msgid "General Options"
 msgstr "Roghanna Coiteann"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Teanga:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Tag:"
 msgstr "Clib:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "Cáilíocht:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Ráta samplaithe:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Gach comhad|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "FLAC options"
 msgstr "Roghanna FLAC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Compression:"
 msgstr "Comhbhrú:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Frame:"
 msgstr "Fráma:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Bain feidhm as LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Min. PdO"
+msgstr "PtO íosta"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Max. PdO"
+msgstr "PtO uasta"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Min. PtO"
 msgstr "PtO íosta"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Max. PtO"
@@ -5888,9 +10680,88 @@ msgid "Use LPC"
 msgstr "Bain feidhm as LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Rogha go dtí an Deireadh"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Luas:"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "&Méid an Riain"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Delete preset '%s'?"
 msgstr "Scrios an réamhshocrú '%s'?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file with presets to import"
+msgstr "Roghnaigh sruth(a) le tabhairt isteach"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "No presets to export"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file to export presets into"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Ní fhéidir a aithint"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Ní fhéidir a aithint"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -5913,8 +10784,30 @@ msgid "Level:"
 msgstr "Leibhéal:"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Bit depth:"
+msgstr "Ráta Giotán:"
+
+#: src/export/ExportFLAC.cpp
 msgid "FLAC Files"
 msgstr "Comhaid FLAC"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Níorbh fhéidir \"%s\" a oscailt"
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the selected audio as FLAC"
+msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the audio as FLAC"
@@ -5924,9 +10817,18 @@ msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 msgid "MP2 Files"
 msgstr "Comhaid MP2"
 
+#: src/export/ExportMP2.cpp
+msgid "Cannot export MP2 with this sample rate and bit rate"
+msgstr ""
+
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
 msgstr "Theip ar oscailt sprioc-chomhad chun scrite"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 
 #: src/export/ExportMP2.cpp
 #, c-format
@@ -5936,6 +10838,42 @@ msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 #: src/export/ExportMP3.cpp
 msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (An Cháilíocht Is Fearr)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Foircneach, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "Gnáth, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "Meánach, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "Meánach, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -5967,7 +10905,8 @@ msgstr "Áiféiseach"
 msgid "Extreme"
 msgstr "Foircneach"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Caighdeánach"
 
@@ -5995,10 +10934,25 @@ msgstr "Comhsteiréó"
 msgid "Stereo"
 msgstr "Steiréó"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "Ráta Giotán:"
+
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "Caighdeán"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "Cainéal"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Bain Amach Rian"
 
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
@@ -6006,8 +10960,8 @@ msgid "Locate LAME"
 msgstr "Aimsigh LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tá an comhad %s de dhíth ar Audacity chun MP3eanna a chruthú."
 
 #: src/export/ExportMP3.cpp
@@ -6035,6 +10989,13 @@ msgid "Where is %s?"
 msgstr "Cá bhfuil %s?"
 
 #: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "Only lame_enc.dll"
 msgstr "lame_enc.dll amháin"
 
@@ -6049,6 +11010,11 @@ msgstr "libmp3lame.dylib amháin"
 #: src/export/ExportMP3.cpp
 msgid "Only libmp3lame.so.0"
 msgstr "libmp3lame.so.0 amháin"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Comhaid Tionscadail Audacity"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -6071,14 +11037,63 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "Tá an leabharlann inchódaithe MP3 neamhdhlistineach, nó ní láimhseáltar é!"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "Ní fhéidir a aithint"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Easpórtáil Iomadúil"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
 msgstr "Easpórtáil Iomadúil"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio with VBR quality %s"
+msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 export library not found"
+msgstr "Níorbh aimsíodh leabharlann FFmpeg"
 
 #: src/export/ExportMP3.cpp
 msgid "(Built-in)"
@@ -6091,6 +11106,12 @@ msgstr "Easpórtáil Iomadúil"
 #: src/export/ExportMultiple.cpp
 msgid "Cannot Export Multiple"
 msgstr "Easpórtáil Iomadúil"
+
+#: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
@@ -6121,12 +11142,27 @@ msgid "First file name:"
 msgstr "Ainm an chéad chomhaid:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Ainm an chéad chomhaid:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "Comhaid ainmneacha:"
 
 #: src/export/ExportMultiple.cpp
 msgid "Using Label/Track Name"
 msgstr "Ainm Lipéid/Riain á nÚsáid"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Ainm Lipéid/Riain á nÚsáid"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Réimír an chomhaid fuaime"
 
 #: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
@@ -6151,6 +11187,31 @@ msgstr "Roghnaigh ionad ina sábháilfear na comhaid easphortáilte"
 
 #: src/export/ExportMultiple.cpp
 #, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
 msgid ""
 "\"%s\" doesn't exist.\n"
 "\n"
@@ -6164,6 +11225,27 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "Lean ar aghaidh ag tabhairt na comhaid atá fágtha amach?"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "Taisc Mar..."
@@ -6171,6 +11253,31 @@ msgstr "Taisc Mar..."
 #: src/export/ExportOGG.cpp
 msgid "Ogg Vorbis Files"
 msgstr "Comhaid Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Ní fhéidir a aithint"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Ní fhéidir a aithint"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Ní fhéidir a aithint"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Ní fhéidir a aithint"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Ní fhéidir a aithint"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -6183,6 +11290,14 @@ msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Fuaim á tabhairt amach mar Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Header:"
@@ -6197,8 +11312,20 @@ msgid "Other uncompressed files"
 msgstr "Comhaid neamhchomhbhrúite eile"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Earráid le linn iomportála"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "GSM 6.10 requires mono"
@@ -6212,23 +11339,204 @@ msgstr "Níl WAVEX agus GSM 6.10 comhoiriúnach lena chéile"
 msgid "Cannot export audio in this format."
 msgstr "Ní féidir fuaim a easpórtáil sa bhformáid seo."
 
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "Fuaim roghnaithe á heaspórtáil mar Ogg Vorbis"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "Gach comhad a dtugtar tacaíocht dóibh"
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "Select stream(s) to import"
 msgstr "Roghnaigh sruth(a) le tabhairt isteach"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Tiomsaíodh an leagan seo d'Audacity gan cumas láimhseála %s."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
 
 #: src/import/Import.cpp
 #, c-format
 msgid "File \"%s\" not found."
 msgstr "Níor aimsíodh an comhad \"%s\"."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, scrúdaitheoir"
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Comhaid Tionscadail Audacity"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -6243,13 +11551,123 @@ msgid "Import Project"
 msgstr "Easpórtáil Lipéid Mar:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Ní bhfuarthas comhadlann sonraí an tionscadail: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Tús an Tionscadail"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -6266,22 +11684,19 @@ msgstr "Ní fhéidir a aithint"
 msgid "Unable to read %lld samples from %s"
 msgstr "Ní fhéidir a aithint"
 
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Comhaid FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Ní fhéidir a aithint"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Ní fhéidir a aithint"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Earráid GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -6339,9 +11754,22 @@ msgstr "Theip ar oscailt an chomhaid: %s."
 msgid "MP3 files"
 msgstr "Comhaid MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Comhaid Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -6368,12 +11796,161 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, agus cineálacha neamhchomhbhrúite eile"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "DWVW 16 bheart"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -6384,12 +11961,20 @@ msgid "24 bit DWVW"
 msgstr "DWVW 24 bheart"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "DPCM 16-bheart"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "DPCM 8 mbeart"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -6399,6 +11984,33 @@ msgstr "Ag tabhairt isteach %s"
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "Comhaid QuickTime"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Ní fhéidir a aithint"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "Theip ar bhaint %s"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Ní fhéidir a aithint"
 
 #. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
 #: src/import/ImportRaw.cpp
@@ -6447,6 +12059,10 @@ msgid "%d Channels"
 msgstr "%d (g)C(h)ainéal"
 
 #: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
 msgid "Channels:"
 msgstr "Bealaí:"
 
@@ -6472,6 +12088,10 @@ msgstr "Ráta samplaithe:"
 msgid "&Import"
 msgstr "&Tabhair Isteach"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -6492,6 +12112,7 @@ msgstr "%s ar dheis"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -6518,6 +12139,7 @@ msgstr "críoch"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -6542,7 +12164,18 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Rianta roghnaithe arna gcur ina dtost ar feadh %.2f soic. ag %.2f"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the left"
+msgstr "Rianta roghnaithe arna gcur ina dtost ar feadh %.2f soic. ag %.2f"
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Bogadh-in-Am"
 
@@ -6553,6 +12186,15 @@ msgstr "níor bogadh an ghearrthóg"
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
 msgstr "Teorainneacha na nGearrthóg"
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "go Tosach an Rogha"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -6569,6 +12211,26 @@ msgstr "Gearrthóg Ar Aghaidh"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Roghnaigh an Ghearrthóg Ar Aghaidh"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "An Ghearrthóg Roimhe"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "Tionscadal nua arna cheapadh"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "Teorainneacha na nGearrthóg"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "go Tosach an Rogha"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -6604,12 +12266,35 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Scriosta %.2f s(h)oicind ag a=%.2f"
 
 #: src/menus/EditMenus.cpp
+msgid "Pasting one type of track into another is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Copying stereo audio into a mono track is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
 msgid "Duplicated"
 msgstr "Macasamhail déanta"
 
 #: src/menus/EditMenus.cpp
 msgid "Duplicate"
 msgstr "Déan macasamhail"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split-cut to the clipboard"
+msgstr "Gearr is cuir sa ghearrathaisce"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Cut"
+msgstr "Eag. Lipéid"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Split-deleted %.2f seconds at t=%.2f"
+msgstr "Scriosta %.2f s(h)oicind ag a=%.2f"
 
 #: src/menus/EditMenus.cpp
 msgid "Split Delete"
@@ -6631,17 +12316,48 @@ msgstr "Tost"
 msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
 msgstr "Rianta roghnaithe arna gcur ina dtost ar feadh %.2f soic. ag %.2f"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "Fuaim"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Deighil"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split to new track"
+msgstr "Deighil Rian Défhónach"
 
 #: src/menus/EditMenus.cpp
 msgid "Split New"
 msgstr "Scoilt Nua"
 
 #: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Joined %.2f seconds at t=%.2f"
+msgstr "Scriosta %.2f s(h)oicind ag a=%.2f"
+
+#: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "Cuir míreanna le chéile"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Scriosta %.2f s(h)oicind ag a=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Detach"
+msgstr "Mionsonraí"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Metadata Tags"
+msgstr "Cuir Clibeanna Meiteashonraí in Eagar"
 
 #: src/menus/EditMenus.cpp
 msgid "&Edit"
@@ -6675,15 +12391,49 @@ msgstr "Dúblaigh"
 msgid "R&emove Special"
 msgstr "Sainuirlis Bhainte"
 
+#. i18n-hint: (verb) Do a special kind of cut
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Spl&it Cut"
+msgstr "Eag. Lipéid"
+
+#. i18n-hint: (verb) Do a special kind of DELETE
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split D&elete"
+msgstr "Scrios an Scoilt"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "Cuir an Fhuaim ina tost"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Tri&m Audio"
+msgstr "Fuaim"
+
 #. i18n-hint: (verb) It's an item on a menu.
 #: src/menus/EditMenus.cpp
 msgid "Sp&lit"
 msgstr "Sc&oilt"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Ne&w"
+msgstr "Scoilt Nua"
+
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
 msgid "&Join"
 msgstr "&Cuir míreanna le chéile"
+
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "Tost á cheapadh"
 
 #: src/menus/EditMenus.cpp
 msgid "&Metadata..."
@@ -6704,34 +12454,6 @@ msgstr "Scrioschnaipe&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "Breis"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Meascthóir"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Seinnt"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Seinnt"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Seinnt"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Taifeadadh á dhéanamh"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Taifeadadh á dhéanamh"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Taifeadadh á dhéanamh"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -6758,8 +12480,21 @@ msgid "&Full Screen (on/off)"
 msgstr "&Lánscáileán (ar siúl/as)"
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Tabhair Amach an Fhuaim Roghnaithe"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Téacs an lipéid"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -6774,12 +12509,23 @@ msgid "Please select a Note Track."
 msgstr "Rian nua fuaime arna cheapadh"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "Tabhair amach MIDI"
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "Comhad MIDI"
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "Gach comhad|*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export MIDI"
@@ -6881,6 +12627,11 @@ msgid "&Labels..."
 msgstr "&Lipéid..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Tabhair MI&DI amach..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Ámhshonraí..."
 
@@ -6897,6 +12648,10 @@ msgstr "&Clóbhuail..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Scoir"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -6921,8 +12676,17 @@ msgid "Fix"
 msgstr "Deisigh"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "Cab&hair"
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "Níl faic le déanamh"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -6957,8 +12721,9 @@ msgid "&Getting Started"
 msgstr "&Ag tosú"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Lámh&leabhar Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Lámhleabhar..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -6972,15 +12737,22 @@ msgstr "&Lámhleabhar..."
 msgid "&Diagnostics"
 msgstr "&Diagnóisic"
 
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Au&dio Device Info..."
+msgstr "Faisnéis an Ghléis Fhuaime"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&MIDI Device Info..."
+msgstr "Faisnéis an Ghléis MIDI"
+
 #: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
 msgid "Show &Log..."
 msgstr "Taispeáin an tOireas..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Mar Gheall ar Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Lipéad a cuireadh leis"
 
@@ -6988,15 +12760,112 @@ msgstr "Lipéad a cuireadh leis"
 msgid "Paste Text to New Label"
 msgstr "Greamaigh an Téacs leis an Lipéad Nua"
 
+#. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
+#. regions.
+#: src/menus/LabelMenus.cpp
+msgid "Cut labeled audio regions to clipboard"
+msgstr ""
+
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
 msgid "Cut Labeled Audio"
 msgstr "Gearr an Mhír Fuaime a bhfuil Lipéad uirthi"
 
+#. i18n-hint: (verb) Audacity has just deleted the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Deleted labeled audio regions"
+msgstr "Cuir an Fhuaim le Lipéad ina Tost"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Delete Labeled Audio"
+msgstr "Cuir an Fhuaim le Lipéad ina Tost"
+
+#. i18n-hint: (verb) Audacity has just split cut the labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut on the labels
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Cut Labeled Audio"
+msgstr "Gearr an Mhír Fuaime a bhfuil Lipéad uirthi"
+
+#. i18n-hint: (verb) Audacity has just done a special kind of DELETE on
+#. the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Deleted labeled audio regions"
+msgstr "Cuir an Fhuaim le Lipéad ina Tost"
+
+#. i18n-hint: (verb) Do a special kind of DELETE on labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Delete Labeled Audio"
+msgstr "Cuir an Fhuaim le Lipéad ina Tost"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silenced labeled audio regions"
+msgstr "Cuir an Fhuaim le Lipéad ina Tost"
+
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
 msgid "Silence Labeled Audio"
 msgstr "Cuir an Fhuaim le Lipéad ina Tost"
+
+#: src/menus/LabelMenus.cpp
+msgid "Copied labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Copy Labeled Audio"
+msgstr "Gearr an Mhír Fuaime a bhfuil Lipéad uirthi"
+
+#. i18n-hint: (verb) past tense.  Audacity has just split the labeled
+#. audio (a point or a region)
+#: src/menus/LabelMenus.cpp
+msgid "Split labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Labeled Audio"
+msgstr "Gearr an Mhír Fuaime a bhfuil Lipéad uirthi"
+
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+msgid "Joined labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Join Labeled Audio"
+msgstr "Cuir an Fhuaim le Lipéad ina Tost"
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+msgid "Detached labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detach Labeled Audio"
+msgstr "Gearr an Mhír Fuaime a bhfuil Lipéad uirthi"
 
 #: src/menus/LabelMenus.cpp
 msgid "&Labels"
@@ -7015,6 +12884,15 @@ msgid "Add Label at &Playback Position"
 msgstr "Cuir Lipéad ag an Ionad Seinnte"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "Greamaigh an Téacs leis an Lipéad Nua"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Fuaim le Lipéid"
 
@@ -7031,9 +12909,25 @@ msgstr "Eag. Lipéid"
 msgid "Label Delete"
 msgstr "Scrios Lipéad"
 
+#. i18n-hint: (verb) A special way to cut out a piece of audio
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Split Cut"
+msgstr "Eag. Lipéid"
+
 #: src/menus/LabelMenus.cpp
 msgid "Label Split Cut"
 msgstr "Eag. Lipéid"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Sp&lit Delete"
+msgstr "Scrios an Scoilt"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Delete"
+msgstr "Scrios an Scoilt"
 
 #: src/menus/LabelMenus.cpp
 msgid "Silence &Audio"
@@ -7078,6 +12972,11 @@ msgid "Foc&us"
 msgstr "Dírigh"
 
 #: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "Bog an Rian Suas"
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
 msgstr "Bog an Rian Suas"
 
@@ -7098,6 +12997,16 @@ msgid "Move Focus to &Last Track"
 msgstr "Bog an Rian Suas"
 
 #: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to P&revious and Select"
+msgstr "Bog an Rian Suas"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to N&ext and Select"
+msgstr "Bog an Rian Suas"
+
+#: src/menus/NavigationMenus.cpp
 msgid "&Toggle Focused Track"
 msgstr "Bog an Rian Suas"
 
@@ -7108,6 +13017,11 @@ msgstr "Bog an Rian Suas"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Neamhaicmithe"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Nua..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -7160,6 +13074,11 @@ msgid "Repeat Last Tool"
 msgstr "Déan Arís an Maisiú Deiridh"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Macros..."
+msgstr "Maicrea"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
 msgstr "Phaser á Fhorchur"
 
@@ -7182,6 +13101,11 @@ msgstr "&Rith Tagarmharc..."
 #: src/menus/PluginMenus.cpp
 msgid "Simulate Recording Errors"
 msgstr "Taifeadadh á dhéanamh"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Detect Upstream Dropouts"
+msgstr "Roghnaigh sruth(a) le tabhairt isteach"
 
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
@@ -7209,6 +13133,11 @@ msgid "Set Track Audio..."
 msgstr "Socraigh an Rian Fuaime..."
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Rian Nótaí"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Faigh Sainrogha..."
 
@@ -7231,6 +13160,12 @@ msgstr "Socraigh Lipéad..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Socraigh Tionscadal..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Gach Comhad (*)|*"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -7264,9 +13199,25 @@ msgstr "Bog an Luchóg..."
 msgid "Compare Audio..."
 msgstr "Cuir Fuaimeanna i gComórtas..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "Gabháil &Scáileáin..."
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Socraigh Pointe an Rogha"
+
 #: src/menus/SelectMenus.cpp
 msgid "Position"
 msgstr "Suíomh"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Socraigh Pointe an Rogha"
 
 #. i18n-hint: (verb) It's an item on a menu.
 #: src/menus/SelectMenus.cpp
@@ -7290,20 +13241,50 @@ msgid "In All &Tracks"
 msgstr "I nGach Rian"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Sync-Locked Tracks"
+msgstr "I nGach Rian"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Ná Roghnaigh Aon Cheann Acu"
+
+#: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "R&éigiún"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Left at Playback Position"
+msgstr "Cuir Lipéad ag an Ionad Seinnte"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Selection Left at Play Position"
 msgstr "Socraigh Pointe an Rogha"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Right at Playback Position"
+msgstr "Cuir Lipéad ag an Ionad Seinnte"
+
+#: src/menus/SelectMenus.cpp
 msgid "Set Selection Right at Play Position"
 msgstr "Socraigh Pointe an Rogha"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "Rogha go dtí an Tosach"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "Rogha go dtí an Tosach"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "Ainm Riain"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -7342,8 +13323,16 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Minicíocht líneach"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Rogha go dtí an Tosach"
+
+#: src/menus/SelectMenus.cpp
+msgid "Store Cursor Pos&ition"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -7356,6 +13345,19 @@ msgstr "Aimsigh Trasnuithe Náide"
 #: src/menus/SelectMenus.cpp
 msgid "&Selection"
 msgstr "&Rogha"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Off"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Snap-To &Nearest"
+msgstr "An ceann is neasa"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection to &Start"
@@ -7472,9 +13474,26 @@ msgstr "Reathaí Deas"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Aimsigh"
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "&Toolbars"
@@ -7489,6 +13508,27 @@ msgstr "&Roghchláir Bhreise (ann/as)"
 msgid "Reset Toolb&ars"
 msgstr "Athshocraigh na Barraí Uirlisí"
 
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr "Rian(ta) arna (n-)asbhaint"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+msgid "Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr ""
+
 #. i18n-hint: One or more audio tracks have been panned
 #: src/menus/TrackMenus.cpp
 msgid "Panned audio track(s)"
@@ -7497,6 +13537,11 @@ msgstr "Rian(ta) arna (n-)asbhaint"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Track"
 msgstr "Peanáil an Rian"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Zero"
+msgstr "Dáta Tosaithe"
 
 #: src/menus/TrackMenus.cpp
 msgid "Start to &Cursor/Selection Start"
@@ -7610,6 +13655,25 @@ msgid "Align Together"
 msgstr "Ailínigh le Chéile"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "Ailínigh an Deireadh le Deireadh an Rogha"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted gain"
+msgstr "Clúdach gléasta."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted Pan"
+msgstr "Clúdach gléasta."
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
 msgstr "Rian nua fuaime arna cheapadh"
 
@@ -7626,16 +13690,75 @@ msgid "Created new label track"
 msgstr "Rian nua lipéid arna cheapadh"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Rian nua ama arna cheapadh"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Ráta samplaithe:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "The entered value is invalid"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Resampling track %d"
+msgstr "Athshampláil cosctha."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resampled audio track(s)"
+msgstr "Rian(ta) arna (n-)asbhaint"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "Bain Amach Rian"
 
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "Roghnaigh aon rian fuaime amháin agus aon rian MIDI amháin ar a laghad."
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "Ailínigh an Deireadh le Deireadh an Rogha"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Tracks sorted by time"
+msgstr "Eagraigh de réir Ama"
+
+#: src/menus/TrackMenus.cpp
 msgid "Sort by Time"
 msgstr "Eagraigh de réir Ama"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Tracks sorted by name"
+msgstr "Eagraigh de réir Ainm"
 
 #: src/menus/TrackMenus.cpp
 msgid "Sort by Name"
@@ -7654,6 +13777,11 @@ msgid "&Mono Track"
 msgstr "&Rian Aonfhónach"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Stereo Track"
+msgstr "Ceap Rian Défhónach"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Label Track"
 msgstr "Rian &Lipéid"
 
@@ -7670,6 +13798,14 @@ msgid "Mix Stereo Down to &Mono"
 msgstr "Deighil Rian Défhónach"
 
 #: src/menus/TrackMenus.cpp
+msgid "Mi&x and Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix and Render to Ne&w Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "&Resample..."
 msgstr "&Athshampláil..."
 
@@ -7682,6 +13818,11 @@ msgid "M&ute/Unmute"
 msgstr "Balbhaigh/Díbhalbhaigh"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "&Díbhalbhaigh Gach Rian"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
 msgstr "&Díbhalbhaigh Gach Rian"
 
@@ -7692,6 +13833,10 @@ msgstr "Balbhaigh Rianta"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Díbhalbhaigh Gach Rian"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -7730,6 +13875,11 @@ msgid "Align &Together"
 msgstr "Ailínigh na Rian&ta le Chéile"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Move Selection with Tracks (on/off)"
+msgstr "go Deireadh an Rogha"
+
+#: src/menus/TrackMenus.cpp
 msgid "Move Sele&ction and Tracks"
 msgstr "go Deireadh an Rogha"
 
@@ -7744,6 +13894,11 @@ msgstr "De réir Am Tosaigh"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "De réir ainm"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "&Roghchláir Bhreise (ann/as)"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -7815,13 +13970,20 @@ msgstr "Ag seinm"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Taifeadadh á dhéanamh"
 
 #: src/menus/TransportMenus.cpp
 msgid "no label track"
 msgstr "gan lipéad riain"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track at or below focused track"
+msgstr "níl aon lipéid i rian na lipéad"
 
 #: src/menus/TransportMenus.cpp
 #, c-format
@@ -7831,6 +13993,20 @@ msgstr "%s %d as %d"
 #: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "níl aon lipéid i rian na lipéad"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -7894,6 +14070,20 @@ msgid "Record &New Track"
 msgstr "Taifead Rian Nua"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pla&y Region"
+msgstr "R&éigiún"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Lock"
 msgstr "Cuir glas air"
 
@@ -7902,12 +14092,35 @@ msgid "&Unlock"
 msgstr "&Bain an glas de"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Gléas Taifeadta"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "Roghanna Iompair"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Sound Activation Le&vel..."
+msgstr "Leibhéal gníomhachtaithe (dB):"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "&Breisdubáil (ar siúl/múchta)"
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -7956,6 +14169,11 @@ msgid "Play Before an&d After Selection End"
 msgstr "go Deireadh an Rogha"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview"
+msgstr "Gearr an Réamhamharc"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Play-at-Speed"
 msgstr "Seinnt"
 
@@ -7966,6 +14184,11 @@ msgstr "Seinnt"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play-at-Speed"
+msgstr "Seinnt"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview-at-Speed"
 msgstr "Seinnt"
 
 #: src/menus/TransportMenus.cpp
@@ -8039,6 +14262,11 @@ msgid "&Collapse All Tracks"
 msgstr "&Leacaigh Gach Rian"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "E&xpand Collapsed Tracks"
+msgstr "&Leacaigh Gach Rian"
+
+#: src/menus/ViewMenus.cpp
 msgid "Sk&ip to"
 msgstr "Léim go"
 
@@ -8092,19 +14320,38 @@ msgstr "&Tabhair chuig an Tulra Gach Ceann"
 msgid "Minimize All Projects"
 msgstr "Íoslaghdaigh Gach Tionscadal"
 
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
+
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
 msgstr "Sainroghanna don Cháilíocht"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Nuashonraigh Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
 msgid "&Check for Updates"
 msgstr "&Lorg nuashonruithe..."
+
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+#, fuzzy
+msgid "Batch"
+msgstr "Comhoiriúnaigh"
 
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
@@ -8113,6 +14360,10 @@ msgstr "Roghanna Audacity"
 #: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Behaviors"
 msgstr "Cineálacha Iompair"
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Devices"
@@ -8137,7 +14388,8 @@ msgstr "&Óstach:"
 msgid "Using:"
 msgstr "Ag baint feidhm as:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Athsheinm"
 
@@ -8157,7 +14409,8 @@ msgstr "Bealaí:"
 msgid "Latency"
 msgstr "Aga folaigh"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milleasoicindí"
 
@@ -8186,7 +14439,8 @@ msgid "2 (Stereo)"
 msgstr "2 (Défhónach)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Comhadlanna"
 
@@ -8199,8 +14453,22 @@ msgid "Default directories"
 msgstr "Comhadlanna"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Siortaigh..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -8260,6 +14528,11 @@ msgstr "Roghnaigh suíomh chun comhaid a chur i dtaisce ann"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "Ní hann don chomhadlann %s . Ceap í?"
 
@@ -8273,18 +14546,73 @@ msgid "Directory %s is not writable"
 msgstr "Ní comhadlann inscríofa í %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Ní chuirfear athruithe ar an gcomhadlann shealadach i gcrích go dtí go n-athmhúsclófar Audacity"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Comhadlann Shealadach Nua"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
 msgstr "Sainroghanna do na Maisiúcháin"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Effect Name"
+msgstr "Eagraigh de réir Ainm"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Publisher and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Type and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Earráid Nyquist"
 
 #. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
 #. It is not an abbreviation for anything.  See http://vamp-plugins.org
 #: src/prefs/EffectsPrefs.cpp
 msgid "&Vamp"
 msgstr "&Réthionlacan"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -8295,20 +14623,66 @@ msgid "Effect Options"
 msgstr "Roghanna Maisiúcháin"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Roghanna Breiseáin"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Idirlonnú Sinc Thapaidh"
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "&Use SSE/SSE2/.../AVX"
 msgstr "&Bain feidhm as SSE/SSE2/.../AVX"
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Iompórtáil"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Roghanna Audacity"
 
 #: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
 msgid "File extensions"
 msgstr "Iarmhíreanna comhadainm"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Cineál comhaid:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Easpórtáil Lipéid Mar:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Move rule &up"
@@ -8339,12 +14713,21 @@ msgid "Unused filters:"
 msgstr "Scagairí gan úsáid:"
 
 #: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
 msgstr "Bearnaí braite"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Do you really want to delete selected rule?"
 msgstr "An bhfuil tú cinnte gur mian leat an rial roghnaithe a scriosadh?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Aga taifeadta:"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -8367,6 +14750,11 @@ msgstr "-36 dB (réimse éadoimhin i gcomhair eagarthóireacht ard-aimplitiúide
 #: src/prefs/GUIPrefs.cpp
 msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (réimse PCM de shamplaí 8 giotán)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (réimse PCM de shamplaí 16 giotán)"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
@@ -8413,8 +14801,52 @@ msgid "Th&eme:"
 msgstr "Téama:"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Tonnchrot (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Show e&xtra menus"
 msgstr "Taispeáin roghchláir bhreise"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Roghanna Breiseáin"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Uirlis"
 
 #: src/prefs/GUIPrefs.cpp
 #, c-format
@@ -8430,8 +14862,18 @@ msgid "Import / Export"
 msgstr "Tabhair isteach/bain amach"
 
 #: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Roghanna Audacity"
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
 msgstr "Deighil Rian Défhónach"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Use Advanced Mixing Options"
+msgstr "Ardroghanna Measctha"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
@@ -8450,8 +14892,29 @@ msgid "&Beats"
 msgstr "&Buillí"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Easpórtáil Lipéid Mar:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -8465,6 +14928,19 @@ msgstr "Roghanna Audacity"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Keyboard preferences currently unavailable."
 msgstr "Níl sainroghanna don mhéarchlár ar fáil faoi láthair."
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Key Bindings"
+msgstr "Ceangail"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "View by:"
@@ -8524,7 +15000,15 @@ msgid "&Defaults"
 msgstr "Réamhshocruithe"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Roghnaigh comhad XML ina bhfuil congair mhéarchláir Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -8533,8 +15017,21 @@ msgstr "Easpórtáil Congair Mhéarchláir Mar:"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d congair mhéarchláir arna lódáil\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -8547,6 +15044,14 @@ msgstr "Easpórtáil Congair Mhéarchláir Mar:"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Easpórtáil Congair Mhéarchláir Mar:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid ""
@@ -8562,6 +15067,21 @@ msgstr ""
 "\n"
 "\t"
 
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "Teaglaim Cnaipí"
@@ -8571,7 +15091,31 @@ msgid "Preferences for Library"
 msgstr "Sainroghanna don Leabharlann"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "LAME MP3 Export Library"
+msgstr "Leabharlann LAME MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
+msgstr "Leagan Leabharlainne MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export Library"
+msgstr "Tabhairt Isteach/Amach FFmpeg"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "No compatible FFmpeg library was found"
+msgstr "Níorbh aimsíodh leabharlann FFmpeg"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
 msgstr "Leagan Leabharlainne MP3:"
 
 #: src/prefs/LibraryPrefs.cpp
@@ -8585,6 +15129,12 @@ msgstr "Aimsigh..."
 #: src/prefs/LibraryPrefs.cpp
 msgid "Dow&nload"
 msgstr "Íos&luchtaigh"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.cpp
 msgid "Success"
@@ -8613,6 +15163,23 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Comhéadan"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -8623,7 +15190,29 @@ msgid "Preferences for Module"
 msgstr "Sainroghanna don Mhodúl"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Ní chuirfear athruithe ar an gcomhadlann shealadach i gcrích go dtí go n-athmhúsclófar Audacity"
 
 #: src/prefs/ModulePrefs.cpp
@@ -8634,9 +15223,18 @@ msgstr "Fiafraigh"
 msgid "Failed"
 msgstr "Theip air"
 
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "No modules were found"
+msgstr "Níor aimsíodh aon rud cosúil leis"
+
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modúl"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -8678,13 +15276,26 @@ msgstr "Clétharraingt"
 msgid "Set Selection Range"
 msgstr "Socraigh Réimse an Rogha"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Iomlaoid-Clé-Cnag"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Extend Selection Range"
 msgstr "Cuir Síneadh leis an Réimse Roghnaithe"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Alt-Clé-Cnag"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "Rogha go dtí an Deireadh"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
@@ -8703,6 +15314,10 @@ msgid "Zoom in on a Range"
 msgstr "Gluais isteach ar Réimse"
 
 #: src/prefs/MousePrefs.cpp
+msgid "same as right-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Right-Click"
 msgstr "Deaschnagadh"
 
@@ -8715,16 +15330,59 @@ msgid "Right-Drag"
 msgstr "Deastharraingt"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "same as left-drag"
+msgstr "Ionann leis an uirlis roghnúcháin"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Clétharraingt"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Zoom out on a Range"
 msgstr "Gluais amach ar Raon"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Cléchnagadh"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Zoom default"
 msgstr "Réamhshocrú gluaise"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip left/right or between tracks"
+msgstr "Bogadh na gearrthóga chuig rian eile"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Left-Drag"
+msgstr "-Clé-Tarraing"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
 msgstr "-Clé-Tarraing"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip up/down between tracks"
+msgstr "Bogadh na gearrthóga chuig rian eile"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Clé-Tarraing"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -8776,6 +15434,11 @@ msgid "Scroll tracks up or down"
 msgstr "Scroláil suas nó anuas"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Wheel-Rotate"
+msgstr "-Iomlaoid-Roth-Rothlú"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Scroll waveform"
 msgstr "Scrollaigh an tonnchruth"
 
@@ -8800,6 +15463,11 @@ msgid "Preferences for Playback"
 msgstr "Sainroghanna Athsheanma"
 
 #: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Effects Preview"
+msgstr "Gearr an Réamhamharc"
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "&Length:"
 msgstr "&Fad:"
 
@@ -8808,8 +15476,41 @@ msgstr "&Fad:"
 msgid "Cut Preview"
 msgstr "Gearr an Réamhamharc"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Roghanna Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -8823,6 +15524,11 @@ msgstr "Sainroghanna:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Sainroghanna don Cháilíocht"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -8840,10 +15546,30 @@ msgstr "Ráta Réamhshocraithe Samplaithe:"
 msgid "Default Sample &Format:"
 msgstr "Formáid Réamhshocraithe Samplaithe:"
 
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Ráta samplaithe:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Con&verter:"
+msgstr "Ráta samplaithe:"
+
 #. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
 #: src/prefs/QualityPrefs.cpp
 msgid "&Dither:"
 msgstr "&Díodán:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Idirlonnú Sinc ar Ardchaighdeán"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Conver&ter:"
+msgstr "Ráta samplaithe:"
 
 #. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
 #: src/prefs/QualityPrefs.cpp
@@ -8863,8 +15589,30 @@ msgid "Preferences for Recording"
 msgstr "Sainroghanna don Taifeadadh"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Déan é a thaifeadadh ar rian nua"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Taifeadadh á dhéanamh"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -8885,6 +15633,11 @@ msgid "Custom Track &Name"
 msgstr "Ainm Riain"
 
 #: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Téacs an lipéid"
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
 msgstr "Fuaim_Thaifeadta"
 
@@ -8893,16 +15646,48 @@ msgid "&Track Number"
 msgstr "Uimhir an Riain"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Laistigh de:"
+#, fuzzy
+msgid "System &Date"
+msgstr "Córas"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milleasoicindí (aga aon mhiondealú amháin)"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Córas"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "Ciallaíonn 0 gan chríoch"
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Sainroghanna don Taifeadadh"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Rian Nótaí"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
 
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -8941,6 +15726,34 @@ msgstr "Athshannú"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Airde (EAC)"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be at least 0 Hz"
+msgstr "Ní mór don mhinicíocht a bheith 0.1 Hz ar a laghad."
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "Ní mór don mhinicíocht a bheith 0.1 Hz ar a laghad."
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -8984,6 +15797,10 @@ msgid "&Range (dB):"
 msgstr "&Réimse (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
 msgstr "Algartam"
 
@@ -8996,19 +15813,61 @@ msgid "Window &size:"
 msgstr "Méid na fuinneoige:"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - réamhshocrú"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr "Cineálacha fuinneoga"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Fachtóir meatha:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Socraigh Pointe an Rogha"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Show a grid along the &Y-axis"
+msgstr "Taispeáin na línte eangaigh"
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "FFT Find Notes"
+msgstr "&Aimsigh Nótaí"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Minimum Amplitude (dB):"
 msgstr "Aimplitiúid íosta (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Find Notes"
+msgstr "&Aimsigh Nótaí"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Quantize Notes"
 msgstr "&Aimsigh Nótaí"
 
 #: src/prefs/SpectrumPrefs.cpp
@@ -9021,6 +15880,41 @@ msgstr "Socraigh Pointe an Rogha"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "The maximum frequency must be an integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum frequency must be an integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
 msgstr "Ní foláir ach gur slánuimhir í an uasmhinicíocht"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
@@ -9040,12 +15934,60 @@ msgid "Info"
 msgstr "Faisnéis"
 
 #: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
 msgid "Save Files"
 msgstr "Taisc comhaid"
 
 #: src/prefs/ThemePrefs.cpp
 msgid "Load Files"
 msgstr "Luchtaigh comhaid"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+#, fuzzy
+msgid "Tracks Behaviors"
+msgstr "Cineálacha Iompair"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "Sainroghanna do Rianta"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Simple"
@@ -9067,6 +16009,26 @@ msgstr "Cumasaigh línte gearrtha"
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Enable &dragging selection edges"
 msgstr "Cuir an Rogha ina thost"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
@@ -9092,6 +16054,10 @@ msgstr "Speictreagram"
 msgid "Connect dots"
 msgstr "Ceangail na poncanna"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "Oiriúnaigh don Leithead"
@@ -9113,6 +16079,34 @@ msgid "Seconds"
 msgstr "Soicindí"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "5ths of Seconds"
+msgstr "Soicindí"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "10ths of Seconds"
+msgstr "Soicindí"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "20ths of Seconds"
+msgstr "Soicindí"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "50ths of Seconds"
+msgstr "Soicindí"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "100ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "500ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "Milleasoicindí"
 
@@ -9120,13 +16114,43 @@ msgstr "Milleasoicindí"
 msgid "Samples"
 msgstr "Samplaí"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Formhéadú Uasta"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Preferences for Tracks"
 msgstr "Sainroghanna do Rianta"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Taifeadadh á dhéanamh"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -9169,6 +16193,38 @@ msgstr "Rabhaidh"
 msgid "Preferences for Warnings"
 msgstr "Sainroghanna do Rabhaí"
 
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&Sábháil Tionscadal"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&Sábháil Tionscadal"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "Deighil Rian Défhónach"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "Deighil Rian Défhónach"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
+
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
 msgid "Waveforms"
@@ -9190,16 +16246,24 @@ msgid "Stopped"
 msgstr "Stadtha"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Sos"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Léim go dtí an Tosach"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Léim go dtí an Deireadh"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Sos"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Roghnaigh go dtí an Tús"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Roghnaigh go dtí an Deireadh"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -9213,20 +16277,24 @@ msgstr "Taifead Rian Nua"
 msgid "Append Record"
 msgstr "Déan Taifeadadh"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Roghnaigh go dtí an Deireadh"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Roghnaigh go dtí an Tús"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s curtha ar sos."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Uirlis an Roghnaithe"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -9263,8 +16331,25 @@ msgid "Select Playback Device"
 msgstr "Roghnaigh Gléas Athsheanma"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Roghnaíonn sé Fuaim."
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Cainéal Deas"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "Níl réamhamharc ar fáil"
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that manages devices
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "&Device Toolbar"
+msgstr "&Barraí uirlisí"
 
 #: src/toolbars/EditToolBar.cpp
 msgid "Cut selection"
@@ -9282,11 +16367,22 @@ msgstr "Bearr a bhfuil lasmuigh den rogha"
 msgid "Silence audio selection"
 msgstr "Cuir an Rogha ina thost"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "Rianta Gearra"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zúmáil Isteach"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zúmáil Amach"
 
@@ -9298,6 +16394,22 @@ msgstr "Socraigh rogha don leithead"
 msgid "Fit project to width"
 msgstr "Socraigh tionscadal don leithead"
 
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "Eallóg na Maisiúchán"
+
+#. i18n-hint: Clicking this menu item shows the toolbar for editing
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "&Edit Toolbar"
+msgstr "&Barraí uirlisí"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "Taifeadadh á dhéanamh"
+
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Meter"
 msgstr "Taifeadadh á dhéanamh"
@@ -9305,6 +16417,22 @@ msgstr "Taifeadadh á dhéanamh"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "Seinnt"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "Déan Taifeadadh"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Play"
+msgstr "Méadar"
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Level"
@@ -9326,36 +16454,24 @@ msgstr "Taifeadadh á dhéanamh"
 msgid "&Playback Meter Toolbar"
 msgstr "Seinnt"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Taifeadadh á dhéanamh"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Airde Athsheanma"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Taifeadadh á dhéanamh"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Seinnt"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Airde Athsheanma: %.2f"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Cuardaigh"
 
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Uirlis"
+
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Leid Nyquist..."
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Leid Nyquist..."
@@ -9363,6 +16479,7 @@ msgstr "Leid Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Leid Nyquist..."
@@ -9370,9 +16487,24 @@ msgstr "Leid Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "go Deireadh an Rogha"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "go Deireadh an Rogha"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Uirlis"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -9383,6 +16515,15 @@ msgstr "Uirlis"
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "Luas an Tionscadail (Hz)"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap-To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
+#, fuzzy
+msgid "Audio Position"
+msgstr "Óstach Fuaime"
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
@@ -9405,12 +16546,23 @@ msgid "Show"
 msgstr "Taispeáin"
 
 #: src/toolbars/SelectionBar.cpp
+msgid "Snap To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
 msgid "Length"
 msgstr "Fad"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Lár"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
 
 #. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated), to indicate that it will be
@@ -9427,6 +16579,13 @@ msgstr "%s - tiománta"
 msgid "Selection %s. %s won't change."
 msgstr "Rogha %s. Ní athrófar %s."
 
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for selecting a time range of audio
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "&Selection Toolbar"
+msgstr "Uirlis an &Roghnaithe"
+
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Center frequency and Width"
 msgstr "Minicíocht líneach"
@@ -9438,6 +16597,10 @@ msgstr "Minicíochtaí Ísle agus Airde"
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Center Frequency"
 msgstr "Minicíocht líneach"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
@@ -9457,13 +16620,18 @@ msgstr "&Barraí uirlisí"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra Uirlisí %s Audacity"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Cnag is tarraing chun an rian a athmhéadú."
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Uirlis"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -9481,13 +16649,26 @@ msgstr "Uirlis Bhogadh in Am"
 msgid "Zoom Tool"
 msgstr "Uirlis Zúmála"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Uirlis Líníochta"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Multi-Tool"
 msgstr "Iluirlis"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "Uirlis an Roghnaithe"
+
+#. i18n-hint: Clicking this menu item shows a toolbar
+#. that has some tools in it
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools Toolbar"
+msgstr "&Barraí uirlisí"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "&Selection Tool"
@@ -9522,8 +16703,18 @@ msgid "&Next Tool"
 msgstr "&Uirlis Ar Aghaidh"
 
 #: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "Ag Seinm ar Luas"
+
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Playback Speed"
 msgstr "Luas Athsheanma"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "Seinnt"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
@@ -9531,11 +16722,21 @@ msgstr "Luas Athsheanma"
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "Seinnt"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Lipéad Caochlaithe"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Eag. Lipéid"
 
@@ -9555,6 +16756,12 @@ msgstr "Cló Rian Lipéid"
 #. i18n-hint: (noun) The name of the typeface
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Face name"
+msgstr "Ainm na haghaidhe"
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
 msgstr "Ainm na haghaidhe"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -9585,31 +16792,42 @@ msgstr "Lipéid Arna nEagrú"
 msgid "New label"
 msgstr "Lipéad nua"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Suas Ochtáibh"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Ochtáibh Síos"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Cnag chun zúmáil isteach go hingearach, Iomlaoid-cnag le zúmáil amach, Tarraing chun ceantar fé leith zúmála a cheapadh."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Deaschnagadh"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zúmáil Amach"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Iomlaoid-Clé-Cnag"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Iomlaoid-Clé-Cnag"
 
@@ -9632,16 +16850,43 @@ msgid "Stretch"
 msgstr "Sín"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "Gearrthóg Chrua"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merge"
 msgstr "Cumaisc"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Fairsingigh"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Removed Cut Line"
+msgstr "Bain Amach an Lár"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Click and drag to edit the samples"
 msgstr "Cnag is tarraing chun na samplaí a chur in eagar"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
@@ -9651,6 +16896,11 @@ msgstr "Sampla Arna Bhogadh"
 msgid "Sample Edit"
 msgstr "Déan Eagarthóireacht ar Shamplaí"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Gluais chun é a chur in Oiriúint"
@@ -9658,6 +16908,12 @@ msgstr "Gluais chun é a chur in Oiriúint"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Sp'graim"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "Stop the Audio First"
@@ -9680,9 +16936,15 @@ msgstr "Luas á Athrú; Airde gan Athrú"
 msgid "Processing...   0%%"
 msgstr "Rian Nótaí"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   %i%%"
+msgstr "Rian Nótaí"
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Athraíodh '%s' go %s"
@@ -9694,6 +16956,54 @@ msgstr "Athrú Formáide"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Luas"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -9713,7 +17023,8 @@ msgstr "Athrú Ráta"
 msgid "Set Rate"
 msgstr "Socraigh Ráta"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Il-amharc"
 
@@ -9805,14 +17116,23 @@ msgstr "Clé, %dHz"
 msgid "Right, %dHz"
 msgstr "Deas, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Clé"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Deas"
@@ -9824,6 +17144,15 @@ msgstr "Cnag is tarraing chun méad coibhneasta rianta déthónacha a ghléasadh
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "Cnag is tarraing chun rian a bhogadh in am"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Cnag is tarraing chun rian a bhogadh in am"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -9881,16 +17210,37 @@ msgid "Set Range"
 msgstr "Socraigh Réimse"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "Socraigh Taispeáint"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Socraigh idirshuí"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "Líneach"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Idirlonnú Sinc Thapaidh"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -9902,9 +17252,8 @@ msgstr "Idirlonnú Sinc Thapaidh"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Cnag is tarraing chun rian a bhogadh in am"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -9955,13 +17304,20 @@ msgstr "Clúdach gléasta."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Sciúr"
 
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Cuardaigh"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Uirlis"
@@ -9977,6 +17333,11 @@ msgstr "Bog an Rian Suas"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Bog an Rian Síos"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Leid Nyquist..."
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -10033,9 +17394,19 @@ msgstr "Cnag is tarraing chun fuaim a roghnú"
 msgid "Click and drag to select audio"
 msgstr "Cnag is tarraing chun fuaim a roghnú"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Cnag is tarraing chun rian a bhogadh in am"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Could not shift between tracks"
+msgstr "Níorbh fhéidir scríobh sa chomhad: %s\n"
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Moved clips to another track"
@@ -10070,6 +17441,24 @@ msgstr "Gníomh Ordaithe"
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Open menu..."
 msgstr "&Oscail roghchlár..."
+
+#. i18n-hint: Command names a modifier key on Macintosh keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Command+Click"
+msgstr "Gníomh Ordaithe"
+
+#. i18n-hint: Ctrl names a modifier key on Windows or Linux keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Ctrl+Click"
+msgstr "Brúigh"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "%s chun rian a roghnú nó a dhíroghnú."
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -10128,6 +17517,12 @@ msgstr "C"
 msgid "R"
 msgstr "D"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -10145,6 +17540,14 @@ msgstr "Cineál comhaid:"
 msgid "&Clear"
 msgstr "&Glan"
 
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
 #: src/widgets/Grid.cpp
 msgid "Empty"
 msgstr "Folaigh"
@@ -10153,9 +17556,19 @@ msgstr "Folaigh"
 msgid "Backwards"
 msgstr "Siar"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Ar aghaidh"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -10167,6 +17580,11 @@ msgstr "Roghchlár"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
+msgstr "Brúigh chun Faireachán a Thosú"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click for Monitoring"
 msgstr "Brúigh chun Faireachán a Thosú"
 
 #: src/widgets/Meter.cpp
@@ -10198,8 +17616,33 @@ msgid "Refresh Rate"
 msgstr "Socraigh Ráta"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Style"
+msgstr "Méadar"
+
+#: src/widgets/Meter.cpp
 msgid "Gradient"
 msgstr "Grádán"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Type"
+msgstr "An Cineál Scagaire:"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
@@ -10238,6 +17681,10 @@ msgstr " Buaic %.2f "
 #: src/widgets/Meter.cpp
 msgid " Clipped "
 msgstr " Gearrtha "
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Please select an action"
@@ -10280,6 +17727,13 @@ msgstr "ll:uu:nn:ss"
 msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 lá  024 u 060 n 060 s"
 
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "uu:nn:ss + samplaí"
+
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
 #. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
@@ -10290,6 +17744,13 @@ msgstr "0100 lá  024 u 060 n 060 s"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060>0100 s"
 msgstr "0100 u 060 n 060>0100 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + milliseconds"
+msgstr "uu:nn:ss + samplaí"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
@@ -10322,6 +17783,7 @@ msgstr "0100 u 060 n 060 s+># samplaí"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "samplaí"
@@ -10365,6 +17827,14 @@ msgstr "frámaí scannáin (24 fps)"
 msgid "01000,01000 frames|24"
 msgstr "01000,01000 frámaí|24"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr "uu:nn:ss + samplaí"
+
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
@@ -10374,6 +17844,14 @@ msgstr "01000,01000 frámaí|24"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s+>30 frames|N"
 msgstr "0100 u 060 n 060 s+>30 frámaí|N"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr "uu:nn:ss + frámaí CDDA (75 fps)"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
@@ -10437,11 +17915,31 @@ msgstr "01000,01000 frámaí|25"
 msgid "hh:mm:ss + CDDA frames (75 fps)"
 msgstr "uu:nn:ss + frámaí CDDA (75 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr "0100 u 060 n 060 s+>25 fhráma"
+
 #. i18n-hint: Name of time display format that shows time in frames at CD
 #. * Audio frame rate (75 frames per second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "CDDA frames (75 fps)"
 msgstr "Frámaí CDDA (75 fps)"
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000,01000 frames|75"
+msgstr "01000,01000 frámaí|25"
 
 #. i18n-hint: Format string for displaying frequency in hertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
@@ -10450,6 +17948,28 @@ msgstr "Frámaí CDDA (75 fps)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "010,01000>0100 Hz"
 msgstr "0100000>0100 Hz"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000>01000 kHz|0.001"
+msgstr "0100000>0100 Hz"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -10464,6 +17984,63 @@ msgstr "Ochtáibh Síos"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "100>01000 octaves|1.442695041"
 msgstr "100>01000 ochtacha|1.442695041"
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "10>01000 decades|0.434294482"
+msgstr "100>01000 ochtacha|1.442695041"
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "soicindí"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -10507,6 +18084,11 @@ msgstr "Deimhnigh an Dúnadh"
 msgid "Unable to write files to directory: %s."
 msgstr "Ní fhéidir a aithint"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -10525,6 +18107,10 @@ msgid "Don't show this warning again"
 msgstr "Ná taispeáin an foláireamh seo arís"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "Éigríoch"
 
@@ -10533,13 +18119,31 @@ msgid "-Infinity"
 msgstr "-Éigríoch"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Luach folamh"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Déan Taifeadadh"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Gan a bheith sa raoin idir %d go %d"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Earráid LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -10557,12 +18161,21 @@ msgid "Value must not be greater than %s"
 msgstr "Ní féidir leis an ainm a bheith bán"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Roghnaigh comhadlann"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
 msgstr "Comhadlanna"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "An fhuinneog aimsithe"
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
@@ -10582,16 +18195,49 @@ msgstr "Níorbh fhéidir an comhad a oscailt"
 msgid "Spectral edit multi tool"
 msgstr "Socraigh Pointe an Rogha"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Ag scagadh..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aRoghnaigh minicíochtaí."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Earráid.~%"
@@ -10606,8 +18252,34 @@ msgstr "Neartúchán (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Minicíocht líneach"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -10620,6 +18292,33 @@ msgstr "Céimnigh Amach"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Phaser á Fhorchur"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Socraigh an Réamhshocrú"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -10642,8 +18341,16 @@ msgid "S-Curve Down"
 msgstr "Bog an Rian Síos"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Tosaigh/Críochnaigh ag"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -10658,6 +18365,10 @@ msgid "End (or start)"
 msgstr "Críoch (nó an tús)"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "None Selected"
 msgstr "Faic Roghnaithe"
 
@@ -10668,6 +18379,14 @@ msgstr "Líneach Isteach"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Líneach Amach"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -10706,6 +18425,24 @@ msgstr "Bog an Rian Síos"
 msgid "Error~%~%"
 msgstr "Earráid~%~%"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Athdhéan"
@@ -10713,6 +18450,11 @@ msgstr "Athdhéan"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Tost á cheapadh"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Céad Mhúscailt Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -10726,6 +18468,23 @@ msgstr "Reathaí Deas"
 msgid "Reconstructing clips..."
 msgstr "Cnaga is plaib á n-asbhaint..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Tairseach %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Rian Nótaí"
@@ -10734,6 +18493,21 @@ msgstr "Rian Nótaí"
 msgid "Crossfading..."
 msgstr "Rian Nótaí"
 
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
 msgstr "Rian Nótaí"
@@ -10741,6 +18515,11 @@ msgstr "Rian Nótaí"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade type"
 msgstr "Céimnigh Amach"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Constant Gain"
+msgstr "Leanúnach"
 
 #: plug-ins/crossfadetracks.ny
 msgid "Constant Power 1"
@@ -10761,6 +18540,19 @@ msgstr "Ainm Riain"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade direction"
 msgstr "Céimnigh Isteach"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Delay"
@@ -10783,16 +18575,47 @@ msgid "Bouncing Ball"
 msgstr "Liathróid Léimneach"
 
 #: plug-ins/delay.ny
+#, fuzzy
+msgid "Reverse Bouncing Ball"
+msgstr "Liathróid Léimneach"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Lei&bhéal (dB):"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Aga moille (soicindí):"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Pitch change effect"
+msgstr "Réamhamharc an maisiú"
 
 #: plug-ins/delay.ny
 msgid "Pitch/Tempo"
 msgstr "Airde (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Pitch change per echo (semitones)"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "Líon uaireanta le hathdhéanamh:"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -10807,6 +18630,10 @@ msgid "XML file"
 msgstr "Comhad XML"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "Déan Taifeadadh"
 
@@ -10819,10 +18646,24 @@ msgstr "Forscríobh"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Earráid.~%Níorbh fhéidir an comhad seo a oscailt~%~s"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Earráid (seans nár scríobhadh an comhad): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Earráid (seans nár scríobhadh an comhad): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -10853,10 +18694,18 @@ msgstr "Fad (soicindí)"
 msgid "Length of label region (seconds)"
 msgstr "Fad (soicindí)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Téacs an lipéid"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "None - Text Only"
@@ -10902,6 +18751,11 @@ msgstr "Mionsonraí"
 msgid "Warnings only"
 msgstr "Rabhaí amháin"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -10911,6 +18765,17 @@ msgstr "Lipéad a cuireadh leis"
 msgid "point labels"
 msgstr "Iompórtáil Lipéid"
 
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
 msgstr "Cothromú á Chur i gCrích"
@@ -10919,13 +18784,50 @@ msgstr "Cothromú á Chur i gCrích"
 msgid "Performing High-Pass Filter..."
 msgstr "Cothromú á Chur i gCrích"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Minicíocht (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Ní mór don mhinicíocht a bheith 0.1 Hz ar a laghad."
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -10973,14 +18875,58 @@ msgid "Point after sound"
 msgstr "Comhsteiréó"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "Comhsteiréó"
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Ciúnas á aimsiú..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Ciúnas á aimsiú..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, fuzzy, lisp-format
+msgid "~ah ~am ~as"
+msgstr "~ah ~am ~as"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Ní mór don luach a bheith níos mó ná %s"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Limiter"
+msgstr "Teorainn dB"
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -11008,12 +18954,29 @@ msgid "Hard Clip"
 msgstr "Gearrthóg Chrua"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Cainéal Deas"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Teorannaigh go (dB)"
 
 #: plug-ins/limiter.ny plug-ins/noisegate.ny
 msgid "Hold (ms)"
 msgstr "Greim (ms)"
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
 
 #: plug-ins/lowpass.ny
 msgid "Low-Pass Filter"
@@ -11036,8 +18999,22 @@ msgid "Gate"
 msgstr "Geata"
 
 #: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Stereo Linking"
+msgstr "Steiréó"
+
+#: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
 msgstr "Ceap Rian Défhónach"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
+msgstr "Comhsteiréó"
 
 #: plug-ins/noisegate.ny
 msgid "Gate threshold (dB)"
@@ -11059,6 +19036,38 @@ msgstr "Aga Ionsaithe:"
 msgid "Decay (ms)"
 msgstr "Meath (soicindí):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Ní mór don luach a bheith níos mó ná %s"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
 #. i18n-hint: hours and minutes. Do not translate "~a".
 #: plug-ins/noisegate.ny
 #, lisp-format
@@ -11076,6 +19085,18 @@ msgstr "Phaser á Fhorchur"
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Steve Daulton agus Bill Wharrie"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -11098,7 +19119,8 @@ msgstr "Comhaid Lisp"
 msgid "HTML file"
 msgstr "Comhaid HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Comhad téacs"
 
@@ -11129,6 +19151,11 @@ msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Theip ar bhaint %s"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
 msgstr "Breiseáin %i go %i"
 
@@ -11137,12 +19164,46 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Roghnaigh comhad breiseáin"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Scagairí gan úsáid:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Roghnaigh comhad breiseáin"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Ton á Cheapadh"
+
+#: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
@@ -11173,8 +19234,36 @@ msgid "Tempo (bpm)"
 msgstr "Luas (bpm)"
 
 #: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Líon na mbarraí"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -11197,6 +19286,18 @@ msgid "Beat sound"
 msgstr "Fuaim buillí"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Cowbell"
 msgstr "Clog bó"
 
@@ -11208,6 +19309,32 @@ msgstr "Fothram á Bhaint Amach"
 msgid "Noise Click"
 msgstr "Cléchnagadh"
 
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
 msgstr "Tost á cheapadh"
@@ -11217,12 +19344,25 @@ msgid "Generating Risset Drum..."
 msgstr "Tost á cheapadh"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Meath (soicindí):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "Minicíocht líneach"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Minicíocht LFO (Hz):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -11235,6 +19375,10 @@ msgstr "Déan Eagarthóireacht ar Shamplaí"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Ag miondealú..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -11253,6 +19397,10 @@ msgid "HTML files"
 msgstr "Comhaid HTML"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Déan Eagarthóireacht ar Shamplaí"
 
@@ -11261,12 +19409,30 @@ msgid "Time Indexed"
 msgstr "Eag. Lipéid"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Ní fhéidir a aithint"
+
+#: plug-ins/sample-data-export.ny
 msgid "Minimal"
 msgstr "Íosta"
 
 #: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Uile"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Alternate Lines"
@@ -11285,6 +19451,11 @@ msgstr "Taispeáin teachtaireachtaí"
 msgid "Errors Only"
 msgstr "Earráidí Amháin"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -11297,8 +19468,43 @@ msgstr "~%~%Bealach Deas.~%~%"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a linear, ~a dB."
 msgstr "~a líneach, ~a dB."
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -11311,8 +19517,40 @@ msgid "~a seconds."
 msgstr "~a soicindí."
 
 #: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr "~a líneach, &nbsp;&nbsp;~a dB."
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr "~a líneach, &nbsp;&nbsp;~a dB."
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr "~a líneach, &nbsp;&nbsp;~a dB."
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
 msgstr "~a líneach, &nbsp;&nbsp;~a dB."
 
 #: plug-ins/sample-data-export.ny
@@ -11332,6 +19570,10 @@ msgid "Value (dB)"
 msgstr "Luach (dB)"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Clé (líneach)"
 
@@ -11348,6 +19590,14 @@ msgid "Right (dB)"
 msgstr "Deas (dB)"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "líneach"
 
@@ -11361,6 +19611,35 @@ msgstr "1Cainéal (Aonfhónach)"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "Error.~%\"~a\" cannot be written."
 msgstr "Earráid.~% Ní féidir \"~a\" a scríobh."
 
@@ -11369,8 +19648,16 @@ msgid "Sample Data Import"
 msgstr "Ráta samplaithe:"
 
 #: plug-ins/sample-data-import.ny
+msgid "Reading and rendering samples..."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Select file"
 msgstr "Roghnaigh comhad"
+
+#: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Throw Error"
@@ -11382,12 +19669,45 @@ msgstr "Léigh mar Náid é"
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
 msgid "Error.~%Unable to open file"
 msgstr "Earráid.~%Ní féidir an comhad a oscailt"
 
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Socraigh Pointe an Rogha"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -11405,9 +19725,21 @@ msgstr "Sábhfhiaclach"
 msgid "Starting phase (degrees)"
 msgstr "Pas Tosaigh LFO (céim.):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Gníomh á Fhorchur..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -11449,6 +19781,94 @@ msgstr "Scrúdaigh"
 msgid "Strength"
 msgstr "Láidreacht"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Processing Vocoder..."
+msgstr "Rian Nótaí"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "Fad: (1 go 120, réamhshocrú = 20)"
@@ -11485,6 +19905,137 @@ msgstr "Minicíocht LFO (Hz):"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Minicíocht LFO (Hz):"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Nuashonraigh Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Suiteáil an nuashonrú"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Oireas na n-athruithe"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Léigh tuilleadh ar GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Bhí na sonraí nuashonraithe truaillithe."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Ní féidir nasc íosluchtaithe Audacity a oscailt."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Barra Uirlisí %s Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Taifeadadh á dhéanamh"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Ní fhéidir a aithint\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Meascthóirí ar fáil:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Taifeadadh á dhéanamh\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Seinnt\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Taifeadadh á dhéanamh\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Taifeadadh á dhéanamh\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Seinnt\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Seinnt\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Ní fhéidir a aithint"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Ní fhéidir a aithint"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Earráid GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Meascthóir"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Seinnt"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Seinnt"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Seinnt"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Taifeadadh á dhéanamh"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Taifeadadh á dhéanamh"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Taifeadadh á dhéanamh"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Lámh&leabhar Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Mar Gheall ar Audacity..."
+
+#~ msgid "Within:"
+#~ msgstr "Laistigh de:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milleasoicindí (aga aon mhiondealú amháin)"
+
+#~ msgid "0 means endless"
+#~ msgstr "Ciallaíonn 0 gan chríoch"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Taifeadadh á dhéanamh"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Airde Athsheanma"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Taifeadadh á dhéanamh"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Seinnt"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Airde Athsheanma: %.2f"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Cnag is tarraing chun rian a bhogadh in am"
+
 #~ msgid "Program build date:"
 #~ msgstr "Dáta tógála an ríomhchláir:"
 
@@ -11518,15 +20069,8 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgid "Unknown error"
 #~ msgstr "Earráid anaithnid"
 
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Ní fhéidir a aithint"
-
 #~ msgid "volunteers"
 #~ msgstr "oibrithe deonacha"
-
-#~ msgid "available"
-#~ msgstr "ar fáil"
 
 #~ msgctxt "dative"
 #~ msgid "forum"
@@ -11565,9 +20109,6 @@ msgstr "Minicíocht LFO (Hz):"
 
 #~ msgid "Master Gain Control"
 #~ msgstr "Rialthóir Máistreach Neartúcháin"
-
-#~ msgid "LAME MP3 Library:"
-#~ msgstr "Leabharlann LAME MP3:"
 
 #~ msgid "&Locate..."
 #~ msgstr "&Aimsigh..."
@@ -11625,10 +20166,6 @@ msgstr "Minicíocht LFO (Hz):"
 #~ "Tabhair amach an taifeadadh chuig %s\n"
 #~ "/%s/%s%s"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "Taifeadadh á dhéanamh"
-
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
 #~ msgstr "Níl ar chumas an tsraith seo d'Audacity Ogg Vorbis a láimhseáil"
 
@@ -11643,17 +20180,11 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgid "Renamed file: %s\n"
 #~ msgstr "Comhad arna athainmniú: %s\n"
 
-#~ msgid "Audacity projects"
-#~ msgstr "Tionscadail Audacity"
-
 #~ msgid "Reclaimable Space"
 #~ msgstr "Slí In-athghafa"
 
 #~ msgid "1.0 or earlier"
 #~ msgstr "1.0 nó níos luaithe"
-
-#~ msgid "Warning - Opening Old Project File"
-#~ msgstr "Rabhadh - Ag Oscailt Comhad Seanthionscadail"
 
 #~ msgid "<unrecognized version -- possibly corrupt project file>"
 #~ msgstr "<leagan neamhaitheanta -- b'fhéidir go bhfuil an comhad truaillithe>"
@@ -11697,9 +20228,6 @@ msgstr "Minicíocht LFO (Hz):"
 #, fuzzy
 #~ msgid "&Save Compressed Copy of Project..."
 #~ msgstr "Sábháil Tionscadal M&ar..."
-
-#~ msgid "Chec&k Dependencies..."
-#~ msgstr "Dearbháil na Spleác&hais..."
 
 #~ msgid "C&hoose..."
 #~ msgstr "Rog&hnaigh..."
@@ -11901,10 +20429,6 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgstr "Roghnaigh"
 
 #, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "Uirlis an Roghnaithe"
-
-#, fuzzy
 #~ msgid "&Tools"
 #~ msgstr "Uirlis"
 
@@ -11920,10 +20444,6 @@ msgstr "Minicíocht LFO (Hz):"
 #~ "Error opening sound device.\n"
 #~ "Try changing the audio host, recording device and the project sample rate."
 #~ msgstr "Earráid le linn oscailt ghléas fuaime. Deimhnigh socruithe ghléas an aschuir, is ráta samplaithe an tionscadail."
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "Taifeadadh á dhéanamh"
 
 #, fuzzy
 #~ msgid "Slider Playback"
@@ -11989,10 +20509,6 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgstr "Lár"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Rogha go dtí an Deireadh"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "go Deireadh an Rogha"
 
@@ -12019,20 +20535,12 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgstr "Céatadán an Athraithe:"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "Aga Ionsaithe:"
-
-#, fuzzy
 #~ msgid "Repeats"
 #~ msgstr "Athdhéan"
 
 #, fuzzy
 #~ msgid "Sequence"
 #~ msgstr "Minicíocht (Hz):"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Aimplitiúid (0-1)"
 
 #, fuzzy
 #~ msgid "CurveName"
@@ -12067,20 +20575,12 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgstr "Minicíocht (Hz):"
 
 #, fuzzy
-#~ msgid "Phase"
-#~ msgstr "Phaser"
-
-#, fuzzy
 #~ msgid "Depth"
 #~ msgstr "Doimhneacht:"
 
 #, fuzzy
 #~ msgid "Feedback"
 #~ msgstr "Aisfhotha (%):"
-
-#, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Méad"
 
 #, fuzzy
 #~ msgid "Reverberance"
@@ -12099,10 +20599,6 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgstr "Neartúchán"
 
 #, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Défh.,"
-
-#, fuzzy
 #~ msgid "RatePercentChangeStart"
 #~ msgstr "Céatadán an Athraithe:"
 
@@ -12118,19 +20614,11 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgid "PitchPercentChangeEnd"
 #~ msgstr "Céatadán an Athraithe:"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Á Aisiompú"
-
 #~ msgid "Size"
 #~ msgstr "Méad"
 
 #~ msgid "Fit &Vertically"
 #~ msgstr "Socraigh go hIn&gearach"
-
-#, fuzzy
-#~ msgid "Co&mbined Meter Toolbar"
-#~ msgstr "Taifeadadh á dhéanamh"
 
 #, fuzzy
 #~ msgid "S&kip to Start"
@@ -12194,10 +20682,6 @@ msgstr "Minicíocht LFO (Hz):"
 #, fuzzy
 #~ msgid "-Left-Click"
 #~ msgstr "Cléchnagadh"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "Alt-Clé-Cnag"
 
 #, fuzzy
 #~ msgid "Zoom in or out on Mouse Pointer"
@@ -12275,13 +20759,6 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgid "Using block size of %ld\n"
 #~ msgstr "Méad bloc de %ld á úsáid\n"
 
-#, fuzzy
-#~ msgid "Plot Spectrum"
-#~ msgstr "Speictream"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "Idirlonnú Sinc ar Ardchaighdeán"
-
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "Idirlonnú Sinc Thapaidh"
 
@@ -12319,9 +20796,6 @@ msgstr "Minicíocht LFO (Hz):"
 #~ msgid "Change Tempo..."
 #~ msgstr "Athraigh Luas; Airde gan Athrú..."
 
-#~ msgid "Click Removal..."
-#~ msgstr "Asbhaint Cnag..."
-
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "Comhbhrú Réimse Dhinimiciúil á Fhorchur..."
 
@@ -12336,9 +20810,6 @@ msgstr "Minicíocht LFO (Hz):"
 
 #~ msgid "Equalization..."
 #~ msgstr "Cothromú..."
-
-#~ msgid "Performing Equalization"
-#~ msgstr "Cothromú á Chur i gCrích"
 
 #~ msgid "Fading In"
 #~ msgstr "Á Chéimniú Isteach"

--- a/locale/gl.po
+++ b/locale/gl.po
@@ -4,53 +4,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Galician <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/gl/>\n"
+"Language-Team: Galician <https://hosted.weblate.org/projects/tenacity/tenacity/gl/>\n"
 "Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Saír de Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Canle"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Produciuse un erro ao abrir o ficheiro"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Produciuse un erro ao cargar os metadatos"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Barra de ferramentas de %s de Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Gravación"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -60,6 +23,24 @@ msgstr "Non foi posíbel determinalo"
 #, c-format
 msgid "%s bytes"
 msgstr "%ld bytes"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -82,12 +63,63 @@ msgid "&Nyquist Workbench..."
 msgstr "Indicador de «Nyquist»..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "Pe&gar"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "Pe&gar"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "Pe&gar"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "Pe&gar"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Seleccionar &todo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -114,8 +146,17 @@ msgid "&Large Icons"
 msgstr "Sala grande"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Small Icons"
+msgstr "Sala grande"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "&Barras de ferramentas"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
@@ -125,8 +166,14 @@ msgstr "Deter"
 msgid "&About"
 msgstr "Sobre"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Variábel"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Saída do efecto"
 
@@ -134,13 +181,50 @@ msgstr "Saída do efecto"
 msgid "Load Nyquist script"
 msgstr "Indicador de «Nyquist»"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Aviso"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Indicador de «Nyquist»"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -151,6 +235,10 @@ msgid "No matches found"
 msgstr "Non se atopan dispositivos"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
 msgstr "sen título"
 
@@ -158,9 +246,15 @@ msgstr "sen título"
 msgid "Nyquist Effect Workbench - "
 msgstr "Efectos «Nyquist»"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Novo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Abrir recente"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -194,7 +288,8 @@ msgstr "Copiar"
 msgid "Copy to clipboard"
 msgstr "Cortar ao portapapeis"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Cortar"
 
@@ -202,7 +297,8 @@ msgstr "Cortar"
 msgid "Cut to clipboard"
 msgstr "Cortar ao portapapeis"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Pegar"
 
@@ -227,7 +323,8 @@ msgstr "Seleccionar &todo"
 msgid "Select all text"
 msgstr "Seleccionar &todo"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Desfacer"
 
@@ -235,9 +332,20 @@ msgstr "Desfacer"
 msgid "Undo last change"
 msgstr "Cambio de formato"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Refacer"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Cambio de formato"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "A&topar notas"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -248,23 +356,46 @@ msgid "Match"
 msgstr "Lote"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "ao tope superior"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Non hai etiquetas que exportar."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Arriba"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Ferramenta anterior"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Mover o foco para a pista anterior e seleccionar"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Seguinte ferramenta"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Inicio"
 
@@ -272,7 +403,8 @@ msgstr "Inicio"
 msgid "Start script"
 msgstr "Indicador de «Nyquist»"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Deter"
 
@@ -287,7 +419,8 @@ msgid "About %s"
 msgstr "Sobre"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Aceptar"
 
@@ -295,11 +428,13 @@ msgstr "Aceptar"
 msgid "Build Information"
 msgstr "Información da compilación"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Activado"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Desactivado"
 
@@ -309,8 +444,9 @@ msgid "The Build"
 msgstr "Depuración da compilación"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Orde:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versión: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -320,13 +456,23 @@ msgstr "Tipo de compilación:"
 msgid "Compiler:"
 msgstr "Compresor"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefixo de instalación: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Cartafol de axustes: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Cartafol de axustes: "
 
 #: src/AboutDialog.cpp
@@ -345,7 +491,6 @@ msgstr "Conversión da frecuencia de mostraxe"
 msgid "MP3 Importing"
 msgstr "Importación de MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importación e exportación de Ogg Vorbis"
@@ -354,7 +499,6 @@ msgstr "Importación e exportación de Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Compatibilidade con etiquetas ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importación e exportación de FLAC"
@@ -372,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importación/exportación FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importar mediante GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Características"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Compatibilidade cos engadidos"
 
@@ -394,6 +530,10 @@ msgstr "Compatibilidade con cambio de ton e «tempo»"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Compatibilidade con cambio extremo de ton e «tempo»"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Características"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -420,6 +560,18 @@ msgstr "Envolvente"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Envolvente"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Envolvente"
 
@@ -431,6 +583,24 @@ msgstr "Envolvente"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Envolvente"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Envolvente"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Envolvente"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "control de calidade"
@@ -438,8 +608,26 @@ msgstr "control de calidade"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, graphic artist"
 msgstr "EQ &gráfico"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Envolvente"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Envolvente"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -459,6 +647,15 @@ msgstr "Envolvente"
 msgid "%s, graphics"
 msgstr "EQ &gráfico"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -468,6 +665,10 @@ msgstr "software gratuíto, de fontes abertas e multiplataforma para a gravació
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Créditos"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -502,14 +703,23 @@ msgid "%s Team Members"
 msgstr " Membros eméritos do equipo"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Outros colaboradores"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Traducido ao galego por:<br>Miguel Anxo Bouzada (de <a href=\"http://trasno.net/\">Proxecto Trasno</a>)<br>Por encargo de <a href=\"http://tegnix.com/\">TEGNIX</a> para o proxecto Abalar"
@@ -527,6 +737,22 @@ msgstr "Agradecementos especiais:"
 #, c-format
 msgid "%s website: "
 msgstr "Primeira execución de Audacity"
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Outros colaboradores"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -549,6 +775,7 @@ msgstr "Cambiador de liña de tempo"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Prema e arrastre para editar as mostraxes"
@@ -556,9 +783,49 @@ msgstr "Prema e arrastre para editar as mostraxes"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Prema e arrastre para modificar o tamaño da barra de ferramentas."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Mover o foco para a pista seguinte e seleccionar"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Desprazar a pista ao tope &inferior"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Pechar a pista en foco"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
@@ -571,6 +838,10 @@ msgstr "Liña de tempo - Activada a reprodución rápida"
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "Opcións do engadido"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -588,7 +859,23 @@ msgstr "Á&rea de reprodución"
 msgid "Pinned Play Head"
 msgstr "Fin da gravación"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Erro"
 
@@ -612,7 +899,8 @@ msgstr ""
 "Isto preguntarase só unha vez, despois dunha «instalación» na que pediu que se restabeleceran as Preferencias"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Restabelecer as preferencias do Audacity"
 
 #: src/AudacityApp.cpp
@@ -625,6 +913,10 @@ msgstr ""
 "Non é posíbel atopar %s.\n"
 "\n"
 "Foi suprimido da lista de ficheiros recentes."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -649,7 +941,7 @@ msgstr "&Abrir..."
 msgid "Open &Recent..."
 msgstr "Abrir &recente..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Sobre o Audacity..."
@@ -663,29 +955,33 @@ msgid "&File"
 msgstr "&Ficheiro"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity non foi quen de atopar un lugar onde almacenar os ficheiros temporais.\n"
 "Indique un cartafol apropiado no diálogo de preferencias."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity non foi quen de atopar un lugar onde almacenar os ficheiros temporais.\n"
 "Indique un cartafol apropiado no diálogo de preferencias."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity vaise pechar. Execute Audacity de novo para usar o novo cartafol temporal."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -694,15 +990,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity non foi quen de bloquear o cartafol de ficheiros temporais.\n"
 "Este cartafol pode estar sendo utilizado por outra copia de Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Aínda quere executar Audacity?"
 
 #: src/AudacityApp.cpp
@@ -710,24 +1008,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "Produciuse un erro ao bloquear o cartafol temporal"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "O sistema detectou que xa se está a executar outra copia de Audacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Utilice a opción Novo ou Abrir no proceso de Audacity que está a executarse\n"
 "actualmente para abrir múltiples proxectos simultaneamente.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity xa se está a executar"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Ficheiros de proxecto de Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -747,7 +1093,8 @@ msgstr "executar o diagnóstico automático"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "amosar a versión do Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -757,9 +1104,10 @@ msgid "audio or project file name"
 msgstr "nome do ficheiro de son ou do proxecto"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -772,20 +1120,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Ficheiros de proxecto de Audacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&Nova mostraxe..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Confirmación de eliminación de regra"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Axuda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Saír de Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Rexistro do Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -797,9 +1174,14 @@ msgstr "&Gardar..."
 msgid "Cl&ear"
 msgstr "&Limpar"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Pechar"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -848,7 +1230,8 @@ msgid "Error Initializing Midi"
 msgstr "Produciuse un erro ao inicializar o MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Rexistro do Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -862,40 +1245,18 @@ msgstr "Produciuse un erro ao abrir o dispositivo de son"
 msgid "Out of memory!"
 msgstr "Sen memoria!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "O axuste automático do nivel de gravación está detido. Non foi posíbel optimizalo máis. Aínda é demasiado alto."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "O axuste automático do nivel de gravación diminuíu o volume a %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "O axuste automático do nivel de gravación está detido. Non foi posíbel optimizalo máis. Aínda é demasiado baixo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "O axuste automático do nivel de gravación aumentou o volume a %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "O axuste automático do nivel de gravación está detido. Excedeuse o número total de análises sen atopar un volume aceptábel. Aínda é demasiado alto."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "O axuste automático do nivel de gravación está detido. Excedeuse o número total de análises sen atopar un volume aceptábel. Aínda é demasiado baixo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "O axuste automático do nivel de gravación está detido. %.2f semella seren un volume aceptábel."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Seleccionar o dispositivo de gravación\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Seleccionar o dispositivo de gravación\n"
 
 #: src/AudioIOBase.cpp
@@ -938,8 +1299,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Fin da gravación\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Fin da gravación\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Fin da gravación\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Fin da gravación\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -953,37 +1324,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Seleccionar o dispositivo de gravación\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Seleccionar o dispositivo de gravación\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Seleccionar o dispositivo de reprodución\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Non é posíbel abrir o ficheiro de xénero.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Seleccionar o dispositivo de reprodución\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Control de gravación\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Frecuencias de mostraxe\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volume de reprodución\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Volume de gravación\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Volume de gravación\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Volume de reprodución: %.2f%s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Volume de reprodución: %.2f%s\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -991,8 +1365,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Seleccionar o dispositivo de gravación\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Seleccionar o dispositivo de gravación\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Seleccionar o dispositivo de reprodución\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Seleccionar o dispositivo de reprodución\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1000,8 +1384,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Recuperación automática de quebra"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1013,12 +1398,14 @@ msgid "Recoverable &projects"
 msgstr "Proxectos recuperábeis"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Seleccionar"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nome"
 
@@ -1029,6 +1416,10 @@ msgstr "Seleccionar"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Seleccionar"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1065,6 +1456,11 @@ msgid "&Parameters"
 msgstr "&Parámetros"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Desbotar"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "&Escoller orde"
 
@@ -1099,6 +1495,22 @@ msgstr "Efectos"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Editar parámetros"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Editar parámetros"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1146,6 +1558,10 @@ msgid "Apply %s"
 msgstr "Aplicar %s"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "Administrar curvas"
 
@@ -1154,6 +1570,17 @@ msgstr "Administrar curvas"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Seleccionar curva"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Etiquetas..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Aplicar secuencia de ordes"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1221,7 +1648,8 @@ msgstr "&Restaurar área"
 msgid "I&mport..."
 msgstr "I&mportar..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xportar..."
 
@@ -1262,9 +1690,15 @@ msgstr "Mover a&rriba"
 msgid "Move &Down"
 msgstr "Mover a&baixo"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Gardar"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1310,11 +1744,38 @@ msgid "Benchmark"
 msgstr "Executar proba de &rendemento..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Número de veces a repetir: "
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Pechar"
 
@@ -1329,12 +1790,32 @@ msgid "Export Benchmark Data as:"
 msgstr "Exportar datos do espectro como:"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "O máximo número de notas debe ser un entre 1 e 128"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "O máximo número de notas debe ser un entre 1 e 128"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "O máximo número de notas debe ser un entre 1 e 128"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Preparando a vista previa\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1343,22 +1824,113 @@ msgstr "Aplicando a repetición\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Pegar\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Gravación de son\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Data e hora final"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Compilación final"
 
 #: src/BuildInfo.h
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Compilación final"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1369,9 +1941,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Para utilizar isto, primeiro debe seleccionar algún son."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Non foi seleccionada ningunha secuencia de ordes"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1399,6 +1995,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Non foi posíbel atopar o códec"
 
@@ -1416,10 +2017,24 @@ msgstr "Aplicar ao &proxecto actual"
 msgid "Checkpointing %s"
 msgstr "Importando %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Non foi posíbel escribir no ficheiro: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Non foi posíbel gardar o proxecto. É probábel que %s \n"
+"non sexa escribíbel ou que o disco estea cheo."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1436,6 +2051,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "Produciuse unha falla ao retirar %s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1533,6 +2152,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Cortar ao portapapeis"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Ficheiros perdidos"
 
@@ -1541,10 +2165,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Se fai isto, o proxecto non será gardado no disco. É isto o que quere facer?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1556,7 +2181,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Comprobación de dependencia"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ningún"
 
@@ -1564,7 +2192,7 @@ msgstr "Ningún"
 msgid "Rectangle"
 msgstr "Rectángulo"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triángulo"
 
@@ -1572,10 +2200,25 @@ msgstr "Triángulo"
 msgid "Shaped"
 msgstr "Moldeado "
 
+#: src/FFT.cpp
+#, fuzzy
+msgid "Rectangular"
+msgstr "Rectángulo"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
 #. i18n-hint a proper name
 #: src/FFT.cpp
 msgid "Hamming"
 msgstr "Hamming, ningún"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
@@ -1592,14 +2235,30 @@ msgstr "Blackman, Hann"
 msgid "Welch"
 msgstr "Benvido/a!"
 
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "A compatibilidade con FFmpeg non foi incluída na compilación"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1621,8 +2280,8 @@ msgid "Locate FFmpeg"
 msgstr "Atopar FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity necesita o ficheiro «%s» para importar e exportar son mediante FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -1635,7 +2294,8 @@ msgstr "Localización de «%s»:"
 msgid "To find '%s', click here -->"
 msgstr "Para atopar «%s», prema aquí -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Examinar..."
 
@@ -1661,8 +2321,9 @@ msgid "FFmpeg not found"
 msgstr "Non foi foi posíbel atopar FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1682,24 +2343,38 @@ msgstr "Non volver amosar este aviso"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Non foi posíbel atopar bibliotecas compatíbeis con FFmpeg."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity non foi quen de escribir no ficheiro:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Audacity non foi quen de escribir no ficheiro:\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Audacity non foi quen de escribir no ficheiro:\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1736,7 +2411,9 @@ msgstr "&Non copiar ningún elemento de son"
 msgid "As&k"
 msgstr "&Preguntar ao usuario"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Todos os ficheiros|*"
 
@@ -1745,6 +2422,11 @@ msgstr "Todos os ficheiros|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Gardando ficheiros de datos do proxecto"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Bibliotecas"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1757,6 +2439,10 @@ msgstr "Asignar nome a ficheiros:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Ficheiros MP3"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1798,6 +2484,14 @@ msgstr "Autocorrelación de raíz cúbica"
 msgid "Enhanced Autocorrelation"
 msgstr "Autocorrelación mellorada"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Espectro"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1814,9 +2508,34 @@ msgstr "Frecuencia lineal"
 msgid "Log frequency"
 msgstr "Frecuencia logarítmica"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Ampliar/Reducir"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1831,6 +2550,10 @@ msgstr "Horizontal"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Cursor á esquerda"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1873,6 +2596,37 @@ msgstr "Demasiado son seleccionado.  Só van seren analizados os primeiros %.1f 
 msgid "Not enough data selected."
 msgstr "Non hai seleccionada información abondo."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "espectro.txt"
@@ -1881,7 +2635,8 @@ msgstr "espectro.txt"
 msgid "Export Spectral Data As:"
 msgstr "Exportar datos do espectro como:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Non foi posíbel escribir no ficheiro: "
@@ -1957,6 +2712,26 @@ msgid "No Local Help"
 msgstr "Non hai axuda local"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "These are our support methods:"
 msgstr "Estes son os nosos métodos de axuda:"
 
@@ -2011,6 +2786,10 @@ msgid "Used Space"
 msgstr "Espazo de disco"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Niveis dispoñíbeis para desfacer"
 
@@ -2024,6 +2803,10 @@ msgid "&Discard"
 msgstr "&Desbotar"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Desbotar"
 
@@ -2031,11 +2814,30 @@ msgstr "&Desbotar"
 msgid "&Compact"
 msgstr "&Orde"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Historial..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2051,7 +2853,9 @@ msgid "Track"
 msgstr "Pista"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -2111,18 +2915,25 @@ msgstr "Introduza o nome da pista"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Pista de etiquetas"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Primeira execución de Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Seleccione o idioma que utilizar:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2132,7 +2943,8 @@ msgstr "Seleccione o idioma que utilizar:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "O idioma que ven de escoller, %s (%s), non é o mesmo idioma que o do sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -2150,13 +2962,19 @@ msgstr ""
 "O ficheiro antigo foi gardado como «%s»"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Abrindo o proxecto de Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke de Audacity%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Examinar..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2202,19 +3020,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mesturando e xerando pistas"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Taboleiro mesturas de Audacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Ganancia"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocidade"
 
@@ -2223,28 +3045,43 @@ msgid "Musical Instrument"
 msgstr "Instrumento musical"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panorama"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Silencio"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Medidor de nivel de señal"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Desprazouse o control de ganancia"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Desprazouse o control de velocidade"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Desprazouse o control de panorama"
 
@@ -2275,9 +3112,9 @@ msgstr ""
 "Non vai seren cargado."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2310,16 +3147,19 @@ msgstr ""
 "\n"
 "Utilice só módulos de orixes fiábeis"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Si"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Non"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Cargador de módulos Audacity"
 
 #: src/ModuleManager.cpp
@@ -2349,18 +3189,121 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Sobrescribir os ficheiros existentes"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2389,6 +3332,16 @@ msgstr "Indicador de «Nyquist»"
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Non é posíbel cargar o engadido %s"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Amosar todos os códecs"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -2420,6 +3373,21 @@ msgstr "Activado"
 msgid "E&nabled"
 msgstr "Activado"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Activado"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Path"
 msgstr "Ruta"
@@ -2432,7 +3400,8 @@ msgstr "Seleccionar &todo"
 msgid "C&lear All"
 msgstr "Limpa&r todo"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Activar"
 
@@ -2496,6 +3465,21 @@ msgstr "Produciuse un erro ao abrir o dispositivo de son. Comprobe os axustes do
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Para aplicar un filtro, todas as pistas seleccionadas deben ter a mesma frecuencia de mostraxe."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Son gravado"
@@ -2503,6 +3487,28 @@ msgstr "Son gravado"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "Gravar"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2530,11 +3536,11 @@ msgid "Inspecting project file data"
 msgstr "Inspeccionando os datos dos ficheiros do proxecto"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2579,11 +3585,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Aviso: non se atopa(n) o(s) ficheiro(s) ligado(s) por alias"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "A comprobación do proxecto do cartafol «%s»\n"
@@ -2608,12 +3614,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Aviso: non se atopa(n) o(s) ficheiro(s) de índice"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2672,7 +3678,8 @@ msgstr "Aviso: bloque(s) de ficheiro(s) orfo(s)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progreso"
 
@@ -2697,6 +3704,11 @@ msgstr "Aviso: xurdiron problemas durante a recuperación automática"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sen título>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Proxectos"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2735,11 +3747,96 @@ msgid ""
 msgstr "Non é posíbel ler o ficheiro de valores predefinidos."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Produciuse unha falla ao retirar %s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Gardando un proxecto de Audacity"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Non é posíbel inicializar o fluxo MP3"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Non é posíbel inicializar o fluxo MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Non é posíbel inicializar o fluxo MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Non é posíbel inicializar o fluxo MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Non é posíbel inicializar o fluxo MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Non é posíbel inicializar o fluxo MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Non é posíbel inicializar o fluxo MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Non é posíbel inicializar o fluxo MP3"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2753,12 +3850,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Ficheiro de bloque orfo: «%s»"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Non é posíbel renomear «%s» a «%s»."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Non foi posíbel atopar o códec"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Produciuse unha falla ao retirar %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2769,9 +3887,9 @@ msgid "Error Writing to File"
 msgstr "Produciuse un erro ao escribir no ficheiro"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2782,6 +3900,19 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Ao gardar un &proxecto"
 
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Velocidade"
+
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
@@ -2789,10 +3920,10 @@ msgstr "(recuperado)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Este ficheiro foi gardado usando Audacity %s.\n"
 "Está a usar Audacity %s. Precisa actualizar a unha versión máis moderna para poder abrir o ficheiro."
@@ -2800,6 +3931,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Non é posíbel abrir o ficheiro de proxecto"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2814,6 +3949,10 @@ msgid "Unable to parse project information."
 msgstr "Non é posíbel ler o ficheiro de valores predefinidos."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Ao gardar un &proxecto"
 
@@ -2822,12 +3961,35 @@ msgid "Error Saving Project"
 msgstr "Produciuse un erro ao gardar proxecto"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Ao gardar un proxecto &baleiro"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2835,8 +3997,24 @@ msgstr ""
 "Afortunadamente, os seguintes proxectos pódense recuperar automaticamente:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Algúns proxectos non foron gardados correctamente a última vez que se executou Audacity.\n"
+"Afortunadamente, os seguintes proxectos pódense recuperar automaticamente:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "O proxecto foi recuperado"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Cartafol de ficheiros temporais"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2867,6 +4045,17 @@ msgstr "Aviso - Proxecto baleiro"
 msgid "Insufficient Disk Space"
 msgstr "Espazo de disco"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -2886,12 +4075,26 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "Gardar o proxecto «%s» como..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "«Gardar unha copia comprimida do proxecto» usase para un proxecto de Audacity, non é un ficheiro de son.\n"
 "Para un ficheiro de son que vai seren aberto noutras aplicacións empregue «Exportar».\n"
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2945,11 +4148,12 @@ msgid "Error Opening Project"
 msgstr "Produciuse un erro ao abrir o proxecto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Está tentado abrir un ficheiro de copia de seguranza xerado automaticamente.\n"
 "Isto pode provocar unha grave perda de datos.\n"
@@ -2982,6 +4186,12 @@ msgid "Error Opening File or Project"
 msgstr "Produciuse un erro ao abrir o ficheiro ou o proxecto"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "O proxecto foi recuperado"
 
@@ -3007,12 +4217,33 @@ msgid "Error Importing"
 msgstr "Produciuse un erro ao importar"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Gardar proxecto"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Non é posíbel abrir o ficheiro de proxecto"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Orde"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3023,8 +4254,8 @@ msgid "Automatic database backup failed."
 msgstr "Automático"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Benvido/a á versión %s de Audacity"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3060,6 +4291,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "Dispón de espazo no disco para gravar %d minutos."
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -3072,6 +4307,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -3088,6 +4335,26 @@ msgstr "Horizontal"
 msgid "Vertical Scrollbar"
 msgstr "Regra vertical"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(mellor calidade)"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Calidade"
@@ -3099,6 +4366,18 @@ msgstr "Calidade"
 #: src/Resample.cpp
 msgid "Best Quality (Slowest)"
 msgstr "(mellor calidade)"
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bit PCM"
 
 #. i18n-hint: Audio data bit depth (precision): 32-bit floating point
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
@@ -3193,7 +4472,8 @@ msgstr "Preferencias:"
 msgid "SelectionBar"
 msgstr "Barra de selección"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Selección do espectro"
 
@@ -3201,44 +4481,58 @@ msgstr "Selección do espectro"
 msgid "Timer"
 msgstr "Tempo"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Reprodución"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mesturador"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Medidor"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Medidor de reprodución"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Medidor de gravación"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Editar"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Dispositivo"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Reproducir á velocidade"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "&Barras de ferramentas"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -3251,7 +4545,10 @@ msgstr "Regra"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Pistas"
 
@@ -3303,6 +4600,15 @@ msgstr "Pistas longas"
 msgid "Choose a location to save screenshot images"
 msgstr "Escolla o lugar no que gardar as imaxes de capturas"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "esta mensaxe de axuda"
+
 #: src/Sequence.cpp
 #, c-format
 msgid ""
@@ -3353,7 +4659,8 @@ msgid "Activation level (dB):"
 msgstr "Nivel de activación (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Benvido/a a Audacity "
 
 #: src/SplashDialog.cpp
@@ -3480,19 +4787,45 @@ msgstr "Produciuse un erro ao gardar o ficheiro de etiquetas"
 msgid "Unsuitable"
 msgstr "Módulo non axeitado"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Cartafol de ficheiros temporais"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity non foi quen de escribir no ficheiro:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3501,18 +4834,26 @@ msgstr ""
 "para escribir nel."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity non foi quen de inserir imaxes no ficheiro:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3522,9 +4863,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3533,8 +4874,9 @@ msgstr ""
 "Quizais o formato «png» do ficheiro é incorrecto."
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity non foi quen de ler o tema predeterminado.\n"
@@ -3572,9 +4914,9 @@ msgstr ""
 "xa están presentes."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity non foi quen de gardar o ficheiro:\n"
@@ -3591,11 +4933,21 @@ msgstr "Filtros clásicos"
 msgid "Light"
 msgstr "Lixeiro"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Contraste..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Nome da pista"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3604,7 +4956,11 @@ msgstr "Contraste..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Duración"
 
@@ -3615,7 +4971,8 @@ msgid "Time Track"
 msgstr "Pista de tempo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Gravación temporizada de Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -3644,12 +5001,38 @@ msgid "Error in Duration"
 msgstr "Hai un erro na duración"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Automático"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Hai un erro na duración"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Automático"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "Hai un erro na duración"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "Gravación &temporizada..."
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3659,7 +5042,8 @@ msgstr "Aplicar ao &proxecto actual"
 msgid "Recording start:"
 msgstr "Inicio da gravación"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Duración:"
 
@@ -3680,7 +5064,8 @@ msgid "Action after Timer Recording:"
 msgstr "Gravación temporizada de Audacity"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Progreso da gravación temporizada de Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -3715,9 +5100,39 @@ msgid ""
 "Recording exported: %s"
 msgstr "Fin da gravación"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Produciuse un erro ao gardar proxecto"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Control de gravación"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 dias 024 h 060 m 060 s"
 
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
@@ -3729,6 +5144,7 @@ msgstr "099 dias 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data e hora de inicio"
@@ -3773,7 +5189,8 @@ msgstr "Non é posíbel exportar"
 msgid "Export Project As:"
 msgstr "Exportar predefinición"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcións..."
 
@@ -3782,8 +5199,21 @@ msgid "After Recording completes:"
 msgstr "Medidor de gravación"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Saír de Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3798,7 +5228,8 @@ msgid "Scheduled to stop at:"
 msgstr "Seleccionar ata o comezo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Gravación temporizada de Audacity. Agardando para comezar"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3806,6 +5237,14 @@ msgstr "Gravación temporizada de Audacity. Agardando para comezar"
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Dispositivo de gravación"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3816,12 +5255,18 @@ msgid "Recording Exported:"
 msgstr "Fin da gravación"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Gravación temporizada de Audacity. Agardando para comezar"
 
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "Estéreo, 999999Hz"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3937,6 +5382,10 @@ msgstr "Desprazar a pista cara a&rriba"
 msgid "Move Track Down"
 msgstr "Desprazar a pista cara a&baixo"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3982,25 +5431,79 @@ msgstr "Non hai espazo abondo para pegar a selección"
 msgid "There is not enough room available to expand the cut line"
 msgstr "Non hai espazo abondo para expandir a liña de corte"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Aplicando..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Orde"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Orde"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repetir %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4015,12 +5518,20 @@ msgid "Compares a range on two tracks."
 msgstr "Compresión baseada en picos"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Tempo de atraso (segundos):"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Factor de decaemento:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -4042,6 +5553,11 @@ msgstr "Pista"
 msgid "Track 1"
 msgstr "Pista"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Tamaño da xanela"
@@ -4053,6 +5569,22 @@ msgstr "Desde RPM"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Desde RPM"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -4078,17 +5610,41 @@ msgstr "Recorte de picos"
 msgid "Envelopes"
 msgstr "Envolvente"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiquetas"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Tipo"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formato:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -4098,6 +5654,10 @@ msgstr "Desprazar a pista cara a&baixo"
 msgid "Types:"
 msgstr "Tipo"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Comentarios"
@@ -4105,6 +5665,18 @@ msgstr "Comentarios"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Orde:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4123,6 +5695,11 @@ msgid "Number of Channels:"
 msgstr "Número de veces a repetir: "
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Exportar múltiple"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Exportar múltiple"
 
@@ -4130,13 +5707,27 @@ msgstr "Exportar múltiple"
 msgid "Builtin Commands"
 msgstr "Seleccionar unha orde"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "O equipo do Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Fornece compatibilidade cos efectos «Nyquist» para Audacity"
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Data e hora final"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -4178,11 +5769,22 @@ msgstr "&Gardar proxecto"
 msgid "Saves a copy of current project."
 msgstr "&Gardar proxecto"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Preferencias:"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nome"
 
@@ -4193,6 +5795,18 @@ msgstr "Preferencias:"
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Valor"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -4218,7 +5832,8 @@ msgstr "Activar/desactivar pantalla completa"
 msgid "Toolbars"
 msgstr "&Barras de ferramentas"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efectos"
 
@@ -4262,6 +5877,10 @@ msgstr "Pistas longas"
 msgid "All Tracks Plus"
 msgstr "Pistas longas"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -4273,13 +5892,26 @@ msgid "Path:"
 msgstr "Ruta"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "&Fondo:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Produciuse un error ao tentar gardar o ficheiro: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "Ferramentas de &captura de pantalla..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -4326,6 +5958,10 @@ msgid "High:"
 msgstr "Paso alto"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&Ordenar pistas"
 
@@ -4338,7 +5974,8 @@ msgstr "Estabelecer"
 msgid "Add"
 msgstr "&Engadir"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Suprimir"
 
@@ -4359,6 +5996,11 @@ msgid "Selects a time range."
 msgstr "Seleccionar un ficheiro MIDI..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Seleccionar un ficheiro MIDI..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Seleccione unha acción"
 
@@ -4370,9 +6012,37 @@ msgstr "Selecciónar o servidor de son"
 msgid "Set Clip"
 msgstr "Seguinte ferramenta"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Inicio"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4391,9 +6061,14 @@ msgid "Edited Envelope"
 msgstr "Envolvente"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Envolvente"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4403,6 +6078,10 @@ msgstr "&Eliminar etiqueta"
 msgid "Label Index"
 msgstr "Edición de etiqueta"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Seleccionar"
@@ -4410,6 +6089,10 @@ msgstr "Seleccionar"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Etiquetas editadas"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4424,12 +6107,25 @@ msgid "Resize:"
 msgstr "Resid&uo"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Largura de banda:"
 
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Lixeiro"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Gardar proxecto"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4460,10 +6156,17 @@ msgid "Gain:"
 msgstr "Ganancia"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&Ordenar pistas"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineal"
 
@@ -4474,6 +6177,10 @@ msgstr "R&establecer"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "Tempo"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4503,13 +6210,28 @@ msgstr "Procesador de espectro"
 msgid "Spectral Select"
 msgstr "Selección do espectro"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Nova pista"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Seleccione unha acción"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Amplificar"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -4527,6 +6249,14 @@ msgstr "Novo pico de amplitude (dB):"
 msgid "Allo&w clipping"
 msgstr "Permitir o recorte de picos"
 
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -4541,12 +6271,18 @@ msgstr "Seleccionou unha pista que non conten son. «Auto Duck» só pode proces
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck necesita unha pista de control que debe situarse baixo a(s) pista(s) seleccionada(s)."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Cantidade de «Duck»:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segundos"
 
@@ -4570,7 +6306,8 @@ msgstr "Duración de descenso de fundido de entrada:"
 msgid "Inner &fade up length:"
 msgstr "Duración de ascenso de fundido de entrada:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Limiar: "
 
@@ -4585,6 +6322,11 @@ msgstr "Graves e agudos"
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Contraer a selección á esquerda"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Limiar"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -4614,6 +6356,10 @@ msgstr "&Agudos (dB):"
 msgid "Level"
 msgstr "Nivel"
 
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "Cambiar ton"
@@ -4621,6 +6367,11 @@ msgstr "Cambiar ton"
 #: src/effects/ChangePitch.cpp
 msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Cambiar ton sen cambiar o «tempo»"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Cambio de «tempo» final (%)"
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
@@ -4685,6 +6436,10 @@ msgid "from (Hz)"
 msgstr "desde (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "ata (Hz)"
 
@@ -4692,13 +6447,23 @@ msgstr "ata (Hz)"
 msgid "t&o"
 msgstr "a"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Porcentaxe do cambio:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Porcentaxe do cambio"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -4710,7 +6475,9 @@ msgstr "8"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n/d"
 
@@ -4738,6 +6505,7 @@ msgstr "RPM de vinilo estándar:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Desde RPM"
@@ -4750,6 +6518,7 @@ msgstr "desde"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Ata RPM"
@@ -4856,6 +6625,10 @@ msgid "Click Removal"
 msgstr "Supresión de «Clic»"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
 msgid "Algorithm not effective on this audio. Nothing changed."
 msgstr "O algoritmo non ten efecto neste son. No se produciron cambios."
 
@@ -4884,6 +6657,16 @@ msgstr "Largo máximo de pico"
 msgid "Compressor"
 msgstr "Compresor"
 
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -4892,6 +6675,20 @@ msgstr "%.2f segs."
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f segs."
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f segs."
 
 #: src/effects/Compressor.cpp
@@ -4989,6 +6786,12 @@ msgstr "Seleccione unha acción"
 
 #: src/effects/Contrast.cpp
 msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid ""
 "Nothing to measure.\n"
 "Please select a section of a track."
 msgstr ""
@@ -5001,9 +6804,15 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analizador de contraste, para medir diferencias de volume RMS entre dúas seleccións de son."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Fin"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "&Agudos (dB):"
 
 #: src/effects/Contrast.cpp
 msgid "&Foreground:"
@@ -5057,6 +6866,18 @@ msgstr "&Diferencia:"
 msgid "&Help"
 msgstr "&Axuda"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "cero"
@@ -5101,6 +6922,10 @@ msgstr "Punto de fin principal do son"
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "Punto de fin de son de fondo"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -5195,6 +7020,12 @@ msgstr "Cumprimentos de criterio de 1.4.7 de WCAG 2.0: non superado"
 msgid "Data gathered"
 msgstr "Datos recollidos"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Análise de contraste (conforme a WCAG 2)"
@@ -5220,6 +7051,19 @@ msgid "Medium Overdrive"
 msgstr "Confirme a sobrescrita"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Confirme a sobrescrita"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Compresor de intervalo dinámico"
 
@@ -5230,6 +7074,96 @@ msgstr "Nivelador"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Distorsión"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Limitador"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Confirme a sobrescrita"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Confirme a sobrescrita"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Confirme a sobrescrita"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -5252,8 +7186,16 @@ msgid "Distortion"
 msgstr "Distorsión"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Distorsión"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -5268,8 +7210,21 @@ msgid "Clipping level"
 msgstr "Recorte de picos"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Aplicar secuencia de ordes"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Limiar de silencio"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -5282,6 +7237,14 @@ msgstr "Saída do efecto"
 #: src/effects/Distortion.cpp
 msgid "Repeat processing"
 msgstr "en grande medida o tempo de procesamento."
+
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
@@ -5298,6 +7261,10 @@ msgstr "2- niveis"
 #: src/effects/Distortion.cpp
 msgid "Residual level"
 msgstr "Resid&uo"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -5324,6 +7291,16 @@ msgid "DTMF Tones"
 msgstr "Tons DTMF..."
 
 #: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Secuencia DTMF:"
 
@@ -5331,7 +7308,9 @@ msgstr "Secuencia DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitude (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Duración:"
 
@@ -5376,6 +7355,11 @@ msgstr "Eco"
 msgid "Repeats the selected audio again and again"
 msgstr "Exportando o son seleccionado como %s"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "Tempo de atraso (segundos):"
@@ -5396,7 +7380,8 @@ msgstr "Predefinicións"
 msgid "Export Effect Parameters"
 msgstr "&Editar parámetros"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Non foi posíbel abrir o ficheiro: «%s»"
@@ -5420,6 +7405,12 @@ msgstr "&Editar parámetros"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Non é posíbel cargar o ficheiro de valores predefinidos.\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Preparando a vista previa"
@@ -5427,6 +7418,15 @@ msgstr "Preparando a vista previa"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Amosando a vista previa"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -5706,6 +7706,11 @@ msgstr "Deter a &reprodución"
 msgid "Play"
 msgstr "Reproducir"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Coseno"
@@ -5727,12 +7732,36 @@ msgid "Graphic EQ"
 msgstr "EQ gráfico"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Graves (dB):"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Graves"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -5767,6 +7796,10 @@ msgid "Effect Unavailable"
 msgstr "A vista previa non está dispoñíbel"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Máx. dB"
 
@@ -5779,6 +7812,26 @@ msgstr "%3d dB"
 msgid "Min dB"
 msgstr "Mín. dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "Tipo"
@@ -5786,6 +7839,11 @@ msgstr "Tipo"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Debuxar curvas"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Ferramenta de debuxo"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -5848,8 +7906,16 @@ msgid "D&efault"
 msgstr "Pr&edeterminado"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE en &paralelo"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -6053,9 +8119,18 @@ msgstr "Esvaecer"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Prema e arrastre para seleccionar son"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Prema e arrastre para seleccionar son"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Buscar o recorte de picos"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -6077,17 +8152,38 @@ msgstr "Non hai espazo abondo para xerar o son"
 msgid "Invert"
 msgstr "Inverter"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Efectos «Nyquist»"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Fornece compatibilidade cos efectos «Nyquist» para Audacity"
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normalizar a amplitude máxima para"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -6107,9 +8203,26 @@ msgstr "Procesando: "
 msgid "&Normalize"
 msgstr "Normalizar"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Normalizar as canles estéreo independentemente"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -6137,6 +8250,10 @@ msgstr "Browniano"
 #: src/effects/Noise.cpp
 msgid "Noise"
 msgstr "Ruído:"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
 
 #: src/effects/Noise.cpp
 msgid "&Noise type:"
@@ -6167,7 +8284,17 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (predeterminado)"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "Blackman, Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, ningún"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, ningún"
 
 #: src/effects/NoiseReduction.cpp
@@ -6177,6 +8304,10 @@ msgstr "Hamming, Hamming recíproco"
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Redución de ruído"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Steps per block are too few for the window types."
@@ -6263,8 +8394,9 @@ msgid "Step 1"
 msgstr "Paso 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Seleccione uns segundos de ruído para que Audacity saiba que filtrar, a seguir\n"
@@ -6316,13 +8448,63 @@ msgstr "Tipos da &xanela"
 msgid "Window si&ze:"
 msgstr "Tama&ño da xanela"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (predeterminado)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Pasos por xanela"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -6335,6 +8517,10 @@ msgstr "&Método de discriminación"
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Supresión de ruído"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -6373,6 +8559,10 @@ msgid "Normalize"
 msgstr "Normalizar"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
 msgstr "Retirando o desprazamento DC e normalizando...\n"
 
@@ -6383,6 +8573,10 @@ msgstr "Retirando o desprazamento DC...\n"
 #: src/effects/Normalize.cpp
 msgid "Normalizing without removing DC offset...\n"
 msgstr "Normalizando sen retirar o desprazamento DC...\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 #, c-format
@@ -6429,9 +8623,14 @@ msgstr "Normalizar as canles estéreo independentemente"
 msgid "Paulstretch"
 msgstr "Paulstretch..."
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Factor de estirado:"
@@ -6440,9 +8639,43 @@ msgstr "Factor de estirado:"
 msgid "&Time Resolution (seconds):"
 msgstr "Tempo de resolución (segundos):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Modulador de fase"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -6505,6 +8738,10 @@ msgid "Repair"
 msgstr "Reparación"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -6533,6 +8770,10 @@ msgid "Repeat"
 msgstr "Repetir"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "Número de veces a repetir: "
 
@@ -6553,6 +8794,19 @@ msgstr "Nova lonxitude de selección: "
 #, c-format
 msgid "New selection length: %s"
 msgstr "Nova lonxitude de selección: "
+
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Suprimir a pista"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "Bathroom"
@@ -6585,6 +8839,10 @@ msgstr "Catedral"
 #: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "Reverberación"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "&Room Size (%):"
@@ -6639,6 +8897,25 @@ msgstr "Reverter"
 msgid "Reverses the selected audio"
 msgstr "Exportando o son seleccionado como %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Paso baixo"
@@ -6650,6 +8927,11 @@ msgstr "Paso alto"
 #: src/effects/ScienFilter.cpp
 msgid "Classic Filters"
 msgstr "Filtros clásicos"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
@@ -6780,11 +9062,20 @@ msgstr "Usar valores predeterminados"
 msgid "Restore Defaults"
 msgstr "Restabelecer valores predeterminados"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Silenciar"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -6809,6 +9100,10 @@ msgstr "Ao mesturar varias pistas a &mono durante a exportación"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "Estirar"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
 
 #: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
@@ -6867,6 +9162,14 @@ msgid "Tone"
 msgstr "Ton..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Forma de onda:"
 
@@ -6907,12 +9210,24 @@ msgid "Truncate Silence"
 msgstr "Truncar o silencio"
 
 #: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Detectar silencio"
 
 #: src/effects/TruncSilence.cpp
 msgid "Tr&uncate to:"
 msgstr "Truncar a:"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
@@ -6927,7 +9242,8 @@ msgid "VST Effects"
 msgstr "Efectos VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Engade a habilidade de usar efectos VST en Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -6939,7 +9255,8 @@ msgstr "Examinado o shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Rexistrando %d de %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Non foi posíbel abrir a biblioteca de codificación de MP3!"
 
@@ -6951,15 +9268,25 @@ msgstr "Opcións do efecto VST"
 msgid "Buffer Size"
 msgstr "Tamaño do búfer"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Tamaño do &búfer (8 de 1048576 mostras):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Compensación da latencia"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Activar a &compensación"
 
@@ -6985,7 +9312,18 @@ msgid "Save VST Preset As:"
 msgstr "Gardar a predefinición VST como:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Exportar valores predefinidos de «Audio Unit»"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Exportar valores predefinidos de «Audio Unit»"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Ficheiros de proxecto de Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -7012,7 +9350,8 @@ msgstr "Produciuse un erro ao cargar as predefinicións VST"
 msgid "Unable to load presets file."
 msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Axustes do efecto"
 
@@ -7029,9 +9368,19 @@ msgstr "Non é posíbel ler o ficheiro de valores predefinidos."
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Este ficheiro de parámetros foi gardado desde %s.  Quere continuar?"
 
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "Wah-wah"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -7059,7 +9408,8 @@ msgid "Audio Unit Effects"
 msgstr "Efectos «Audio Unit»"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Fornece compatibilidade cos efectos «Audio Unit» para Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -7075,16 +9425,33 @@ msgid "Audio Unit Effect Options"
 msgstr "Opcións de efectos «Audio Unit»"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Interface"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Contraer a selección á esquerda"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Multibanda"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Xerar"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
@@ -7168,6 +9535,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Non é posíbel obter a descrición do fluxo"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Non é posíbel ler o ficheiro de valores predefinidos."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Conversión da frecuencia de mostraxe"
 
@@ -7176,8 +9548,31 @@ msgstr "Conversión da frecuencia de mostraxe"
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Produciuse unha falla ao retirar %s"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Non é posíbel obter a descrición do fluxo"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Non é posíbel obter a descrición do fluxo"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Non é posíbel ler o ficheiro de valores predefinidos."
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efectos LADSPA"
@@ -7187,8 +9582,25 @@ msgid "Provides LADSPA Effects"
 msgstr "Fornece efectos LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Opcións do efecto LADSPA"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -7196,6 +9608,7 @@ msgstr "Saída do efecto"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "Efectos LADSPA"
@@ -7210,8 +9623,16 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Tamaño do &búfer (8 de 1048576 mostras):"
 
 #: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
 msgstr "A maior parte dos efectos VST teñen unha interface gráfica para axustar os valores dos parámetros."
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
@@ -7227,12 +9648,19 @@ msgstr "%d curvas exportadas a %s\n"
 msgid "Generator"
 msgstr "Xerador"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efectos VST"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Fornece compatibilidade cos efectos LV2 para Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -7240,7 +9668,8 @@ msgid "Nyquist Effects"
 msgstr "Efectos «Nyquist»"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Fornece compatibilidade cos efectos «Nyquist» para Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -7257,6 +9686,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Saída de «Nyquist»: "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Non foi seleccionada ningunha secuencia de ordes"
 
@@ -7269,12 +9716,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Non é posíbel aplicar o efecto en pistas estéreo nas que as pistas non coinciden."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Saída de «Nyquist»: "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Procesando: "
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -7354,6 +9819,19 @@ msgid "Could not determine language"
 msgstr "Non foi posíbel abrir o ficheiro: "
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Non é posíbel cargar o ficheiro de valores predefinidos.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Introduza a orde para «Nyquist»: "
 
@@ -7370,6 +9848,22 @@ msgstr "Indicador de «Nyquist»"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Indicador de «Nyquist»"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Non foi posíbel abrir o ficheiro"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "Non hai son en primeiro plano que medir"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -7390,7 +9884,8 @@ msgstr "Seleccionar un ficheiro MIDI..."
 msgid "Save file as"
 msgstr "Gardar ficheiros"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "sen título"
 
@@ -7399,7 +9894,8 @@ msgid "Vamp Effects"
 msgstr "Efectos «Vamp»"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Fornece compatibilidade cos efectos «Vamp» para Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -7421,6 +9917,17 @@ msgstr "Axustes do engadido"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Opcións xerais"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -7583,9 +10090,18 @@ msgstr ""
 "Está seguro de que quere continuar?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "Atopouse o módulo «%s»."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -7632,6 +10148,14 @@ msgid ""
 msgstr ""
 "FFmpeg non e quen de atopar o códec de son 0x%x.\n"
 "Probabelmente non foi incluída a compatibilidade na compilación."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -7697,7 +10221,8 @@ msgstr "Exportando o son seleccionado como %s"
 msgid "Invalid sample rate"
 msgstr "Frecuencia de mostraxe incorrecta"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Nova mostraxe"
 
@@ -7729,7 +10254,8 @@ msgstr "Frecuencias de mostraxe"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -7741,6 +10267,49 @@ msgstr "Velocidade de transferencia:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Calidade:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%i kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -7755,6 +10324,10 @@ msgid "Constrained"
 msgstr "Constante"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Son..."
 
@@ -7763,8 +10336,44 @@ msgid "Low Delay"
 msgstr "Atraso"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Medio"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -7835,8 +10444,17 @@ msgid "Replace preset '%s'?"
 msgstr "Eliminar a predefinición «%s»?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principal"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -7944,6 +10562,10 @@ msgstr "Idioma:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Reserva de bits"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -8078,6 +10700,11 @@ msgstr ""
 "0 - predeterminado\n"
 "mín. - 1\n"
 "máx. - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -8237,6 +10864,17 @@ msgstr "Non hai etiquetas que exportar."
 msgid "Select xml file to export presets into"
 msgstr "Seleccione un ficheiro XML ao que exportar os valores predefinidos"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Non foi posíbel adiviñar o formato"
@@ -8245,6 +10883,16 @@ msgstr "Non foi posíbel adiviñar o formato"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to find the codec"
 msgstr "Non foi posíbel atopar o códec"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "24 bit"
 
 #: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
@@ -8315,12 +10963,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(mellor calidade)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(ficheiros máis pequenos)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -8331,7 +11031,8 @@ msgstr "Tolo"
 msgid "Extreme"
 msgstr "Extremo"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Estándar"
 
@@ -8372,14 +11073,19 @@ msgstr "Calidade"
 msgid "Channel Mode:"
 msgstr "Modo de canle:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Suprimida a liña de corte"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Atopar Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity necesita o ficheiro «%s» para crear MP3."
 
 #: src/export/ExportMP3.cpp
@@ -8407,13 +11113,34 @@ msgid "Where is %s?"
 msgstr "Onde está %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Está ligando con «lame_enc.dll v%d.%d». Esta versión non é compatíbel con Audacity %d.%d.%d.\n"
 "Descargue a última versión dispoñíbel da biblioteca LAME MP3."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Gardando ficheiros de datos do proxecto"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -8519,6 +11246,10 @@ msgstr ""
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Exportar o lugar:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -8659,6 +11390,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Non é posíbel estabelecer a calidade da renderización de QuickTime"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
 
@@ -8669,6 +11420,10 @@ msgstr "Exportando o son seleccionado como Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Exportando o son seleccionado como Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -8687,8 +11442,28 @@ msgid "Other uncompressed files"
 msgstr "Outros ficheiros sen comprimir"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Produciuse un erro ao importar"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -8716,11 +11491,11 @@ msgid "All supported files"
 msgstr "Todos os ficheiros|*|Todos os ficheiros compatíbeis|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "«%s» \n"
@@ -8729,11 +11504,11 @@ msgstr ""
 "editalo premendo en Ficheiro > Importar > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "«%s» \n"
 "é un ficheiro MIDI, non un ficheiro de son. \n"
@@ -8745,18 +11520,18 @@ msgid "Select stream(s) to import"
 msgstr "Seleccionar o(s) fluxo(s) a importar"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Esta versión de Audacity non foi compilada con soporte para %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "«%s» é unha pista de son dun CD. \n"
 "Audacity non pode abrir ficheiros de son de CD directamente. \n"
@@ -8765,10 +11540,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "«%s» é un ficheiro de lista de reprodución. \n"
@@ -8777,10 +11552,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro de Windows Media Audio. \n"
@@ -8789,10 +11564,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro AAC (Advanced Audio Coding)Audacity non pode abrir este tipo de ficheiro. \n"
@@ -8800,12 +11575,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro de son cifrado. \n"
@@ -8816,10 +11591,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro de RealPlayer media. \n"
@@ -8828,12 +11603,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "«%s» é un ficheiro baseado en notas, non un ficheiro de son. \n"
 "Audacity non pode abrir este tipo de ficheiro. \n"
@@ -8842,10 +11617,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -8858,10 +11633,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro de son Wavpack. \n"
@@ -8870,10 +11645,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro de son Dolby Digital. \n"
@@ -8882,10 +11657,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro de son Ogg Speex. \n"
@@ -8894,10 +11669,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "«%s» é un ficheiro de vídeo. \n"
@@ -8911,20 +11686,31 @@ msgstr "Atopouse o módulo «%s»."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity no recoñece este tipo de ficheiro «%s».\n"
 "Se é son sen compresión, tente importalo usando «Importar en bruto»."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -8933,6 +11719,11 @@ msgstr ""
 "Os importadores deste tipo de ficheiro, supostamente, son:\n"
 "%s,\n"
 "mais ningún deles entende este formato de ficheiro."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Gardando ficheiros de datos do proxecto"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8949,8 +11740,57 @@ msgid "Import Project"
 msgstr "Importar predefinición"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "O proceso de aliñamento informa dun erro interno"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8958,16 +11798,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Non foi posíbel atopar o cartafol de datos do proxecto: «%s»"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Proxectos"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Frecuencia de mostraxe incorrecta"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Frecuencia de mostraxe incorrecta"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8997,31 +11895,6 @@ msgstr "Índice[%02x] Códec[%s], Idioma[%s], Velocidade de transferencia[%s], C
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Ficheiros FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Ficheiros compatíbeis con GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importación estendida"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Non é posíbel renomear «%s» a «%s»."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Índice[%02x] Códec[%s], Idioma[%s], Velocidade de transferencia[%s], Canles[%d], Duración[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Non é posíbel abrir ou crear o ficheiro de proba."
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -9079,6 +11952,14 @@ msgstr "Non foi posíbel abrir o ficheiro"
 msgid "MP3 files"
 msgstr "Ficheiros MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ficheiros Ogg Vorbis"
@@ -9113,8 +11994,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF e outros tipos de datos sen comprimir"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) PCM con asinado de 16 bit"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -9125,12 +12100,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-bit flotante"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-bit flotante"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) PCM con asinado de 16 bit"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bit"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -9141,12 +12160,20 @@ msgid "24 bit DWVW"
 msgstr "24 bit"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -9196,6 +12223,19 @@ msgstr "Importar datos en bruto"
 msgid "No endianness"
 msgstr "Sen «endianness»"
 
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Mediana"
+
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
 #: src/import/ImportRaw.cpp
@@ -9229,6 +12269,11 @@ msgid "Start offset:"
 msgstr "Desprazamento de inicio:"
 
 #: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "bytes"
+msgstr "%ld bytes"
+
+#: src/import/ImportRaw.cpp
 msgid "Amount to import:"
 msgstr "Cantidade a importar:"
 
@@ -9240,6 +12285,10 @@ msgstr "Frecuencia de mostraxe:"
 #: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
 msgid "&Import"
 msgstr "&Importar"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -9261,6 +12310,7 @@ msgstr "dereita"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -9284,6 +12334,7 @@ msgstr "Fin"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -9303,15 +12354,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Pistas ou fragmentos desprazados no tempo %s %.02f segundos"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Pistas ou fragmentos desprazados no tempo %s %.02f segundos"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Desprazamento no tempo"
 
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "Lí&mites de fragmento"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Lí&mites de fragmento"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "Lí&mites de fragmento"
 
 #: src/menus/ClipMenus.cpp
@@ -9432,7 +12503,8 @@ msgstr "Recortar as pistas seleccionadas por %.2f segundos en %.2f"
 msgid "Trim Audio"
 msgstr "Recortar son"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Dividir"
 
@@ -9553,32 +12625,8 @@ msgid "Delete Key&2"
 msgstr "Tecla de borrado 2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Barra de ferramentas de mestura&dor"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Axustar o volume de reprodución"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Aumentar o volume de reprodución"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Diminuír o volume de reprodución"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Axustar o volume de gravación"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Aumentar o volume de gravación"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Diminuír o volume de gravación"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -9603,6 +12651,13 @@ msgstr "Cambiar as canles de gravación"
 #: src/menus/ExtraMenus.cpp
 msgid "&Full Screen (on/off)"
 msgstr "Activar/desactivar pantalla completa"
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -9661,6 +12716,11 @@ msgstr "Importar etiquetas"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Seleccionar un ficheiro MIDI..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Todos os ficheiros|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -9741,6 +12801,11 @@ msgid "&Labels..."
 msgstr "&Etiquetas..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Exportar MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Datos en &bruto..."
 
@@ -9757,6 +12822,10 @@ msgstr "I&mprimir..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Saír"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -9789,6 +12858,10 @@ msgid "Nothing to do"
 msgstr "Nada para desfacer"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Pechar a pista en foco"
 
@@ -9799,6 +12872,10 @@ msgstr "Non é posíbel abrir o ficheiro de proxecto"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Inicio da gravación"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -9817,8 +12894,9 @@ msgid "&Getting Started"
 msgstr "Inicio da selección:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manual"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -9844,11 +12922,8 @@ msgstr "Información do dispositivo de _son..."
 msgid "Show &Log..."
 msgstr "Amosar o re&xistro..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Sobre o Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Engadiuse unha etiqueta"
 
@@ -9974,6 +13049,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "Pegar te&xto como unha nova etiqueta"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Son eti&quetado"
 
@@ -10046,6 +13125,10 @@ msgid "Move Forward Through Active Windows"
 msgstr "Avanzar a través das xanelas activas"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Retroceder desde as barras de ferramentas ata as pistas"
 
@@ -10110,6 +13193,10 @@ msgstr "Engadidos %d a %d"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "&Xerar"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -10193,6 +13280,16 @@ msgid "Set Track Status..."
 msgstr "ao i&nicio da pista"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Silenciar son"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&Ordenar pistas"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Preferencias..."
 
@@ -10215,6 +13312,12 @@ msgstr "&Editar etiquetas"
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Gardar proxecto &como..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Variábel"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -10291,6 +13394,11 @@ msgid "In All &Sync-Locked Tracks"
 msgstr "En todas as &pistas ligadas"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr " Sincronización bloqueada"
+
+#: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "Á&rea de reprodución"
 
@@ -10359,8 +13467,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Seguinte pico baixo de frecuencia"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Seleccionar ata o comezo"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Posición do son:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -10497,6 +13614,14 @@ msgstr "Movemento longo do cursor á esquerda"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "Movemento longo do cursor á dereita"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
@@ -10705,18 +13830,21 @@ msgid "Created new label track"
 msgstr "Creouse unha nova pista de etiquetas"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Esta versión de Audacity só permite unha pista de tempo en cada xanela de proxecto."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Creouse unha nova pista de tempo"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nova frecuencia de mostraxe (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "O valor introducido non é correcto"
 
@@ -10796,6 +13924,11 @@ msgid "&Time Track"
 msgstr "Pista de &tempo"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Barra de ferramentas de mestura&dor"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Dividir pista estéreo a mo&no"
 
@@ -10834,6 +13967,10 @@ msgstr "Silenciar &todas as pistas"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Desactivar silencio en todas as pistas"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -10965,7 +14102,9 @@ msgstr "Reproducir"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Gravación"
 
@@ -10978,8 +14117,27 @@ msgid "no label track at or below focused track"
 msgstr "Desprazar o panorama á esquerda na pista en foco."
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Creouse unha nova pista de etiquetas"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -11047,6 +14205,11 @@ msgid "&Timer Record..."
 msgstr "Gravación &temporizada..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Gravación activada polo son"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Á&rea de reprodución"
 
@@ -11075,16 +14238,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "Gravación a&ctivada polo son (activar/desactivar)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Fin da gravación"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "&Remestura (activar/desactivar)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Reprodución a través do so&ftware (activar/desactivar)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Axuste a&utomático do nivel de gravación (activar/desactivar)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -11094,6 +14258,11 @@ msgstr "&Reprodución"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "Reproducir/P&arar"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -11211,6 +14380,11 @@ msgid "&Fit to Width"
 msgstr "Axustar á &xanela"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "Axustar á &xanela"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Contraer todas as pistas"
 
@@ -11254,6 +14428,18 @@ msgstr "Amosar o panel de efectos"
 msgid "&Window"
 msgstr "xanela"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
@@ -11279,7 +14465,7 @@ msgstr "Preferencias:"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Saír de Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -11311,6 +14497,13 @@ msgstr "Dispositivos"
 msgid "Preferences for Device"
 msgstr "Preferencias:"
 
+#. i18n-hint Software interface to audio devices
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgctxt "device"
+msgid "Interface"
+msgstr "Interface"
+
 #. i18n-hint: (noun)
 #: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
 msgid "&Host:"
@@ -11320,7 +14513,8 @@ msgstr "&Servidor"
 msgid "Using:"
 msgstr "Usando:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Reprodución"
 
@@ -11340,7 +14534,8 @@ msgstr "Ca&nles"
 msgid "Latency"
 msgstr "Latencia"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisegundos"
 
@@ -11361,11 +14556,17 @@ msgid "No devices found"
 msgstr "Non se atopan dispositivos"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Canle (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "2 (Stereo)"
 msgstr "2 (Estéreo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Cartafoles"
 
@@ -11378,8 +14579,22 @@ msgid "Default directories"
 msgstr "Cartafoles"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Examinar..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -11439,6 +14654,11 @@ msgstr "Escolla o lugar no que gardar os ficheiros"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "O cartafol %s non existe. Quere crealo?"
 
@@ -11452,7 +14672,8 @@ msgid "Directory %s is not writable"
 msgstr "O cartafol %s non ten permiso de escritura"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Os cambios do cartafol temporal non terán efecto ata que se reinicie Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -11485,9 +14706,16 @@ msgstr "Agrupado por tipo"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "Efectos LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -11496,6 +14724,18 @@ msgstr "Efectos LADSPA"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -11506,6 +14746,10 @@ msgid "Effect Options"
 msgstr "Opcións do efecto"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "&Maximum effects per group (0 to disable):"
 msgstr "Máximo de efectos por grupo (0 para desactivar):"
 
@@ -11514,11 +14758,13 @@ msgid "Plugin Options"
 msgstr "Opcións do engadido"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Buscar actualizacións de engadidos ao iniciar Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Buscar de novo os engadidos a próxima vez que se inicie Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -11607,6 +14853,13 @@ msgstr "Confirmación de eliminación de regra"
 msgid "Ext Import"
 msgstr "Importación estendida"
 
+#. i18n-hint: refers to Audacity's user interface settings
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgctxt "GUI"
+msgid "Interface"
+msgstr "Interface"
+
 #: src/prefs/GUIPrefs.cpp
 msgid "Preferences for GUI"
 msgstr "Preferencias:"
@@ -11644,6 +14897,11 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (intervalo PCM de mostras de 24 bit)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Localización"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
 msgstr "Desde Internet"
 
@@ -11660,6 +14918,10 @@ msgid "Location of &Manual:"
 msgstr "Localización do &manual:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr ""
 "Intervalo en dB de\n"
@@ -11674,6 +14936,10 @@ msgid "Show e&xtra menus"
 msgstr "Amosar os ficheiros agochados"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "A&visar cun son ao completar procesos longos"
 
@@ -11681,9 +14947,46 @@ msgstr "A&visar cun son ao completar procesos longos"
 msgid "Re&tain labels if selection snaps to a label"
 msgstr "Con&servar as etiquetas se a selección axustase a un bordo da etiqueta"
 
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Opcións do engadido"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Regra"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Importar / Exportar"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Preferencias:"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -11696,6 +14999,10 @@ msgstr "Opcións avanzadas de mestura"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Estándar"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -11721,6 +15028,14 @@ msgstr "Ignorar os silencios nos principios e nos finais"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Exportar etiquetas como:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11805,7 +15120,15 @@ msgid "&Defaults"
 msgstr "&Predeterminadas"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Seleccione un ficheiro XML que conteña accesos directos de teclado de Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11814,8 +15137,21 @@ msgstr "Produciuse un erro ao importar os accesos directos de teclado"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d accesos directos de teclado cargados\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -11836,6 +15172,15 @@ msgstr "Vostede non pode asignar unha tecla a esta entrada"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "Ten que seleccionar unha combinación antes de asignar un acceso directo"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -11906,12 +15251,17 @@ msgid "Dow&nload"
 msgstr "De&scargar"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity detectou automaticamente unhas bibliotecas FFmpeg correctas.\n"
 "Aínda así quere atopalas manualmente?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -11930,6 +15280,13 @@ msgstr "Preferencias:"
 msgid "No MIDI interfaces"
 msgstr "Non hai interfaces MIDI"
 
+#. i18n-hint Software interface to MIDI
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgctxt "MIDI"
+msgid "Interface"
+msgstr "Interface"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Using: PortMidi"
 msgstr "Usando: PortMidi"
@@ -11942,6 +15299,10 @@ msgstr "Latencia do sintetizador MIDI (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "A latencia do sintetizador MIDI debe ser un número enteiro"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -11952,8 +15313,9 @@ msgid "Preferences for Module"
 msgstr "Preferencias:"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Isto son módulos experimentais. Actíveo só se leeu o manual do Audacity\n"
@@ -11961,12 +15323,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "«Preguntar» significa que Audacity consultará se quere cargar o módulo con cada inicio."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "«Falla» significa que Audacity considera que o módulo está estragado e non o executará"
 
 #. i18n-hint preserve the leading spaces
@@ -11975,7 +15339,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "«Novo» significa que aínda non fixo ningunha escolla."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Os cambios destes axustes só serán efectivos após se reinicie Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -11993,6 +15358,10 @@ msgstr "Non se atoparon módulos"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Módulos"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -12034,7 +15403,10 @@ msgstr "Arrastre esquerdo"
 msgid "Set Selection Range"
 msgstr "Estabelecer o intervalo de selección"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Maiús-Clic esquerdo"
 
@@ -12122,6 +15494,15 @@ msgstr "Arrastre esquerdo"
 msgid "Move clip up/down between tracks"
 msgstr "Desprazar o fragmento arriba/abaixo entre pistas"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Arrastre esquerdo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -12150,6 +15531,11 @@ msgstr "Cambiar varias mostraxes"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Cambiar só UNHA mostraxe"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Ferramenta múltiple"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -12230,8 +15616,21 @@ msgstr "Período c&urto:"
 msgid "Lo&ng period:"
 msgstr "Período l&ongo:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferencias de Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -12245,6 +15644,11 @@ msgstr "Preferencias:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferencias:"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -12305,12 +15709,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "Remestura: &Reproduce outras pistas mentres se grava unha nova"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "Reprodución a través do so&ftware (activar/desactivar)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Nova pista"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Seleccionar o(s) fluxo(s) a importar"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -12351,41 +15765,37 @@ msgid "System &Date"
 msgstr "Data de inicio"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Axuste automático do nivel de gravación"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Activar o axuste automático do nivel de gravación."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Pico que obter:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Interior:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Tempo de análise:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisegundos (tempo dunha análise)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Numero de análises consecutivas:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 significa infinitos"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Data de inicio"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Gravación activada polo son"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Pista de notas"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -12419,6 +15829,11 @@ msgstr "&Lineal"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Frecuencia"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -12479,12 +15894,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Frecuencia má&xima (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "&Ganancia (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "Inter&valo (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -12507,12 +15930,21 @@ msgid "1024 - default"
 msgstr "256 - predeterminado"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - banda máis estreita"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "Ti&po da xanela"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Factor de decaemento:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -12600,13 +16032,14 @@ msgid "Info"
 msgstr "Información"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -12665,6 +16098,11 @@ msgid "Preferences for TracksBehaviors"
 msgstr "Comportamentos"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "mostras"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
 msgstr "Multi"
 
@@ -12690,6 +16128,18 @@ msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "«Mover a pista seleccionada» &repítese ciclicamente a través das pistas"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Axustes avanzados"
 
@@ -12710,6 +16160,10 @@ msgid "Spectrogram"
 msgstr "Espectrograma"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "Volver representar"
 
@@ -12724,6 +16178,10 @@ msgstr "Ampliar a &selección"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Ampliación predeterminada"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -12746,6 +16204,16 @@ msgid "50ths of Seconds"
 msgstr "segundos"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "segundos"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "segundos"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "milisegundos"
 
@@ -12753,7 +16221,12 @@ msgstr "milisegundos"
 msgid "Samples"
 msgstr "mostras"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Ampliar/Reducir"
 
@@ -12762,8 +16235,29 @@ msgid "Preferences for Tracks"
 msgstr "Preferencias:"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "A&mosar o nome da pista en forma de onda"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Fin da gravación"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -12772,6 +16266,11 @@ msgstr "Modo de &vista predeterminado:"
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "&Formato predeterminado de mostraxe:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "mostras"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -12823,6 +16322,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "Ao mesturar varias pistas a &estéreo durante a exportación"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "Ao mesturar varias pistas a &mono durante a exportación"
 
@@ -12849,16 +16352,24 @@ msgid "Stopped"
 msgstr "Deter"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Ir ao comezo"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Ir á fin"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Seleccionar ata o comezo"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Seleccionar ata a fin"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -12872,20 +16383,17 @@ msgstr "Nova pista"
 msgid "Append Record"
 msgstr "Engadir &gravación"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Seleccionar ata a fin"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Seleccionar ata o comezo"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -12965,11 +16473,17 @@ msgstr "Silenciar a selección de son"
 msgid "Sync-Lock Tracks"
 msgstr "Ligar pistas"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Ampliar"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Reducir"
 
@@ -13036,50 +16550,23 @@ msgstr "Barra de ferramentas de medición de g&ravación"
 msgid "&Playback Meter Toolbar"
 msgstr "Barra de ferramentas de medición de re&produción"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volume de gravación"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volume de reprodución"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volume de gravación: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volume de gravación (Non dispoñíbel, utilice o mesturador do sistema)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volume de reprodución: %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volume de reprodución: %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volume de reprodución (Non dispoñíbel, utilice o mesturador do sistema)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra de ferramentas de mestura&dor"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "Regra"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Indicador de «Nyquist»"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Indicador de «Nyquist»"
@@ -13087,6 +16574,7 @@ msgstr "Indicador de «Nyquist»"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Indicador de «Nyquist»"
@@ -13094,9 +16582,24 @@ msgstr "Indicador de «Nyquist»"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Iniciar a monitorización"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Iniciar a monitorización"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Regra"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -13144,7 +16647,9 @@ msgstr "Axustar a"
 msgid "Length"
 msgstr "Duración"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centro"
 
@@ -13152,6 +16657,14 @@ msgstr "Centro"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "Axustar clic/selección a %s"
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -13200,8 +16713,8 @@ msgstr "Barra de ferramentas de &dispositivos"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra de ferramentas de %s de Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -13228,7 +16741,8 @@ msgstr "Ferramenta de desprazamento de tempo"
 msgid "Zoom Tool"
 msgstr "Ferramenta de zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Ferramenta de debuxo"
 
@@ -13304,11 +16818,13 @@ msgstr "Arrastrar un ou máis límites de etiqueta."
 msgid "Drag label boundary."
 msgstr "Arrastrar o límite de etiqueta."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Etiqueta modificada"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Edición de etiqueta"
 
@@ -13363,31 +16879,42 @@ msgstr "Etiquetas editadas"
 msgid "New label"
 msgstr "Engadiuse unha etiqueta"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Subir unha &oitava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Baixar unha oita&va"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Prema para ampliar verticalmente, Maiús-premer para reducir, arrastrar para especificar unha área de zoom."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clic dereito"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Reducir"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Maiús-Clic esquerdo"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Maiús-Clic esquerdo"
 
@@ -13410,6 +16937,14 @@ msgid "Stretch"
 msgstr "Estirar"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Fragmentos combinados"
 
@@ -13421,7 +16956,8 @@ msgstr "Combinar"
 msgid "Expanded Cut Line"
 msgstr "A liña de corte foi expandida"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expandir"
 
@@ -13445,6 +16981,11 @@ msgstr "Mostraxe movida"
 msgid "Sample Edit"
 msgstr "Edición de mostraxe"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Ampliar nun punto"
@@ -13452,6 +16993,16 @@ msgstr "Ampliar nun punto"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "E&spectrograma"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -13477,7 +17028,8 @@ msgstr "Procesando: "
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Cambiado «%s» a %s"
@@ -13491,7 +17043,60 @@ msgid "Rat&e"
 msgstr "Estabelecer a fr&ecuencia"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100000>0100 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -13512,7 +17117,8 @@ msgstr "Cambio de frecuencia"
 msgid "Set Rate"
 msgstr "Estabelecer a frecuencia"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Multi"
 
@@ -13531,6 +17137,10 @@ msgstr "Di&vidir pista estéreo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Dividir pista estéreo a mono «%s»"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -13601,10 +17211,25 @@ msgid "Right, %dHz"
 msgstr "Dereito,"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "dereita"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -13614,6 +17239,15 @@ msgstr "Prema e arrastre para modificar o tamaño relativo de pistas estéreo."
 msgid "Click and drag to rearrange sub-views"
 msgstr "Prema e arrastre para mover unha pista no tempo"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Prema e arrastre para mover unha pista no tempo"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Ampliar"
@@ -13621,6 +17255,10 @@ msgstr "Ampliar"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Ampliar/Reducir"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -13707,9 +17345,8 @@ msgstr "&Interpolación logarítmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Prema e arrastre para mover unha pista no tempo"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -13760,6 +17397,21 @@ msgstr "Envolvente axustada."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "&Barras de ferramentas"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Iniciar a monitorización"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Regra"
@@ -13775,6 +17427,11 @@ msgstr "Pechar a pista en foco"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Desprazar a pista ao tope &inferior"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Indicador de «Nyquist»"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -13831,6 +17488,11 @@ msgstr "Prema e arrastre para estabelecer o largo de banda da frecuencia."
 msgid "Click and drag to select audio"
 msgstr "Prema e arrastre para seleccionar son"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Prema e arrastre para mover unha pista no tempo"
@@ -13852,6 +17514,10 @@ msgstr "Silenciar as pistas seleccionadas por %.2f segundos en %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Silenciar as pistas seleccionadas por %.2f segundos en %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -13878,6 +17544,12 @@ msgstr "Orde"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl-Clic esquerdo"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Seleccione unha acción"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -13975,9 +17647,19 @@ msgstr "Baleiro"
 msgid "Backwards"
 msgstr "Retrocesos"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Avances"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -14062,6 +17744,16 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Horizontal"
+msgstr "Horizontal"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "Axustar &verticalmente"
+
+#: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr " Monitorización "
 
@@ -14098,6 +17790,29 @@ msgstr "Seleccione unha acción"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 segundos"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + mostras"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 dias 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -14113,11 +17828,35 @@ msgstr "0100 dias 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + centésimas"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 fotogramas|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + milisegundos"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 fotogramas|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -14139,6 +17878,7 @@ msgstr "0100 h 060 m 060 s+># mostras"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "mostras"
@@ -14300,6 +18040,15 @@ msgstr "01000,01000 fotogramas|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000>0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -14307,6 +18056,10 @@ msgstr "0100000>0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100.01000 kHz|0.001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -14372,6 +18125,11 @@ msgstr "(Utilice o menú de contexto para cambiar o formato)"
 msgid "centiseconds"
 msgstr "centisegundos"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Tempo transcorrido:"
@@ -14414,6 +18172,11 @@ msgstr "Confirmar"
 msgid "Unable to write files to directory: %s."
 msgstr "Non é posíbel ler o ficheiro de valores predefinidos."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -14430,6 +18193,10 @@ msgstr "Preferencias:"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Non volver amosar este aviso"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -14480,11 +18247,20 @@ msgid "Value must not be greater than %s"
 msgstr "Iniciar e deter debe ser maior que cero."
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Creouse un directorio novo"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Cartafoles"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Cartafoles"
 
 #: src/xml/XMLFileReader.cpp
@@ -14505,16 +18281,49 @@ msgstr "Non foi posíbel abrir o ficheiro"
 msgid "Spectral edit multi tool"
 msgstr "Selección do espectro"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtro"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Frecuencia"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Erro"
@@ -14529,8 +18338,34 @@ msgstr "&Ganancia (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "A frecuencia mínima debe ser polo menos de 0 Hz."
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -14544,9 +18379,22 @@ msgstr "Esvaecer"
 msgid "Applying Fade..."
 msgstr "Aplicando..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "&Estabelecer valores predeterminados"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -14578,8 +18426,16 @@ msgid "S-Curve Down"
 msgstr "Mover cara abaixo"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Inicio"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -14588,6 +18444,14 @@ msgstr "Ganancia"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Inicio"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -14600,6 +18464,14 @@ msgstr "Lineal"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Lineal"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -14648,6 +18520,14 @@ msgstr "A ganancia da frecuencia non pode ser negativa"
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "A ganancia da frecuencia non pode ser negativa"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Repetir"
@@ -14655,6 +18535,11 @@ msgstr "Repetir"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Buscar o recorte de picos..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Rexistro do Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -14668,6 +18553,23 @@ msgstr "Recorte de picos"
 msgid "Reconstructing clips..."
 msgstr "Suprimindo os «Clic» e «Pops»..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Limiar: %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Pista de notas"
@@ -14675,6 +18577,21 @@ msgstr "Pista de notas"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Pista de notas"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -14708,6 +18625,19 @@ msgstr "Nome da pista"
 msgid "Fade direction"
 msgstr "ler directamente"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Atraso"
@@ -14733,6 +18663,11 @@ msgid "Reverse Bouncing Ball"
 msgstr "Revertendo"
 
 #: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "&Redución de ruído (dB):"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Tempo de atraso (segundos):"
 
@@ -14756,6 +18691,14 @@ msgstr "&Vista previa"
 msgid "Number of echoes"
 msgstr "Número de veces a repetir: "
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Repetir o último efecto"
@@ -14767,6 +18710,10 @@ msgstr "Ecualización"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "Ficheiros MP3"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -14781,10 +18728,24 @@ msgstr "Confirme a sobrescrita"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Non é posíbel abrir o ficheiro de xénero."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Erro (o ficheiro pode non ter sido escrito): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Erro (o ficheiro pode non ter sido escrito): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -14815,10 +18776,50 @@ msgstr "Duración (segundos)"
 msgid "Length of label region (seconds)"
 msgstr "Duración (segundos)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Edición de etiqueta"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -14832,6 +18833,11 @@ msgstr "Desbotar"
 msgid "Warnings only"
 msgstr "Avisos"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -14840,6 +18846,12 @@ msgstr "&Gardar área"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Etiquetas editadas"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -14854,13 +18866,50 @@ msgstr "Filtros clásicos"
 msgid "Performing High-Pass Filter..."
 msgstr "Aplicando filtrado clásico"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frecuencia (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "A frecuencia mínima debe ser polo menos de 0 Hz."
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -14908,6 +18957,11 @@ msgid "Point after sound"
 msgstr "Estéreo unido"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "De duración en segundos"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "De duración en segundos"
 
@@ -14915,11 +18969,41 @@ msgstr "De duración en segundos"
 msgid "Maximum leading silence"
 msgstr "Truncado de silencio..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Truncado de silencio..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "A selección debe ser maior que %d mostras."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -14951,8 +19035,25 @@ msgid "Hard Clip"
 msgstr "Buscar o recorte de picos"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Canle dereita"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "&Nivel (dB):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -15014,6 +19115,44 @@ msgstr "Tempo de ataque/decaemento"
 msgid "Decay (ms)"
 msgstr "Tempo de ataque/decaemento"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "A selección debe ser maior que %d mostras."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Lonxitude do filtro"
@@ -15025,6 +19164,18 @@ msgstr "Aplicando o nivelador..."
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "&Estabelecer valores predeterminados"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -15047,7 +19198,8 @@ msgstr "Ficheiros MP3"
 msgid "HTML file"
 msgstr "Ficheiros MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Asignar nome a ficheiros:"
 
@@ -15064,9 +19216,24 @@ msgid "Disallow"
 msgstr "Desbotado"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Desbotado"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Produciuse unha falla ao retirar %s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -15077,16 +19244,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Seleccionar un ficheiro MIDI..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Filtros non usados:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Seleccionar un ficheiro MIDI..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Xerando ton"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Tipo de &filtro:"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -15099,6 +19308,10 @@ msgstr "Suprimir pista"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Xerando renxido"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -15117,8 +19330,20 @@ msgid "Swing amount"
 msgstr "Distorsión"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Número de veces a repetir: "
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -15141,12 +19366,54 @@ msgid "Beat sound"
 msgstr "Repetir"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Suprimindo ruído"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Límite inferior de ruído"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -15169,6 +19436,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Frecuencia central e largo"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Frecuencia (Hz)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Amplitude (0-1)"
 
@@ -15179,6 +19455,10 @@ msgstr "Non é posíbel exportar"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Aplicando..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -15197,6 +19477,10 @@ msgid "HTML files"
 msgstr "Ficheiros MP3"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Edición de mostraxe"
 
@@ -15209,8 +19493,29 @@ msgid "Include header information"
 msgstr "Información da compilación"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Todo"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -15225,6 +19530,11 @@ msgstr "esta mensaxe de axuda"
 msgid "Errors Only"
 msgstr "Erro: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -15237,6 +19547,46 @@ msgstr "Canle dereita"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "mostras"
 
@@ -15244,6 +19594,43 @@ msgstr "mostras"
 #, lisp-format
 msgid "~a seconds."
 msgstr "segundos"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -15262,6 +19649,10 @@ msgid "Value (dB)"
 msgstr "&Agudos (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Lineal"
 
@@ -15278,6 +19669,14 @@ msgid "Right (dB)"
 msgstr "Dereito,"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Lineal"
 
@@ -15288,6 +19687,40 @@ msgstr "2 Canles (Estéreo)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 Canle (Mono)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Erro (o ficheiro pode non ter sido escrito): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -15302,8 +19735,40 @@ msgid "Select file"
 msgstr "Seleccionar un ficheiro MIDI..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Erro"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -15313,6 +19778,15 @@ msgstr "Non é posíbel abrir o ficheiro de xénero."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Selección do espectro"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -15335,8 +19809,16 @@ msgid "Wet level (percent)"
 msgstr "2- niveis"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Aplicando..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -15378,9 +19860,96 @@ msgstr "A&nalizar"
 msgid "Strength"
 msgstr "Filtro"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Procesando: "
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -15414,6 +19983,189 @@ msgstr "Frecuencia (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Frecuencia (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Saír de Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Canle"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Produciuse un erro ao abrir o ficheiro"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Produciuse un erro ao cargar os metadatos"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Barra de ferramentas de %s de Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Gravación"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Orde:"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importar mediante GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "O axuste automático do nivel de gravación está detido. Non foi posíbel optimizalo máis. Aínda é demasiado alto."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "O axuste automático do nivel de gravación diminuíu o volume a %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "O axuste automático do nivel de gravación está detido. Non foi posíbel optimizalo máis. Aínda é demasiado baixo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "O axuste automático do nivel de gravación aumentou o volume a %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "O axuste automático do nivel de gravación está detido. Excedeuse o número total de análises sen atopar un volume aceptábel. Aínda é demasiado alto."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "O axuste automático do nivel de gravación está detido. Excedeuse o número total de análises sen atopar un volume aceptábel. Aínda é demasiado baixo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "O axuste automático do nivel de gravación está detido. %.2f semella seren un volume aceptábel."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Non é posíbel abrir o ficheiro de xénero.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Control de gravación\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volume de reprodución\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Volume de gravación\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Volume de gravación\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Volume de reprodución: %.2f%s\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Volume de reprodución: %.2f%s\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Ficheiros compatíbeis con GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Non é posíbel cargar o ficheiro de valores predefinidos."
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importación estendida"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Non é posíbel renomear «%s» a «%s»."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Índice[%02x] Códec[%s], Idioma[%s], Velocidade de transferencia[%s], Canles[%d], Duración[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Non é posíbel abrir ou crear o ficheiro de proba."
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Axustar o volume de reprodución"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Aumentar o volume de reprodución"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Diminuír o volume de reprodución"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Axustar o volume de gravación"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Aumentar o volume de gravación"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Diminuír o volume de gravación"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Sobre o Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Axuste a&utomático do nivel de gravación (activar/desactivar)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Axuste automático do nivel de gravación"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Activar o axuste automático do nivel de gravación."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Pico que obter:"
+
+#~ msgid "Within:"
+#~ msgstr "Interior:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Tempo de análise:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisegundos (tempo dunha análise)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Numero de análises consecutivas:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 significa infinitos"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volume de gravación"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volume de reprodución"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volume de gravación: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume de gravación (Non dispoñíbel, utilice o mesturador do sistema)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volume de reprodución: %.2f%s"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volume de reprodución: %.2f%s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume de reprodución (Non dispoñíbel, utilice o mesturador do sistema)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra de ferramentas de mestura&dor"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Prema e arrastre para mover unha pista no tempo"
+
 #~ msgid "Program build date:"
 #~ msgstr "Data de compilación do programa:"
 
@@ -15431,10 +20183,6 @@ msgstr "Frecuencia (Hz)"
 #, fuzzy
 #~ msgid "Unknown error"
 #~ msgstr "Descoñecido"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Non é posíbel ler o ficheiro de valores predefinidos."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -16214,10 +20962,6 @@ msgstr "Frecuencia (Hz)"
 #~ msgstr "Para usar a ferramenta de debuxo seleccione «Forma de onda» no menú despregábel de pista."
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "Suprimir a pista"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "Suprimindo os «Clic» e «Pops»..."
 
@@ -16255,10 +20999,6 @@ msgstr "Frecuencia (Hz)"
 
 #~ msgid "false"
 #~ msgstr "falso"
-
-#, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "Audio Unit"
 
 #, fuzzy
 #~ msgid "Nyquist Effects Prompt"
@@ -16461,10 +21201,6 @@ msgstr "Frecuencia (Hz)"
 #~ msgstr "Transcrición"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "&Barras de ferramentas"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "Orde"
 
@@ -16574,10 +21310,6 @@ msgstr "Frecuencia (Hz)"
 #, fuzzy
 #~ msgid "S-E"
 #~ msgstr "SSE"
-
-#, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
 
 #, fuzzy
 #~ msgid "Show start time and end time"
@@ -16807,10 +21539,6 @@ msgstr "Frecuencia (Hz)"
 #~ msgid "Truncate"
 #~ msgstr "Truncar a:"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Versión: %s"
-
 #~ msgid "C&ategory:"
 #~ msgstr "C&ategoría"
 
@@ -16836,9 +21564,6 @@ msgstr "Frecuencia (Hz)"
 
 #~ msgid "Mo&ve Cursor"
 #~ msgstr "Despra&zar o cursor"
-
-#~ msgid "Fit &Vertically"
-#~ msgstr "Axustar &verticalmente"
 
 #, fuzzy
 #~ msgid "Co&mbined Meter Toolbar"

--- a/locale/he.po
+++ b/locale/he.po
@@ -10,82 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-24 19:27+0000\n"
 "Last-Translator: Omer I.S. <omeritzicschwartz@gmail.com>\n"
-"Language-Team: Hebrew <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"he/>\n"
+"Language-Team: Hebrew <https://hosted.weblate.org/projects/tenacity/tenacity/he/>\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "עדכון Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&דילוג"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&התקנת העדכון"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "יומן שינויים"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "למידע נוסף ב־GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "שגיאה בבדיקה אם יש עדכונים"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "אין אפשרות להתחבר לשרת העדכונים של Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "נתוני העדכון היו פגומים."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "שגיאה בהורדת העדכון."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "לא ניתן לפתוח את קישור ההורדה של Tenacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "זמינה גרסה %s של Tenacity!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "הקלטה"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -131,6 +65,11 @@ msgid "2nd Experimental Command"
 msgstr "פקודה ניסיונית מס׳ 2"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "...Nyquist מיישם אפקט"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Undo\tCtrl+Z"
 msgstr "&ביטול\tCtrl+Z"
 
@@ -165,6 +104,23 @@ msgstr "אי&תור...\tCtrl+F"
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Matching Paren\tF8"
 msgstr "&סוגריים תואמות\tF8"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Top S-expr\tF9"
+msgstr "דלג אל S-expr עליונה"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Go to"
@@ -219,7 +175,8 @@ msgid "Script"
 msgstr "סקריפט"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "פלט"
 
@@ -228,10 +185,19 @@ msgid "Load Nyquist script"
 msgstr "טעינת תסריט Nyquist"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Script was not saved."
 msgstr "התסריט לא נשמר."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "אזהרה"
 
@@ -248,6 +214,10 @@ msgid "Harvey Lubin (logo)"
 msgstr "הרוי לובלין (לוגו)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
 msgstr "Leland Lucius ע\"י"
 
@@ -256,7 +226,8 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "Leland Lucius ע\"י"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "מודול Tenacity חיצוני שמספק IDE פשוט לכתיבת אפקטים."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -279,7 +250,8 @@ msgstr "ללא שם"
 msgid "Nyquist Effect Workbench - "
 msgstr "...Nyquist מיישם אפקט"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "חדש"
 
@@ -319,7 +291,8 @@ msgstr "העתק"
 msgid "Copy to clipboard"
 msgstr "גזור ללוח העתקה"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "גזור"
 
@@ -327,7 +300,8 @@ msgstr "גזור"
 msgid "Cut to clipboard"
 msgstr "גזור ללוח העתקה"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "הדבק"
 
@@ -352,12 +326,24 @@ msgstr "בחר"
 msgid "Select all text"
 msgstr "בחר"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "ביטול-ביצוע"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Undo last change"
+msgstr "שנה פורמט"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&בצע שוב"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
 msgstr "שנה פורמט"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -389,15 +375,31 @@ msgid "Up"
 msgstr "למעלה"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to higher S-expr"
+msgstr "דלג אל S-expr עליונה"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "אחורה"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "דלג אל S-expr עליונה"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "קדימה"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to next S-expr"
+msgstr "דלג אל S-expr עליונה"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "התחלה"
 
@@ -405,7 +407,8 @@ msgstr "התחלה"
 msgid "Start script"
 msgstr "...Nyquist פקודת"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "עצור"
 
@@ -420,7 +423,8 @@ msgid "About %s"
 msgstr "על אודות %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "אישור"
 
@@ -428,11 +432,13 @@ msgstr "אישור"
 msgid "Build Information"
 msgstr "מידע על בניית התוכנה"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "מופעל"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "מושבת"
 
@@ -442,8 +448,9 @@ msgid "The Build"
 msgstr "הפצה לאיתור באגים"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr ":פקודה"
+#, fuzzy
+msgid "Version:"
+msgstr "הופך"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -453,13 +460,23 @@ msgstr ":סוג הפצה"
 msgid "Compiler:"
 msgstr "מקמפל:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr ":תחביר התקנה"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "תיקיית ההגדרות:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "תיקיית ההגדרות:"
 
 #: src/AboutDialog.cpp
@@ -478,7 +495,6 @@ msgstr "המרת קצב דגימה"
 msgid "MP3 Importing"
 msgstr "ייבוא MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis ייצוא וייבוא של "
@@ -487,7 +503,6 @@ msgstr "Ogg Vorbis ייצוא וייבוא של "
 msgid "ID3 tag support"
 msgstr "תמיכה בתגיות ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC ייבוא ויצוא של"
@@ -505,10 +520,6 @@ msgid "FFmpeg Import/Export"
 msgstr "ייבוא/ייצוא FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Features"
-msgstr "תכונות"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "תוספים נתמכים"
 
@@ -523,6 +534,10 @@ msgstr "תמיכה בשינוי קצב וגובה צליל"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "תמיכה בשינוי קצב וגובה צליל"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "תכונות"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -590,9 +605,33 @@ msgstr "%s, תיעוד ותמיכה בצרפתית טרום-פיצול"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
-#, c-format, fuzzy
+#, fuzzy, c-format
 msgid "%s, quality assurance"
 msgstr "‏%s, בקרת האיכות של Audacity"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "מעטפת"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "מעטפת"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -606,6 +645,21 @@ msgstr ":Nyquist פלט"
 msgid "%s, web developer"
 msgstr "מעטפת"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
@@ -614,6 +668,10 @@ msgstr "התכנה החופשית, פתוחת הקוד וחוצת הפלטפור
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "תודות"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -648,14 +706,23 @@ msgid "%s Team Members"
 msgstr "חברי צוות %s"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr ": אחרים תורמים"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr "האתר והעיצוב הגרפי של Audacity"
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "תודות למתרגמים: רני, עומר א״ש"
@@ -674,6 +741,22 @@ msgstr "תודות מיוחדות מ־Audacity:"
 #, c-format
 msgid "%s website: "
 msgstr "האתר של %s:‏ "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "התורמים ל־Tenacity"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -696,6 +779,7 @@ msgstr "ציר הזמן"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "בחר וגרור בכדי לערוך את הדגימות"
@@ -703,17 +787,66 @@ msgstr "בחר וגרור בכדי לערוך את הדגימות"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr ".בחר וגרור בכדי לשנות את גודל הרצועה"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "הזז פוקוס לרצועההבאה"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "הזז רצועה למטה"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "סגור רצועה ממוקדת"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr "חסום"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr "חסום"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "הגדרות ציר הזמן"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -724,10 +857,30 @@ msgid "Update display while playing"
 msgstr "&עדכן תצוגה בזמן השמעה"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "סוף ההקלטה"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "שגיאה"
 
@@ -751,7 +904,8 @@ msgstr ""
 "שאלה זו תופיע רק פעם אחת, לאחר התקנה עם אפשרות איפוס ההעדפות."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Audacity העדפות של"
 
 #: src/AudacityApp.cpp
@@ -764,6 +918,14 @@ msgstr ""
 "%s לא ניתן למצוא את\n"
 "\n"
 "הוסר מרשימת הקבצים האחרונים."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Tenacity is starting up..."
@@ -783,7 +945,7 @@ msgstr "&פתיחה..."
 msgid "Open &Recent..."
 msgstr "...פתח &אחרונים"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "על &אודות Tenacity..."
 
@@ -796,31 +958,33 @@ msgid "&File"
 msgstr "&קובץ"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 ".התוכנה לא מצאה מקום לאחסון קבצים זמניים\n"
 "\"אנא בחר מיקום מתאים בתיבת \"העדפות"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 ".התוכנה לא מצאה מקום לאחסון קבצים זמניים\n"
 "\"אנא בחר מיקום מתאים בתיבת \"העדפות"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"‏Tenacity עומדת להיסגר. נא להפעיל שוב את Tenacity כדי להשתמש בתיקייה הזמנית "
-"החדשה."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "‏Tenacity עומדת להיסגר. נא להפעיל שוב את Tenacity כדי להשתמש בתיקייה הזמנית החדשה."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -829,15 +993,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "לא הצליח לקבל נעילה לתיקיית הקבצים הזמניים Audacity\n"
 ".Audacity ייתכן ותיקייה זו כבר בשימוש ע\"י מופע אחר של\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "האם עדיין ברצונך להפעיל את Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -845,24 +1011,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "שגיאה בנעילת התיקייה זמנית"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr ".Audacity המערכת זיהתה הפעלה נוספת של\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Audacity השתמש בפקודות חדש או פתח בהפעלה נוכחית של\n"
 "לפתיחת כמה פרוייקטים בו זמנית.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "‏Tenacity כבר פועלת"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "הפעלת Tenacity נכשלה"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -882,7 +1096,8 @@ msgstr "\t-test (מריץ בדיקה עצמית)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (מציג את גרסת התוכנה)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -892,9 +1107,10 @@ msgid "audio or project file name"
 msgstr "שם קובץ לשמע או למיזם"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -907,29 +1123,73 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "קובצי מיזם של Tenacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&...דגימה מחדש"
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "מקליט שמע"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "עזרה"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Audacity - צא מ"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "קובץ היומן של Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "ש&מירה..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&סגור"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "נשמר"
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -974,7 +1234,8 @@ msgid "Error Initializing Midi"
 msgstr "Midi שגיאה באתחול אודיו"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "עורך השמע Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -988,36 +1249,24 @@ msgstr ".שגיאה בפתיחת התקן שמע"
 msgid "Out of memory!"
 msgstr "אין זיכרון פנוי!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr ".כוונון עוצמת כניסה אוטומטית הופסקה. לא ניתן למטב יותר. עדיין הרמה גבוהה מדי"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "כוונון עוצמת כניסה אוטומטי הופסקה. לא ניתן למטב יותר. הרמה עדיין נמוכה מדי."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr ".%.2f כוונון עוצמת כניסה אוטומטית הגביר את העוצמה לרמה"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "כוונון עוצמת כניסה אוטומטית הופסקה. חרג ממספר הנסיונות ולא התקבל רמת שמע תקינה. הרמה עדיין גבוהה מדי."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "כוונון עוצמת כניסה אוטומטית הופסקה. חרג ממספר הנסיונות ולא התקבל רמת שמע תקינה. הרמה עדיין נמוכה מדי."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "היא רמת שמע תקינה %.2f כוונון עוצמת כניסה אוטומטית הופסקה. כנראה."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "בחר התקן כניסה\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "בחר התקן כניסה\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy
+msgid "No devices found\n"
+msgstr "לא נמצאו התאמות"
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1055,8 +1304,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "סוף ההקלטה\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "סוף ההקלטה\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "סוף ההקלטה\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "סוף ההקלטה\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -1070,37 +1329,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "בחר התקן כניסה\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "בחר התקן כניסה\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "בחר התקן כניסה\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr ".לא יכול לפתןח קובץ סגנון\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "בחר התקן כניסה\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "מקליט\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "קצבי דגימה\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "ניגון\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "סוף ההקלטה\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "סוף ההקלטה\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "ניגון\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "ניגון\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1108,8 +1370,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "בחר התקן כניסה\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "בחר התקן כניסה\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "בחר התקן כניסה\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "בחר התקן כניסה\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1117,8 +1389,9 @@ msgid "Automatic Crash Recovery"
 msgstr "התאוששות שגיאה אוטומטית "
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1130,12 +1403,14 @@ msgid "Recoverable &projects"
 msgstr "פרויקטים ברי שחזור"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "בחר"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "שם"
 
@@ -1146,6 +1421,11 @@ msgstr "בחר"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "בחר"
+
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Skip"
+msgstr "&דילוג"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1181,8 +1461,16 @@ msgid "&Parameters"
 msgstr "&פרמטרים"
 
 #: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "ב&חר פקודה"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -1191,6 +1479,11 @@ msgstr "Fade In - כניסה "
 #: src/BatchCommands.cpp
 msgid "Import Macro"
 msgstr "ייבוא מאקרו"
+
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr "הקובץ \"%s\" כבר קיים, להחליף אותו?"
 
 #: src/BatchCommands.cpp
 msgid "Export Macro"
@@ -1203,6 +1496,22 @@ msgstr "&אפקטים"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&ערוך פרמטרים"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&ערוך פרמטרים"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1249,11 +1558,30 @@ msgstr "מצב נסיון (TEST MODE)"
 msgid "Apply %s"
 msgstr "החלת %s"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "ערכים קבועים מראש"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "תוויות&"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "יישם שרשור פקודות"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1309,6 +1637,26 @@ msgstr "&ביטול"
 msgid "Remo&ve"
 msgstr "&הסר"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "&...דגימה מחדש"
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "ייבוא..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "ייצוא..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "שלבי עריכה"
@@ -1346,9 +1694,15 @@ msgstr "הזז ל&מעלה"
 msgid "Move &Down"
 msgstr "הזז &למטה"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&שמירה"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1394,11 +1748,38 @@ msgid "Benchmark"
 msgstr "&...הרץ מבחן השוואה"
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "מספר עריכות:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "סגור"
 
@@ -1413,8 +1794,30 @@ msgid "Export Benchmark Data as:"
 msgstr ":יצא מידע ספקטרלי"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "מכין תצוגה מקדימה\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1423,20 +1826,104 @@ msgstr "\"מבצע \"חזרה על\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "הדבקה: %lld\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "מקליט שמע\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
 
 #: src/BuildInfo.h
 msgid "No revision identifier was provided"
 msgstr "מזהה רויזיה לא סופק"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "תאריך ושעה בלתי־ידועים"
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "הפצת שחרור"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1456,9 +1943,39 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr ".ראשית צריך לבחור רצועת שמע לשימוש "
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "לא נבחר שרשור פקודות"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1471,6 +1988,11 @@ msgid ""
 "You must first select some audio to perform this action.\n"
 "(Selecting other kinds of track won't work.)"
 msgstr ".ראשית צריך לבחור רצועת שמע לשימוש "
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1487,9 +2009,28 @@ msgid "Checkpointing project"
 msgstr "יישם &בפרוייקט נוכחי"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "יישם &בפרוייקט נוכחי"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr ":לא יכול לכתוב קובץ\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"לא יכול לכתוב קובץ:\n"
+"  %s."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1506,6 +2047,10 @@ msgid ""
 "\n"
 "%s"
 msgstr ".'%s' לא ניתן למחוק את"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1603,6 +2148,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "גזור ללוח העתקה"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "קבצים חסרים"
 
@@ -1611,10 +2161,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "אם ממשיכים, המיזם שלך לא יישמר בכונן. האם זהו רצונך?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1626,7 +2177,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "בדיקת תלויות"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "כלום"
 
@@ -1634,7 +2188,7 @@ msgstr "כלום"
 msgid "Rectangle"
 msgstr "מרובע"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "בצורת משולש"
 
@@ -1642,12 +2196,98 @@ msgstr "בצורת משולש"
 msgid "Shaped"
 msgstr "מעוצב"
 
+#: src/FFT.cpp
+#, fuzzy
+msgid "Rectangular"
+msgstr "מרובע"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
 #. i18n-hint a proper name
 #: src/FFT.cpp
 msgid "Welch"
 msgstr "!ברוכים הבאים"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg library not found"
+msgstr ":FFmpeg ספריית"
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr ":מיקום"
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "To find '%s', click here -->"
+msgstr ""
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "עיון..."
 
@@ -1669,23 +2309,55 @@ msgid "Where is '%s'?"
 msgstr "היכן \"%s\"?"
 
 #: src/FFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg not found"
+msgstr "לא נמצא עיקום"
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
 msgid "Do not show this warning again"
 msgstr "לא להציג אזהרה זו שוב"
 
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "‏Tenacity נכשלה בפתיחת קובץ בתוך %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "‏Tenacity נכשלה בקריאת קובץ בתוך %s."
 
 #: src/FileException.cpp
 #, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1703,10 +2375,29 @@ msgid "Error (file may not have been written): %s"
 msgstr "%s :(שגיאה (ייתכן והקובץ לא נשמר"
 
 #: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr "...מעתיק נתוני אודיו בפרוייקט"
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
 msgstr "...מעתיק נתוני אודיו בפרוייקט"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "כל הקבצים"
 
@@ -1715,6 +2406,11 @@ msgstr "כל הקבצים"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "קובצי מיזם של AUP3"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "ספריות"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1728,12 +2424,20 @@ msgstr "קובצי טקסט"
 msgid "XML files"
 msgstr "קובצי XML"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "קובצי %s"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
 
 #: src/FileNames.cpp
 msgid "Specify New Filename:"
@@ -1764,6 +2468,14 @@ msgstr "האצת שורש שלישי"
 msgid "Enhanced Autocorrelation"
 msgstr "תיקון עצמי מוגדש"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "ספקטרום"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1780,9 +2492,34 @@ msgstr "תדירות לינארית"
 msgid "Log frequency"
 msgstr "תדירות לוגריתמית"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "(הגדל (זום"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1797,6 +2534,10 @@ msgstr "סטריאו אופקי"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "סמן:"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1819,6 +2560,10 @@ msgid "&Function:"
 msgstr ":מיקום"
 
 #: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Replot..."
 msgstr "...חזור על"
 
@@ -1837,11 +2582,49 @@ msgstr ""
 msgid "Not enough data selected."
 msgstr "לא נבחרו מספיק נתונים."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "s"
+msgstr "מילישניות"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "ספקטרום"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr ":יצא מידע ספקטרלי"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr ":לא יכול לכתוב קובץ"
@@ -1894,8 +2677,19 @@ msgstr "עריכה והצללה של תפריטים"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "&...Audacity אודות"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
 msgid "Saving an Audacity Project"
 msgstr "שמירת מיזם Tenacity"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
@@ -1905,6 +2699,64 @@ msgstr "CD-צרוב ל"
 #: src/HelpText.cpp
 msgid "No Local Help"
 msgstr "אין עזרה למקום זה"
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1923,6 +2775,10 @@ msgid "Used Space"
 msgstr "שטח דיסק"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&מספר רמות ביטול-ביצוע זמינות"
 
@@ -1936,6 +2792,10 @@ msgid "&Discard"
 msgstr "זרוק&"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "זרוק&"
 
@@ -1943,11 +2803,30 @@ msgstr "זרוק&"
 msgid "&Compact"
 msgstr "&פקודה"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "הי&סטוריה..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -1963,7 +2842,9 @@ msgid "Track"
 msgstr "ערוץ"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "תווית"
 
@@ -1991,6 +2872,10 @@ msgstr "(Hz) תדר"
 msgid "New..."
 msgstr "חדש..."
 
+#: src/LabelDialog.cpp
+msgid "Press F2 or double click to edit cell contents."
+msgstr ""
+
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Select a text file containing labels"
 msgstr "...בחר את קובץ הטקסט המכיל את התויות"
@@ -2016,17 +2901,40 @@ msgstr "תוית רצועה חדשה"
 msgid "Enter track name"
 msgstr "נא לתת שם לרצועה"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "&תן שם לרצועה"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity ריצה ראשונה של"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "נא לבחור שפה לשימוש ב־Tenacity:"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "אשר"
 
@@ -2044,8 +2952,19 @@ msgstr ""
 "הקובץ הישן נשמר בשם \"%s\""
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity פותח פרויקט"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "תודות מיוחדות מ־Tenacity:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "...עיין"
 
 #: src/Menus.cpp
 #, c-format
@@ -2065,6 +2984,17 @@ msgstr "&בצע שוב %s"
 msgid "&Redo"
 msgstr "&בצע שוב"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "מושבת"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
@@ -2074,25 +3004,84 @@ msgstr "עירבול"
 msgid "Mix and Render"
 msgstr "&ערבל והפוך"
 
+#: src/Mix.cpp
+#, fuzzy
+msgid "Mixing and rendering tracks"
+msgstr "Mixing and rendering tracks"
+
+#: src/MixerBoard.cpp
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr "Audacity הקלטה מתוזמנת ע\"י"
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "הגבר"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "Musical Instrument"
+msgstr "כלי מוזיקלי"
+
+#. i18n-hint: Title of the Pan slider, used to move the sound left or right
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Pan"
+msgstr "Track Panel"
+
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "השתק"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "יחיד"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "הזז סמן ההגבר"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "הזז סמן ההגבר"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved pan slider"
+msgstr "הזז סמן ההגבר"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "סרגל כלי הערבוב"
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -2102,17 +3091,73 @@ msgid ""
 "Error: %s"
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "מופעל"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy, c-format
+msgid "Module \"%s\" found."
+msgstr "הקובץ \"%s\" לא נמצא."
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "כן"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "כלום"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "מודולים"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -2122,18 +3167,126 @@ msgstr "הערה לרצועה"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr ".דרוך על קבצים קיימים"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2155,9 +3308,29 @@ msgstr[1] "להפעיל תוספים אלו?\n"
 msgid "Enable new plug-ins"
 msgstr "Vamp מצטער, כישלון בטעינת תוסף"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "...Nyquist מיישם אפקט"
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Vamp מצטער, כישלון בטעינת תוסף"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "מופעל"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -2184,6 +3357,25 @@ msgstr "מופעל"
 msgid "E&nabled"
 msgstr "מופעל"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "מופעל"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "בחר"
@@ -2192,7 +3384,8 @@ msgstr "בחר"
 msgid "C&lear All"
 msgstr "&נקה"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "מופעל"
 
@@ -2256,6 +3449,21 @@ msgstr "Error while opening sound device. Please check the output device setting
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr ".בכדי לצייר את הספקטרום, כלל הרצועות הנבחרות חייבות להיות בעלות אותו קצב דגימה"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "שמע מוקלט"
@@ -2263,6 +3471,28 @@ msgstr "שמע מוקלט"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "הקלטה"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2292,8 +3522,50 @@ msgid "Inspecting project file data"
 msgstr "מאבחן נתוני קובץ הפרוייקט"
 
 #: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
 msgid "Treat missing audio as silence (this session only)"
 msgstr "טפל בקטעים חסרים ע''י מילוי שקט (הפעלה זו בלבד)"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr "טפל בקטעים חסרים ע''י מילוי שקט (הפעלה זו בלבד)"
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Fill in silence for missing display data (this session only)"
@@ -2303,15 +3575,89 @@ msgstr "[מלא בשקט מקומות בהן חסר מידע להצגה [בפע�
 msgid "Close project immediately with no further changes"
 msgstr "סגור את הפרויקט מיידית ללא שינויים נוספים"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr "טפל בקטעים חסרים ע''י מילוי שקט (הפעלה זו בלבד)"
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "התקדמות"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "מנקה תוכן תיקיית המטמון"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning: Problems in Automatic Recovery"
+msgstr "שגיאה בשמירה אוטומטית"
 
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<ללא שם>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "מיזם"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2350,12 +3696,97 @@ msgid ""
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ".'%s' לא ניתן למחוק את"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "קובץ זה אינו מיזם Tenacity"
+
+#: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
 msgstr "אין אפשרות לפתוח את קובץ המיזם"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 לא יכול לאתחל זרם "
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 לא יכול לאתחל זרם "
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 לא יכול לאתחל זרם "
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 לא יכול לאתחל זרם "
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 לא יכול לאתחל זרם "
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 לא יכול לאתחל זרם "
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 לא יכול לאתחל זרם "
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: src/ProjectFileIO.cpp
@@ -2363,12 +3794,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "MP3 לא יכול לאתחל זרם "
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr ".'%s' ל- '%s' -לא מצליח לשנות שם מ"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ".'%s' לא ניתן למחוק את"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2379,9 +3836,9 @@ msgid "Error Writing to File"
 msgstr "שגיאה בכתיבה לקובץ"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2392,8 +3849,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "שומר פרוייקטים"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2401,9 +3867,21 @@ msgstr "Tenacity"
 msgid "(Recovered)"
 msgstr "(הוקלט)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "לא ניתן לפתוח את קובץ המיזם"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2418,16 +3896,47 @@ msgid "Unable to parse project information."
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "שומר פרוייקטים"
+
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+msgid "Error Saving Project"
+msgstr "שגיאה בשמירת המיזם"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "שומר פרוייקט ריק"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2435,8 +3944,36 @@ msgstr ""
 "למזלך, הפרוייקט/ים הבא/ים ניתנים לשחזור:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+".האחרונה כמה פרוייקטים לא נשמרו כראוי Audaciy בהפעלת\n"
+"למזלך, הפרוייקט/ים הבא/ים ניתנים לשחזור:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "הפרויקט שוחזר"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "תקיה לקבצים זמניים"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Warning - Empty Project"
@@ -2446,15 +3983,51 @@ msgstr "אזהרה - פרוייקט ריק"
 msgid "Insufficient Disk Space"
 msgstr "שטח דיסק"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
 msgstr "%s נשמר"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "...שמור פרויקט &בתור"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2462,9 +4035,21 @@ msgid "Overwrite Project Warning"
 msgstr ".דרוך על קבצים קיימים"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "...שמור העתק דחוס מהפרוייקט"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -2487,6 +4072,23 @@ msgstr "...בחר קובץ שמע אחד או יותר"
 msgid "%s is already open in another window."
 msgstr ".כבר פתוח בחלון אחר %s"
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "שגיאה בשמירת המיזם"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "שגיאה בפתיחת קובץ"
@@ -2503,6 +4105,17 @@ msgid ""
 msgstr ""
 ":הקובץ אינו מתאים או אינו תקין\n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "שגיאה בפתיחת קובץ"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -2530,12 +4143,33 @@ msgid "Error Importing"
 msgstr "שגיאה ביבוא"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&שמור פרויקט"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "לא יכול לפתוח קובץ פרויקט"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&פקודה"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2546,8 +4180,8 @@ msgid "Automatic database backup failed."
 msgstr "התאוששות שגיאה אוטומטית"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "ברוך בואך לגרסה %s של Tenacity"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2561,9 +4195,23 @@ msgid "Save project before closing?"
 msgstr "לשמור את המיזם לפני הסגירה?"
 
 #: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "Disk space remaining for recording: %s"
 msgstr "שטח פנוי בכונן להקלטה: %s"
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -2578,6 +4226,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2594,6 +4254,26 @@ msgstr "סטריאו אופקי"
 msgid "Vertical Scrollbar"
 msgstr "סטריאו אנכי"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(איכות מיטבית)"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "איכות"
@@ -2606,9 +4286,105 @@ msgstr "איכות"
 msgid "Best Quality (Slowest)"
 msgstr "(איכות מיטבית)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "32-bit float"
+msgstr "32-bit float"
+
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "Unknown format"
+msgstr "שגיאה לא ידועה"
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "בחר מיקום עבור קבצים מיוצאים"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "לשמור שינויים?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "בחירה..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "שינוי גודל:"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "שינוי גודל:"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "White Bkgnd"
+msgstr "לבן"
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr "חלון מלא"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr ":סוג חלון"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "יישם &בפרוייקט נוכחי"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "כלי"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -2622,7 +4398,13 @@ msgstr "כל הקבצים (*)|*"
 msgid "All Preferences"
 msgstr ":העדפות"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "מקטע נבחר"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "מקטע נבחר"
 
@@ -2630,47 +4412,154 @@ msgstr "מקטע נבחר"
 msgid "Timer"
 msgstr "זמן סיום"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "כלים"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "בקרה"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "מערבב"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "מד"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "מד ניגון"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "מד הקלטה"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "עריכה"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "התקן"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "נגן-בקצב"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "סרגל כלי העריכה"
+
+#: src/Screenshot.cpp src/TrackPanel.cpp
+#, fuzzy
+msgid "Track Panel"
+msgstr "Track Panel"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
 
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "רצועות"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "&רצועות"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "ערוץ חדש"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Scale"
+msgstr "ציר הזמן"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "נגן שניה אחת"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "&רצועות"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "&רצועות"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "רצועות"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "בחר מיקום עבור קבצים מיוצאים"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (הודעה זו)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
@@ -2688,8 +4577,32 @@ msgstr "&...אפשרויות"
 msgid "Debu&g"
 msgstr "&Debug - בחן"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "Snap-To On"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Sound Activated Record"
+msgstr "הקלטה לפי השמעה (מופעל/מושבת)"
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "...רמת הפעלה לפי השמעה"
+
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "ברוך בואך אל Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -2729,6 +4642,14 @@ msgid "Comments"
 msgstr "הערות"
 
 #: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
 msgid "Value"
 msgstr "ערך"
 
@@ -2745,6 +4666,16 @@ msgid "Genres"
 msgstr "סגנונות"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&עריכה..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "איתחול"
+
+#: src/Tags.cpp
 msgid "Template"
 msgstr "תבנית"
 
@@ -2753,12 +4684,22 @@ msgid "&Load..."
 msgstr "טעי&נה..."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "ער&כי ברירת מחדל"
+
+#: src/Tags.cpp
 msgid "Don't show this when exporting audio"
 msgstr "אל תראה אזהרה זו שוב"
 
 #: src/Tags.cpp
 msgid "Edit Genres"
 msgstr "ערוך סגנון"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to save genre file."
+msgstr ".לא יכול לפתןח קובץ סגנון"
 
 #: src/Tags.cpp
 msgid "Reset Genres"
@@ -2784,23 +4725,54 @@ msgstr "שגיאה בטעינת נתוני העל"
 msgid "Save Metadata As:"
 msgstr "שמירת נתוני העל בתור:"
 
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "שגיאה בפתיחת קובץ"
+
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "מופעל"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "תקיה לקבצים זמניים"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "לא יכול לכתוב קובץ:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2809,13 +4781,57 @@ msgstr ""
 ".לכתיבה"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 " לא יכול לכתוב קובץ בבואה:\n"
 "  %s."
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+"לא יכול לכתוב קובץ:\n"
+"  %s."
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+"לא יכול לפתוח קובץ:\n"
+"  %s\n"
+".לכתיבה"
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
 
 #: src/Theme.cpp
 #, c-format
@@ -2829,16 +4845,47 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "לא יכול לשמור קובץ:\n"
 "  %s"
 
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+#, fuzzy
+msgid "Classic"
+msgstr "צבע (קלאסי)"
+
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "קל"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "רצועה מספר"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2847,12 +4894,24 @@ msgstr "קל"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "משך זמן"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "&רצועת זמן"
+
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity הקלטה מתוזמנת ע\"י"
 
 #: src/TimerRecordDialog.cpp
@@ -2860,12 +4919,59 @@ msgid "Save Timer Recording As"
 msgstr "מקליט"
 
 #: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
 msgstr "שגיאה בטעינת עקמומי האקולייזר"
 
 #: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "מקליט שמע"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "התאוששות שגיאה אוטומטית "
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "שגיאה בשמירה אוטומטית"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "התאוששות שגיאה אוטומטית "
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "שגיאה בשמירה אוטומטית"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "מקליט"
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -2874,6 +4980,12 @@ msgstr "המיזם הנוכחי"
 #: src/TimerRecordDialog.cpp
 msgid "Recording start:"
 msgstr "תחילת ההקלטה"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "מש&ך זמן:"
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
@@ -2889,6 +5001,11 @@ msgstr "התאוששות שגיאה אוטומטית "
 
 #: src/TimerRecordDialog.cpp
 msgid "Action after Timer Recording:"
+msgstr "Audacity הקלטה מתוזמנת ע\"י"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity הקלטה מתוזמנת ע\"י"
 
 #: src/TimerRecordDialog.cpp
@@ -2923,9 +5040,39 @@ msgid ""
 "Recording exported: %s"
 msgstr "סוף ההקלטה"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "שגיאה בטעינת עקמומי האקולייזר"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "מקליט"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 días 024 h 060 m 060 s"
 
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
@@ -2937,16 +5084,32 @@ msgstr "099 días 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "תאריך וזמן התחלה"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "זמן התחלה"
 
 #: src/TimerRecordDialog.cpp
 msgid "End Date and Time"
 msgstr "תאריך וזמן סיום"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date"
+msgstr "תאריך וזמן סיום"
+
+#: src/TimerRecordDialog.cpp
 msgid "Automatic Save"
+msgstr "התאוששות שגיאה אוטומטית "
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
 msgstr "התאוששות שגיאה אוטומטית "
 
 #: src/TimerRecordDialog.cpp
@@ -2969,7 +5132,8 @@ msgstr "להפעיל את היי&צוא האוטומטי?"
 msgid "Export Project As:"
 msgstr ":ייצא תויות בתור"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "אפשרויות"
 
@@ -2978,8 +5142,21 @@ msgid "After Recording completes:"
 msgstr "מד הקלטה"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Audacity - צא מ"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -2993,11 +5170,24 @@ msgstr "מקליט שמע"
 msgid "Scheduled to stop at:"
 msgstr "בחירה מההתחלה"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr "Audacity הקלטה מתוזמנת ע\"י"
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "בחר התקן כניסה"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3008,12 +5198,30 @@ msgid "Recording Exported:"
 msgstr "סוף ההקלטה"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity הקלטה מתוזמנת ע\"י"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr ",סטריאו"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
 msgstr "מבט רצועות"
+
+#. i18n-hint: The %d is replaced by the number of the track.
+#. i18n-hint: compose a name identifying an unnamed track by number
+#: src/TrackPanelAx.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "Track %d"
+msgstr "ערוץ"
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this track is muted. (The mute button is on.)
@@ -3118,6 +5326,10 @@ msgstr "הזז רצועה למעלה"
 msgid "Move Track Down"
 msgstr "הזז רצועה למטה"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3131,6 +5343,22 @@ msgstr "הבחירה קטנה מדי לשימוש של מפתח קולי"
 msgid "Calibration Results\n"
 msgstr "תוצאות כיול\n"
 
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
 #: src/VoiceKey.cpp
 msgid "Calibration Complete"
 msgstr "ל"
@@ -3140,28 +5368,87 @@ msgid "Resampling failed."
 msgstr ".דגימה מחדש מנוטרלת"
 
 #: src/WaveTrack.cpp
+#, fuzzy
+msgid "There is not enough room available to paste the selection"
+msgstr "אין מספיק מקום להרחיב את השורה שנחתכה"
+
+#: src/WaveTrack.cpp
 msgid "There is not enough room available to expand the cut line"
 msgstr "אין מספיק מקום להרחיב את השורה שנחתכה"
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "החלת %s מתבצעת..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "פקודה"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "פקודה"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s חזור שוב"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -3171,6 +5458,15 @@ msgstr " העתק תוויות"
 msgid "Threshold:"
 msgstr "סף:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "רצועת שמע חדשה נוצרה"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr ":(זמן השהייה (בשניות"
@@ -3178,6 +5474,10 @@ msgstr ":(זמן השהייה (בשניות"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr ":מקדם דעיכה"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -3199,9 +5499,38 @@ msgstr "ערוץ"
 msgid "Track 1"
 msgstr "ערוץ"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "שם החלון:"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -3227,17 +5556,55 @@ msgstr "חיתוך"
 msgid "Envelopes"
 msgstr "מעטפת"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "תוויות"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "מד"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr ":פורמט"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "הזז רצועה למטה"
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "מד"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
 
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
@@ -3246,6 +5613,18 @@ msgstr "הערות"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "פקודה:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -3264,6 +5643,11 @@ msgid "Number of Channels:"
 msgstr "מספר ערוצים:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "יצא לכמה פורמטים"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "יצא לכמה פורמטים"
 
@@ -3271,9 +5655,26 @@ msgstr "יצא לכמה פורמטים"
 msgid "Builtin Commands"
 msgstr "בחר פקודה"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity %s של התמיכה צוות"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "תאריך ושעה בלתי־ידועים"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -3315,11 +5716,22 @@ msgstr "&שמור פרויקט"
 msgid "Saves a copy of current project."
 msgstr "&שמור פרויקט"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr ":העדפות"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "שם:"
 
@@ -3330,6 +5742,18 @@ msgstr ":העדפות"
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "ערך:"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3348,8 +5772,18 @@ msgid "Window Plus"
 msgstr ":סוג חלון"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "כלי"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "&אפקטים"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Scriptables"
@@ -3391,6 +5825,10 @@ msgstr "רצועות"
 msgid "All Tracks Plus"
 msgstr "Track Panel"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -3398,9 +5836,30 @@ msgid "White"
 msgstr "לבן"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "שגיאה בניסיון לשמור את הקובץ: %s"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&...כלי לכידת תמונת מסך"
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -3443,6 +5902,14 @@ msgid "Select Frequencies"
 msgstr "(Hz) תדר"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&רצועות"
 
@@ -3454,6 +5921,12 @@ msgstr "בחר"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "&הוסף"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&הסר"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -3472,6 +5945,11 @@ msgid "Selects a time range."
 msgstr "...MIDI בחר קובץ"
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "...MIDI בחר קובץ"
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "רצועת שמע חדשה נוצרה"
 
@@ -3483,9 +5961,37 @@ msgstr "אורך השקט:"
 msgid "Set Clip"
 msgstr "הכלי הבא"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "התחלה"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -3504,9 +6010,14 @@ msgid "Edited Envelope"
 msgstr "מעטפת"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "מעטפת"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -3516,6 +6027,10 @@ msgstr "פצל תוויות"
 msgid "Label Index"
 msgstr "ערוך תווית"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "בחר"
@@ -3523,6 +6038,10 @@ msgstr "בחר"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "ערוך תווית"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -3536,9 +6055,26 @@ msgstr "קבע קצב"
 msgid "Resize:"
 msgstr "שינוי גודל:"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "גובה:"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&שמור פרויקט"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -3553,6 +6089,10 @@ msgid "Set Track Status"
 msgstr "רצועה מספר"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "הפסקה"
 
@@ -3565,16 +6105,32 @@ msgid "Gain:"
 msgstr "הגבר"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&רצועות"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "לינארי"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "איתחול"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "זמן סיום"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -3604,16 +6160,36 @@ msgstr "ערכי האפקטים"
 msgid "Spectral Select"
 msgstr "מקטע נבחר"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "ערוץ חדש"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "רצועת שמע חדשה נוצרה"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "הגבר"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr ":(dB) הגברה"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr ":(dB) הגברה"
 
 #: src/effects/Amplify.cpp
@@ -3629,11 +6205,35 @@ msgid "Auto Duck"
 msgstr "התחמקות אוטומטית"
 
 #: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr ":מידת ההתחמקות"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "שניות"
 
@@ -3657,7 +6257,8 @@ msgstr ":אורך החלשה פנימית"
 msgid "Inner &fade up length:"
 msgstr ":אורך הגברה פנימית"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr ":רמת סף"
 
@@ -3672,6 +6273,11 @@ msgstr "בס וטרבל"
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "כווץ בחירה שמאלה"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr ":רמת הסף לרעש"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3701,6 +6307,10 @@ msgstr ":(dB) טרבל"
 msgid "Level"
 msgstr ":רמה"
 
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "שנה גובה צליל"
@@ -3710,13 +6320,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "שנה גובה צליל מבלי לשנות את הקצב"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "תמיכה בשינוי קצב וגובה צליל"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "שנה גובה צליל מבלי לשנות את הקצב"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "(EAC) גובה צליל "
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -3750,13 +6382,40 @@ msgstr ":(חצאי טונים (חצאי צעד"
 msgid "Frequency"
 msgstr "(Hz) תדר"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "ל ->"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "אחוז שינוי:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "אחוז שינוי:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -3768,7 +6427,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "לא זמין"
 
@@ -3787,6 +6448,32 @@ msgstr "שנה מהירות, משפיע על הקצב וגם על גובה הצ�
 #: src/effects/ChangeSpeed.cpp
 msgid "&Speed Multiplier:"
 msgstr "יצא לכמה פורמטים"
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -3807,6 +6494,12 @@ msgstr ""
 #: src/effects/ChangeSpeed.cpp
 msgid "Current length of selection."
 msgstr "קצוץ קובץ עד לבחירה"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
@@ -3834,6 +6527,26 @@ msgstr "תמיכה בשינוי קצב וגובה צליל"
 msgid "Change Tempo without Changing Pitch"
 msgstr "שנה קצב מבלי להשפיע על גובה הצליל"
 
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
+
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
@@ -3843,6 +6556,12 @@ msgstr "ל ->"
 #: src/effects/ChangeTempo.cpp
 msgid "Length (seconds)"
 msgstr "(אורך (שניות"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "from"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -3860,15 +6579,101 @@ msgid "Click Removal"
 msgstr "הסרת קליקים"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "השם לא יכול להשאר ריק"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "(בחר ברמת סף (נמוך יותר הינו רגיש יותר"
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "סף:"
 
 #: src/effects/ClickRemoval.cpp
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "(רוחב קפיצה מירבי (גבוה הינו רגיש יותר"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "...דוחס"
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "%.1f :זמן מתקף בשניות"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "סוג רעש"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "...רעש"
+
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "משך זמן"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "משך זמן"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -3876,6 +6681,14 @@ msgstr "משך זמן"
 #. * sound dies away.  So this means 'onset duration'.
 #: src/effects/Compressor.cpp
 msgid "&Attack Time:"
+msgstr "זמן מתקף:"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
 msgstr "זמן מתקף:"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -3892,10 +6705,26 @@ msgstr ":זמן חולף"
 msgid "Release Time"
 msgstr "הפצת שחרור"
 
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "רמת סף: %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -3908,21 +6737,83 @@ msgid "Release Time %.1f secs"
 msgstr "%.1f :זמן דעיכה בשניות"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "רצועת שמע חדשה נוצרה"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "רצועת שמע חדשה נוצרה"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "רצועת שמע חדשה נוצרה"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "סוף"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr ":(dB) טרבל"
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "התאם מקטע נבחר"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "תאריך ושעה בלתי־ידועים"
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "התאם מקטע נבחר"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "R&eset"
@@ -3936,6 +6827,182 @@ msgstr ":העדפות"
 msgid "&Help"
 msgstr "&עזרה"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "אין אפשרות להחליט"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr ""
+"לא יכול לייצר ספריה:\n"
+"  %s"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "ייצוא התוויות בשם:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "שינוי שם \"%s\""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "חזור שוב"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "&ערכי ברירת המחדל"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "&גופן..."
+
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
 msgstr "מצא מקטע"
@@ -3945,12 +7012,124 @@ msgid "Soft Clipping"
 msgstr "הצג חיתוך"
 
 #: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "דוחס תחום דינמי"
 
 #: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "מתאם עוצמות"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "משך זמן"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "מצא מקטע"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -3973,8 +7152,16 @@ msgid "Distortion"
 msgstr "משך זמן"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "אינטרפולציה"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -3989,8 +7176,26 @@ msgid "Clipping level"
 msgstr "חיתוך"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "יישם שרשור פקודות"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr ":רמת סף"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "משך זמן"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -4001,12 +7206,69 @@ msgid "Repeat processing"
 msgstr "יישום שרשור פקודות לניקיון דיבור"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "רמת ההחלקה"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "מצא מקטע"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "קצב ניגון"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "קצב ניגון"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "...DTMF צלילי"
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -4016,7 +7278,9 @@ msgstr "DTMF סדר:"
 msgid "&Amplitude (0-1):"
 msgstr "(עוצמה (0-1"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "מש&ך זמן:"
 
@@ -4029,12 +7293,29 @@ msgid "Duty cycle:"
 msgstr ":זמן מחזור"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr ":משך צליל"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr ":אורך השקט"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -4043,6 +7324,11 @@ msgstr "הד"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "מייצא את חלק השמע הנבחר בתור קובץ %s"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -4053,6 +7339,10 @@ msgid "D&ecay factor:"
 msgstr ":מקדם דעיכה"
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "ערכים קבועים מראש"
 
@@ -4060,7 +7350,8 @@ msgstr "ערכים קבועים מראש"
 msgid "Export Effect Parameters"
 msgstr "&ערוך פרמטרים"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "\"%s\" :לא יכול לפתוח קובץ"
@@ -4084,6 +7375,12 @@ msgstr "&ערוך פרמטרים"
 msgid "%s: is not a valid presets file.\n"
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "מכין תצוגה מקדימה"
@@ -4091,6 +7388,15 @@ msgstr "מכין תצוגה מקדימה"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "תצוגה מקדימה"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -4114,6 +7420,11 @@ msgstr "ערכים קבועים מראש"
 msgid "User Presets"
 msgstr "ערכי האפקטים"
 
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "&ערכי ברירת המחדל"
+
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
 msgstr "ערכי האפקטים"
@@ -4123,8 +7434,28 @@ msgid "Factory Defaults"
 msgstr "&ערכי ברירת המחדל"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr "Vamp מצטער, כישלון באיתחול תוסף"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -4143,6 +7474,27 @@ msgid "Latency: 0"
 msgstr "בעיית השעיה"
 
 #: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "מייושר"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "הזז ל&מעלה"
 
@@ -4159,8 +7511,45 @@ msgid "Move effect down in the rack"
 msgstr "הזז מקטע לרצועה אחרת"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "הזז מקטע לרצועה אחרת"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "הכנס שם עבור רצף שרשור פקודות חדש"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Latency: %4d"
+msgstr "בעיית השעיה"
+
+#: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "בחר פקודה"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "ניהול היסטוריה"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "ניגון"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -4177,6 +7566,16 @@ msgid "&Preview effect"
 msgstr "&הצג קודם"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "דלג להתחלה"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "דלג להתחלה"
+
+#: src/effects/EffectUI.cpp
 msgid "Skip forward"
 msgstr "דלג להתחלה"
 
@@ -4191,6 +7590,11 @@ msgstr "מופעל"
 #: src/effects/EffectUI.cpp
 msgid "Save Preset..."
 msgstr "...שמור בשם"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "ערכים קבועים מראש"
 
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
@@ -4209,9 +7613,24 @@ msgid "Options..."
 msgstr "אפשרויות..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "מד"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "שם: %s"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "הופך"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "שגיאה: %s"
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -4219,9 +7638,19 @@ msgid "Description: %s"
 msgstr "תיאור: %s"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "About"
+msgstr "על &אודות"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "למחוק את \"%s\"?"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "...שמור בשם"
 
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
@@ -4248,6 +7677,16 @@ msgstr "ניגון"
 msgid "Play"
 msgstr "ניגון"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Fading Out - יוצא"
+
 #: src/effects/Equalization.cpp
 msgid "Cubic"
 msgstr "מעוקב"
@@ -4260,6 +7699,22 @@ msgstr "השוואה"
 msgid "Filter Curve EQ"
 msgstr "ערכים קבועים מראש"
 
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "הגברת הבס"
@@ -4269,12 +7724,34 @@ msgid "Bass Cut"
 msgstr "הגברת הבס"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Treble Boost"
 msgstr "(dB) טרבל"
 
 #: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "(dB) טרבל"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -4289,24 +7766,113 @@ msgid "Effect Unavailable"
 msgstr "תצוגה מקדימה לא זמינה"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "dB מירבי"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "dB מינימלי"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "מד"
 
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "צייר עקומות"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "כלי הציור"
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Interpolation type"
 msgstr "אינטרפולציה"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "תדירות לינארית"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "תדירות לינארית"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr ":אורך תצוגה מקדימה"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr ":אורך תצוגה מקדימה"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "ערכים קבועים מראש"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "ערכים קבועים מראש"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "היפוך"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Processing: "
@@ -4315,6 +7881,32 @@ msgstr "...מעבד"
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "&ערכי ברירת המחדל"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&...הרץ מבחן השוואה"
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
 
 #. i18n-hint: EQ stands for 'Equalization'.
 #: src/effects/Equalization.cpp
@@ -4335,6 +7927,11 @@ msgid "Error Loading EQ Curves"
 msgstr "שגיאה בטעינת עקמומי האקולייזר"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Equalization - מבצע יישור "
+
+#: src/effects/Equalization.cpp
 msgid "Requested curve not found, using 'unnamed'"
 msgstr "'העיקום המבוקש לא נמצא, משתמש ב- 'ללא שם"
 
@@ -4343,8 +7940,52 @@ msgid "Curve not found"
 msgstr "לא נמצא עיקום"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "ניהול היסטוריה"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "צייר עקומות"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "סמן שמאלה"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "שם"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "מחק"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "...בחר"
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "ער&כי ברירת מחדל"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4352,14 +7993,43 @@ msgid "Rename '%s' to..."
 msgstr "שינוי השם של \"%s\" לשם..."
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "&...דגימה מחדש"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "שינוי שם \"%s\""
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "ש&נה שם"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr ".דרוך על קבצים קיימים"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "הזז &למטה"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "You cannot delete the 'unnamed' curve."
+msgstr "לא ניתן למחוק עיקום 'ללא שם', זה ייחודי."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "%s לא יכול ליצא שמע אל"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4376,12 +8046,53 @@ msgid "Delete %d items?"
 msgstr "למחוק %d פריטים?"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr "לא ניתן למחוק עיקום 'ללא שם', זה ייחודי."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Could not remove old auto save file"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "...ייצא &תוויות"
+
+#: src/effects/Equalization.cpp
 msgid "You cannot export 'unnamed' curve, it is special."
 msgstr "לא ניתן למחוק עיקום 'ללא שם', זה ייחודי."
 
 #: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "%s לא יכול ליצא שמע אל"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "סוף ההקלטה"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "לא נמצא עיקום"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr ".אין תוויות לייצא"
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -4395,9 +8106,18 @@ msgstr "Fade Out - יציאה"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "בחר וגרור בכדי לבחור שמע"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "בחר וגרור בכדי לבחור שמע"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "מצא מקטע"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -4411,13 +8131,47 @@ msgstr ":(סף התחלה (דגימות"
 msgid "St&op threshold (samples):"
 msgstr ":(סף סיום (דגימות"
 
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "אין מספיק מקום להרחיב את השורה שנחתכה"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "היפוך"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "אפקט Nyquist"
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "נרמל"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -4437,9 +8191,30 @@ msgstr "...מעבד"
 msgid "&Normalize"
 msgstr "נרמל"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr ":מעבד ערוצי סטראו בצורה עצמאית"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -4465,6 +8240,10 @@ msgid "Noise"
 msgstr "...רעש"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "סוג רעש"
 
@@ -4477,16 +8256,73 @@ msgid "Second greatest"
 msgstr "שניות"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "זום ברירת המחדל"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "זום ברירת המחדל"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr ":(dB) הנמכת רעש"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr ".כל הרצועות חייבות להיות בעלות אותו קצב דגימה"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -4494,6 +8330,11 @@ msgstr "הבחירה קטנה מדי לשימוש של מפתח קולי"
 
 #: src/effects/NoiseReduction.cpp
 msgid "&Noise reduction (dB):"
+msgstr ":(dB) הנמכת רעש"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
 msgstr ":(dB) הנמכת רעש"
 
 #: src/effects/NoiseReduction.cpp
@@ -4524,6 +8365,11 @@ msgstr "הפצת שחרור"
 msgid "&Frequency smoothing (bands):"
 msgstr ":(Hz) החלקת תדר"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr ":(Hz) החלקת תדר"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "רגישות"
@@ -4537,8 +8383,9 @@ msgid "Step 1"
 msgstr "צעד 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "בחר מספר שניות שבהן רעש בלבד ,בכדי שהתוכנה תדע מה לסנן החוצה\n"
@@ -4561,6 +8408,27 @@ msgstr ""
 ",בחר כמה רעש ברצונך לסנן החוצה\n"
 ".ואז הקש 'אישור' להסרת הרעש\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "...רעש"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "הס&ר רצועה"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "שינוי גודל:"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "תכונות ערבול מתקדמות"
@@ -4572,6 +8440,11 @@ msgstr ":סוג חלון"
 #: src/effects/NoiseReduction.cpp
 msgid "Window si&ze:"
 msgstr ":סוג חלון"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
 
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
@@ -4585,17 +8458,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - ערך מחדל"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "זום ברירת המחדל"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "הסרת רעש"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -4611,6 +8530,11 @@ msgid "Noise re&duction (dB):"
 msgstr ":(dB) הנמכת רעש"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "רגישות"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr ":(Hz) החלקת תדר"
 
@@ -4618,9 +8542,23 @@ msgstr ":(Hz) החלקת תדר"
 msgid "Attac&k/decay time (secs):"
 msgstr ":(זמן מתקף/דעיכה (בשניות"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr ":(זמן מתקף/דעיכה (בשניות"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&הסר"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "נרמל"
+
+#: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
@@ -4633,6 +8571,10 @@ msgstr "...DC מסיר הסטת\n"
 #: src/effects/Normalize.cpp
 msgid "Normalizing without removing DC offset...\n"
 msgstr "...DC מבצע נירמול ללא הסטת\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 #, c-format
@@ -4660,6 +8602,10 @@ msgid "Processing second track of stereo pair: %s"
 msgstr ":מעבד רצועה שניה מזוג סטראו"
 
 #: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
 msgstr ":(dB) שיא עוצמה חדש"
 
@@ -4675,9 +8621,14 @@ msgstr ":מעבד ערוצי סטראו בצורה עצמאית"
 msgid "Paulstretch"
 msgstr "...מותח"
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr ":מקדם דעיכה"
@@ -4686,25 +8637,95 @@ msgstr ":מקדם דעיכה"
 msgid "&Time Resolution (seconds):"
 msgstr "(זמן השהייה (בשניות:"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Phaser"
+msgstr "Phaser"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "שלבים:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "שלבים:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr ":(Hz) LFO תדירות"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr ":(Hz) LFO תדירות"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr ":(deg.) LFO פאזת התחלה של"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr ":(deg.) LFO פאזת התחלה של"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "עומק:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr ":(%) משוב"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "&Output gain (dB):"
@@ -4718,9 +8739,33 @@ msgstr ":(dB) שער"
 msgid "Repair"
 msgstr "תקן"
 
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "חזור שוב"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -4744,6 +8789,10 @@ msgstr ":אורך מקטע חדש"
 msgid "New selection length: %s"
 msgstr ":אורך מקטע חדש"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
 msgstr "מקומי"
@@ -4753,8 +8802,52 @@ msgid "Vocal II"
 msgstr "מקומי"
 
 #: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "בינוני"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Large Room"
+msgstr "סמלים גדו&לים"
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "היפוך מהתחלה"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "גודל"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr ":(זמן מתקף/דעיכה (בשניות"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -4765,12 +8858,30 @@ msgid "Da&mping (%):"
 msgstr "(%) עומק:"
 
 #: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "(%) עומק:"
+
+#: src/effects/Reverb.cpp
 msgid "Wet &Gain (dB):"
 msgstr ":(dB) שער"
 
 #: src/effects/Reverb.cpp
 msgid "Dr&y Gain (dB):"
 msgstr ":(dB) שער"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "סטריאו"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -4785,17 +8896,98 @@ msgstr "היפוך מהתחלה"
 msgid "Reverses the selected audio"
 msgstr "מייצא את חלק השמע הנבחר בתור קובץ %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "&...טען קובץ"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr ".בכדי לצייר את הספקטרום, כלל הרצועות הנבחרות חייבות להיות בעלות אותו קצב דגימה"
 
 #: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "מד"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
 msgstr ":סוג הפצה"
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "יישר סיום עם סוף מקטע נבחר"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "משך זמן"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "משך זמן"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -4804,6 +8996,14 @@ msgstr ":סוג חלון"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr ":סוג חלון"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -4819,6 +9019,15 @@ msgstr ":רמת סף"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "מיין לפי זמן"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "מיין לפי זמן"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -4857,15 +9066,28 @@ msgstr "&ערכי ברירת המחדל"
 msgid "Restore Defaults"
 msgstr "&ערכי ברירת המחדל"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "שקט"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "&סטריאו למונו"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -4882,6 +9104,40 @@ msgstr " מיישם &סטריאו למונו"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr ":מקדם דעיכה"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Tempo Change (%)"
+msgstr "תמיכה בשינוי קצב וגובה צליל"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Tempo Change (%)"
+msgstr "תמיכה בשינוי קצב וגובה צליל"
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
 
 #: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
 msgid "Logarithmic"
@@ -4900,12 +9156,24 @@ msgid "Sawtooth"
 msgstr "שן מסור"
 
 #: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Chirp"
 msgstr "&...ציוץ"
 
 #: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr " ...צליל"
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
 
 #: src/effects/ToneGen.cpp
 msgid "&Waveform:"
@@ -4916,6 +9184,26 @@ msgid "&Frequency (Hz):"
 msgstr ":(Hz) תדר"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "(Hz) תדר"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "(Hz) תדר"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "(עוצמה (0-1"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "(עוצמה (0-1"
+
+#: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "אינטרפולציה"
 
@@ -4924,8 +9212,20 @@ msgid "Truncate Detected Silence"
 msgstr "חתוך שקט"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "חתוך שקט"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -4935,6 +9235,10 @@ msgstr "בחר-שקט"
 msgid "Tr&uncate to:"
 msgstr "חתוך שקט"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "...דוחס"
@@ -4943,7 +9247,26 @@ msgstr "...דוחס"
 msgid "Trunc&ate tracks independently"
 msgstr ":מעבד ערוצי סטראו בצורה עצמאית"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "&אפקטים"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "!MP3 לא יכול לפתוח ספריית קידוד של "
 
@@ -4951,16 +9274,68 @@ msgstr "!MP3 לא יכול לפתוח ספריית קידוד של "
 msgid "VST Effect Options"
 msgstr "ערכי האפקטים"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "אורך "
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "קומבינציית מפתחות"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "קומבינציית מפתחות"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Save CleanSpeech Preset File As:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "&...Audacity אודות"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "&...Audacity אודות"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity קבצי פרוייקט של"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -4970,6 +9345,11 @@ msgstr "סיומות קבצים"
 #: src/effects/VST/VSTEffect.cpp
 msgid "Error Saving VST Presets"
 msgstr "שגיאה בטעינת עקמומי האקולייזר"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "טען קבצים"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
@@ -4983,13 +9363,38 @@ msgstr "שגיאה בטעינת עקמומי האקולייזר"
 msgid "Unable to load presets file."
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "ערכי האפקטים"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -5000,8 +9405,29 @@ msgid "Reso&nance:"
 msgstr "תהודה:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "תהודה:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Wah הזזת תדר (%):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Wah הזזת תדר (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "ערכי האפקטים"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "ערכי האפקטים"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -5016,16 +9442,42 @@ msgid "Audio Unit Effect Options"
 msgstr "ערכי האפקטים"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "ממשק"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "בחר התקן יציאה"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr " חלון "
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&צור"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "&...Audacity אודות"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -5101,6 +9553,11 @@ msgid "Failed to retrieve preset content"
 msgstr ".'%s' לא ניתן למחוק את"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "המרת קצב דגימה"
 
@@ -5109,15 +9566,60 @@ msgstr "המרת קצב דגימה"
 msgid "Failed to write XML preset to \"%s\""
 msgstr ".'%s' לא ניתן למחוק את"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr ".'%s' לא ניתן למחוק את"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr ".'%s' לא ניתן למחוק את"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "שליחת דו״ח התקלה נכשלה"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "קובץ אודיו"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "&אפקטים"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "&אפקטים"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "ערכי האפקטים"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -5125,6 +9627,7 @@ msgstr "ערכי האפקטים"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "&אפקטים"
@@ -5133,13 +9636,59 @@ msgstr "&אפקטים"
 msgid "LV2 Effect Settings"
 msgstr "ערכי האפקטים"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&צור"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "&אפקטים"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "אפקט Nyquist"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -5155,6 +9704,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr ":Nyquist פלט"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "יושר עם סוף מקטע נבחר"
 
@@ -5167,12 +9734,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "מצטער, לא יכול לבצע אפקט עבור ערוצי סטריאו כאשר הערוצים אינם מתואמים"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr ":Nyquist פלט"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "העיבוד הושלם."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -5215,6 +9800,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "לא החזיר שמע Nyquist\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "This version of Audacity was not compiled with %s support."
@@ -5223,10 +9812,37 @@ msgstr "This version of Audacity was not compiled with %s support."
 msgid "Could not open file"
 msgstr ":לא יכול לפתוח קובץ"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr ":לא יכול לפתוח קובץ"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -5247,6 +9863,21 @@ msgid "Lisp scripts"
 msgstr "...Nyquist פקודת"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr ":לא יכול לפתוח קובץ"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -5265,9 +9896,19 @@ msgstr "...MIDI בחר קובץ"
 msgid "Save file as"
 msgstr "שמירת הקובץ בשם"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "untitled"
+msgstr "<ללא שם>"
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "&אפקטים"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -5288,6 +9929,17 @@ msgstr "הגדרות התוספים"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "תוכנית"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "אפשרויות"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -5325,8 +9977,7 @@ msgid ""
 msgstr ""
 "ייצוא קובץ %s בשם \"%s\" עומד להתבצע.\n"
 "\n"
-"לרוב יש לקבצים הללו סיומת \"‎.%s\"‏, ומספר תוכניות אינן פותחות קבצים בעלי "
-"סיומות שאינן שגורות.\n"
+"לרוב יש לקבצים הללו סיומת \"‎.%s\"‏, ומספר תוכניות אינן פותחות קבצים בעלי סיומות שאינן שגורות.\n"
 "\n"
 "האם לייצא את הקובץ בשם הזה?"
 
@@ -5377,6 +10028,16 @@ msgid "%s - R"
 msgstr "- ימין"
 
 #: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Output Channels: %2d"
+msgstr "ערוצים :%2d"
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "מערבב"
+
+#: src/export/Export.cpp
 #, c-format
 msgid ""
 "Unable to export.\n"
@@ -5387,10 +10048,25 @@ msgstr "לא מסוגל לייצא"
 msgid "Show output"
 msgstr "הצגת הפלט"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "משתנה"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "פקודה"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -5414,6 +10090,11 @@ msgid "Exporting the audio using command-line encoder"
 msgstr "מייצא את כל השמע הנבחר תוך שימוש במקודד פקודת השורה"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "פקודה  "
+
+#: src/export/ExportCL.cpp
 msgid "&OK"
 msgstr "&אישור"
 
@@ -5422,13 +10103,123 @@ msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "ציינת שם קובץ בלי סיומת. להמשיך?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "‏\"%s\" לא נמצא."
 
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr ":FFmpeg ספריית"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "מייצא את חלק השמע הנבחר בתור קובץ %s"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -5439,13 +10230,40 @@ msgstr "מייצא את חלק השמע הנבחר בתור קובץ %s"
 msgid "Invalid sample rate"
 msgstr "קצב לא חוקי"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "דגימה מחדש"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
 msgid "Sample Rates"
 msgstr "קצבי דגימה"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -5454,6 +10272,51 @@ msgstr ":קצב הביטים"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr ":איכות"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -5468,6 +10331,10 @@ msgid "Constrained"
 msgstr "קבוע"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&...שמע"
 
@@ -5476,8 +10343,44 @@ msgid "Low Delay"
 msgstr "סוג מקש"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "בינוני"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -5500,6 +10403,14 @@ msgid "Application:"
 msgstr "יישם שרשור פקודות"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "יישם &בפרוייקט נוכחי"
 
@@ -5512,29 +10423,435 @@ msgid "Error Saving FFmpeg Presets"
 msgstr "שגיאה בטעינת עקמומי האקולייזר"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr ".דרוך על קבצים קיימים"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "אשר"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "רצועת שמע חדשה נוצרה"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "התיקייה %s אינה קיימת. ליצור אותה?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "'%s' במקום '%s'  משנה לשם"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "ראשי"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "ייבוא/ייצוא FFmpeg"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr ":רמה"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr ":רמה"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr ":רמה"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "ערכים קבועים מראש"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "טען קבצים"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr ":ייצא תויות בתור"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr ":ייצא תויות בתור"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "יישם &בפרוייקט נוכחי"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "הגדרות ציר הזמן"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr ":שפת ממשק"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr ":איכות"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "קצבי דגימה"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Profile:"
 msgstr ":פרופיל"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "FLAC קבצי "
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "...דוחס"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "שם:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "בחירה עד הסוף"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "קבע קצב"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "כותרת הרצועה"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "'%s' במקום '%s'  משנה לשם"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr ".אין תוויות לייצא"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "...בחר קובץ (קבצים) לעיבוד אצווה "
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "שליחת דו״ח התקלה נכשלה"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "24 bit"
 
 #: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
@@ -5557,6 +10874,18 @@ msgid "FLAC Files"
 msgstr "FLAC קבצי "
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "\"%s\" :לא יכול לפתוח קובץ"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr "Vamp מצטער, כישלון באיתחול תוסף"
+
+#: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
 msgstr "FLAC מייצא את חלק השמע הנבחר בתור"
 
@@ -5577,6 +10906,11 @@ msgid "Unable to open target file for writing"
 msgstr ".לא יכול לפתוח קובץ יעד לכתיבה"
 
 #: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr "%d Kbps מייצא קטע אודיו נבחר בקצב"
+
+#: src/export/ExportMP2.cpp
 #, c-format
 msgid "Exporting the audio at %ld kbps"
 msgstr "%d Kbps מייצא קטע אודיו נבחר בקצב"
@@ -5586,14 +10920,69 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(איכות מיטבית)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(קובץ קטן יותר)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "Extreme"
 msgstr "קיצוני"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "סטנדרטי"
 
@@ -5614,6 +11003,11 @@ msgid "Constant"
 msgstr "קבוע"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "סטריאו"
+
+#: src/export/ExportMP3.cpp
 msgid "Stereo"
 msgstr "סטריאו"
 
@@ -5630,15 +11024,37 @@ msgstr "איכות"
 msgid "Channel Mode:"
 msgstr ":מצב ערוץ"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "הסר שורה שנגזרה"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Lame אתר את "
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "MP3 ליצירת %s זקוק לקובץ  Audacity"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr ":מיקום"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "To find %s, click here -->"
+msgstr "כדי לקבל עותק של FFmpeg בחינם, יש ללחוץ כאן -->"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "To get a free copy of LAME, click here -->"
+msgstr "כדי לקבל עותק של FFmpeg בחינם, יש ללחוץ כאן -->"
 
 #. i18n-hint: It's asking for the location of a file, for
 #. * example, "Where is lame_enc.dll?" - you could translate
@@ -5647,6 +11063,34 @@ msgstr "MP3 ליצירת %s זקוק לקובץ  Audacity"
 #, c-format
 msgid "Where is %s?"
 msgstr "היכן %s?"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "קובצי מיזם של AUP3"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -5683,6 +11127,11 @@ msgid "Exporting the audio with %s preset"
 msgstr "%s מייצא את חלק השמע הנבחר עם ערך קבוע "
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "%s VBR מייצא את כל הקובץ באיכות "
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with VBR quality %s"
 msgstr "%s VBR מייצא את כל הקובץ באיכות "
@@ -5701,6 +11150,28 @@ msgstr "%d Kbps מייצא קטע אודיו נבחר בקצב"
 #, c-format
 msgid "Error %ld returned from MP3 encoder"
 msgstr "MP3 חזרה ממקודד  %ld שגיאת "
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
@@ -5726,6 +11197,10 @@ msgid "Export files to:"
 msgstr ":יצא למיקום"
 
 #: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Create"
 msgstr "יצירה"
 
@@ -5746,6 +11221,11 @@ msgid "First file name:"
 msgstr "שם קובץ ראשון:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "שם קובץ ראשון:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr ":תן לבצים שמות לפי:"
 
@@ -5754,7 +11234,22 @@ msgid "Using Label/Track Name"
 msgstr "שימוש בתוויות/שמות הרצועות"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "שימוש בתוויות/שמות הרצועות"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr ":סיומת שם הקובץ"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr ":סיומת שם הקובץ"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr ":סיומת שם הקובץ"
 
 #: src/export/ExportMultiple.cpp
@@ -5771,8 +11266,62 @@ msgid "Choose a location to save the exported files"
 msgstr "בחר מיקום עבור קבצים מיוצאים"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
 msgstr "להמשיך בייצוא הקבצים הנותרים?"
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
@@ -5783,8 +11332,28 @@ msgid "Ogg Vorbis Files"
 msgstr "Ogg Vorbis קבצי "
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with metadata"
 msgstr "אין אפשרות לייצא - בעיה עם מידע העל"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -5798,6 +11367,14 @@ msgstr "מייצא את חלק השמע הנבחר בתור Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "מייצא את חלק השמע הנבחר בתור Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "כותרת:"
@@ -5807,8 +11384,33 @@ msgid "Encoding:"
 msgstr ":קידוד"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "...בחר קובץ לא דחוס כלשהו"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "שגיאה ביבוא"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -5819,18 +11421,55 @@ msgstr ".לא יכול ליצא שמע בפורמט זה"
 msgid "Exporting the selected audio as %s"
 msgstr "מייצא את חלק השמע הנבחר בתור קובץ %s"
 
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "כל הקבצים|*|כל הקבצים הנתמכים|"
 
-#. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
 #, c-format
 msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Vamp מצטער, כישלון באיתחול תוסף"
+
+#: src/import/Import.cpp
+#, c-format
+msgid "This version of Tenacity was not compiled with %s support."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 ".CD הינה רצועת שמע מ \"%s\" \n"
 ".CD אינה יכולה לפתוח ספריית Audacity \n"
@@ -5841,8 +11480,17 @@ msgstr ""
 #: src/import/Import.cpp
 #, c-format
 msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 ".הינו קובץ שמע של חלונות \"%s\" \n"
@@ -5851,10 +11499,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 ".הינו קובץ שמע בקידוד מתקדם \"%s\" \n"
@@ -5863,20 +11511,144 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+".הינו קובץ שמע של חלונות \"%s\" \n"
+". אינה יכולה לפתוח קובץ זה כתוצאה ממגבלות פטנטים Audacity\n"
+".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 ".RealPlayer הינו קובץ שמע של \"%s\" \n"
 ".אינה יכולה לפתוח קובץ זה Audacity\n"
 ".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
 
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+".הינו קובץ שמע של חלונות \"%s\" \n"
+". אינה יכולה לפתוח קובץ זה כתוצאה ממגבלות פטנטים Audacity\n"
+".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+".הינו קובץ שמע של חלונות \"%s\" \n"
+". אינה יכולה לפתוח קובץ זה כתוצאה ממגבלות פטנטים Audacity\n"
+".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+".RealPlayer הינו קובץ שמע של \"%s\" \n"
+".אינה יכולה לפתוח קובץ זה Audacity\n"
+".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+".הינו קובץ שמע של חלונות \"%s\" \n"
+". אינה יכולה לפתוח קובץ זה כתוצאה ממגבלות פטנטים Audacity\n"
+".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+".הינו קובץ שמע של חלונות \"%s\" \n"
+". אינה יכולה לפתוח קובץ זה כתוצאה ממגבלות פטנטים Audacity\n"
+".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+".הינו קובץ שמע של חלונות \"%s\" \n"
+". אינה יכולה לפתוח קובץ זה כתוצאה ממגבלות פטנטים Audacity\n"
+".WAV או AIFF יש להמירו לפורמט שמע שנתמך ע\"י התוכנה , כמו "
+
 #: src/import/Import.cpp
 #, c-format
 msgid "File \"%s\" not found."
 msgstr "הקובץ \"%s\" לא נמצא."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "קובצי מיזם של AUP3"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5893,21 +11665,132 @@ msgid "Import Project"
 msgstr ":ייצא תויות בתור"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "\"%s\" :לא יכול למצוא את ספריית הפרויקט"
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr ":(Hz) קצב פרוייקט"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "קצב לא חוקי"
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "קצב לא חוקי"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5924,21 +11807,19 @@ msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 msgid "Unable to read %lld samples from %s"
 msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC קבצי"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr ".'%s' ל- '%s' -לא מצליח לשנות שם מ"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -5998,9 +11879,22 @@ msgstr "לא היה ניתן לפתוח את הקובץ \"%s\"."
 msgid "MP3 files"
 msgstr "MP3 קבצי"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis קובצי "
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -6023,12 +11917,124 @@ msgid "Internal logic fault"
 msgstr "שגיאה לוגית פנימית"
 
 #: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -6039,12 +12045,49 @@ msgid "64 bit float"
 msgstr "32-bit float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bit"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "16 bit"
 
 #: src/import/ImportPCM.cpp
 msgid "24 bit DWVW"
 msgstr "24 bit"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
@@ -6054,9 +12097,51 @@ msgstr "16-bit PCM"
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
 
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "ייבוא MP3"
+
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "QuickTime קבצי "
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "לא מסוגל להחליט"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr ".'%s' לא ניתן למחוק את"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr ".לא יכול לפתןח קובץ סגנון"
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "ייבא נתונים גולמיים"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -6067,6 +12152,19 @@ msgstr "ייבא נתונים גולמיים"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "ללא סיומות"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "בינוני"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -6086,6 +12184,10 @@ msgstr "2 ערוצים (סטריאו)"
 #, c-format
 msgid "%d Channels"
 msgstr "%d ערוצים"
+
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
 
 #: src/import/ImportRaw.cpp
 msgid "Channels:"
@@ -6113,6 +12215,10 @@ msgstr ":קצב דגימה"
 msgid "&Import"
 msgstr "&ייבוא"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -6133,6 +12239,7 @@ msgstr "ימינה"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -6156,6 +12263,7 @@ msgstr "סוף"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -6175,12 +12283,36 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Time shifted tracks/clips %s %.02f seconds"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Time shifted tracks/clips %s %.02f seconds"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "הזזה-בזמן"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "clip not moved"
+msgstr "התסריט לא נשמר."
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "לתחילת הקטע הנבחר"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -6197,6 +12329,26 @@ msgstr "הכלי ה&בא"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "בחירת הכלי הבא"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "כלי קודם"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "יישם &בפרוייקט נוכחי"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "הכלי ה&בא"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "לתחילת הקטע הנבחר"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -6232,6 +12384,11 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr ""
 "%.2f נמחקו\n"
 "%.2f שניות בנקודה "
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasting one type of track into another is not allowed."
+msgstr ".העתקת שמע סטריאופוני לרצועת מונו אסורה"
 
 #: src/menus/EditMenus.cpp
 msgid "Copying stereo audio into a mono track is not allowed."
@@ -6288,7 +12445,8 @@ msgstr ""
 msgid "Trim Audio"
 msgstr "מקליט שמע"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "פצל"
 
@@ -6310,6 +12468,17 @@ msgstr ""
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "צרף"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr ""
+"%.2f נמחקו\n"
+"%.2f שניות בנקודה "
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
@@ -6343,6 +12512,11 @@ msgstr "&הדבק"
 msgid "Duplic&ate"
 msgstr "&שכפל"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "הס&ר רצועה"
+
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
 msgid "Spl&it Cut"
@@ -6352,6 +12526,12 @@ msgstr "&פיצול גזירה"
 #: src/menus/EditMenus.cpp
 msgid "Split D&elete"
 msgstr "&פיצול מחיקה"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "מקטע שקט בעל תווית"
 
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
@@ -6372,9 +12552,19 @@ msgstr "&פצל חדש"
 msgid "&Join"
 msgstr "&צרף"
 
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "בחר-שקט"
+
 #: src/menus/EditMenus.cpp
 msgid "&Metadata..."
 msgstr "מ&ידע על..."
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "העד&פות..."
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -6385,32 +12575,8 @@ msgid "Delete Key&2"
 msgstr "מקש מחיקה2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "סרגל כלי הערבוב"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "ניגון"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "ניגון"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "ניגון"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "סוף ההקלטה"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "סוף ההקלטה"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "סוף ההקלטה"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -6437,8 +12603,21 @@ msgid "&Full Screen (on/off)"
 msgstr "הקלט על (מופעל/מושבת)"
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "&...יצא בחירה בתור"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "ערוך תווית"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -6451,6 +12630,11 @@ msgstr "רצועת שמע חדשה נוצרה"
 #: src/menus/FileMenus.cpp
 msgid "Please select a Note Track."
 msgstr "רצועת שמע חדשה נוצרה"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "...MIDI ייצא"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI file"
@@ -6469,6 +12653,11 @@ msgstr ""
 "להמשיך?"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "...MIDI ייצא"
+
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Imported labels from '%s'"
 msgstr "'%s' ייבא תוויות מתוך"
@@ -6480,6 +12669,11 @@ msgstr "ייבא תויות"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "...MIDI בחר קובץ"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "כל הקבצים (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -6582,6 +12776,10 @@ msgid "E&xit"
 msgstr "&צא"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr ":ייצא תויות בתור"
 
@@ -6612,6 +12810,10 @@ msgid "Nothing to do"
 msgstr "שום דבר לביטול ביצוע"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "סגור רצועה ממוקדת"
 
@@ -6622,6 +12824,15 @@ msgstr "לא יכול לפתוח קובץ פרויקט"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "תחילת ההקלטה"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Audio Device Info"
+msgstr "...מידע על התקן אודיו"
 
 #: src/menus/HelpMenus.cpp
 msgid "MIDI Device Info"
@@ -6636,12 +12847,17 @@ msgid "&Getting Started"
 msgstr "תחילת קטע נבחר:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "Audacity פרוייקטים של"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "עזרה &מהירה"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -6659,13 +12875,15 @@ msgstr "...מידע על התקן אודיו"
 msgid "Show &Log..."
 msgstr "הצגת קובץ ה&יומן..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "על &אודות Tenacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "תווית הוספה"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "הזז פוקוס לרצועההבאה"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -6781,6 +12999,15 @@ msgid "Add Label at &Playback Position"
 msgstr "&הוסף תוית בנקודת ההשמעה"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "הזז פוקוס לרצועההבאה"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "שמע מוקלט"
 
@@ -6815,6 +13042,11 @@ msgid "Label Split Delete"
 msgstr "פצל ומחק"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "מקטע שקט בעל תווית"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "שקט"
 
@@ -6839,6 +13071,18 @@ msgstr "ערוך תווית"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "ערוך תווית"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -6881,8 +13125,17 @@ msgid "Toggle Focuse&d Track"
 msgstr "שנה רצועה ממוקדת"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "...חדש"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Unknown"
+msgstr "שגיאה לא ידועה"
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -6899,6 +13152,10 @@ msgid "&Generate"
 msgstr "&צור"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
 msgstr "מייצר צלילים"
 
@@ -6907,8 +13164,18 @@ msgid "Effe&ct"
 msgstr "&אפקטים"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "מייצר צלילים"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&נתח"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "מייצר צלילים"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -6946,6 +13213,10 @@ msgstr "&...הרץ מבחן השוואה"
 msgid "Simulate Recording Errors"
 msgstr "מקליט"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -6966,6 +13237,16 @@ msgstr "בחירת רצועות..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "רצועה מספר"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "אורך השקט:"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&רצועות"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -6991,9 +13272,20 @@ msgstr "&ערוך תוויות "
 msgid "Set Project..."
 msgstr "...שמור פרויקט &בתור"
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "משתנה"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "&רצועות"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "אינפורמציה"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -7025,8 +13317,24 @@ msgid "Screenshot (short format)..."
 msgstr "&...כלי לכידת תמונת מסך"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "קבע נקודת בחירה"
+
+#: src/menus/SelectMenus.cpp
 msgid "Position"
 msgstr "מיקום"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "קבע נקודת בחירה"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "בחר"
 
 #: src/menus/SelectMenus.cpp
 msgid "&None"
@@ -7041,16 +13349,54 @@ msgid "&Tracks"
 msgstr "&רצועות"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "רצועות"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "הופעל נעילת סנכרון"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Left at Playback Position"
+msgstr "&הוסף תוית בנקודת ההשמעה"
+
+#: src/menus/SelectMenus.cpp
 msgid "Set Selection Left at Play Position"
 msgstr "קבע נקודת בחירה ונגן"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Right at Playback Position"
+msgstr "&הוסף תוית בנקודת ההשמעה"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Selection Right at Play Position"
 msgstr "קבע נקודת בחירה ונגן"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "בחירה מההתחלה"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "בחירה מההתחלה"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "רצועה מספר"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -7089,8 +13435,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "תדירות לינארית"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "בחירה מההתחלה"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr ":מיקום השמע"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -7228,6 +13583,14 @@ msgstr "סמן שמאלה"
 msgid "Cursor Long Ju&mp Right"
 msgstr "סמן ימינה"
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
 msgstr "חפש מרווח קצר לכיוון שמאל במהלך ההשמעה"
@@ -7244,6 +13607,11 @@ msgstr "חפש מרווח ארוך לכיוון שמאל במהלך ההשמעה
 msgid "Long Seek Rig&ht During Playback"
 msgstr "חפש מרווח ארוך לכיוון ימין במהלך ההשמעה"
 
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "כלי"
+
 #. i18n-hint: (verb)
 #: src/menus/ToolbarMenus.cpp
 msgid "Edit &Mode (on/off)"
@@ -7252,6 +13620,18 @@ msgstr "הקלט על (מופעל/מושבת)"
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
 msgstr "סרגל כלי איפוס"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr "הסר רצועות שמע "
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Render"
+msgstr "&ערבל והפוך"
 
 #: src/menus/TrackMenus.cpp
 #, c-format
@@ -7388,6 +13768,25 @@ msgid "Align Together"
 msgstr "יישר רצועות יחדיו"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "יישר סיום עם סוף מקטע נבחר"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted gain"
+msgstr "Adjusted gain"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted Pan"
+msgstr "מעטת מתואמת."
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
 msgstr "רצועת שמע חדשה נוצרה"
 
@@ -7404,14 +13803,20 @@ msgid "Created new label track"
 msgstr "תוית רצועה חדשה נוצרה"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "רצועת זמן חדשה ייוצרה"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "(Hz) קצב דגימה חדש:"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "הערך המוכנס אינו חוקי"
 
@@ -7431,6 +13836,25 @@ msgstr "דגום רצועה מחדש"
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "רצועת שמע חדשה נוצרה"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "יישר סיום עם סוף מקטע נבחר"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -7453,6 +13877,11 @@ msgid "Can't delete track with active audio"
 msgstr "לא יכול למחוק רצועה עם שמע אקטיבי"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&חדש"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "הזז רצועה"
 
@@ -7469,8 +13898,18 @@ msgid "&Time Track"
 msgstr "&רצועת זמן"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "סרגל כלי הערבוב"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr " מיישם &סטריאו למונו"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x and Render"
+msgstr "&ערבל והפוך"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix and Render to Ne&w Track"
@@ -7489,6 +13928,11 @@ msgid "M&ute/Unmute"
 msgstr "השתק/בטל השתקה של רצועה ממוקדת"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "&רווח כל הרצועות"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
 msgstr "&רווח כל הרצועות"
 
@@ -7499,6 +13943,10 @@ msgstr "&רצועות"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&רווח כל הרצועות"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -7523,6 +13971,11 @@ msgstr "מרכז"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Center"
 msgstr "מרכז"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "רצועות"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
@@ -7551,6 +14004,11 @@ msgstr "זמן התחלה"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "חפש "
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "הזז מקטע לרצועה אחרת"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -7622,7 +14080,9 @@ msgstr "נגן "
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "מקליט"
 
@@ -7635,8 +14095,27 @@ msgid "no label track at or below focused track"
 msgstr "העבר תצוגה לשמאל ברצועה הפעילה"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "תוית רצועה חדשה נוצרה"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -7675,8 +14154,24 @@ msgid "Play/Stop and &Set Cursor"
 msgstr "נגן/עצור וקבע סמן"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "נגן במהירות"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "הפסקה"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "מקליט"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "הקלטה"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -7685,6 +14180,27 @@ msgstr "הקלטה"
 #: src/menus/TransportMenus.cpp
 msgid "Record &New Track"
 msgstr "הס&ר רצועה"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "מקליט"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "R&escan Audio Devices"
@@ -7703,16 +14219,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "הקלטה לפי השמעה (מופעל/מושבת)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "סוף ההקלטה"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "הקלט על (מופעל/מושבת)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "השמעה באמצעות תוכנה (מופעל/מושבת)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr ".%f כוונון עוצמת כניסה אוטומטי הפחית לעוצמה ברמה"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -7722,6 +14239,11 @@ msgstr "בקרה"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "נ&גן"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -7839,6 +14361,11 @@ msgid "&Fit to Width"
 msgstr "&התאם לחלון"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&התאם לחלון"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&צמצם כל הרצועות"
 
@@ -7874,16 +14401,54 @@ msgstr "הקלט על (מופעל/מושבת)"
 msgid "&Show Clipping (on/off)"
 msgstr "הצג חיתוך"
 
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "&אפקטים"
+
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr " חלון "
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "סוף ההקלטה"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
 msgstr ":העדפות"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "עדכון Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -7902,6 +14467,10 @@ msgstr ":העדפות"
 msgid "Behaviors"
 msgstr "התנהגויות"
 
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Devices"
 msgstr "התקנים"
@@ -7916,11 +14485,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "ממשק"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "משתמש ב:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "ניגון"
 
@@ -7936,7 +14511,13 @@ msgstr "התקן"
 msgid "Cha&nnels:"
 msgstr ":ערוצים"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Latency"
+msgstr "בעיית השעיה"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "מילישניות"
 
@@ -7949,6 +14530,16 @@ msgid "&Latency compensation:"
 msgstr "קומבינציית מפתחות"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "הסר רצועות שמע "
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No devices found"
+msgstr "לא נמצאו התאמות"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "1 (מונו)"
 
@@ -7957,7 +14548,8 @@ msgid "2 (Stereo)"
 msgstr "2 (סטריאו)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "ספריות"
 
@@ -7970,8 +14562,22 @@ msgid "Default directories"
 msgstr "ספריות"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "...עיין"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -8022,8 +14628,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "בחר מיקום עבור ספריה זמנית"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "ב&חר פקודה"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -8040,8 +14655,14 @@ msgid "Directory %s is not writable"
 msgstr " אינה ברת כתיבה %s ספריה"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "שינויים לספרייה הזמנית לא יכנסו לתוקף עד שהתוכנה תאותחל"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "תקיה זמנית חדשה"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -8051,11 +14672,36 @@ msgstr ":העדפות"
 msgid "Sorted by Effect Name"
 msgstr "מיין לפי שם"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "מיין לפי שם"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "מיין לפי שם"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&אפקטים"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -8065,25 +14711,142 @@ msgstr "&אפקטים"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "&אפקטים"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "ערכי האפקטים"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "הגדרות התוספים"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Enable these Modules (if present), next time Audacity is started"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "אינטרפולציה"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "ייבא"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr ":העדפות"
 
 #: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
 msgid "File extensions"
 msgstr "סיומות קבצים"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "סוג רעש"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr ":ייצא תויות בתור"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "הזז ל&מעלה"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "הזז &למטה"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "הזז ל&מעלה"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "הזז &למטה"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "נמחקו איזורי בעלי תויות"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr ":יצא למיקום"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "בחר"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "למחוק את %s?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "מקליט שמע"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -8106,6 +14869,11 @@ msgstr "-36 dB (תחום רדוד עבור עריכת עוצמות גבוהות)
 #: src/prefs/GUIPrefs.cpp
 msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (PCM תחום דגימה של 8 סיביות)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (PCM תחום דגימה של 16 סיביות)"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
@@ -8144,12 +14912,80 @@ msgid "&Language:"
 msgstr ":שפה"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr ":מיקום"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "(dB) צורת הגל"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "\t-help (הודעה זו)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Re&tain labels if selection snaps to a label"
 msgstr "Re&tain labels if selection snaps to a label edge"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "הגדרות ציר הזמן"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "אפשר כלי מדידה"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "ייבא / ייצא"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr ":העדפות"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -8164,6 +15000,10 @@ msgid "S&tandard"
 msgstr "סטנדרטי"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
 msgstr "שניות"
 
@@ -8172,12 +15012,29 @@ msgid "&Beats"
 msgstr "חזור שוב"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "S&how Metadata Tags editor before export"
 msgstr "ה&צגת עורך תגיות מידע העל לפני הייצוא"
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr ":ייצא תויות בתור"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -8189,6 +15046,18 @@ msgid "Preferences for KeyConfig"
 msgstr ":העדפות"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "קישור מקשים"
 
@@ -8197,12 +15066,49 @@ msgid "View by:"
 msgstr "&תצוגה"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "שם"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&תצוגה"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&תצוגה"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&תצוגה"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
 msgstr "קישור מקשים"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&...אפשרויות"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -8217,7 +15123,15 @@ msgid "&Defaults"
 msgstr "&ערכי ברירת המחדל"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "...שמכיל את קיצורי המקשים עבור התוכנה XML בחר קובץ"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -8226,8 +15140,21 @@ msgstr ":ייצא קיצורי מקשים בתור"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "קיצורי מקשים %d נטענו\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -8241,6 +15168,38 @@ msgstr ":ייצא קיצורי מקשים בתור"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr ":ייצא קיצורי מקשים בתור"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "קומבינציית מפתחות"
@@ -8250,7 +15209,29 @@ msgid "Preferences for Library"
 msgstr ":העדפות"
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
+msgstr ":MP3 גרסת ספריית"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export Library"
+msgstr "ייבוא/ייצוא FFmpeg"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
 msgstr ":MP3 גרסת ספריית"
 
 #: src/prefs/LibraryPrefs.cpp
@@ -8265,19 +15246,57 @@ msgstr "אי&תור"
 msgid "Dow&nload"
 msgstr "הורד"
 
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
 msgstr "ספריות"
 
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "...מידע על התקן אודיו"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr ":העדפות"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "ממשק"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
 msgctxt "MIDI"
 msgid "Interface"
 msgstr "ממשק"
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "התדר המינימלי חייב להיות מספר שלם"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
 
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
@@ -8289,15 +15308,32 @@ msgid "Preferences for Module"
 msgstr ":העדפות"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "These are experimental. Enable them only if you've read the manual\n"
 "and know what you are doing."
 
+#. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "שינויים לספרייה הזמנית לא יכנסו לתוקף עד שהתוכנה תאותחל"
 
 #: src/prefs/ModulePrefs.cpp
@@ -8308,9 +15344,18 @@ msgstr "שאל"
 msgid "Failed"
 msgstr "Fallo"
 
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "No modules were found"
+msgstr "לא נמצאו התאמות"
+
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "מודולים"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -8352,7 +15397,10 @@ msgstr "גרירה-שמאלית"
 msgid "Set Selection Range"
 msgstr "קבע תחום הבחירה"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-קליק שמאלי"
 
@@ -8405,6 +15453,11 @@ msgid "same as left-drag"
 msgstr "כמו גרירה שמאלית"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Shift-גרירה-שמאלית"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Zoom out on a Range"
 msgstr "זום החוצה לתחום"
 
@@ -8425,8 +15478,26 @@ msgid "Shift-Left-Drag"
 msgstr "Shift-גרירה-שמאלית"
 
 #: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
 msgstr "גרירה-שמאלית"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip up/down between tracks"
+msgstr "הזז מקטע לרצועה אחרת"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "גרירה-שמאלית"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -8518,9 +15589,47 @@ msgstr "אורך "
 msgid "Cut Preview"
 msgstr "הצג גזירה"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Seek Time when playing"
+msgstr "&עדכן תצוגה בזמן השמעה"
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity העדפות של"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -8529,6 +15638,11 @@ msgstr ":העדפות"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr ":העדפות"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -8547,12 +15661,32 @@ msgid "Default Sample &Format:"
 msgstr ":ערך מחדל של פורמט הדגימה"
 
 #: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "המרת קצב דגימה"
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Con&verter:"
 msgstr ":ממיר קצב הדגימה"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr " באיכות גבוהה sync אינטרפולצית "
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "ממיר קצב הדגימה"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -8567,12 +15701,30 @@ msgid "Preferences for Recording"
 msgstr ":העדפות"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "השמעה באמצעות תוכנה (מופעל/מושבת)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "ערוץ חדש"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "הקלטה לפי השמעה (מופעל/מושבת)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -8583,9 +15735,19 @@ msgstr ":(dB) טרבל"
 msgid "Name newly recorded tracks"
 msgstr "Mixing and rendering tracks"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "רצועה מספר"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "ערוך תווית"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -8596,12 +15758,48 @@ msgid "&Track Number"
 msgstr "רצועה מספר"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr ".%f כוונון עוצמת כניסה אוטומטי הפחית לעוצמה ברמה"
+#, fuzzy
+msgid "System &Date"
+msgstr "מערכת"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr ".%f כוונון עוצמת כניסה אוטומטי הפחית לעוצמה ברמה"
+#, fuzzy
+msgid "System T&ime"
+msgstr "מערכת"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr ":העדפות"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "הערה לרצועה"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
 
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -8631,14 +15829,42 @@ msgstr "לינארי"
 msgid "Frequencies"
 msgstr "(Hz) תדר"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "(EAC) גובה צליל "
 
 #: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "0Hz התדר חייב להיות לפחות "
+
+#: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "0Hz התדר חייב להיות לפחות "
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "0Hz התדר חייב להיות לפחות "
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "0Hz התדר חייב להיות לפחות "
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -8670,6 +15896,24 @@ msgid "Ma&x Frequency (Hz):"
 msgstr ": (Hz) תדירות מינימלית"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "הגבר"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "(db) הגבר:"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
 msgstr "אלגוריתם:"
 
@@ -8690,6 +15934,10 @@ msgid "1024 - default"
 msgstr "256 - ערך מחדל"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - רוחב סרט הצר ביותר"
 
@@ -8698,15 +15946,39 @@ msgid "Window &type:"
 msgstr ":סוג חלון"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr ":מקדם דעיכה"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "מקטע נבחר"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "FFT Find Notes"
+msgstr "מצא תווים"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Minimum Amplitude (dB):"
 msgstr ":(dB) עוצמה מירבית"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Find Notes"
+msgstr "מצא תווים"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Quantize Notes"
 msgstr "מצא תווים"
 
 #: src/prefs/SpectrumPrefs.cpp
@@ -8725,6 +15997,36 @@ msgstr "התדר המירבי חייב להיות מספר שלם"
 msgid "The minimum frequency must be an integer"
 msgstr "התדר המינימלי חייב להיות מספר שלם"
 
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "התדר המירבי חייב להיות מספר שלם"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "התדר המירבי חייב להיות מספר שלם"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "התדר המירבי חייב להיות מספר שלם"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "התדר המינימלי חייב להיות מספר שלם"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "התדר המירבי חייב להיות מספר שלם"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "התדר המירבי חייב להיות מספר שלם"
+
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
 #. such as those on button controls.  Audacity can load and save alternative
@@ -8740,6 +16042,31 @@ msgstr ":העדפות"
 #: src/prefs/ThemePrefs.cpp
 msgid "Info"
 msgstr "אינפורמציה"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
 
 #: src/prefs/ThemePrefs.cpp
 msgid "Save Theme Cache"
@@ -8771,6 +16098,11 @@ msgid "Preferences for TracksBehaviors"
 msgstr "התנהגויות"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "דגימות"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
 msgstr "ריבוי"
 
@@ -8788,8 +16120,33 @@ msgid "Enable &dragging selection edges"
 msgstr "אפשר ג&רירה של השוליים הימני והשמאלי של הקטע הנבחר"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "תכונות ערבול מתקדמות"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "כפתור"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -8803,6 +16160,14 @@ msgstr "צורת הגל"
 msgid "Spectrogram"
 msgstr "ספקטוגרמה"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "&התאם לחלון"
@@ -8814,6 +16179,10 @@ msgstr "&הגדל את הבחירה"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "זום ברירת המחדל"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -8836,6 +16205,16 @@ msgid "50ths of Seconds"
 msgstr "שניות"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "שניות"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "שניות"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "מילישניות"
 
@@ -8843,7 +16222,12 @@ msgstr "מילישניות"
 msgid "Samples"
 msgstr "דגימות"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "(הגדל (זום"
 
@@ -8852,12 +16236,42 @@ msgid "Preferences for Tracks"
 msgstr ":העדפות"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "סוף ההקלטה"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "ברירת המחדל של צורת התצוגה"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr ":ערך מחדל של פורמט הדגימה"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "דגימות"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -8889,12 +16303,34 @@ msgid "Preferences for Warnings"
 msgstr ":העדפות"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Saving &projects"
 msgstr "שומר פרוייקטים"
 
 #: src/prefs/WarningsPrefs.cpp
 msgid "Saving &empty project"
 msgstr "שומר פרוייקט ריק"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr " מיישם &סטריאו למונו"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr " מיישם &סטריאו למונו"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -8917,16 +16353,24 @@ msgid "Stopped"
 msgstr "עצור"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "הפסקה"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "דלג להתחלה"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "דלג לסוף"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "הפסקה"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "בחירה מההתחלה"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "בחירה עד הסוף"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -8940,20 +16384,24 @@ msgstr "ערוץ חדש"
 msgid "Append Record"
 msgstr "הקלטה"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "בחירה עד הסוף"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "בחירה מההתחלה"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "הפסקה"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "סרגל כלי תעתיק"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -8964,6 +16412,11 @@ msgstr "קצב ניגון"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "בחר התקן כניסה"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr ":מיקום השמע"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -8984,6 +16437,11 @@ msgstr "בחר התקן כניסה"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Select Playback Device"
 msgstr "בחר התקן כניסה"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "אורך השקט:"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
@@ -9015,11 +16473,22 @@ msgstr "קצוץ מחוץ לבחירה"
 msgid "Silence audio selection"
 msgstr "מקטע שקט"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "&רצועות"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "זום פנימה"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "זום החוצה"
 
@@ -9030,6 +16499,11 @@ msgstr "התאם מקטע לחון"
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "התאם פרויקט לחלון"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "&אפקטים"
 
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
@@ -9047,6 +16521,14 @@ msgstr "מד הקלטה"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "מד ניגון"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "הקלטה"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
 #. This is the name used in screen reader software, where having 'Meter' first
@@ -9075,46 +16557,24 @@ msgstr "מד הקלטה"
 msgid "&Playback Meter Toolbar"
 msgstr "מד ניגון"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "סוף ההקלטה"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "ניגון"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "אפשר כלי מדידה"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "סוף ההקלטה"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "עוצמת כניסה (לא זמין, השתמש במערבל המערכת)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "ניגון"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "ניגון"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "עוצמת כניסה (לא זמין, השתמש במערבל המערכת)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "סרגל כלי הערבוב"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "...Nyquist פקודת"
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "...Nyquist פקודת"
@@ -9122,6 +16582,7 @@ msgstr "...Nyquist פקודת"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "...Nyquist פקודת"
@@ -9129,9 +16590,24 @@ msgstr "...Nyquist פקודת"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "(minitor) התחל ניטור"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "(minitor) התחל ניטור"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "בטל כלי מדידה"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -9167,6 +16643,10 @@ msgstr " קבע (או הרחב) גבול בחירה שמאלית"
 msgid "Length and Center of Selection"
 msgstr "קצוץ קובץ עד לבחירה"
 
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Snap To"
 msgstr "היצמד ל"
@@ -9175,7 +16655,9 @@ msgstr "היצמד ל"
 msgid "Length"
 msgstr "אורך "
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "מרכז"
 
@@ -9183,6 +16665,14 @@ msgstr "מרכז"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "%s התאם פעימות/בחירות ל "
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -9209,6 +16699,10 @@ msgstr "תדרי הגברת הבס"
 msgid "Center Frequency"
 msgstr "תדירות לינארית"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -9227,13 +16721,18 @@ msgstr "סרגל כלי ההתקן"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %s סרגל כלים"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr ".בחר וגרור בכדי לשנות את גודל הרצועה"
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "כלי"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -9251,7 +16750,8 @@ msgstr "כלי הזזת הזמן"
 msgid "Zoom Tool"
 msgstr "כלי הזום"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "כלי הציור"
 
@@ -9327,11 +16827,13 @@ msgstr "גרור תוית גבולות אחת או יותר"
 msgid "Drag label boundary."
 msgstr "גרור תוית גבולות"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "תווית ששונתה"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "ערוך תווית"
 
@@ -9351,6 +16853,12 @@ msgstr "גופן תוית הרצועה"
 #. i18n-hint: (noun) The name of the typeface
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Face name"
+msgstr "ש&נה שם"
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
 msgstr "ש&נה שם"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -9381,31 +16889,42 @@ msgstr "ערוך תווית"
 msgid "New label"
 msgstr "תווית הוספה"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "אוקטבה גבוהה יותר"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "אוקטבה נמוכה יותר"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "...להקטנה, גרור לקביעת גודל ההגדלה Shift בחר להגדלה אנכית, הוסף "
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "לחיצה ימנית תפתח תפריט."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "זום החוצה"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-קליק שמאלי"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-קליק שמאלי"
 
@@ -9428,6 +16947,14 @@ msgid "Stretch"
 msgstr ":מקדם דעיכה"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "אחד מקטעים"
 
@@ -9439,7 +16966,8 @@ msgstr "איחוד"
 msgid "Expanded Cut Line"
 msgstr "הסר שורה שנגזרה"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "רווח"
 
@@ -9452,12 +16980,21 @@ msgid "Click and drag to edit the samples"
 msgstr "בחר וגרור בכדי לערוך את הדגימות"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "דגימה שהועברה"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "עריכת דגימה"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -9466,6 +17003,16 @@ msgstr "זום פנימה לנקודה"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "ספקטוגרמה"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -9491,7 +17038,8 @@ msgstr "...מעבד"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' הרץ את  %s שונה ל "
@@ -9503,6 +17051,54 @@ msgstr "שנה פורמט"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "קבע קצב"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -9522,7 +17118,8 @@ msgstr "שינוי קצב"
 msgid "Set Rate"
 msgstr "קבע קצב"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "ריבוי"
 
@@ -9557,6 +17154,12 @@ msgstr "ערוץ ימני"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Channel"
 msgstr "ערוץ"
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Made '%s' a stereo track"
+msgstr "ייצר רצועת סטריאו"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Make Stereo"
@@ -9608,6 +17211,27 @@ msgstr ",שמאל"
 msgid "Right, %dHz"
 msgstr ",ימינה"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "ימינה"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr ".בחר וגרור בכדי לכוון גודל יחסי של רצועות סטריאו"
@@ -9615,6 +17239,15 @@ msgstr ".בחר וגרור בכדי לכוון גודל יחסי של רצועו
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "בחר וגרור בכדי להזיז את הרצועה בזמן"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "בחר וגרור בכדי להזיז את הרצועה בזמן"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -9624,6 +17257,10 @@ msgstr "זום פנימה"
 msgid "Zoom x2"
 msgstr "(הגדל (זום"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "צורת הגל"
@@ -9631,6 +17268,11 @@ msgstr "צורת הגל"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "צורת הגל"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -9704,9 +17346,8 @@ msgstr "מהירה Sinc אינטרפולציית"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "בחר וגרור בכדי להזיז את הרצועה בזמן"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -9757,6 +17398,21 @@ msgstr "מעטת מתואמת."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "סרגל כלי העריכה"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "(minitor) התחל ניטור"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "אפשר כלי מדידה"
@@ -9772,6 +17428,16 @@ msgstr "סגור רצועה ממוקדת"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "הזז רצועה למטה"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "...Nyquist פקודת"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "דלג להתחלה"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -9824,6 +17490,11 @@ msgstr "בחר וגרור בכדי לבחור שמע"
 msgid "Click and drag to select audio"
 msgstr "בחר וגרור בכדי לבחור שמע"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "בחר וגרור בכדי להזיז את הרצועה בזמן"
@@ -9851,6 +17522,10 @@ msgstr ""
 "%.2f בנקודה "
 
 #: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
+
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
 msgstr "פקודה"
 
@@ -9875,6 +17550,12 @@ msgstr "פקודה"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl-קליק שמאלי"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "רצועת שמע חדשה נוצרה"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -9905,6 +17586,10 @@ msgstr "בכדי להקטין Shift בחר בכדי להגדיל והוסף "
 msgid "Drag to Zoom Into Region, Right-Click to Zoom Out"
 msgstr "בכדי להקטין Shift גרור כדי להגדיל ולחיצת עכבר עם"
 
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Left=Zoom In, Right=Zoom Out, Middle=Normal"
+msgstr ""
+
 #: src/widgets/AButton.cpp
 msgid "(disabled)"
 msgstr "חסום"
@@ -9916,6 +17601,24 @@ msgstr "לחץ"
 #: src/widgets/AButton.cpp
 msgid "Button"
 msgstr "כפתור"
+
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
@@ -9934,13 +17637,45 @@ msgstr "סוג רעש"
 msgid "&Clear"
 msgstr "&נקה"
 
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
 #: src/widgets/Grid.cpp
 msgid "Empty"
 msgstr "ריק"
 
 #: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "דלג להתחלה"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "עזרה באינטרנט"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "כל הקבצים (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -9979,6 +17714,13 @@ msgid "Refresh Rate"
 msgstr "קבע קצב"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "[1-100] מד קצב העדכון לשניה :"
 
@@ -9991,12 +17733,21 @@ msgid "Meter Style"
 msgstr "מד"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "מד"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "משך זמן"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "התאוששות שגיאה אוטומטית "
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -10010,18 +17761,143 @@ msgstr "סרגל אנכי"
 msgid " Monitoring "
 msgstr "(minitor) הפסק ניטור"
 
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "רצועת שמע חדשה נוצרה"
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr " דגימות + שנ:דק:שע"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "099 días 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 days 024 h 060 m 060 s"
+msgstr "099 días 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr " דגימות + שנ:דק:שע"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "099 días 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + milliseconds"
+msgstr " דגימות + שנ:דק:שע"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "099 días 024 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + samples"
 msgstr " דגימות + שנ:דק:שע"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+># samples"
+msgstr ""
+
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "דגימות"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
 
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at 24 frames per second (commonly used for films)
@@ -10029,11 +17905,175 @@ msgstr "דגימות"
 msgid "hh:mm:ss + film frames (24 fps)"
 msgstr " תמונות סרט (24 בשניה) + שנ:דק:שע"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr ""
+
 #. i18n-hint: Name of time display format that shows time in frames (lots of
 #. * frames) at 24 frames per second (commonly used for films)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "film frames (24 fps)"
 msgstr "(תמונות סרט (24 בשניה"
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr " דגימות + שנ:דק:שע"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr " דגימות + שנ:דק:שע"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr " תמונות סרט (24 בשניה) + שנ:דק:שע"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at PAL
+#. * TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "PAL frames (25 fps)"
+msgstr "(תמונות סרט (24 בשניה"
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr " תמונות סרט (24 בשניה) + שנ:דק:שע"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "CDDA frames (75 fps)"
+msgstr "(תמונות סרט (24 בשניה"
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -10041,9 +18081,69 @@ msgstr "(תמונות סרט (24 בשניה"
 msgid "octaves"
 msgstr "אוקטבה נמוכה יותר"
 
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "השתמש בכפתור עכבר ימני או במקש ההקשר בכדי לשנות פורמט"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "שניות"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -10087,6 +18187,11 @@ msgstr "אשר"
 msgid "Unable to write files to directory: %s."
 msgstr "לא ניתן לפתוח את קובץ המיזם"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -10104,14 +18209,44 @@ msgstr ":העדפות"
 msgid "Don't show this warning again"
 msgstr "אל תראה אזהרה זו שוב"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
 #: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "ריק"
 
 #: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "הקלטה"
+
+#: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "זום פנימה לתחום"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "LOF שגיאת"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -10129,12 +18264,26 @@ msgid "Value must not be greater than %s"
 msgstr ".התחלה וסיום חייבים להיות גדולים מ-0"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "נא לבחור תיקייה"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
 msgstr "ספריות"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "מצא דיאלוג"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "שגיאה: %s"
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
@@ -10149,16 +18298,49 @@ msgstr ":לא יכול לפתוח קובץ"
 msgid "Spectral edit multi tool"
 msgstr "מקטע נבחר"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "אורך "
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "(Hz) תדר"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "שגיאה"
@@ -10173,8 +18355,34 @@ msgstr "הגבר"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "0Hz התדר חייב להיות לפחות "
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -10188,9 +18396,27 @@ msgstr "Fade Out - יציאה"
 msgid "Applying Fade..."
 msgstr "ההדרגה חלה..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Steve Daulton ע\"י"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -10217,8 +18443,16 @@ msgid "S-Curve Down"
 msgstr "הזז &למטה"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "התחלה"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -10227,6 +18461,14 @@ msgstr "הגבר"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "התחלה"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -10239,6 +18481,14 @@ msgstr "לינארי"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "לינארי"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -10277,6 +18527,24 @@ msgstr "הזז &למטה"
 msgid "Error~%~%"
 msgstr "שגיאה"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "חזור שוב"
@@ -10284,6 +18552,10 @@ msgstr "חזור שוב"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "...מצא חיתוכים"
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -10297,6 +18569,23 @@ msgstr "חיתוך"
 msgid "Reconstructing clips..."
 msgstr "...מסיר קליקים ופופים"
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "רמת סף: %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "הערה לרצועה"
@@ -10304,6 +18593,21 @@ msgstr "הערה לרצועה"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "הערה לרצועה"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -10337,6 +18641,19 @@ msgstr "רצועה מספר"
 msgid "Fade direction"
 msgstr "מקטע נבחר"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "סוג מקש"
@@ -10354,6 +18671,19 @@ msgid "Regular"
 msgstr "Rectangular"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr ":(dB) הנמכת רעש"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr ":(זמן השהייה (בשניות"
 
@@ -10366,12 +18696,24 @@ msgid "Pitch/Tempo"
 msgstr "(EAC) גובה צליל "
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
 msgstr "&הצג קודם"
 
 #: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr ":מספר פעמים לחזרה"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -10386,18 +18728,40 @@ msgid "XML file"
 msgstr "MP3 קבצי"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "הקלטה"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr ".לא יכול לפתןח קובץ סגנון"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "%s :(שגיאה (ייתכן והקובץ לא נשמר"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "%s :(שגיאה (ייתכן והקובץ לא נשמר"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -10428,18 +18792,67 @@ msgstr "(אורך (שניות"
 msgid "Length of label region (seconds)"
 msgstr "(אורך (שניות"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "ערוך תווית"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "קומבינציית מפתחות"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "אזהרות"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -10449,6 +18862,17 @@ msgstr "אחד תוויות"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "אחד תוויות"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -10462,13 +18886,46 @@ msgstr "Equalization - מבצע יישור "
 msgid "Dominic Mazzoni"
 msgstr "Dominic Mazzoni הסרת רעש ע\"י"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "(Hz) תדר"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "0Hz התדר חייב להיות לפחות "
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -10492,6 +18949,11 @@ msgid "Average level"
 msgstr "מיצוע"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "קצב ניגון"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "אורך השקט המירבי:"
 
@@ -10504,14 +18966,65 @@ msgid "Label type"
 msgstr "ערוך תווית"
 
 #: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Point after sound"
+msgstr "לא נמצאו התאמות"
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "...חתוך שקט"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "...חתוך שקט"
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "השם לא יכול להשאר ריק"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -10539,8 +19052,25 @@ msgid "Hard Clip"
 msgstr "מצא מקטע"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "ערוץ ימני"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr ":(dB) טרבל"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -10563,11 +19093,24 @@ msgid "Select Function"
 msgstr "מקטע נבחר"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Stereo Linking"
 msgstr "סטריאו"
 
 #: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
+msgstr "ייצר רצועת סטריאו"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
 msgstr "ייצר רצועת סטריאו"
 
 #: plug-ins/noisegate.ny
@@ -10590,6 +19133,44 @@ msgstr ":(זמן מתקף/דעיכה (בשניות"
 msgid "Decay (ms)"
 msgstr ":(זמן מתקף/דעיכה (בשניות"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "השם לא יכול להשאר ריק"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "מיישם התאמת עוצמות"
@@ -10601,6 +19182,18 @@ msgstr "מיישם התאמת עוצמות"
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Steve Daulton ע\"י"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -10623,7 +19216,8 @@ msgstr "MP3 קבצי"
 msgid "HTML file"
 msgstr "MP3 קבצי"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr ":תן לבצים שמות לפי:"
 
@@ -10640,9 +19234,24 @@ msgid "Disallow"
 msgstr "מושבת"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "מושבת"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr ".'%s' לא ניתן למחוק את"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -10653,16 +19262,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "...MIDI בחר קובץ"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr ":יצא למיקום"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "...MIDI בחר קובץ"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "מייצר טון"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "סוג רעש"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -10677,8 +19328,40 @@ msgid "Generating Rhythm..."
 msgstr "מייצר ציוץ"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr ":מספר פעמים לחזרה"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -10701,12 +19384,54 @@ msgid "Beat sound"
 msgstr "חזור שוב"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "מסיר רעש"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "...רעש"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -10729,6 +19454,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "תדירות לינארית"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "(Hz) תדר"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "(עוצמה (0-1"
 
@@ -10739,6 +19473,10 @@ msgstr "לא מסוגל לייצא"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "...מיישם"
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -10757,6 +19495,10 @@ msgid "HTML files"
 msgstr "MP3 קבצי"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "עריכת דגימה"
 
@@ -10769,8 +19511,29 @@ msgid "Include header information"
 msgstr "מידע על בניית התוכנה"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "הכול"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -10785,6 +19548,11 @@ msgstr "\t-help (הודעה זו)"
 msgid "Errors Only"
 msgstr ":שגיאה"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -10797,6 +19565,46 @@ msgstr "ערוץ ימני"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "דגימות"
 
@@ -10804,6 +19612,43 @@ msgstr "דגימות"
 #, lisp-format
 msgid "~a seconds."
 msgstr "שניות"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -10822,6 +19667,10 @@ msgid "Value (dB)"
 msgstr ":(dB) טרבל"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "לינארי"
 
@@ -10838,6 +19687,14 @@ msgid "Right (dB)"
 msgstr ",ימינה"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "לינארי"
 
@@ -10848,6 +19705,40 @@ msgstr "2 ערוצים (סטריאו)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "ערוץ 1 (מונו)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "%s :(שגיאה (ייתכן והקובץ לא נשמר"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -10862,8 +19753,40 @@ msgid "Select file"
 msgstr "...MIDI בחר קובץ"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "שגיאה"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -10873,6 +19796,15 @@ msgstr ".לא יכול לפתןח קובץ סגנון"
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "מקטע נבחר"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -10890,9 +19822,21 @@ msgstr "שן מסור"
 msgid "Starting phase (degrees)"
 msgstr ":(deg.) LFO פאזת התחלה של"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "הפעולה חלה..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -10934,9 +19878,96 @@ msgstr "&נתח"
 msgid "Strength"
 msgstr "אורך "
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "...מעבד"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -10970,6 +20001,167 @@ msgstr "(Hz) תדר"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "(Hz) תדר"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "עדכון Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&התקנת העדכון"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "יומן שינויים"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "למידע נוסף ב־GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "שגיאה בבדיקה אם יש עדכונים"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "אין אפשרות להתחבר לשרת העדכונים של Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "נתוני העדכון היו פגומים."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "שגיאה בהורדת העדכון."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "לא ניתן לפתוח את קישור ההורדה של Tenacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "זמינה גרסה %s של Tenacity!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "הקלטה"
+
+#~ msgid "Commit Id:"
+#~ msgstr ":פקודה"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr ".כוונון עוצמת כניסה אוטומטית הופסקה. לא ניתן למטב יותר. עדיין הרמה גבוהה מדי"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "כוונון עוצמת כניסה אוטומטי הופסקה. לא ניתן למטב יותר. הרמה עדיין נמוכה מדי."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr ".%.2f כוונון עוצמת כניסה אוטומטית הגביר את העוצמה לרמה"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "כוונון עוצמת כניסה אוטומטית הופסקה. חרג ממספר הנסיונות ולא התקבל רמת שמע תקינה. הרמה עדיין גבוהה מדי."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "כוונון עוצמת כניסה אוטומטית הופסקה. חרג ממספר הנסיונות ולא התקבל רמת שמע תקינה. הרמה עדיין נמוכה מדי."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "היא רמת שמע תקינה %.2f כוונון עוצמת כניסה אוטומטית הופסקה. כנראה."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr ".לא יכול לפתןח קובץ סגנון\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "מקליט\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "ניגון\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "סוף ההקלטה\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "סוף ההקלטה\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "ניגון\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "ניגון\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr ".'%s' ל- '%s' -לא מצליח לשנות שם מ"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr ".לא ניתן לפתוח או ליצור קובץ נסיון"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "ניגון"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "ניגון"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "ניגון"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "סוף ההקלטה"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "סוף ההקלטה"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "סוף ההקלטה"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "על &אודות Tenacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr ".%f כוונון עוצמת כניסה אוטומטי הפחית לעוצמה ברמה"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr ".%f כוונון עוצמת כניסה אוטומטי הפחית לעוצמה ברמה"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr ".%f כוונון עוצמת כניסה אוטומטי הפחית לעוצמה ברמה"
+
+#~ msgid "Recording Volume"
+#~ msgstr "סוף ההקלטה"
+
+#~ msgid "Playback Volume"
+#~ msgstr "ניגון"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "סוף ההקלטה"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "עוצמת כניסה (לא זמין, השתמש במערבל המערכת)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "ניגון"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "ניגון"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "עוצמת כניסה (לא זמין, השתמש במערבל המערכת)"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "בחר וגרור בכדי להזיז את הרצועה בזמן"
+
 #~ msgid "Program build date:"
 #~ msgstr ":תאריך הפצת תוכנה"
 
@@ -10996,12 +20188,6 @@ msgstr "(Hz) תדר"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "ת"
-
-#~ msgid "Unknown error"
-#~ msgstr "שגיאה לא ידועה"
-
-#~ msgid "Failed to send crash report"
-#~ msgstr "שליחת דו״ח התקלה נכשלה"
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -11069,10 +20255,6 @@ msgstr "(Hz) תדר"
 #~ msgstr ".'%s' לא ניתן למחוק את"
 
 #, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "...בחר קובץ לא דחוס כלשהו"
-
-#, fuzzy
 #~ msgid ""
 #~ "One or more external audio files could not be found.\n"
 #~ "It is possible they were moved, deleted, or the drive they were on was unmounted.\n"
@@ -11092,10 +20274,6 @@ msgstr "(Hz) תדר"
 
 #~ msgid "Files Missing"
 #~ msgstr "קבצים חסרים"
-
-#, fuzzy
-#~ msgid "decode an autosave file"
-#~ msgstr "Could not remove old auto save file"
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -11178,9 +20356,6 @@ msgstr "(Hz) תדר"
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "מנקה קבצים זמניים"
 
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "מנקה תוכן תיקיית המטמון"
-
 #~ msgid "%s-old%d"
 #~ msgstr "%s-בן%d"
 
@@ -11214,10 +20389,6 @@ msgstr "(Hz) תדר"
 #, fuzzy
 #~ msgid "%sSave Compressed Copy of Project \"%s\" As..."
 #~ msgstr "...שמור העתק דחוס מהפרוייקט"
-
-#, fuzzy
-#~ msgid "Compress"
-#~ msgstr "...דוחס"
 
 #, fuzzy
 #~ msgid ""
@@ -11355,10 +20526,6 @@ msgstr "(Hz) תדר"
 #~ msgstr "&עדכן תצוגה בזמן השמעה"
 
 #, fuzzy
-#~ msgid "Disable Scrub Ruler"
-#~ msgstr "בטל כלי מדידה"
-
-#, fuzzy
 #~ msgid "Enable Scrub Ruler"
 #~ msgstr "אפשר כלי מדידה"
 
@@ -11381,9 +20548,6 @@ msgstr "(Hz) תדר"
 #, fuzzy
 #~ msgid "Selected:"
 #~ msgstr "בחר"
-
-#~ msgid "ms"
-#~ msgstr "מילישניות"
 
 #, fuzzy
 #~ msgid "XML files (*.xml)|*.xml|All files|*"
@@ -11464,20 +20628,8 @@ msgstr "(Hz) תדר"
 #~ msgstr "שקר"
 
 #, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "קובץ אודיו"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "...Nyquist מיישם אפקט"
-
-#, fuzzy
 #~ msgid "Save Device Info"
 #~ msgstr "...מידע על התקן אודיו"
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "לא מסוגל להחליט"
 
 #, fuzzy
 #~ msgid "Save MIDI Device Info"
@@ -11550,10 +20702,6 @@ msgstr "(Hz) תדר"
 #~ msgstr "...ערוך שר&שור פקודות"
 
 #, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "סרגל כלי תעתיק"
-
-#, fuzzy
 #~ msgid "&Tools"
 #~ msgstr "כלים"
 
@@ -11619,10 +20767,6 @@ msgstr "(Hz) תדר"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "תעתיק"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "סרגל כלי העריכה"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -11693,10 +20837,6 @@ msgstr "(Hz) תדר"
 #~ msgstr "אורך "
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "בחירה עד הסוף"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "לסוף הקטע הנבחר"
 
@@ -11755,10 +20895,6 @@ msgstr "(Hz) תדר"
 #~ msgstr "אחוז שינוי:"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "זמן מתקף:"
-
-#, fuzzy
 #~ msgid "ReleaseTime"
 #~ msgstr "הפצת שחרור"
 
@@ -11775,16 +20911,8 @@ msgstr "(Hz) תדר"
 #~ msgstr ":זמן מחזור"
 
 #, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "(עוצמה (0-1"
-
-#, fuzzy
 #~ msgid "Decay"
 #~ msgstr ":זמן ניוון"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "שם"
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -11824,20 +20952,12 @@ msgstr "(Hz) תדר"
 #~ msgstr "(Hz) תדר"
 
 #, fuzzy
-#~ msgid "Phase"
-#~ msgstr "Phaser"
-
-#, fuzzy
 #~ msgid "Depth"
 #~ msgstr "עומק:"
 
 #, fuzzy
 #~ msgid "Feedback"
 #~ msgstr ":(%) משוב"
-
-#, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "גודל"
 
 #, fuzzy
 #~ msgid "Reverberance"
@@ -11854,14 +20974,6 @@ msgstr "(Hz) תדר"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "הגבר"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "סטריאו"
-
-#, fuzzy
-#~ msgid "FilterType"
-#~ msgstr "מד"
 
 #, fuzzy
 #~ msgid "FilterSubtype"
@@ -11898,10 +21010,6 @@ msgstr "(Hz) תדר"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "חתוך שקט"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "הופך"
 
 #~ msgid "Size"
 #~ msgstr "גודל"
@@ -11948,9 +21056,6 @@ msgstr "(Hz) תדר"
 #, fuzzy
 #~ msgid "You must select audio in the project window."
 #~ msgstr ".ראשית צריך לבחור ברצועה "
-
-#~ msgid "&Length of preview:"
-#~ msgstr ":אורך תצוגה מקדימה"
 
 #, fuzzy
 #~ msgid "Add &Track Number"
@@ -12030,10 +21135,6 @@ msgstr "(Hz) תדר"
 #~ msgstr "ערוץ ימני"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "(db) הגבר:"
-
-#, fuzzy
 #~ msgid "&Enable level control"
 #~ msgstr "אפשר כלי מדידה"
 
@@ -12098,12 +21199,6 @@ msgstr "(Hz) תדר"
 
 #, fuzzy
 #~ msgid "Go to parent directory"
-#~ msgstr ""
-#~ "לא יכול לייצר ספריה:\n"
-#~ "  %s"
-
-#, fuzzy
-#~ msgid "Current directory:"
 #~ msgstr ""
 #~ "לא יכול לייצר ספריה:\n"
 #~ "  %s"
@@ -12211,9 +21306,6 @@ msgstr "(Hz) תדר"
 #~ msgid "&Audio Track"
 #~ msgstr "&רצועת שמע"
 
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr " באיכות גבוהה sync אינטרפולצית "
-
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "מהירה Sinc אינטרפולציית"
 
@@ -12301,9 +21393,6 @@ msgstr "(Hz) תדר"
 #~ msgid "Equalization..."
 #~ msgstr "...השוואה"
 
-#~ msgid "Performing Equalization"
-#~ msgstr "Equalization - מבצע יישור "
-
 #~ msgid "Fading In"
 #~ msgstr "Fading In - נכנס"
 
@@ -12366,24 +21455,12 @@ msgstr "(Hz) תדר"
 #~ msgstr "ש&נה שם"
 
 #, fuzzy
-#~ msgid "Load preset:"
-#~ msgstr "טען קבצים"
-
-#, fuzzy
 #~ msgid "Change name to:"
 #~ msgstr ":שנה שם רצועה ל"
 
 #, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "היפוך מהתחלה"
-
-#, fuzzy
 #~ msgid "Applying Reverb"
 #~ msgstr "מיישם התאמת עוצמות"
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "&...טען קובץ"
 
 #~ msgid "Silence..."
 #~ msgstr "...שקט"
@@ -12486,10 +21563,6 @@ msgstr "(Hz) תדר"
 
 #, fuzzy
 #~ msgid "Adjust output gain"
-#~ msgstr "Adjusted gain"
-
-#, fuzzy
-#~ msgid "Adjust input gain"
 #~ msgstr "Adjusted gain"
 
 #, fuzzy
@@ -12646,9 +21719,6 @@ msgstr "(Hz) תדר"
 #~ msgid "Threshold for silence:"
 #~ msgstr "רמת סף לשקט:"
 
-#~ msgid "Musical Instrumnet"
-#~ msgstr "כלי מוזיקלי"
-
 #~ msgid "Dynamic Transient Sharpening"
 #~ msgstr "חידוד העברה דינמית"
 
@@ -12736,15 +21806,3 @@ msgstr "(Hz) תדר"
 
 #~ msgid "This is a Beta version of the program. It may contain bugs and unfinished features. We depend on your feedback: please send bug reports and feature requests to our <a href=\"mailto:feedback@audacityteam.org\">Feedback</a> address. For help, use the Help menu in the program, view the tips and tricks on our <a href=\"http://wiki.audacityteam.org/\">Wiki</a> or visit our <a href=\"http://forum.audacityteam.org/\">Forum</a>."
 #~ msgstr "תוכנה זו היא גירסת פיתוח. ועלול להכיל שגיאות ותכונות שלא הושלמו. אנו זקוקים למשוב שלכם: נא שלח דיווחי קריסה ובקשת תכונות לכתובת שלנו <a href=\"mailto:feedback@audacityteam.org\">Feedback</a>. לעזרה, נא העזר בפתריט העזרה דרך התוכנה, עיין בעצות וטריקים בדף הויקי שלנו <a href=\"http://wiki.audacityteam.org/\">Wiki</a> או בקר בפורום שלנו <a href=\"http://forum.audacityteam.org/\">Forum</a>."
-
-#: src/AboutDialog.cpp
-msgid "Website and Graphics"
-msgstr "האתר והעיצוב הגרפי של Audacity"
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
-msgid "Error Saving Project"
-msgstr "שגיאה בשמירת המיזם"

--- a/locale/hi.po
+++ b/locale/hi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:14+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/tenacity/tenacity/hi/>\n"
@@ -22,72 +22,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Audacity अपडेट करें"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "छोड़ें (&S)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "अद्यतन स्थापित करें (&I)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "परिवर्तन लॉग"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "GitHub पर और पढ़ें"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "अद्यतन के लिए जाँच में त्रुटि"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Audacity अपडेट सर्वर से कनेक्ट करने में असमर्थ."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "अद्यतन डेटा दूषित था."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "अपडेट डाउनलोड करने में त्रुटि."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Audacity ऑडेसिटी डाउनलोड लिंक नहीं खोल सकता."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s उपलब्ध है!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "ध्वन्यांकन"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "पता लगाने में असमर्थ"
@@ -96,6 +30,24 @@ msgstr "पता लगाने में असमर्थ"
 #, c-format
 msgid "%s bytes"
 msgstr "%s बाइट्स"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -222,7 +174,8 @@ msgid "Script"
 msgstr "स्क्रिप्ट"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "आउटपुट"
 
@@ -238,7 +191,12 @@ msgstr "Nyquist स्क्रिप्ट्स (*.ny)|*.ny|Lisp स्क्�
 msgid "Script was not saved."
 msgstr "स्क्रिप्ट संचित नहीं हुआ."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "चेतावनी"
 
@@ -251,15 +209,25 @@ msgid "Find dialog"
 msgstr "संवाद खोजें"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "टैंगो आइकन गैलरी (औजारपट्टी आइकन्स)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "Leland Lucius रचित (C) 2009"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "Leland Lucius रचित (C) 2009"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "बाहरी Audacity मॉड्यूल जो प्रभाव लिखने के लिए एक सरल  IDE प्रदान करता है."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -282,7 +250,8 @@ msgstr "बेनाम"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist प्रभाव वर्कबेंच - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "नया"
 
@@ -322,7 +291,8 @@ msgstr "प्रतिलिपि बनाएं"
 msgid "Copy to clipboard"
 msgstr "प्रतिलिपि क्लिपबोर्ड में डालें"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "काटें"
 
@@ -330,7 +300,8 @@ msgstr "काटें"
 msgid "Cut to clipboard"
 msgstr "कतरन क्लिपबोर्ड में डालें"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "चिपकाएं"
 
@@ -355,7 +326,8 @@ msgstr "सब को चुनें"
 msgid "Select all text"
 msgstr "सब पाठ चुनें"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "पूर्ववत करें"
 
@@ -363,7 +335,8 @@ msgstr "पूर्ववत करें"
 msgid "Undo last change"
 msgstr "पिछला परिवर्तन पूर्ववत करें"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "दोहराएं"
 
@@ -420,7 +393,8 @@ msgid "Go to next S-expr"
 msgstr "अगले S-expr पर जाएं"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "आरंभ"
 
@@ -428,7 +402,8 @@ msgstr "आरंभ"
 msgid "Start script"
 msgstr "स्क्रिप्ट आरंभ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "रोकें"
 
@@ -443,7 +418,8 @@ msgid "About %s"
 msgstr "%s के बारे में"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "ठीक"
 
@@ -451,11 +427,13 @@ msgstr "ठीक"
 msgid "Build Information"
 msgstr "निर्माण जानकारी"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "सक्रिय"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "निष्क्रिय"
 
@@ -465,8 +443,9 @@ msgid "The Build"
 msgstr "निर्माण"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "कमिट आइडी :"
+#, fuzzy
+msgid "Version:"
+msgstr "संस्करण : %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -476,22 +455,28 @@ msgstr "निर्माण प्रकार:"
 msgid "Compiler:"
 msgstr "कम्पाइलर :"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "स्थापना उपसर्ग :"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "सेटिग्स फोल्डर :"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "सेटिग्स फोल्डर :"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "फ़ाईल प्रारुप समर्थन"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "क्रॉस-प्लेटफॉर्म GUI लाइब्रेरी"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -505,7 +490,6 @@ msgstr "नमूना दर परिवर्तन"
 msgid "MP3 Importing"
 msgstr "MP3 आयात जारी"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis आयात और निर्यात"
@@ -514,7 +498,6 @@ msgstr "Ogg Vorbis आयात और निर्यात"
 msgid "ID3 tag support"
 msgstr "ID3  टैग समर्थन"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC आयात और निर्यात"
@@ -532,14 +515,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg आयात / निर्यात"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "GStreamer से आयात करें"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "विशेषताएं"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "प्लग-इन समर्थन"
 
@@ -554,6 +529,10 @@ msgstr "पिच और टेम्पो परिवर्तन का स�
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "चरम पिच तथा टेम्पो में परिवर्तन का समर्थन"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "विशेषताएं"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -672,6 +651,10 @@ msgstr "%s, ग्राफिक्स"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (लागू कर रहे हैं %s, %s, %s, %s and %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -681,6 +664,10 @@ msgstr "%s खुले सोर्स वाला, क्रॉस-प्ल�
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "श्रेयसूची"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -731,6 +718,7 @@ msgstr "वेबसाइट तथा ग्राफ़िक्स"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -751,6 +739,22 @@ msgstr "विशेष आभार :"
 #, c-format
 msgid "%s website: "
 msgstr "%s वेबसाइट : "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "योगदानकर्ता"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -773,6 +777,7 @@ msgstr "समयरेखा"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "खोज आरंभ के लिए क्लिक करें या खीचें"
@@ -780,6 +785,7 @@ msgstr "खोज आरंभ के लिए क्लिक करें य
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "स्क्रब आरंभ के लिए क्लिक करें या खीचें"
@@ -787,6 +793,7 @@ msgstr "स्क्रब आरंभ के लिए क्लिक कर�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "स्क्रब के लिए क्लिक कर खीचें. खोज के लिए क्लिक कर खीचें."
@@ -794,6 +801,7 @@ msgstr "स्क्रब के लिए क्लिक कर खीचे�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "खोजने के लिए आगे बढ़ें"
@@ -801,6 +809,7 @@ msgstr "खोजने के लिए आगे बढ़ें"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "स्क्रब के लिए घुमाएं"
@@ -857,7 +866,17 @@ msgstr ""
 "परियोजना के परे क्षेत्र को ताला नहीं\n"
 "लगा सकते."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "त्रुटि"
 
@@ -881,7 +900,8 @@ msgstr ""
 "यह प्रश्न केवल एक बार 'स्थापना' के बाद पूछा जाएगा, जहां आप वरीयताएँ पहली बार संचित करते हैं."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Audacity वरीयताएं रीसेट करें"
 
 #: src/AudacityApp.cpp
@@ -896,7 +916,8 @@ msgstr ""
 "इसे हाल की फ़ाइलों की सूची से हटा दिया गया है."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite लाइब्रेरी आरंभ होने में विफल रही. Audacity आगे नहीं जा सकता."
 
 #: src/AudacityApp.cpp
@@ -922,7 +943,7 @@ msgstr "खोलें...(&O)"
 msgid "Open &Recent..."
 msgstr "खोलें हाल की फ़ाइलें (&R)..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "Audacity के बारे में...(&A)"
@@ -936,9 +957,10 @@ msgid "&File"
 msgstr "फ़ाइल(&F)"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity को अस्थायी फ़ाइलों को संचित करने के लिए सुरक्षित जगह नहीं मिली.\n"
@@ -946,20 +968,23 @@ msgstr ""
 "कृपया वरीयताएँ संवादपत्र में एक उचित निर्देशिका दर्ज करें."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity को अस्थायी फ़ाइलों को संचित करने के लिए जगह नहीं मिली.\n"
 "कृपया वरीयताएँ संवादपत्र में एक उचित निर्देशिका दर्ज करें."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity अभी बंद हो रहा है. कृपया नए अस्थायी निर्देशिका का उपयोग करने के लिए Audacity फिर से शुरु करें."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -967,15 +992,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity अस्थायी फाइल निर्देशिका को ताला-बंद नहीं कर पाया.\n"
 "हो सकता है कि यह निर्देशिका (फ़ोल्डर) Audacity की एक और प्रति द्वारा उपयोग में हो\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "आप अब भी Audacity शुरू करना चाहते हैं?"
 
 #: src/AudacityApp.cpp
@@ -983,19 +1010,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "अस्थायी निर्देशिका (फ़ोल्डर) को तालाबंद करने में त्रुटि"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "इस प्रणाली को पता चला है कि Audacity की एक और प्रति चल रही है.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "एक साथ कई परियोजनाओं को खोलने के लिए वर्तमान चलते हुए Audacity\n"
 "में नई या खोलें आदेश का प्रयोग करें.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity पहले से चल रहा है"
 
 #: src/AudacityApp.cpp
@@ -1011,7 +1041,8 @@ msgstr ""
 "तथा एक रिबूट की आवश्यकता हो सकती है."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity स्टार्टअप विफलता"
 
 #: src/AudacityApp.cpp
@@ -1051,8 +1082,9 @@ msgstr ""
 "तथा एक रिबूट की आवश्यकता हो सकती है."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1084,7 +1116,8 @@ msgstr "आत्म-निदान चलाएं"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Audacity संस्करण दिखाएं"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1094,9 +1127,10 @@ msgid "audio or project file name"
 msgstr "ऑडियो या परियोजना फ़ाइल का नाम"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1109,16 +1143,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity परियोजना फ़ाईलें"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "संदेश"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Audacity कॉन्फ़िगरेशन त्रुटि"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1128,7 +1164,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "निम्न कॉन्फ़िगरेशन फ़ाइल तक नहीं पहुँच सकते हैं :\n"
 "\n"
@@ -1140,12 +1176,15 @@ msgstr ""
 "\n"
 "यदि आप \"Audacity से निकलें\" चुनते हैं, तो आपकी परियोजना को बिना सहेजे स्थिति में छोड़ दिया जा सकता है, जिसे अगली बार खोलने पर पुनः प्राप्त किया जाएगा."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "सहायता"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Audacity छोड़ें"
 
 #: src/AudacityFileConfig.cpp
@@ -1153,7 +1192,8 @@ msgid "&Retry"
 msgstr "पुनः प्रयास करें(&R)"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity लॉग"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1165,9 +1205,14 @@ msgstr "संचित करें..."
 msgid "Cl&ear"
 msgstr "साफ़(&e)"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "बंद करें(&C)"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1216,7 +1261,8 @@ msgid "Error Initializing Midi"
 msgstr "Midi शुरू करने में त्रुटि"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity ऑडियो"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1231,37 +1277,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "स्मॄति से बाहर!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. इससे और अधिक सही नहीं किया जा सकता था. अभी भी बहुत ऊँचा है."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "स्वचालित इनपुट स्तर अनुकूलन ने वाल्यूम घटा कर %f कर दिया है."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. इसे और अधिक सही नहीं किया जा सकता था. अभी भी बहुत नीचे है."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "स्वचालित इनपुट स्तर अनुकूलन ने वाल्यूम बढ़ा कर %.2f कर दिया है."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. स्वीकार्य वाल्यूम मिले बिना ही विश्लेशण की कुल संख्या सीमा पार हो गई है. अभी भी बहुत ऊँचा है."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. स्वीकार्य वाल्यूम मिले बिना ही विश्लेशण की कुल संख्या सीमा पार हो गई है. अभी भी बहुत नीचे है."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. %.2f एक स्वीकार्य वाल्यूम लगता है."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1360,43 +1375,6 @@ msgstr "कोई प्लेबैक यंत्र  '%s' के लिए �
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "बिना यंत्रो के उनके परस्पर नमूना दरों को परखा नहीं जा सकता.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "डिवाइसों को खोलने के दौरान %d प्राप्त किया\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "पोर्टमिक्सर को खोलने में अक्षम\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "उपलब्ध मिक्सर :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "उपलब्ध रिकॉर्डिंग स्रोत :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "उपलब्ध प्लेबैक वॉल्यूम :\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "रिकॉर्डिंग वॉल्यूम एम्यूलेटेड है\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "रिकॉर्डिंग वॉल्यूम नेटिव है\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "प्लेबैक वॉल्यूम एम्यूलेटेड है\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "प्लेबैक वॉल्यूम नेटिव है\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1439,8 +1417,9 @@ msgid "Automatic Crash Recovery"
 msgstr "दुर्घटना से स्वचालित बचाव"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1453,12 +1432,14 @@ msgid "Recoverable &projects"
 msgstr "पुनर्प्राप्त करने योग्य परियोजनाएं (&p)"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "चुनें"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "नाम"
 
@@ -1544,6 +1525,11 @@ msgstr "प्रभाव"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "मेनू आदेश (पैरामिटर्स के साथ)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1690,7 +1676,8 @@ msgstr "बहाल करें (&s)"
 msgid "I&mport..."
 msgstr "आयात (&m)करें..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "निर्यात (&x)..."
 
@@ -1731,7 +1718,8 @@ msgstr "ऊपर जाएं(&U)"
 msgid "Move &Down"
 msgstr "नीचे जाएं(&D)"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "संचित करें"
 
@@ -1814,9 +1802,17 @@ msgid "Run"
 msgstr "चलाएं"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "बंद करें"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "मान-दंड"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1954,11 +1950,6 @@ msgid "No revision identifier was provided"
 msgstr "कोई संशोधन पहचानकर्ता प्रदान नहीं किया गया था"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "समाप्ति तिथि और समय"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "डीबग निर्माण (डीबग स्तर%d)"
@@ -2042,6 +2033,11 @@ msgid ""
 msgstr ""
 "आप इसके उपयोग लिए पहले कुछ ऑडियो चुनें.\n"
 " (अन्य प्रकार के ट्रैक काम नहीं करेंगे.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2204,6 +2200,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "नामों की प्रतिलिपि क्लिपबोर्ड में डालें (&C)"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "लापता"
 
@@ -2212,10 +2213,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "यदि आप आगे बढ़ते हैं, तो आपकी परियोजना को डिस्क पर सहेजा नहीं जाएगा. क्या आप यही चाहते हैं?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2229,7 +2231,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "निर्भरता निरीक्षण"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "कुछ नहीं"
 
@@ -2237,7 +2242,7 @@ msgstr "कुछ नहीं"
 msgid "Rectangle"
 msgstr "आयत"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "त्रिभुज"
 
@@ -2248,6 +2253,37 @@ msgstr "तराशा"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "आयताकार"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "स्वागतम्!"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2269,9 +2305,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg समर्थन यहाँ समायोजित नहीं"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2293,8 +2330,8 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg ढूंढें"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "FFmpeg द्वारा ऑडियो आयात-निर्यात हेतु Audacity को  '%s' फ़ाइल की जरूरत है."
 
 #: src/FFmpeg.cpp
@@ -2307,7 +2344,8 @@ msgstr "'%s' का स्थान :"
 msgid "To find '%s', click here -->"
 msgstr "'%s' को ढूंढ़ने के लिए, यहाँ क्लिक करें -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "ब्राऊज़..."
 
@@ -2333,8 +2371,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg नहीं मिला"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2364,24 +2403,24 @@ msgid "Only libavformat.so"
 msgstr "केवल libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity %s में एक फ़ाइल खोलने में विफल रहा."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity %s में एक फ़ाइल से पढ़ने में असमर्थ रहा."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity ने सफलतापूर्वक एक फ़ाइल %s में लिखा, लेकिन इसका नामकरण %s करने में नाकाम रहा."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2419,7 +2458,9 @@ msgstr "कोई भी ध्वनि नकल न करें(&n)"
 msgid "As&k"
 msgstr "पूछिए(&k)"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "सभी फ़ाइलें"
 
@@ -2444,6 +2485,10 @@ msgstr "टेक्स्ट फ़ाईलें"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML फ़ाइलें"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2485,6 +2530,14 @@ msgstr "घनमूल ऑटोकोरीलेशन"
 msgid "Enhanced Autocorrelation"
 msgstr "अन्यतम ऑटोकोरीलेशन"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "वर्णक्रम"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2501,6 +2554,18 @@ msgstr "रेखीय आवृति"
 msgid "Log frequency"
 msgstr "Log आवृति"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "नि"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "स्क्रौल"
@@ -2508,6 +2573,15 @@ msgstr "स्क्रौल"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "बड़ा करें"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2568,6 +2642,23 @@ msgstr "बहुत सारा ऑडियो चुना गया है.
 msgid "Not enough data selected."
 msgstr "समुचित डाटा नहीं चुना गया."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f सेकेंड (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f सेकेंड (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2583,10 +2674,16 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f सेकेंड (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "वर्णक्रम"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Spectral डेटा निर्यात इस तरह:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "फ़ाइल में लिख नहीं सका: %s"
@@ -2776,19 +2873,19 @@ msgid "&History..."
 msgstr "इतिहास..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s में %s की %d पंक्ति पर अंदरुनी त्रुटि.\n"
 "Audacity टीम को कृपया https://forum.audacityteam.org/ पर सूचित करें."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s की %d पंक्ति पर अंदरुनी त्रुटि.\n"
 "Audacity टीम को कृपया https://forum.audacityteam.org/ पर सूचित करें."
@@ -2807,7 +2904,9 @@ msgid "Track"
 msgstr "ट्रैक"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "नाम-पट्टी"
 
@@ -2867,7 +2966,8 @@ msgstr "ट्रैक का नाम बताएं"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "नाम ट्रैक"
 
@@ -2878,11 +2978,13 @@ msgstr "एक या अधिक संचित लेबल पढ़ा न
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity की पहली चाल"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Audacity के उपयोग की भाषा चुनें:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2892,7 +2994,8 @@ msgstr "Audacity के उपयोग की भाषा चुनें:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "आपकी चुनी गई भाषा, %s (%s), इस कंप्युटर प्रणाली की भाषा, %s (%s), नहीं है."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "संपुष्टी दें"
 
@@ -2910,12 +3013,13 @@ msgstr ""
 "पुरानी फाइल '%s' के रूप में सहेजी गई"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity परियोजना खोलते हैं"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity काराओके%s"
 
 #: src/LyricsWindow.cpp
@@ -2964,19 +3068,23 @@ msgid "Mixing and rendering tracks"
 msgstr "मिश्रण द्वारा ट्रैक निर्माण"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity मिक्सर बोर्ड%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "गेन"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "गति"
 
@@ -2985,17 +3093,23 @@ msgid "Musical Instrument"
 msgstr "वाद्य यंत्र"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "दाँए-बाँए"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "मौन"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "एकल"
 
@@ -3003,15 +3117,18 @@ msgstr "एकल"
 msgid "Signal Level Meter"
 msgstr "सिगनल स्तर मीटर"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "गेन स्लाइडर स्थानांतरित"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "गति स्लाइडर स्थानांतरित"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "पैन स्लाइडर स्थानांतरित"
 
@@ -3046,9 +3163,9 @@ msgstr ""
 "इसे लोड नहीं किया जाएगा."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3082,16 +3199,19 @@ msgstr ""
 "\n"
 "केवल विश्वसनीय स्रोतों से मॉड्यूल का उपयोग करें"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "हाँ"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "ना"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacity मॉड्यूल लोडर"
 
 #: src/ModuleManager.cpp
@@ -3333,7 +3453,8 @@ msgstr "सबको चुनें (&S)"
 msgid "C&lear All"
 msgstr "पूर्ण सफ़ाई (&l )"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "सक्रिय करें(&E)"
 
@@ -3413,9 +3534,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "बेमेल नमूना दरें"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "इस नमूना दर पर रिकॉर्डिंग के लिए बहुत कम  ट्रैकों का चयन किया गया है.\n"
@@ -3444,10 +3566,11 @@ msgid "Dropouts"
 msgstr "लापता"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3487,11 +3610,11 @@ msgid "Inspecting project file data"
 msgstr "परियोजना फ़ाईल में डेटा की जाँच हो रही है"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3534,11 +3657,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "चेतावनी - लापता उपनाम फ़ाइलें"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "परियोजना जांच में \"%s\" फोल्डर में  \n"
@@ -3563,12 +3686,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "चेतावनी - लापता उपनाम सारांश फ़ाइल(लें)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3626,7 +3749,8 @@ msgstr "चेतावनी - अनाथ ब्लाक फ़ाइल (�
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "प्रगति"
 
@@ -3651,6 +3775,11 @@ msgstr "चेतावनी: स्वचालित रिकवरी म�
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<बेनामी>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[परियोजना %02i]  Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3720,12 +3849,14 @@ msgstr ""
 "(आवश्यक अस्थायी फ़ाइलें बनाने में असमर्थ)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "यह एक Audacity प्रोजेक्ट फ़ाइल नहीं है"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr "यह प्रोजेक्ट Audacity के नए संस्करण के साथ बनाया गया था. इसे खोलने के लिए आपको अपग्रेड करना होगा."
@@ -3854,9 +3985,9 @@ msgid "Error Writing to File"
 msgstr "फ़ाइल में लिखने में त्रुटि"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3870,9 +4001,16 @@ msgstr "परियोजना का सघन रूप बना रहे 
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[परियोजना %02i]  Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "गति"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3881,10 +4019,10 @@ msgstr "(बरामद हुआ)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "इस फाइल को Audacity %s  से संचित किया गया था\n"
 "आप Audacity %s का प्रयोग कर रहे हैं. इस फ़ाइल को खोलने के लिए Audacity के एक नए उन्नत संस्करण की जरूरत है."
@@ -3956,8 +4094,9 @@ msgid "Backing up project"
 msgstr "परियोजना का बैकअप बन रहा है"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3966,8 +4105,9 @@ msgstr ""
 "इसे पिछले स्नैपशॉट तक पुनर्प्राप्त किया गया है."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4046,8 +4186,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sपरियोजना \"%s\" ऐसे सहेजें..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'परियोजना सहेजें' एक Audacity परियोजना के लिए है, ऑडियो फ़ाइल के लिए नहीं.\n"
@@ -4124,11 +4265,12 @@ msgid "Error Opening Project"
 msgstr "परियोजना खोलने में त्रुटि"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "आप को एक स्वत: निर्मित बैकअप फ़ाइल को खोलने की कोशिश कर रहे हैं.\n"
 "इसका दुष्परिणाम गंभीर डेटा हानि हो सकता है.\n"
@@ -4237,8 +4379,8 @@ msgid "Automatic database backup failed."
 msgstr "स्वचालित डेटाबेस बैकअप विफल हो गया."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Audacity के %s संस्करण में आपका स्वागत है"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4453,7 +4595,8 @@ msgstr "सभी वरीयतायें"
 msgid "SelectionBar"
 msgstr "चयनपट्टी"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "वर्णक्रम चयन"
 
@@ -4461,44 +4604,58 @@ msgstr "वर्णक्रम चयन"
 msgid "Timer"
 msgstr "टाइमर"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "औज़ार"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "भ्रमण"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "मिक्सर"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "मीटर"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "बजाने का मीटर"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "ध्वन्यांकन मीटर"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "संपादन"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "यंत्र"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "इस-गति-पर बजाएं"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "स्क्रब(&S)"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -4511,7 +4668,10 @@ msgstr "मापक"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "ट्रैक"
 
@@ -4621,7 +4781,8 @@ msgid "Activation level (dB):"
 msgstr "ध्वनि-चालन स्तर (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Audacity में आपका स्वागत है!"
 
 #: src/SplashDialog.cpp
@@ -4768,9 +4929,9 @@ msgstr ""
 "उपयुक्त ड्राइव के सुझाव के लिए, मदद बटन पर क्लिक करें."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity इस फ़ाइल को लिख नहीं सका :\n"
@@ -4790,9 +4951,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4801,9 +4962,9 @@ msgstr ""
 " को लिखने के लिए  खोला नहीं जा सका."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity इस फ़ाइल में छवियों को लिख पाया:\n"
@@ -4820,9 +4981,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4832,9 +4993,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4843,8 +5004,9 @@ msgstr ""
 "शायद png प्रारूप सही न हो?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity अपनी डिफ़ॉल्ट थीम नहीं पढ़ सका.\n"
@@ -4882,9 +5044,9 @@ msgstr ""
 "में पहले से ही मौजूद थीं. उसीके ऊपर लिखें?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity फ़ाइल को संचित नहीं कर सका:\n"
@@ -4923,7 +5085,11 @@ msgstr "विशिष्ट"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "अवधि"
 
@@ -4934,7 +5100,8 @@ msgid "Time Track"
 msgstr "समय ट्रैक"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity घड़ी से अंकन"
 
 #: src/TimerRecordDialog.cpp
@@ -5008,7 +5175,8 @@ msgstr "वर्तमान परियोजना"
 msgid "Recording start:"
 msgstr "ध्वन्यांकन आरंभ :"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "अंतराल :"
 
@@ -5029,7 +5197,8 @@ msgid "Action after Timer Recording:"
 msgstr "घड़ी से रिकार्डिंग के बाद की कार्यवाही:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity टाइमर रिकार्ड प्रगति"
 
 #: src/TimerRecordDialog.cpp
@@ -5125,6 +5294,7 @@ msgstr "099 दिन 024 घं 060 मि 060 से"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "आरंभ तिथि और समय"
@@ -5169,7 +5339,8 @@ msgstr "स्वचालित निर्यात सक्रिय कर
 msgid "Export Project As:"
 msgstr "परियोजना निर्यात इस नाम से:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "विकल्प"
 
@@ -5182,7 +5353,8 @@ msgid "Do nothing"
 msgstr "कुछ भी नहीं"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Audacity से प्रस्थान"
 
 #: src/TimerRecordDialog.cpp
@@ -5206,7 +5378,8 @@ msgid "Scheduled to stop at:"
 msgstr "इस समय रोक दें:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity टाइमर रिकार्ड - शुरूआत की प्रतीक्षा"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5232,7 +5405,8 @@ msgid "Recording Exported:"
 msgstr "ध्वन्यांकन निर्यात किया :"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity टाइमर रिकार्ड - प्रतीक्षारत"
 
 #: src/TrackInfo.cpp
@@ -5428,6 +5602,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s लागू कर रहे हैं..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "असफल"
@@ -5446,13 +5630,15 @@ msgstr "%s वह पैरामीटर नहीं जो %s को मा�
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "पैरामीटर '%s': should be %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "आदेश"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s दुहराएं"
@@ -5579,13 +5765,24 @@ msgstr "क्लिप्स"
 msgid "Envelopes"
 msgstr "लिफ़ाफ़े"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "लेबल"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "बक्से"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5595,7 +5792,8 @@ msgstr "सारांश"
 msgid "Type:"
 msgstr "प्रकार :"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "प्रारुप:"
 
@@ -5622,6 +5820,10 @@ msgstr "टिप्पणी"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "आदेश:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5659,12 +5861,17 @@ msgstr "फाइल में निर्यात करें."
 msgid "Builtin Commands"
 msgstr "अंतर्निहित आदेश"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity टीम"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Audacity में अंतर्निहित आदेश प्रदान करता है"
 
 #: src/commands/LoadCommands.cpp
@@ -5727,7 +5934,10 @@ msgstr "लॉग सामग्री मिटाता है."
 msgid "Get Preference"
 msgstr "पसंद जानें"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "नाम :"
 
@@ -5775,7 +5985,8 @@ msgstr "पूर्ण स्क्रीन"
 msgid "Toolbars"
 msgstr "औजार-पट्टी"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "प्रभाव"
 
@@ -5915,7 +6126,8 @@ msgstr "सेट करें"
 msgid "Add"
 msgstr "जोड़ें"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "हटाएं"
 
@@ -6000,7 +6212,8 @@ msgid "Edited Envelope"
 msgstr "संपादित लिफाफा"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "लिफ़ाफ़ा"
 
@@ -6043,6 +6256,14 @@ msgstr "दर :"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "आकार परिवर्तन :"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -6092,7 +6313,10 @@ msgstr "दाँए-बाँए :"
 msgid "Set Track Visuals"
 msgstr "ट्रैक प्रदर्शन निर्धारित करें"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "रेखीय"
 
@@ -6196,12 +6420,18 @@ msgstr "आपने एक ऐसा ट्रैक चुना है जि
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "ऑटो डक को एक नियंत्रक ट्रैक चाहिए जो कि चुने हुए ट्रैक (ट्रैकों)के ठीक नीचे रखा गया हो."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "डक परिमाण :"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "सेकेंड"
 
@@ -6225,7 +6455,8 @@ msgstr "आंतरिक  फेएड डाऊन लंबाई :"
 msgid "Inner &fade up length:"
 msgstr "आंतरिक  फेएड अप लंबाई :"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "परिसीमा :"
 
@@ -6363,11 +6594,13 @@ msgstr "से (Hz)"
 msgid "t&o"
 msgstr "से अब"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "प्रतिशत परिवर्तन :"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "प्रतिशत परिवर्तन"
 
@@ -6375,9 +6608,23 @@ msgstr "प्रतिशत परिवर्तन"
 msgid "&Use high quality stretching (slow)"
 msgstr "उच्च गुणवत्ता विस्तारक का प्रयोग करें (धीमा)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "अनुपयुक्त"
 
@@ -6405,6 +6652,7 @@ msgstr "स्टैंडर्ड विनाईल घूर्णन प्
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "चक्कर प्रति मिनट से"
@@ -6417,6 +6665,7 @@ msgstr "पहले"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "RPM तक"
@@ -6559,6 +6808,12 @@ msgstr "संपीड़क"
 msgid "Compresses the dynamic range of audio"
 msgstr "ऑडियो के डायनमिक रेंज को कम्प्रेश करते हैं"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6568,6 +6823,20 @@ msgstr "%.2f सेकेंड"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f सेकेंड"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f ms तक"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6684,7 +6953,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "कॉनट्रास्ट विश्लेषक, दो चुने हुए ऑडियो के बीच rms वाल्यूम में अंतर मापने के लिए."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "अंत"
 
@@ -6744,6 +7014,18 @@ msgstr "अंतर(&D) :"
 msgid "&Help"
 msgstr "सहायता(&H)"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "शून्य"
@@ -6751,6 +7033,13 @@ msgstr "शून्य"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "पता लगाने में असमर्थ"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6804,6 +7093,12 @@ msgstr "ताज़ा अंतर"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "समक्ष स्तर माप"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f सेकेंड"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6948,6 +7243,10 @@ msgstr "फ़ज बॉक्स"
 #: src/effects/Distortion.cpp src/effects/Equalization.cpp
 msgid "Walkie-talkie"
 msgstr "वॉकी-टॉकी"
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Light Crunch Overdrive"
@@ -7153,7 +7452,9 @@ msgstr "DTMF अनुक्रम :"
 msgid "&Amplitude (0-1):"
 msgstr "तीव्रता (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "अंतराल:"
 
@@ -7164,6 +7465,11 @@ msgstr "टोन/मौन अनुपात :"
 #: src/effects/DtmfGen.cpp
 msgid "Duty cycle:"
 msgstr "कर्तव्य चक्र :"
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f सेकेंड"
 
 #: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
@@ -7193,7 +7499,8 @@ msgstr "गूँज"
 msgid "Repeats the selected audio again and again"
 msgstr "चुनी हुई ध्वनी को बार-बार दोहराता है"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "यह मूल्य मेमोरी की क्षमता को पार कर जाएगा."
 
@@ -7217,7 +7524,8 @@ msgstr "पूर्व-निर्धारण"
 msgid "Export Effect Parameters"
 msgstr "निर्यात प्रभाव पैरामीटर"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "फ़ाइल खोला नहीं जा सका : \"%s\""
@@ -7254,6 +7562,15 @@ msgstr "पूर्वालोकन की तैयारी"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "पुर्वालोकन करते हुए"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist त्रुटि"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7542,6 +7859,11 @@ msgid "B-spline"
 msgstr "बी-स्पलाइन"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Cosine प्रवेश"
+
+#: src/effects/Equalization.cpp
 msgid "Cubic"
 msgstr "घन"
 
@@ -7562,6 +7884,10 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "विशेष आवृत्तियों के वॉल्यूम स्तर को समायोजित करता है"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "AM Radio"
 msgstr "AM रेडियो"
 
@@ -7576,6 +7902,10 @@ msgstr "बेस ह्रास"
 #: src/effects/Equalization.cpp
 msgid "Low rolloff for speech"
 msgstr "संवाद के लिए निम्न रॉलऑफ़"
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Telephone"
@@ -7614,12 +7944,41 @@ msgid "Effect Unavailable"
 msgstr "प्रभाव अनुपलब्ध"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "अधिकतम dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "न्यूनतम dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7692,6 +8051,22 @@ msgstr "प्रक्रिया चल रही है (&P) : "
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "डिफ़ाल्ट् (&e)"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Bench"
@@ -7932,7 +8307,8 @@ msgid "Builtin Effects"
 msgstr "अंतर्निहित प्रभाव"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Audacity में अंतर्निहित प्रभाव प्रदान करता है"
 
 #: src/effects/LoadEffects.cpp
@@ -7942,6 +8318,10 @@ msgstr "बेनाम अंतर्निर्मित प्रभाव"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "आभासित  लाउडनेस"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7973,6 +8353,14 @@ msgstr "नियमित करें"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "लाऊडनेस LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -8040,6 +8428,20 @@ msgstr "हान्न, कोई नहीं"
 #: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (डिफ़ाल्ट)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, none"
+msgstr "हान्न, कोई नहीं"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
+msgstr "हान्न, कोई नहीं"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Hamming, Reciprocal Hamming"
@@ -8138,8 +8540,9 @@ msgid "Step 1"
 msgstr "चरण 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "कुछ सेकंड केवल शोर चुनें, जिससे Audacity को पता चले कि क्या फ़िल्टर कर बाहर निकालना है,\n"
@@ -8191,13 +8594,62 @@ msgstr "विंडो प्रकार (&W) :"
 msgid "Window si&ze:"
 msgstr "विंडो का आकार(&s) :"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 - (डिफ़ाल्ट)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "प्रति विंडो पायदान :"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8323,6 +8775,7 @@ msgstr "केवल एक चरम समय-खिंचाव या \"stas
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "विस्तार गुणांक :"
@@ -8712,6 +9165,56 @@ msgstr "मौन शिखर:"
 msgid "Silence Threshold"
 msgstr "मौन शिखर"
 
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time:"
+msgstr "प्रिसेट का नाम :"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
+msgstr "प्रिसेट का नाम :"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time:"
+msgstr "समापन समय :"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time"
+msgstr "समापन समय"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time:"
+msgstr "शुरुआत समय :"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time"
+msgstr "समयानुसार सजाएं"
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Use Defaults"
 msgstr "डिफ़ाल्ट का प्रयोग करें"
@@ -8719,6 +9222,11 @@ msgstr "डिफ़ाल्ट का प्रयोग करें"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "डिफ़ाल्ट पर लाएं"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8789,6 +9297,10 @@ msgstr "(अर्धस्वर) [-12 to 12] :"
 #: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
 msgid "Logarithmic"
 msgstr "लॉगरिद्मिक"
+
+#: src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Sine"
+msgstr ""
 
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Square"
@@ -8874,6 +9386,10 @@ msgstr "चुप्पी पता करें"
 msgid "Tr&uncate to:"
 msgstr "यहाँ तक काटें :"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "यहाँ तक संपीड़ित करें :"
@@ -8887,7 +9403,8 @@ msgid "VST Effects"
 msgstr "VST प्रभाव"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Audacity में VST प्रभाव इस्तेमाल करने की क्षमता जोड़ता है."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8899,7 +9416,8 @@ msgstr "Shell VST ढूंढ रहे हैं"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "पंजीकरण  %d of %d चल रहा है: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "लाइब्रेरी को लोड नहीं किया जा सका"
 
@@ -8919,7 +9437,8 @@ msgstr "बफर आकार प्रत्येक पुनरावृत
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&बफ़र आकार (8 से 1048576 नमूनों तक) :"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "विलंबता भरपाई"
 
@@ -8927,7 +9446,8 @@ msgstr "विलंबता भरपाई"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "उनके प्रसंस्करण के समय, कुछ VST प्रभावों को ऑडियो को Audacity में लौटने में विलंब करनी चाहिए. जब इस देरी की भरपाई नहीं होती है, तो आप देखेंगे कि ऑडियो में छोटी चुप्पी डाली गई है. इस विकल्प को सक्षम करने से यह भरपाई हो जाएगी, लेकिन यह सभी VST प्रभावों के लिए काम नहीं भी कर सकता है."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "भरपाई सक्रिय (&c)"
 
@@ -8961,7 +9481,8 @@ msgid "Standard VST program file"
 msgstr "मानक VST प्रोग्राम फ़ाइल"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity VST पूर्व निर्धारित फ़ाइल"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8988,7 +9509,8 @@ msgstr "VST प्रिसेट लोड करने में त्रु�
 msgid "Unable to load presets file."
 msgstr "प्रिसेट फ़ाइल लोड नहीं किया जा सका."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "प्रभाव सेटिंग्स"
 
@@ -9004,6 +9526,12 @@ msgstr "प्रिसेट फ़ाइल पढ़ नहीं सका."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "यह पैरामीटर फाइल %s से सहेजा गया था. जारी रखें?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -9039,7 +9567,8 @@ msgid "Audio Unit Effects"
 msgstr "आडियो युनिट प्रभाव"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Audacity में ऑडियो यूनिट प्रभाव  का समर्थन प्रदान करता है"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9055,7 +9584,8 @@ msgid "Audio Unit Effect Options"
 msgstr "आडियो युनिट प्रभाव विकल्प"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "उनके प्रसंस्करण के समय, कुछ ऑडियो यूनिट प्रभावों को ऑडियो को Audacity में लौटने में विलंब करनी चाहिए. जब इस देरी की भरपाई नहीं होती है, तो आप देखेंगे कि ऑडियो में छोटी चुप्पी डाली गई है. इस विकल्प को सक्षम करने से यह भरपाई हो जाएगी, लेकिन यह सभी ऑडियो यूनिट प्रभावों के लिए काम नहीं भी कर सकता है."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9199,6 +9729,7 @@ msgstr "ऑडियो युनिट"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA प्रभाव"
@@ -9208,7 +9739,8 @@ msgid "Provides LADSPA Effects"
 msgstr "LADSPA प्रभाव प्रदान करता है"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity अब vst-bridge का प्रयोग नहीं करता"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9216,12 +9748,15 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA प्रभाव विकल्प"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "उनके प्रसंस्करण के भाग के रूप में, कुछ LADSPA प्रभावों को Audacity में ऑडियो लौटने में देरी करनी चाहिए. जब इस देरी की भरपाई नहीं होती है, तो आप देखेंगे कि ऑडियो में छोटी चुप्पी डाली गई है. इस विकल्प को सक्षम करने से वह मुआवजा मिल जाएगा, लेकिन यह सभी LADSPA प्रभावों के लिए काम नहीं कर सकता है."
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s :"
@@ -9229,6 +9764,14 @@ msgstr "%s :"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "प्रभाव आउटपुट"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA प्रभाव"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9240,7 +9783,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "बफर आकार (8 से %d) नमूने :"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "उनके प्रसंस्करण के हिस्से के रूप में, कुछ LV2 प्रभावों को ऑडियो को Audacity में लौटने में देरी करनी चाहिए. जब इस देरी की भरपाई नहीं होती है, तो आप देखेंगे कि ऑडियो में छोटी चुप्पी डाली गई है. इस सेटिंग को सक्षम करने से वह मुआवजा मिलेगा, लेकिन यह सभी LV2 प्रभावों के लिए काम नहीं कर सकता है."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9265,12 +9809,19 @@ msgstr "%s को एक असमर्थित विकल्प %s की �
 msgid "Generator"
 msgstr "सृजनकर्ता"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 प्रभाव"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Audacity में LV2  का समर्थन प्रदान करता है"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9278,7 +9829,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist प्रभाव"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Audacity में Nyquist प्रभाव का समर्थन प्रदान करता है"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9502,7 +10054,8 @@ msgstr "एक फ़ाइल चुनें"
 msgid "Save file as"
 msgstr "फ़ाइलों को ऐसे सहेजें"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "बेनाम"
 
@@ -9511,7 +10064,8 @@ msgid "Vamp Effects"
 msgstr "Vamp प्रभाव"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Audacity में Vamp प्रभाव का समर्थन प्रदान करता है"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9533,6 +10087,12 @@ msgstr "प्लगइन सेटिग्स"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "कार्यक्रम"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9833,7 +10393,8 @@ msgstr "%s में चुनी हुई ध्वनी निर्या�
 msgid "Invalid sample rate"
 msgstr "अमान्य सैंपल रेट"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "पुन: नमूना लें"
 
@@ -9863,6 +10424,14 @@ msgstr "आप निम्न दरों में से एक पर प�
 msgid "Sample Rates"
 msgstr "सैंपल रेट"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "बिट रेट:"
@@ -9870,6 +10439,48 @@ msgstr "बिट रेट:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "गुणवत्ता (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f सेकेंड"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9880,12 +10491,40 @@ msgid "Constrained"
 msgstr "विवश"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "ऑडियो"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "अल्प विलंब"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9972,8 +10611,17 @@ msgid "Replace preset '%s'?"
 msgstr "'%s' पूर्व-निर्धारित को मिटाकर लिखें?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "सा"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "मुख्य"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10081,6 +10729,10 @@ msgstr "भाषा :"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "बिट् रिज़रवायर"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10214,6 +10866,11 @@ msgstr ""
 "0 - डिफ़ॉल्ट\n"
 "न्यूनतम - 1\n"
 "अधिकतम - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LPC का प्रयोग करें"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10470,6 +11127,42 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (सर्वोत्तम गुणवत्ता)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "अतीव, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "सामान्य, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "मध्यम, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "मध्यम, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (छोटी फाइलें)"
 
@@ -10499,7 +11192,8 @@ msgstr "असामान्य"
 msgid "Extreme"
 msgstr "तीव्रतम"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "सामान्य"
 
@@ -10550,8 +11244,8 @@ msgid "Locate LAME"
 msgstr "LAME ढूंढे"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "ऑडेसिटी को MP3 बनाने के लिए %s फ़ाइल की जरूरत है."
 
 #: src/export/ExportMP3.cpp
@@ -10579,13 +11273,18 @@ msgid "Where is %s?"
 msgstr "%s कहाँ है?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "आप lame_enc.dll v%d.%d को जोड़ रहे हैं. यह संस्करण ऑडेसिटी %d.%d.%d से सुसंगत नहीं है.\n"
 "कृपया  'Audacity के लिए LAME' लाइब्रेरी का नवीनतम संस्करण डाउनलोड करें."
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Only lame_enc.dll"
+msgstr "केवल avformat.dll"
 
 #: src/export/ExportMP3.cpp
 msgid "Only libmp3lame64bit.dylib"
@@ -10883,6 +11582,14 @@ msgstr "चयनित ऑडियो को  Ogg वॉर्बिस  क�
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "ऑडियो को Ogg वॉर्बिस के रूप में निर्यात कर रहे हैं"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "शीर्ष:"
@@ -10896,9 +11603,10 @@ msgid "Other uncompressed files"
 msgstr "अन्य असंपीड़ित फ़ाइलें"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "आपने एक WAV या AIFF फ़ाइल निर्यात करने का प्रयास किया है जो 4GB से अधिक का होगा.\n"
 "Audacity ऐसा नहीं कर सकती, अत: एक्सपोर्ट रद्द कर दिया गया."
@@ -10908,8 +11616,9 @@ msgid "Error Exporting"
 msgstr "त्रुटि निर्यात"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "आपकी निर्यात की गई WAV फ़ाइल को काट कर छोटा कर दिया गया है क्योंकि Audacity\n"
@@ -10949,11 +11658,11 @@ msgid "All supported files"
 msgstr "सभी समर्थित फ़ाइलें"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10962,11 +11671,11 @@ msgstr ""
 "फ़ाइल > आयात > MIDI क्लिक करके इसे संपादित कर सकते हैं."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\"\n"
 "एक ऑडियो फाइल नहीं है.\n"
@@ -10977,18 +11686,18 @@ msgid "Select stream(s) to import"
 msgstr "आयात के लिए प्रवाह(stream)चुनें"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "ऑडेसिटी का यह संस्करण %s  समर्थन के साथ तैयार नहीं किया गया."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक ऑडियो सीडी ट्रैक है. \n"
 "ऑडेसिटी ऑडियो सीडी को सीधे नहीं खोल सकता. \n"
@@ -10997,10 +11706,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" एक प्लेलिस्ट फ़ाइल है.\n"
@@ -11009,10 +11718,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक विंडोज मीडिया ऑडियो फ़ाइल है.\n"
@@ -11021,10 +11730,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक उन्नत ऑडियो कोडिंग फाइल है. \n"
@@ -11033,12 +11742,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक एन्क्रिप्टेड ऑडियो फ़ाइल है. \n"
@@ -11048,10 +11757,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक RealPlayer मीडिया फाइल है. \n"
@@ -11060,12 +11769,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" एक स्वराधारित फ़ाइल  है, न कि एक ऑडियो फ़ाइल.\n"
 "ऑडेसिटी इस प्रकार की फ़ाइल नहीं खोल सकता. \n"
@@ -11073,10 +11782,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11087,10 +11796,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक Wavpack ऑडियो फ़ाइल है \n"
@@ -11099,10 +11808,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक Dolby डिजिटल ऑडियो फ़ाइल है \n"
@@ -11111,10 +11820,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक Ogg Speex ऑडियो फ़ाइल है. \n"
@@ -11123,10 +11832,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक विडियो फ़ाइल है. \n"
@@ -11140,9 +11849,9 @@ msgstr "\"%s\" फ़ाइल नहीं मिला."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11158,11 +11867,16 @@ msgstr ""
 "FFmpeg स्थापित करने का प्रयास करें\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, परीक्षक"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11192,12 +11906,13 @@ msgid "Import Project"
 msgstr "परियोजना आयात करें"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "इस परियोजना को Audacity संस्करण 1.0 या उससे पहले के द्वारा सहेजा गया था. प्रारूप में परिवर्तन है और Audacity का यह संस्करण परियोजना को आयात करने में असमर्थ है.\n"
 "\n"
@@ -11247,7 +11962,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "परियोजना डाटा फ़ोल्डर नहीं मिला : \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "प्रोजेक्ट फाइल में MIDI ट्रैक मिले हैं, लेकिन Audacity के इस निर्माण में MIDI का समर्थन शामिल नहीं है, इसलिए ट्रैकों को छोड़ रहे हैं."
 
 #: src/import/ImportAUP.cpp
@@ -11352,40 +12068,6 @@ msgstr "सूचकांक[%02x] कोडेक[%s], भाषा[%s], ब�
 msgid "FLAC files"
 msgstr "FLAC फ़ाइलें"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-compatible फ़ाइलें"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "डिकोडर को पाइपलाइन से जोड़ने में असमर्थ"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer आयातक"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "प्रवाह स्थिति को रुका-हुआ सेट करने में असमर्थ."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "इंडेक्स[%02d], प्रकार[%s], चैनल[%d], दर[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "फ़ाइल में कोई भी ऑडियो प्रवाह नहीं है."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "फ़ाइल आयात करने में असमर्थ, स्थिति परिवर्तन में विफल हुआ."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer- त्रुटि : %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "सरल टेक्स्ट स्वरुप में फ़ाइलों की सूची"
@@ -11488,6 +12170,10 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, तथा अन्य असंपीड़ित प्रकार"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "AVR (Audio Visual Research)"
 msgstr "AVR (ऑडियो विजुअल रिसर्च)"
 
@@ -11509,6 +12195,11 @@ msgid "IFF (Amiga IFF/SVX8/SV16)"
 msgstr "IFF (अमिगा IFF/SVX8/SV16)"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr "MAT5 (GNU ऑक्टेव 2.1 / मैटलैब 5.0)"
+
+#: src/import/ImportPCM.cpp
 msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
 msgstr "MAT5 (GNU ऑक्टेव 2.1 / मैटलैब 5.0)"
 
@@ -11521,12 +12212,20 @@ msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG कंटेनर प्रारूप)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "PVF (Portable Voice Format)"
 msgstr "PVF (पोर्टेबल वॉयस फॉरमैट)"
 
 #: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (बिना शीर्षक)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "SD2 (Sound Designer II)"
@@ -11537,8 +12236,32 @@ msgid "SDS (Midi Sample Dump Standard)"
 msgstr "SDS (Midi नमूना डंप मानक)"
 
 #: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "VOC (Creative Labs)"
 msgstr "VOC (क्रिएटिव लैब्स)"
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11569,6 +12292,34 @@ msgid "64 bit float"
 msgstr "64 बिट फ्लोट"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12 बिट DWVW"
 
@@ -11581,12 +12332,20 @@ msgid "24 bit DWVW"
 msgstr "24 बिट DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16 बिट DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8 बिट DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11635,6 +12394,19 @@ msgstr "Raw डाटा आयात करें"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "कोई endianness नहीं"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "मध्य"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -11709,6 +12481,7 @@ msgstr "%s दायाँ"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11732,6 +12505,7 @@ msgstr "अंत"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11758,7 +12532,8 @@ msgstr "समय स्थानांतरित क्लिप को द�
 msgid "Time shifted clips to the left"
 msgstr "समय स्थानांतरित क्लिप को बाईं ओर"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "समय-स्थानांतरण"
 
@@ -11896,7 +12671,8 @@ msgstr "चयनित ऑडियो ट्रैकों को छाँ�
 msgid "Trim Audio"
 msgstr "आडियो छाँटें"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "तोड़ें"
 
@@ -12021,34 +12797,6 @@ msgid "Ext&ra"
 msgstr "अतिरिक्त (&r)"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "मिक्सर औजार-पट्टी (&x)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "प्लेबैक वॉल्यूम सही करें... (&j)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "प्लेबैक वॉल्यूम बढ़ाएं (&I)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "प्लेबैक वॉल्यूम कम करें (&D)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "रिकॉर्डिंग वॉल्यूम सही करें...(&u)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "रिकार्डिंग वॉल्यूम बढ़ाएं (&n)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "रिकार्डिंग वॉल्यूम घटाएं (&e)"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "यंत्र (&v)"
 
@@ -12084,6 +12832,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "चयनित ऑडियो का निर्यात करें"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "लेबल टेक्सट्"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -12309,8 +13063,9 @@ msgid "&Getting Started"
 msgstr "आरंभ करें (&G)"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity मदद पुस्तिका (&M)"
+#, fuzzy
+msgid "&Manual"
+msgstr "मार्गदर्शक-पुस्तिका... (&M)"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12336,11 +13091,8 @@ msgstr "&MIDI यंत्र सूचना..."
 msgid "Show &Log..."
 msgstr "लाग दिखाएँ... (&L)"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Audacity के बारे में...(&A)"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "नाम-पट्ट लगाया"
 
@@ -12588,6 +13340,11 @@ msgstr "ट्रैक केंद्रित/अकेंद्रित क
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "श्रेणी-रहित"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "नया..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -13026,6 +13783,7 @@ msgstr "कर्सर की लंबी छलांग (&m) दाँई �
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "ढूंढें"
@@ -13237,18 +13995,21 @@ msgid "Created new label track"
 msgstr "नया नाम ट्रैक बनाया गया"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Audacity का यह संस्करण प्रत्येक परियोजना विंडो के लिए केवल एक समय ट्रैक की अनुमति देता है."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "नया समय ट्रैक बनाया गया"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "नया नमूना आवृति दर(Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "प्रविष्टि अमान्य है"
 
@@ -13505,7 +14266,9 @@ msgstr "बजना जारी"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "ध्वन्यांकन"
 
@@ -13654,10 +14417,6 @@ msgstr "ओवर-डबिंग(चालू/बंद)(&O)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "सॉफ़्टवेयर से बजाना(चालू/बंद)(&f)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "स्वचालित रिकार्डिंग स्तर अनुकूलन (चालू/बंद) (&u)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13873,7 +14632,7 @@ msgstr "गुणवत्ता के लिए वरीयतायें"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Audacity अपडेट करें"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13920,7 +14679,8 @@ msgstr "मेज़बान :"
 msgid "Using:"
 msgstr "उपयोग में:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "बजाएं"
 
@@ -13940,7 +14700,8 @@ msgstr "चैनल्स (&n):"
 msgid "Latency"
 msgstr "विलंबता"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "मिलिसेकेंड"
 
@@ -13969,7 +14730,8 @@ msgid "2 (Stereo)"
 msgstr "2 (स्टिरियो)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "निर्देशिकाएं"
 
@@ -14077,7 +14839,8 @@ msgid "Directory %s is not writable"
 msgstr "निर्देशिका %s लेख्य नहीं है"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "अस्थायी निर्देशिका में परिवर्तन Audacity पुनः आरंभ होने तक लागू नहीं होगा"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14108,6 +14871,40 @@ msgstr "प्रकाशक द्वारा समूहीकृत"
 msgid "Grouped by Type"
 msgstr "प्रकार द्वारा समूहीकृत"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Nyquist त्रुटि"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "प्रभाव सक्रिय"
@@ -14129,11 +14926,13 @@ msgid "Plugin Options"
 msgstr "प्लगइन विकल्प"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Audacity के शुरूआत में प्लगइन अद्यतन के लिए जाँच करें"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "अगली बार Audacity शुरू होने पर सभी पल्गइन को रीस्कैन करें"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14313,7 +15112,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "नामपट्ट यथावत (&t) रखें यदि चयन नामपट्ट से चिपका हो"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "सिस्टम और Audacity रंग-रूप एकसार करें (&l)"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14337,6 +15137,10 @@ msgstr "स्क्रब मापक दिखाएं"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "\"%s\" अन्जान भाषा है"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14487,7 +15291,8 @@ msgstr ""
 "   *   \"%s\"  (क्योंकि  '%s'  शॉर्टकट  '%s' द्वारा प्रयोग किया जाता है)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "ऑडेसिटी लघुकुंजी युक्त एक XML फ़ाइल चुनें..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14620,8 +15425,9 @@ msgid "Dow&nload"
 msgstr "डाउनलोड(&n)"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "ऑडेसिटी स्वचालित रूप से एक वैध FFmpeg लाइब्रेरी पाया है.\n"
@@ -14666,6 +15472,10 @@ msgstr "MIDI सिंथेसाइज़र विलंबता(&a) (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "MIDI Synthesizer Latency एक पूर्णांक ही होना चाहिए"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -14676,8 +15486,9 @@ msgid "Preferences for Module"
 msgstr "मोड्यूल के लिए वरीयतायें"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "ये केवल प्रयोगात्मक मोड्यूल्स हैं. उन्हें तभी सक्रिय करें जब आपने Audacity मदद पुस्तिका पढ़ी हो\n"
@@ -14685,12 +15496,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr " 'पूछें' का मतलब है कि Audacity हर बार शुरू होते समय पूछेगी कि क्या आप मॉड्यूल को लोड करना चाहते हैं."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'विफल' का अर्थ है कि Audacity को लगता है कि मॉड्यूल टूट गया है और इसे नहीं चलाएगा."
 
 #. i18n-hint preserve the leading spaces
@@ -14699,7 +15512,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr " 'नया' का मतलब अभी तक कोई विकल्प नहीं चुना गया है."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "इन परिवर्तनों को प्रभावी करने के  लिए Audacity को दुबारा शुरू करना होगा."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14717,6 +15531,10 @@ msgstr "कोई भी मॉड्यूल नहीं मिला"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "मोड्यूल"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14758,7 +15576,10 @@ msgstr "बायाँ-खीचें"
 msgid "Set Selection Range"
 msgstr "चयन क्षेत्र बताएं"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "ऊच्च-बायाँ-क्लिक"
 
@@ -14845,6 +15666,21 @@ msgstr "-बायाँ-खीचें"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "क्लिप को ट्रैकों के बीच ऊपर/नीचे स्थानांतरित करें"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-बायाँ-खीचें"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
+#. i18n-hint: The envelope is a curve that controls the audio loudness.
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Change Amplification Envelope"
+msgstr "प्रवर्धन dB"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Pencil"
@@ -14964,7 +15800,8 @@ msgid "Always scrub un&pinned"
 msgstr "बिना पिन लगे  को हमेशा स्क्रब करें"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "ऑडेसिटी ईच्छानुसार"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14978,6 +15815,11 @@ msgstr "पसंद :"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "गुणवत्ता के लिए वरीयतायें"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -15097,39 +15939,6 @@ msgid "System T&ime"
 msgstr "सिस्टम समय(&i)"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "स्वचालित रिकार्डिंग स्तर अनुकूलन"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "स्वचालित रिकॉर्डिंग स्तर समायोजन सक्षम करें."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "लक्षित शिखर:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "के भीतर:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "विश्लेशन समय:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "मिलीसेकेंड(एक विश्लेषण का समय)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "लगातार विश्लेषणों की संख्या :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 मतलब अनंत"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "पंच और रोल रिकार्डिंग"
 
@@ -15140,6 +15949,21 @@ msgstr "प्रि-रोल (&l):"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "क्रॉसफ़ेड (&f):"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15173,6 +15997,11 @@ msgstr "उलटा ग्रेस्केल"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "आवृत्तियाँ"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -15267,6 +16096,10 @@ msgstr "8 - सबसे वाइडबैंड"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - डिफ़ाल्ट"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -15366,13 +16199,14 @@ msgid "Info"
 msgstr "सूचना"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15553,7 +16387,8 @@ msgstr "नमूने"
 msgid "4 Pixels per Sample"
 msgstr "4 पिक्सेल प्रति नमूना"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "सबसे बड़ा दिखाएं"
 
@@ -15675,16 +16510,24 @@ msgid "Stopped"
 msgstr "रुक गया"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "ठहरें"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "शुरुआत पर जाएं"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "समाप्ति पर जाएं"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "ठहरें"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "आरंभ से चुनें"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "अंत तक चुनें"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15698,20 +16541,17 @@ msgstr "नया ट्रैक रिकार्ड करें"
 msgid "Append Record"
 msgstr "रिकार्डिंग जोड़ें"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "अंत तक चुनें"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "आरंभ से चुनें"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s रुका हुआ."
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s :"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15791,11 +16631,17 @@ msgstr "मूक ऑडियो को चुनना"
 msgid "Sync-Lock Tracks"
 msgstr "ट्रैकों को गठबंधन में रखें"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "बड़ा करें"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "छोटा करें"
 
@@ -15862,43 +16708,6 @@ msgstr "रिकार्डिंग मीटर औजार-पट्टी
 msgid "&Playback Meter Toolbar"
 msgstr "प्लेबैक मीटर औजार-पट्टी"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "रिकॉर्डिंग वॉल्यूम"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "प्लेबैक वॉल्यूम"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "रिकार्डिंग वाल्यूम : %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "रिकार्डिंग वॉल्यूम (अनुपलब्ध; सिस्टम मिक्सर का प्रयोग करें.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "प्लेबैक वॉल्यूम : %.2f (एम्यूलेटेड)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "प्लेबैक वॉल्यूम : %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "प्लेबैक वॉल्यूम (अनुपलब्ध; सिस्टम मिक्सर का प्रयोग करें.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "मिक्सर औजार-पट्टी"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "खोज"
@@ -15914,6 +16723,7 @@ msgstr "स्क्रबिंग"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "स्क्रबिंग बंद करें"
@@ -15921,6 +16731,7 @@ msgstr "स्क्रबिंग बंद करें"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "स्क्रबिंग आरंभ"
@@ -15928,6 +16739,7 @@ msgstr "स्क्रबिंग आरंभ"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "खोजना बंद करें"
@@ -15935,6 +16747,7 @@ msgstr "खोजना बंद करें"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "खोजना आरंभ"
@@ -15989,7 +16802,9 @@ msgstr "साथ जोड़ें"
 msgid "Length"
 msgstr "लंबाई"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "मध्य"
 
@@ -16053,8 +16868,8 @@ msgstr "घड़ी औजार-पट्टी"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity  %s औजार-पट्टी"
 
 #: src/toolbars/ToolBar.cpp
@@ -16081,7 +16896,8 @@ msgstr "समय आगे-पीछे करें"
 msgid "Zoom Tool"
 msgstr "बड़ा-छोटा करें"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "पेंसिल औजार"
 
@@ -16157,11 +16973,13 @@ msgstr "नाम-पट्टी (या पट्टियों) को क�
 msgid "Drag label boundary."
 msgstr "नाम-पट्टी सीमा को खीचें."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "परिवर्तित नाम"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "नाम संपादन"
 
@@ -16216,31 +17034,42 @@ msgstr "संपादित नाम-पट्टी"
 msgid "New label"
 msgstr "नया लेबल"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "ऊपरी सप्तक(&O)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "निम्न सप्तक(&v)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "क्लिक करें ऊर्ध्व में ज़ूम के लिए, उच्च-क्लिक ज़ूम-आउट के लिए. ज़ूम-क्षेत्र बताने के लिए क्लिक करते हुए खींचें."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "मेन्यू के लिए दायां-क्लिक."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "ज़ूम रिसेट"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "शिफ्ट-दायां-क्लिक करें"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "बायाँ-क्लिक / बायाँ-ड्रैग"
 
@@ -16282,7 +17111,8 @@ msgstr "विलय"
 msgid "Expanded Cut Line"
 msgstr "विस्तृत काट-रेखा"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "विस्तार"
 
@@ -16305,6 +17135,11 @@ msgstr "खिसकाए गये नमूने"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "संपादन नमूना"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16350,7 +17185,8 @@ msgstr "प्रक्रिया जारी...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "परिवर्तित '%s' से %s"
@@ -16362,6 +17198,54 @@ msgstr "स्वरुप परिवर्तन"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "दर"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16381,7 +17265,8 @@ msgstr "आवृति दर परिवर्तन"
 msgid "Set Rate"
 msgstr "आवृति दर निर्धारित करें"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "बहु-दृश्य (&M)"
 
@@ -16473,14 +17358,23 @@ msgstr "बायाँ, %dHz"
 msgid "Right, %dHz"
 msgstr "दायाँ, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% बायां"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% दायां"
@@ -16598,9 +17492,8 @@ msgstr "लघुगणकीय अंतर्वेषण"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "ट्रैक को समय में खिसकाने के लिए क्लिक कर खींचें"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16651,6 +17544,7 @@ msgstr "ऐडजस्टेड लिफ़ाफ़ा."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "स्क्रब(&S)"
@@ -16662,6 +17556,7 @@ msgstr "खोजना"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "स्क्रब(&R) पैमाना"
@@ -16857,6 +17752,12 @@ msgstr "बाएं"
 msgid "R"
 msgstr "दाएं"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16890,9 +17791,19 @@ msgstr "रिक्त"
 msgid "Backwards"
 msgstr "पीछे"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "आगे"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -17105,6 +18016,7 @@ msgstr "0100 घं 060 मि 060 से+># नमूने"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "नमूने"
@@ -17258,9 +18170,31 @@ msgstr "CDDA फ़्रेम्स (75 फ़्रेम/से.)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 फ़्रेम्स|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "0100 घं 060 मि 060>0100 से"
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centihertz"
 msgstr "सेंटीहर्टज्"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hertz"
@@ -17271,6 +18205,15 @@ msgstr "हर्टज्"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "octaves"
 msgstr "सप्तक"
+
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "100>01000 octaves|1.442695041"
+msgstr "10>01000 दशक|0.434294482"
 
 #. i18n-hint: an octave is a doubling of frequency
 #: src/widgets/NumericTextCtrl.cpp
@@ -17322,6 +18265,11 @@ msgstr "(स्वरूप बदलने के लिए संदर्भ 
 msgid "centiseconds"
 msgstr "सेंटी-सेकेंड"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "बीता समय :"
@@ -17364,6 +18312,11 @@ msgstr "बंद करने की पुष्टि करें"
 msgid "Unable to write files to directory: %s."
 msgstr "\"%s\" में से प्रिसेट नहीं पढ़ सका."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17380,6 +18333,10 @@ msgstr "डायरेक्टरी के लिए वरीयताये
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "यह चेतावनी दुबारा न दिखाएँ"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17463,15 +18420,27 @@ msgstr "XML का विश्लेषण नहीं किया जा स
 msgid "Spectral edit multi tool"
 msgstr "वर्णक्रम संपादन विभिन्न औजार"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "फिल्टर लगाना..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "जीएनयू जनरल पब्लिक लाइसेंस संस्करण 2 के तहत जारी किया गया"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aकृपया आवृत्तियाँ चुनें."
@@ -17498,7 +18467,8 @@ msgstr ""
 "                      निम्न आवृत्ति बाध्य बढ़ाने की कोशिश करें~% ~\n"
 "                      या फ़िल्टर की 'चौड़ाई' को कम करें."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "त्रुटि.~%"
@@ -17560,9 +18530,23 @@ msgstr "स्टूडियो फ़ेड आउट"
 msgid "Applying Fade..."
 msgstr "फ़ेड लागू करना..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "स्टीव डॉल्टन"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "GNU जनरल पब्लिक लाइसेंस संस्करण 2 या उसके बाद की शर्तों के अधीन प्रकाशित किया गया."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17706,6 +18690,11 @@ msgstr "ताल शोधक"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "ताल की खोज..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Audacity लॉग"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18034,13 +19023,34 @@ msgstr "हाइ-पास फ़िल्टर संपादित हो �
 msgid "Dominic Mazzoni"
 msgstr "डॉमिनिक मज्जो़नी"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "आवृति (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "रॉल-ऑफ़ (dB प्रति सप्तक)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -18061,10 +19071,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "आवाज को लेबल लगाता है"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "GNU जनरल पब्लिक लाइसेंस संस्करण 2 या उसके बाद की शर्तों के अधीन प्रकाशित किया गया."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18365,7 +19371,8 @@ msgstr "Lisp फ़ाईल"
 msgid "HTML file"
 msgstr "HTML फ़ाईल"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "टेक्स्ट फ़ाईल"
 
@@ -18442,6 +19449,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI के मान सा सुर के लिए : 36, 48, 60 [मध्य सा], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "MIDI पिच बजाएं"
 
@@ -18490,12 +19501,20 @@ msgid "Swing amount"
 msgstr "दोलन परिमाण"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
 msgstr "'ताल ट्रैक अवधि' को सक्रिय करने के लिए 'स्तंभों की संख्या' को शून्य सेट करें."
 
 #: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "स्तंभों की संख्या"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -18552,6 +19571,10 @@ msgstr "ड्रिप (दीर्घ )"
 #: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of strong beat"
 msgstr "मजबूत धड़कन की MIDI पिच"
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
@@ -18763,6 +19786,12 @@ msgstr "<b>नमूना दर :</b> &nbsp;&nbsp;~a Hz."
 #, lisp-format
 msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
 msgstr "<b>उच्चतम ऐम्पलिच्यूड :</b> &nbsp;&nbsp;~a (रैखिक) &nbsp;&nbsp;~a dB."
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr "<b>नमूना दर :</b> &nbsp;&nbsp;~a Hz."
 
 #. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
 #: plug-ins/sample-data-export.ny
@@ -19129,6 +20158,10 @@ msgid "Processing Vocoder..."
 msgstr "वोकोडर प्रक्रिया जारी..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "दूरी : (1 से 120, सामान्यत: = 20)"
 
@@ -19168,6 +20201,232 @@ msgstr "रडार सुई की आवृति (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "त्रुटि.~%स्टिरियो ट्रैक चाहिए."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Audacity अपडेट करें"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "छोड़ें (&S)"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "अद्यतन स्थापित करें (&I)"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "परिवर्तन लॉग"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "GitHub पर और पढ़ें"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "अद्यतन के लिए जाँच में त्रुटि"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Audacity अपडेट सर्वर से कनेक्ट करने में असमर्थ."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "अद्यतन डेटा दूषित था."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "अपडेट डाउनलोड करने में त्रुटि."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Audacity ऑडेसिटी डाउनलोड लिंक नहीं खोल सकता."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s उपलब्ध है!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "ध्वन्यांकन"
+
+#~ msgid "Commit Id:"
+#~ msgstr "कमिट आइडी :"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "क्रॉस-प्लेटफॉर्म GUI लाइब्रेरी"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "GStreamer से आयात करें"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. इससे और अधिक सही नहीं किया जा सकता था. अभी भी बहुत ऊँचा है."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "स्वचालित इनपुट स्तर अनुकूलन ने वाल्यूम घटा कर %f कर दिया है."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. इसे और अधिक सही नहीं किया जा सकता था. अभी भी बहुत नीचे है."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "स्वचालित इनपुट स्तर अनुकूलन ने वाल्यूम बढ़ा कर %.2f कर दिया है."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. स्वीकार्य वाल्यूम मिले बिना ही विश्लेशण की कुल संख्या सीमा पार हो गई है. अभी भी बहुत ऊँचा है."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. स्वीकार्य वाल्यूम मिले बिना ही विश्लेशण की कुल संख्या सीमा पार हो गई है. अभी भी बहुत नीचे है."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "स्वचालित इनपुट स्तर अनुकूलन रुक गया. %.2f एक स्वीकार्य वाल्यूम लगता है."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "डिवाइसों को खोलने के दौरान %d प्राप्त किया\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "पोर्टमिक्सर को खोलने में अक्षम\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "उपलब्ध मिक्सर :\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "उपलब्ध रिकॉर्डिंग स्रोत :\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "उपलब्ध प्लेबैक वॉल्यूम :\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "रिकॉर्डिंग वॉल्यूम एम्यूलेटेड है\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "रिकॉर्डिंग वॉल्यूम नेटिव है\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "प्लेबैक वॉल्यूम एम्यूलेटेड है\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "प्लेबैक वॉल्यूम नेटिव है\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "समाप्ति तिथि और समय"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-compatible फ़ाइलें"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "डिकोडर को पाइपलाइन से जोड़ने में असमर्थ"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer आयातक"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "प्रवाह स्थिति को रुका-हुआ सेट करने में असमर्थ."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "इंडेक्स[%02d], प्रकार[%s], चैनल[%d], दर[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "फ़ाइल में कोई भी ऑडियो प्रवाह नहीं है."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "फ़ाइल आयात करने में असमर्थ, स्थिति परिवर्तन में विफल हुआ."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer- त्रुटि : %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "मिक्सर औजार-पट्टी (&x)"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "प्लेबैक वॉल्यूम सही करें... (&j)"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "प्लेबैक वॉल्यूम बढ़ाएं (&I)"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "प्लेबैक वॉल्यूम कम करें (&D)"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "रिकॉर्डिंग वॉल्यूम सही करें...(&u)"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "रिकार्डिंग वॉल्यूम बढ़ाएं (&n)"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "रिकार्डिंग वॉल्यूम घटाएं (&e)"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity मदद पुस्तिका (&M)"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Audacity के बारे में...(&A)"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "स्वचालित रिकार्डिंग स्तर अनुकूलन (चालू/बंद) (&u)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "स्वचालित रिकार्डिंग स्तर अनुकूलन"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "स्वचालित रिकॉर्डिंग स्तर समायोजन सक्षम करें."
+
+#~ msgid "Target Peak:"
+#~ msgstr "लक्षित शिखर:"
+
+#~ msgid "Within:"
+#~ msgstr "के भीतर:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "विश्लेशन समय:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "मिलीसेकेंड(एक विश्लेषण का समय)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "लगातार विश्लेषणों की संख्या :"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 मतलब अनंत"
+
+#~ msgid "Recording Volume"
+#~ msgstr "रिकॉर्डिंग वॉल्यूम"
+
+#~ msgid "Playback Volume"
+#~ msgstr "प्लेबैक वॉल्यूम"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "रिकार्डिंग वाल्यूम : %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "रिकार्डिंग वॉल्यूम (अनुपलब्ध; सिस्टम मिक्सर का प्रयोग करें.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "प्लेबैक वॉल्यूम : %.2f (एम्यूलेटेड)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "प्लेबैक वॉल्यूम : %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "प्लेबैक वॉल्यूम (अनुपलब्ध; सिस्टम मिक्सर का प्रयोग करें.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "मिक्सर औजार-पट्टी"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "ट्रैक को समय में खिसकाने के लिए क्लिक कर खींचें"
 
 #~ msgid "Program build date:"
 #~ msgstr "प्रोग्राम निर्माण तिथि :"

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -3,55 +3,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Croatian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/hr/>\n"
+"Language-Team: Croatian <https://hosted.weblate.org/projects/tenacity/tenacity/hr/>\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
-"%100==4 ? 3 : 0);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-SourceCharset: utf-8\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Ugasi Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Kanal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Pogrješka pri otvaranju datoteke"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Pogrješka pri učitavanju metapodataka"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacityjeva alatna traka - %s"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Snimanje"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -61,6 +23,24 @@ msgstr "Nemoguće odrediti"
 #, c-format
 msgid "%s bytes"
 msgstr "B"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -83,12 +63,63 @@ msgid "&Nyquist Workbench..."
 msgstr "Nyquistov upit..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Zalijepi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Zalijepi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Zalijepi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Zalijepi"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Izabire"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -115,15 +146,34 @@ msgid "&Large Icons"
 msgstr "Velika soba"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Small Icons"
+msgstr "Velika soba"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "&Alatne trake"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Ob&ustavi"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "promijenjivi"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Mjerilo izlaza"
 
@@ -131,13 +181,38 @@ msgstr "Mjerilo izlaza"
 msgid "Load Nyquist script"
 msgstr "Nyquistov upit"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Upozorenje"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Nyquistov upit"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -148,12 +223,20 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "napravio Lelanda Luciusa"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Učinci"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "No matches found"
 msgstr "Nema uređaja"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
@@ -163,9 +246,15 @@ msgstr "neimenovano"
 msgid "Nyquist Effect Workbench - "
 msgstr "Učinci"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Novo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Otvori nedavne"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -199,7 +288,8 @@ msgstr "Kopiraj"
 msgid "Copy to clipboard"
 msgstr "Izreži u međuspremnik"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Izreži"
 
@@ -207,7 +297,8 @@ msgstr "Izreži"
 msgid "Cut to clipboard"
 msgstr "Izreži u međuspremnik"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Zalijepi"
 
@@ -232,7 +323,8 @@ msgstr "Izabire"
 msgid "Select all text"
 msgstr "Izabire"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Vrati"
 
@@ -240,9 +332,20 @@ msgstr "Vrati"
 msgid "Undo last change"
 msgstr "Promjena formata"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Poništi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Promjena formata"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "&Nađi note"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -253,23 +356,46 @@ msgid "Match"
 msgstr "Svežanj"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "Do:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Nema oznaka za izvoz."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "gore"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Prethodni alat"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Premjesti žarište na prethodni zapis i izaberi"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Sljedeći alat"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Početak"
 
@@ -277,7 +403,8 @@ msgstr "Početak"
 msgid "Start script"
 msgstr "Nyquistov upit"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Zaustavi"
 
@@ -285,8 +412,15 @@ msgstr "Zaustavi"
 msgid "Stop script"
 msgstr "Nyquistov upit"
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "U redu"
 
@@ -294,11 +428,13 @@ msgstr "U redu"
 msgid "Build Information"
 msgstr "Podatci o gradnji"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "omogućeno"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "onemogućeno"
 
@@ -308,8 +444,9 @@ msgid "The Build"
 msgstr "Gradnja za debug"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Naredba:"
+#, fuzzy
+msgid "Version:"
+msgstr "Obrtanje vodoravno"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -319,13 +456,23 @@ msgstr "Vrsta gradnje:"
 msgid "Compiler:"
 msgstr "Sažimač"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Ugradni predmetak:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Mapa postavaka:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Mapa postavaka:"
 
 #: src/AboutDialog.cpp
@@ -344,7 +491,6 @@ msgstr "pretvorba uzorkovne brzine"
 msgid "MP3 Importing"
 msgstr "uvoz MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "uvoz i izvoz Ogg Vorbis"
@@ -353,7 +499,6 @@ msgstr "uvoz i izvoz Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "podrška značkama ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "uvoz i izvoz FLAC"
@@ -371,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Knjižnica za uvoz/izvoz FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "uvoz QuickTimeom"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Odlike"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "podrška za priključke"
 
@@ -393,6 +530,10 @@ msgstr "podrška za promjenu visine zvuka i tempa"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "podrška za promjenu visine zvuka i tempa"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Odlike"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -419,6 +560,18 @@ msgstr "Omotnica"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Omotnica"
 
@@ -430,6 +583,24 @@ msgstr "Omotnica"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "jamstvo kakvoće"
@@ -437,8 +608,26 @@ msgstr "jamstvo kakvoće"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, graphic artist"
 msgstr "&Grafički EQ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Omotnica"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -458,6 +647,15 @@ msgstr "Omotnica"
 msgid "%s, graphics"
 msgstr "&Grafički EQ"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -467,6 +665,10 @@ msgstr "besplatan program otvorena koda za snimanje i uređivanje zvuka ugradiv 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Zasluge"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -501,14 +703,23 @@ msgid "%s Team Members"
 msgstr "Časni članovi ekipe"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Drugi pridonositelji"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Hrvatski prijevod napravio Martin Bagić uz pomoć Mislava Lukšića."
@@ -527,6 +738,26 @@ msgstr "Posebna hvala:"
 msgid "%s website: "
 msgstr "Prvi pogon Audacityja"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Drugi pridonositelji"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Kliknite i povucite za prilagođivanje omjer veličina stereo zapisa."
@@ -544,6 +775,7 @@ msgstr "Promjena ravnala"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kliknite i povucite za uređivanje uzoraka"
@@ -551,17 +783,66 @@ msgstr "Kliknite i povucite za uređivanje uzoraka"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Kliknite i povucite za prepovećavanje zapisa."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Premjesti žarište na prethodni zapis i izaberi"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Pomakni zapis do&lje"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Zatvori žarišni zapis"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr " (onemogućeno)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr " (onemogućeno)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "Postavke priključka"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -579,7 +860,23 @@ msgstr "Svi&raj područje"
 msgid "Pinned Play Head"
 msgstr "Snimanje završeno"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Pogrješka"
 
@@ -603,7 +900,8 @@ msgstr ""
 "Ovo se pitanje samo jednom prikazuje nakon 'ugradbe' koja je pitala za prepostavljanje (reset) postavaka."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Preprilagodi Audacity"
 
 #: src/AudacityApp.cpp
@@ -616,6 +914,14 @@ msgstr ""
 "%s nenađeno.\n"
 "\n"
 "Uklonjeno je s popisa nedavnih datoteka."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -636,7 +942,7 @@ msgstr "&Otvori..."
 msgid "Open &Recent..."
 msgstr "&Otvori nedavnu..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&O Audacityju..."
@@ -650,29 +956,33 @@ msgid "&File"
 msgstr "&Datoteka"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nije našao prostora za spremanje privremenih datoteka.\n"
 "Molimo unijeti prikladnu mapu u postavkama."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nije našao prostora za spremanje privremenih datoteka.\n"
 "Molimo unijeti prikladnu mapu u postavkama."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity se zatvara. Molimo ponovno upaliti Audacity za uporabu novih privremenih mapa."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -681,15 +991,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity ne može zaključati mapu privremenih datoteka.\n"
 "Tu mapu možda rabi drugi Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Želite li svejedno upaliti Audacity?"
 
 #: src/AudacityApp.cpp
@@ -697,24 +1009,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "Pogrješka pri zaključavanju privremene mape"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Sustav je uočio da je Audacity već upaljen.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Uporabite naredbe Novo ili Otvori u trenutačno upaljenom Audacityju\n"
 "za istovremeno otvaranje više projekata.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity je već upaljen"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacityjeve datoteke projekta"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -734,7 +1094,8 @@ msgstr "\t-test (pokreni samodijagnostiku)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (prikaži inačicu Audacityja)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -744,9 +1105,10 @@ msgid "audio or project file name"
 msgstr "Nije moguće otvoriti datoteku projekta"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -759,20 +1121,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacityjeve datoteke projekta"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&Preuzorkuj..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Potvrda brisanja pravila"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Pomoć"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Ugasi Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacityjev dnevnik"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -784,9 +1175,14 @@ msgstr "&Spremi..."
 msgid "Cl&ear"
 msgstr "Iz&briši uneseno"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Zatvori"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -835,7 +1231,8 @@ msgid "Error Initializing Midi"
 msgstr "Pogrješka pri inicijalizaciji MIDI-ja"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacityjev dnevnik"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -849,40 +1246,18 @@ msgstr "Pogrješka pri otvaranju zvučnoga uređaja."
 msgid "Out of memory!"
 msgstr "Nema više mjesta!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automatsko prilagođivanje razine ulaza je stalo. Nije moguće bolje postaviti. Još uvijek previsoka."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Zbog automatskoga prilagođivanja razine ulaza, glasnoća se snizila na %f. "
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatsko prilagođivanje razine ulaza je stalo. Nije moguće bolje postaviti. Još uvijek preniska."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Zbog automatskoga prilagođivanja razine ulaza, glasnoća se povisila na %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automatsko prilagođivanje razine ulaza je stalo. Ukupan broj analiza prešao je granicu a da nije našao prihvatljivu glasnoću. Još uvijek previsoka."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automatsko prilagođivanje razine ulaza je stalo. Ukupan broj analiza prešao je granicu a da nije našao prihvatljivu glasnoću. Još uvijek preniska."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatsko prilagođivanje razine ulaza je stalo. %.2f izgleda kao prihvatljiva glasnoća."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Izaberite ulazni uređaj\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Izaberite ulazni uređaj\n"
 
 #: src/AudioIOBase.cpp
@@ -925,8 +1300,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Snimanje završeno\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Snimanje završeno\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Snimanje završeno\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Snimanje završeno\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -940,37 +1325,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Izaberite ulazni uređaj\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Izaberite ulazni uređaj\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Izaberite ulazni uređaj\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Datoteke žanra nije moguće otvoriti.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Izaberite ulazni uređaj\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Snimanje\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Uzorkovna brzina\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Sviranje\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Snimanje završeno\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Snimanje završeno\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Jačina ulaza: %.2f\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Jačina ulaza: %.2f\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -978,8 +1366,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Izaberite ulazni uređaj\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Izaberite ulazni uređaj\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Izaberite ulazni uređaj\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Izaberite ulazni uređaj\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -987,8 +1385,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Samoobnova pri urušenju"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1000,12 +1399,14 @@ msgid "Recoverable &projects"
 msgstr "Obnovljivi projekti"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Izabire"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Ime"
 
@@ -1016,6 +1417,10 @@ msgstr "Izabire"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Izabire"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1049,6 +1454,11 @@ msgstr "Spremi predzadanost"
 #: src/BatchCommandDialog.cpp
 msgid "&Parameters"
 msgstr "&Parametri"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Otrgni"
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
@@ -1085,6 +1495,22 @@ msgstr "Učinci"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Uredi parametre"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Uredi parametre"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1132,6 +1558,10 @@ msgid "Apply %s"
 msgstr "Uporabi %s"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "Upravljaj s krivuljama"
 
@@ -1140,6 +1570,17 @@ msgstr "Upravljaj s krivuljama"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Izaberite krivulju"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Oznake..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Uporabi lanac"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1207,7 +1648,8 @@ msgstr "O&bnovi područja"
 msgid "I&mport..."
 msgstr "U&vezi..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "I&zvezi..."
 
@@ -1248,9 +1690,15 @@ msgstr "Pomakni &gore"
 msgid "Move &Down"
 msgstr "Pomakni &dolje"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Spremi"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1296,11 +1744,38 @@ msgid "Benchmark"
 msgstr "&Pokreni pokus brzine..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Broj ponova:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Zatvori"
 
@@ -1315,12 +1790,32 @@ msgid "Export Benchmark Data as:"
 msgstr "Izvezi spektrene podatke kao:"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "Najveći broj nota mora biti cijeli broj u opsegu 1-128"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "Najveći broj nota mora biti cijeli broj u opsegu 1-128"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "Najveći broj nota mora biti cijeli broj u opsegu 1-128"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Priprema pretposlušanja\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1329,17 +1824,104 @@ msgstr "Primjenjivanje ponove\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Zalijepi\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Snimanje zvuka\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Završi (dan, vrijeme)"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Gradnja izdanja"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1360,9 +1942,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Molimo prvo izabrati zvuk za uporabu."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Nije izabran ni jedan lanac"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1390,6 +1996,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Nije nađen kodek"
 
@@ -1407,10 +2018,24 @@ msgstr "Primijeni &tu"
 msgid "Checkpointing %s"
 msgstr "Uvoženje %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Pogrješka pri pisanju u datoteku: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Pogrješka pri spremanju projekta. Možda nije moguće\n"
+"pisati u %s ili je disk pun."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1427,6 +2052,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "Uklanjanje %s nije uspjelo"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1524,6 +2153,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Izreži u međuspremnik"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Nedostaju datoteke"
 
@@ -1532,10 +2166,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ako nastavite, vaš projekt ne će se spremiti. Zbilja to želite?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1547,7 +2182,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Provjera ovisnosti"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nema"
 
@@ -1555,7 +2193,7 @@ msgstr "Nema"
 msgid "Rectangle"
 msgstr "Pravokutnik"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trokut"
 
@@ -1569,17 +2207,58 @@ msgstr "Pravokutno"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Dobro došli!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Podrška za FFmpeg nije prevedena u"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1601,8 +2280,8 @@ msgid "Locate FFmpeg"
 msgstr "Nađi FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity treba datoteku '%s' za uvoz i izvoz zvuka preko FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -1615,7 +2294,8 @@ msgstr "Mjesto '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Ako želite naći '%s', stisnite tu -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Pretraži..."
 
@@ -1641,8 +2321,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg nije nađen"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1662,24 +2343,38 @@ msgstr "Na to me više ne podsjećaj"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Uskladive knjižnice FFmpeg nemoguće naći."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity ne može pisati u datoteku:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Audacity ne može pisati u datoteku:\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Audacity ne može pisati u datoteku:\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1716,7 +2411,9 @@ msgstr "&Ne kopiraj nikakav zvuk"
 msgid "As&k"
 msgstr "Pitaj &korisnika"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Sve datoteke (*)|*"
 
@@ -1725,6 +2422,11 @@ msgstr "Sve datoteke (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Spremanje datoteka projekta"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Knjižnice"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1737,6 +2439,10 @@ msgstr "Imena datoteka:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1762,6 +2468,30 @@ msgstr "Mapa %s ne postoji. Želite li ju stvoriti?"
 msgid "Frequency Analysis"
 msgstr "Analiza frekvencije"
 
+#: src/FreqWindow.cpp src/prefs/SpectrumPrefs.h
+#, fuzzy
+msgid "Spectrum"
+msgstr "Nacrtaj spektar"
+
+#: src/FreqWindow.cpp
+msgid "Standard Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Cuberoot Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Enhanced Autocorrelation"
+msgstr ""
+
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+msgid "Cepstrum"
+msgstr ""
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1778,9 +2508,34 @@ msgstr "Linearna frekvencija"
 msgid "Log frequency"
 msgstr "Logaritamska frekvencija"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Povećanost"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1795,6 +2550,10 @@ msgstr "Vodoravni prikaz"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Okomica lijevo"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1837,6 +2596,37 @@ msgstr "Izabrali ste previše zvuka. Analiziram samo prvih %.1f sekunda."
 msgid "Not enough data selected."
 msgstr "Izabrali ste nedovoljno podataka."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "spektar.txt"
@@ -1845,7 +2635,8 @@ msgstr "spektar.txt"
 msgid "Export Spectral Data As:"
 msgstr "Izvezi spektrene podatke kao:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Pogrješka pri pisanju u datoteku: "
@@ -1921,6 +2712,26 @@ msgid "No Local Help"
 msgstr "Nema mjesne pomoći"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "These are our support methods:"
 msgstr "Ovdje ćete naći odgovore na sva pitanja:"
 
@@ -1975,6 +2786,10 @@ msgid "Used Space"
 msgstr "Prostor na disku"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Broj koraka za vratiti"
 
@@ -1988,6 +2803,10 @@ msgid "&Discard"
 msgstr "&Zaboravi"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Zaboravi"
 
@@ -1995,11 +2814,30 @@ msgstr "&Zaboravi"
 msgid "&Compact"
 msgstr "&Naredba"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Upravitelj poviješću..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2015,7 +2853,9 @@ msgid "Track"
 msgstr "Zapis"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Oznaka"
 
@@ -2075,18 +2915,25 @@ msgstr "Unesite ime zapisa"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Oznakovni zapis"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Prvi pogon Audacityja"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Izaberite jezik za Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2096,7 +2943,8 @@ msgstr "Izaberite jezik za Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Izabran jezik, %s (%s), nije isti kao jezik sustava, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Potvrdi"
 
@@ -2114,13 +2962,19 @@ msgstr ""
 "Stara datoteka spremljena je kao '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Otvaranje Audacityjeva projekta"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacityjeve karaoke%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Pretraži..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2166,19 +3020,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Miješanje i renderiranje zapisa"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "DJ%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Pojačanje"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Brzina"
 
@@ -2187,28 +3045,43 @@ msgid "Musical Instrument"
 msgstr "Glazbalo"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Nagib"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Nijem"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Mjerilo razine signala"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Pomaknut klizač pojačanja"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Pomaknut klizač brzine"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Pomaknut klizač nagiba"
 
@@ -2239,9 +3112,9 @@ msgstr ""
 "Ne će biti učitan."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2274,16 +3147,19 @@ msgstr ""
 "\n"
 "Rabite module samo iz pouzdanih izvora"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Da"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ne"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Učitač modula"
 
 #: src/ModuleManager.cpp
@@ -2313,18 +3189,121 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Prekopisanje postojeće datoteke"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2356,6 +3335,16 @@ msgstr "Nyquistov upit"
 msgid "Manage Plug-ins"
 msgstr "Oprostite, učitavanje priključka Vamp nije uspjelo."
 
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Prikaži sve kodeke"
+
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
 msgid "Show all"
@@ -2386,6 +3375,25 @@ msgstr "omogućeno"
 msgid "E&nabled"
 msgstr "omogućeno"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "omogućeno"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Izabire"
@@ -2394,7 +3402,8 @@ msgstr "Izabire"
 msgid "C&lear All"
 msgstr "Po&čisti"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "omogućeno"
 
@@ -2460,6 +3469,21 @@ msgstr "Pogrješka pri otvaranju zvučnoga uređaja. Molimo provjeriti postavke 
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Za crtanje spektra svi izabrani zapisi moraju imati istu uzorkovnu brzinu."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Snimljen zvuk"
@@ -2467,6 +3491,28 @@ msgstr "Snimljen zvuk"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "Snimi"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2494,11 +3540,11 @@ msgid "Inspecting project file data"
 msgstr "Pregledavanje datoteka projekta"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2539,11 +3585,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Upozorenje: nedostaju aliased datoteke"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Provjera projekta mape \"%s\"\n"
@@ -2568,12 +3614,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Upozorenje: nedostaju alias summary datoteke"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2630,7 +3676,8 @@ msgstr "Upozorenje: blokovske osamljene datoteke"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Tijek"
 
@@ -2655,6 +3702,11 @@ msgstr "Upozorenje: teškoće sa samoobnovom"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<neimenovano>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekt"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2693,11 +3745,96 @@ msgid ""
 msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Uklanjanje %s nije uspjelo"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Spremanje Audacityjeva projekta"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Tok MP3 nije moguće inicijalizirati"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tok MP3 nije moguće inicijalizirati"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tok MP3 nije moguće inicijalizirati"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tok MP3 nije moguće inicijalizirati"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tok MP3 nije moguće inicijalizirati"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tok MP3 nije moguće inicijalizirati"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tok MP3 nije moguće inicijalizirati"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Tok MP3 nije moguće inicijalizirati"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2711,12 +3848,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Osamljena blokovska datoteka: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "'%s' nemoguće preimenovati u '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Nije nađen kodek"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Uklanjanje %s nije uspjelo"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2727,9 +3885,9 @@ msgid "Error Writing to File"
 msgstr "Pogrješka pri pisanju u datoteku"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2740,8 +3898,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Spremanje &projekta"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacityjev dnevnik"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2751,10 +3918,10 @@ msgstr "(Obnovljeno)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Ova datoteka spremljena je u Audacityju %s.\n"
 "Vi rabite Audacity %s. Možda biste ga trebali nadograditi prije otvaranja."
@@ -2762,6 +3929,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Nije moguće otvoriti datoteku projekta"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2776,6 +3947,10 @@ msgid "Unable to parse project information."
 msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Spremanje &projekta"
 
@@ -2784,12 +3959,35 @@ msgid "Error Saving Project"
 msgstr "Pogrješka pri spremanju projekta"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "&Spremanje praznoga projekta"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2797,8 +3995,24 @@ msgstr ""
 "Na sreću, Audacity ih može automatski obnoviti:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Neki projekti nisu se dobro spremili pri zadnjem pogonu Audacityja.\n"
+"Na sreću, Audacity ih može automatski obnoviti:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Projekt je obnovljen"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Mapa privremenih datoteka"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2828,6 +4042,17 @@ msgstr "Upozorenje: prazan projekt"
 msgid "Insufficient Disk Space"
 msgstr "Prostor na disku"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -2845,6 +4070,25 @@ msgstr ""
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Spremi projekt \"%s\" kao..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2898,11 +4142,12 @@ msgid "Error Opening Project"
 msgstr "Pogrješka pri otvaranju projekta"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Pokušavate otvoriti samostvorenu sigurnosnu presliku.\n"
 "Zbog toga moglo bi doći do golemoga gubitka podataka.\n"
@@ -2935,6 +4180,12 @@ msgid "Error Opening File or Project"
 msgstr "Pogrješka pri otvaranju datoteke ili projekta"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Projekt je obnovljen"
 
@@ -2960,12 +4211,33 @@ msgid "Error Importing"
 msgstr "Pogrješka pri uvozu"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Spremi projekt"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Nije moguće otvoriti datoteku projekta"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Naredba"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2976,8 +4248,8 @@ msgid "Automatic database backup failed."
 msgstr "Samoobnova pri urušenju"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Dobro došli u Audacity, inačica %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3012,6 +4284,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "Ima mjesta za još %d minuta snimanja."
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -3029,6 +4305,18 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3043,6 +4331,26 @@ msgstr "Vodoravni prikaz"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Okomiti prikaz"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(najkvalitetnije)"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -3070,6 +4378,10 @@ msgstr "24-bitni PCM"
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
 msgstr "32-bitni brojevi"
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -3155,7 +4467,8 @@ msgstr "Postavke: "
 msgid "SelectionBar"
 msgstr "Za navođenje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Izbor"
 
@@ -3163,44 +4476,58 @@ msgstr "Izbor"
 msgid "Timer"
 msgstr "Vrijeme"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "S pomagalima"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Za gibanje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "S klizačima"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "S mjerilima"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Mjerilo sviranoga"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Mjerilo snimljenoga"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Za uređivanje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Za uređaje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Sviraj-pri-brzini"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "&Alatne trake"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -3213,7 +4540,10 @@ msgstr "Ravnalo"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Zapisi"
 
@@ -3265,6 +4595,15 @@ msgstr "Visoki zapisi"
 msgid "Choose a location to save screenshot images"
 msgstr "Izaberite mjesto za spremanje slika zaslona."
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (ovu poruku)"
+
 #: src/Sequence.cpp
 #, c-format
 msgid ""
@@ -3294,6 +4633,19 @@ msgstr "&Mogućnosti..."
 msgid "Debu&g"
 msgstr "&Raskukči (debug)"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "Uključi Približno"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
 #: src/SoundActivatedRecord.cpp
 msgid "Sound Activated Record"
 msgstr "Podraženo snimanje"
@@ -3303,7 +4655,8 @@ msgid "Activation level (dB):"
 msgstr "Podražajna glasnoća (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Dobro došli u Audacity!"
 
 #: src/SplashDialog.cpp
@@ -3430,19 +4783,45 @@ msgstr "Pogrješka pri spremanju datoteke značaka"
 msgid "Unsuitable"
 msgstr "Modul neprikladan"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Mapa privremenih datoteka"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity ne može pisati u datoteku:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3451,18 +4830,26 @@ msgstr ""
 "za pisanje."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity ne može pisati slike u datoteke:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3472,9 +4859,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3483,8 +4870,9 @@ msgstr ""
 "Možda loš png format?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity nije mogao pročitati svoje predzadane teme.\n"
@@ -3522,24 +4910,40 @@ msgstr ""
 "već su bile prisutne."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity ne može spremiti datoteke:\n"
 "  %s"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "Slabo"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Kontrast..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Ime zapisa"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3548,7 +4952,11 @@ msgstr "Kontrast..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Trajanje"
 
@@ -3559,7 +4967,8 @@ msgid "Time Track"
 msgstr "Vremenski zapis"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Snimanje sa štopericom"
 
 #: src/TimerRecordDialog.cpp
@@ -3588,12 +4997,38 @@ msgid "Error in Duration"
 msgstr "Pogrješka u trajanju"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Samoobnova pri urušenju"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Pogrješka u trajanju"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Izvoz FFmpeg po mjeri"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "Pogrješka u trajanju"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "&Snimi sa štopericom... "
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3603,7 +5038,8 @@ msgstr "Primijeni &tu"
 msgid "Recording start:"
 msgstr "Snimanje započeto"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Trajanje:"
 
@@ -3624,7 +5060,8 @@ msgid "Action after Timer Recording:"
 msgstr "Snimanje sa štopericom"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Snimanja sa štopericom"
 
 #: src/TimerRecordDialog.cpp
@@ -3659,9 +5096,39 @@ msgid ""
 "Recording exported: %s"
 msgstr "Snimanje završeno"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Pogrješka pri spremanju projekta"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Snimanje"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 dana 024 h 060 m 060 s"
 
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
@@ -3673,6 +5140,7 @@ msgstr "099 dana 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Započni (dan, vrijeme)"
@@ -3717,7 +5185,8 @@ msgstr "Nemoguće izvoziti"
 msgid "Export Project As:"
 msgstr "Izvezi predzadanosti"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Mogućnosti..."
 
@@ -3726,8 +5195,21 @@ msgid "After Recording completes:"
 msgstr "Mjerilo snimljenoga"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Ugasi Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3742,7 +5224,8 @@ msgid "Scheduled to stop at:"
 msgstr "Izbor do početka"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Snimanje sa štopericom - čekanje na početak"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3750,6 +5233,14 @@ msgstr "Snimanje sa štopericom - čekanje na početak"
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Snimanje završeno"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3760,8 +5251,19 @@ msgid "Recording Exported:"
 msgstr "Snimanje završeno"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Snimanje sa štopericom - čekanje na početak"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3877,6 +5379,10 @@ msgstr "Pomakni zapis g&ore"
 msgid "Move Track Down"
 msgstr "Pomakni zapis do&lje"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3922,25 +5428,79 @@ msgstr "Nema dosta prostora za lijepljenje izbora"
 msgid "There is not enough room available to expand the cut line"
 msgstr "Nema dosta prostora za širenje crte reza"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Primjenjivanje..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Naredba"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Naredba"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ponovi %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -3955,12 +5515,20 @@ msgid "Compares a range on two tracks."
 msgstr "Sažimanje temeljeno na Peaksu"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Odgoda (s):"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Čimbenik raspada: "
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -3982,6 +5550,11 @@ msgstr "Zapis"
 msgid "Track 1"
 msgstr "Zapis"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Veličina prozora"
@@ -3993,6 +5566,22 @@ msgstr "Od:"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Od:"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -4018,9 +5607,43 @@ msgstr "Rezanje"
 msgid "Envelopes"
 msgstr "Omotnica"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Oznake"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Filtar"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Format:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -4030,6 +5653,10 @@ msgstr "Pomakni zapis do&lje"
 msgid "Types:"
 msgstr "Filtar"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Komentari"
@@ -4037,6 +5664,18 @@ msgstr "Komentari"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Naredba:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4055,6 +5694,11 @@ msgid "Number of Channels:"
 msgstr "Broj ponova:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Višestruk izvoz"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Višestruk izvoz"
 
@@ -4062,9 +5706,26 @@ msgstr "Višestruk izvoz"
 msgid "Builtin Commands"
 msgstr "Izaberite naredbu"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacityjeva ekipa za podršku"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Završi (dan, vrijeme)"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -4106,11 +5767,22 @@ msgstr "&Spremi projekt"
 msgid "Saves a copy of current project."
 msgstr "&Spremi projekt"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Postavke: "
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Ime"
 
@@ -4121,6 +5793,18 @@ msgstr "Postavke: "
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Podatak"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -4146,7 +5830,8 @@ msgstr "Cjelozaslonski da/ne"
 msgid "Toolbars"
 msgstr "&Alatne trake"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Učinci"
 
@@ -4191,13 +5876,41 @@ msgid "All Tracks Plus"
 msgstr "Visoki zapisi"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
+#. i18n-hint:  This really means the color, not as in "white noise"
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgctxt "color"
+msgid "White"
+msgstr "Bijela pozadina"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Pozadina:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Pogrješka pri spremanju datoteke: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Slikaj zaslon..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -4244,6 +5957,10 @@ msgid "High:"
 msgstr "Visokopropusni"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&Razvrstaj zapise"
 
@@ -4256,7 +5973,8 @@ msgstr "Postavi"
 msgid "Add"
 msgstr "&Dodaj"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Ukloni"
 
@@ -4277,6 +5995,11 @@ msgid "Selects a time range."
 msgstr "Izaberite datoteku MIDI..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Izaberite datoteku MIDI..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Molimo izabrati radnju"
 
@@ -4288,9 +6011,37 @@ msgstr "Izaberite zvučni poslužnik"
 msgid "Set Clip"
 msgstr "Sljedeći alat"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Početak"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4309,9 +6060,14 @@ msgid "Edited Envelope"
 msgstr "Omotnica"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Omotnica"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4321,6 +6077,10 @@ msgstr "Oznake razdvojbe"
 msgid "Label Index"
 msgstr "Uredi oznaku"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Izabire"
@@ -4328,6 +6088,10 @@ msgstr "Izabire"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Uređene oznake"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4341,9 +6105,26 @@ msgstr "Postavi brzinu"
 msgid "Resize:"
 msgstr "Smanji prozor"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Slabo"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Spremi projekt"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4374,10 +6155,17 @@ msgid "Gain:"
 msgstr "Pojačanje"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&Razvrstaj zapise"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "0-1"
 
@@ -4388,6 +6176,10 @@ msgstr "Resetiraj"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "Vrijeme"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4417,13 +6209,28 @@ msgstr "Spektralni procesor"
 msgid "Spectral Select"
 msgstr "Izbor"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Novi zapis"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Molimo izabrati radnju"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Pojačaj"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -4445,6 +6252,10 @@ msgstr "Dopusti rezanje"
 msgid "Auto Duck"
 msgstr "Samospust"
 
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -4459,12 +6270,18 @@ msgstr "Izabrali ste zapis bez zvuka. Samospust može obraditi jedino zvučne za
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Samospust treba upravljajući zapis ispod izabranoga zapisa."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Jačina spuštanja:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekunda"
 
@@ -4488,7 +6305,8 @@ msgstr "Dužina unutarnje izblijede:"
 msgid "Inner &fade up length:"
 msgstr "Dužina unutarnje odblijede:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Prag:"
 
@@ -4505,6 +6323,11 @@ msgid "Simple tone control effect"
 msgstr "Stegni izbor s lijeva"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Prag šuma:"
+
+#: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
 msgstr "Bas (dB):"
 
@@ -4517,12 +6340,26 @@ msgid "Bass"
 msgstr "Bas"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "&Razina (dB):"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Treble"
+
+#: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
 msgstr "&Treble (dB):"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Razina"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -4531,6 +6368,11 @@ msgstr "Promijeni visinu zvuka"
 #: src/effects/ChangePitch.cpp
 msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Promijeni visinu zvuka bez promjene tempa"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Završna promjena tempa (%)"
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
@@ -4595,6 +6437,10 @@ msgid "from (Hz)"
 msgstr "od (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "u (Hz)"
 
@@ -4602,13 +6448,23 @@ msgstr "u (Hz)"
 msgid "t&o"
 msgstr "do"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Promjena u postotcima:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Promjena u postotcima"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -4620,7 +6476,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "neodređeno"
 
@@ -4648,6 +6506,7 @@ msgstr "Standardni broj okretaja gramofonske ploče po minuti:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Iz broja okretaja"
@@ -4657,6 +6516,14 @@ msgstr "Iz broja okretaja"
 msgctxt "change speed"
 msgid "&from"
 msgstr "od"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "Iz broja okretaja"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4760,6 +6627,19 @@ msgid "Click Removal"
 msgstr "Uklanjanje škljocaja"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Ime ne smije biti prazno"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "Prag (niži je osjetljiviji):"
 
@@ -4779,6 +6659,16 @@ msgstr "Najveća širina vrška"
 msgid "Compressor"
 msgstr "Sažimač"
 
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -4787,6 +6677,20 @@ msgstr "%.2f sekundi"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f s"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f s"
 
 #: src/effects/Compressor.cpp
@@ -4884,6 +6788,12 @@ msgstr "Molimo izabrati radnju"
 
 #: src/effects/Contrast.cpp
 msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid ""
 "Nothing to measure.\n"
 "Please select a section of a track."
 msgstr ""
@@ -4896,7 +6806,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analizator kontrasta mjeri razliku glasnoće RMS dvaju područja izbora (ne upisujte brojeve!)."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Kraj"
 
@@ -4956,6 +6867,18 @@ msgstr "Razlika:"
 msgid "&Help"
 msgstr "&Pomoć"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nula"
@@ -5000,6 +6923,10 @@ msgstr "Završno vrijeme prednine"
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "Završno vrijeme pozadine"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -5094,6 +7021,12 @@ msgstr "Mjerilo uspješnosti 1.4.7 za WCAG 2.0: neuspjeh"
 msgid "Data gathered"
 msgstr "Skupljeni podatci"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Analiza kontrasta (sukladna s WCAG 2)"
@@ -5119,6 +7052,19 @@ msgid "Medium Overdrive"
 msgstr "Potvrda prekopisanja"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Potvrda prekopisanja"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Sažimač opsega glasnoće"
 
@@ -5129,6 +7075,96 @@ msgstr "Uravnavalac"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Izobličavalac"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Graničnik"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Potvrda prekopisanja"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Potvrda prekopisanja"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Potvrda prekopisanja"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -5151,8 +7187,16 @@ msgid "Distortion"
 msgstr "Izobličavalac"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Izobličavalac"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -5167,8 +7211,21 @@ msgid "Clipping level"
 msgstr "Rezanje"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Uporabi lanac"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Izaberite prag"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -5183,6 +7240,14 @@ msgid "Repeat processing"
 msgstr "Obrada u svežnju CleanSpeech"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Stupanj uravnjenja"
 
@@ -5193,6 +7258,15 @@ msgstr "Graničnik"
 #: src/effects/Distortion.cpp
 msgid "Wet level"
 msgstr "2-razinski"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2-razinski"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -5219,6 +7293,16 @@ msgid "DTMF Tones"
 msgstr "Zvukovi DTMF..."
 
 #: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Niz DTMF:"
 
@@ -5226,7 +7310,9 @@ msgstr "Niz DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplituda (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Trajanje:"
 
@@ -5271,6 +7357,11 @@ msgstr "Jeka"
 msgid "Repeats the selected audio again and again"
 msgstr "Izvoz izabranoga zvuka kao %s"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "Odgoda (s):"
@@ -5291,7 +7382,8 @@ msgstr "Predzadanost:"
 msgid "Export Effect Parameters"
 msgstr "&Uredi parametre"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Pogrješka pri otvaranju datoteke: \"%s\""
@@ -5315,6 +7407,12 @@ msgstr "&Uredi parametre"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke.\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Priprema pretposlušanja"
@@ -5322,6 +7420,15 @@ msgstr "Priprema pretposlušanja"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Pretposlušanje"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -5358,10 +7465,30 @@ msgid "Factory Defaults"
 msgstr "Obnovi predzadanosti"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr ""
 "Koder FLAC nije se uspio inicijalizirati\n"
 "Stanje: %d"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -5386,6 +7513,23 @@ msgid "&Bypass"
 msgstr "Pojasnopropusni"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Poravnaj i pomakni okomicu"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Pomakni &gore"
 
@@ -5402,6 +7546,24 @@ msgid "Move effect down in the rack"
 msgstr "Snimka premještena u drugi zapis"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Snimka premještena u drugi zapis"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Unesite ime novoga lanca"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Latencija"
@@ -5411,8 +7573,17 @@ msgid "Some Command"
 msgstr "Izaberite naredbu"
 
 #: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "&Manage"
 msgstr "Upravljaj s krivuljama"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Sviranje"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -5473,14 +7644,33 @@ msgid "Options..."
 msgstr "Mogućnosti..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Filtar"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Ime"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Obrtanje vodoravno"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Pogrješka:"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "Za prijepis"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -5516,6 +7706,11 @@ msgstr "Sviranje"
 msgid "Play"
 msgstr "Sviraj"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "kosinusni"
@@ -5537,12 +7732,36 @@ msgid "Graphic EQ"
 msgstr "Grafički EQ"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Pojačanje basa"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Pojačanje basa"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -5577,6 +7796,10 @@ msgid "Effect Unavailable"
 msgstr "Pretposlušavanje nedostupno"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Najveći dB"
 
@@ -5589,6 +7812,26 @@ msgstr "%3d dB"
 msgid "Min dB"
 msgstr "Najmanji dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "Filtar"
@@ -5596,6 +7839,11 @@ msgstr "Filtar"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Nacrtaj krivulje"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Crtalo"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -5656,6 +7904,27 @@ msgstr "Obrađivanje: "
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "&Predzadano"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Pokreni pokus brzine..."
 
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
@@ -5822,6 +8091,17 @@ msgstr "Krivulje izvezene"
 msgid "No curves exported"
 msgstr "Nema izvezenih krivulja"
 
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
+
 #: src/effects/Fade.cpp
 msgid "Fade In"
 msgstr "Promjena glasnoće: Odblijedi"
@@ -5834,9 +8114,18 @@ msgstr "Promjena glasnoće: Izblijedi"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Kliknite i povucite za stvaranje područja izbora"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Kliknite i povucite za stvaranje područja izbora"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Nađi porezano"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -5858,13 +8147,37 @@ msgstr "Nema dosta prostora za stvaranje zvuka"
 msgid "Invert"
 msgstr "Obrni okomito"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Učinci zvučne jedinice"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normaliziraj najveću amplitudu na"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -5884,17 +8197,58 @@ msgstr "Obrađivanje: "
 msgid "&Normalize"
 msgstr "Normaliziraj"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Stereo kanale neovisno normaliziraj"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
 msgstr ".  Maksimum 0dB."
 
+#. i18n-hint: not a color, but "white noise" having a uniform spectrum
+#: src/effects/Noise.cpp
+#, fuzzy
+msgctxt "noise"
+msgid "White"
+msgstr "Bijela pozadina"
+
+#. i18n-hint: not a color, but "pink noise" having a spectrum with more power
+#. in low frequencies
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Pink"
+msgstr ""
+
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
 #: src/effects/Noise.cpp
 msgid "Noise"
 msgstr "Radnja:"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
 
 #: src/effects/Noise.cpp
 msgid "&Noise type:"
@@ -5909,16 +8263,73 @@ msgid "Second greatest"
 msgstr "Drugi zapis"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Predzadano povećanje"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Predzadano povećanje"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Uklanjanje šuma"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Svi zapisi moraju imati istu stopu uzorčenja"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -5977,8 +8388,9 @@ msgid "Step 1"
 msgstr "1. korak"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Izaberite par sekundi samo šuma kako bi Audacity znao što treba ukloniti,\n"
@@ -6002,9 +8414,20 @@ msgstr "Izaberite sav zvuk koji želite obraditi, izaberite čimbenike šuma i s
 msgid "Noise:"
 msgstr "Radnja:"
 
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Isolate"
 msgstr "&Izluči samo zvuk"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Smanji prozor"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -6018,6 +8441,11 @@ msgstr "V&rsta prozora"
 msgid "Window si&ze:"
 msgstr "Veli&čina prozora"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
+
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
 msgstr "1"
@@ -6030,17 +8458,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - predzadano"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "Predzadano povećanje"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Uklanjanje šuma"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -6077,6 +8551,10 @@ msgid "Normalize"
 msgstr "Normaliziraj"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
 msgstr "Uklanjanje otklona DC i normaliziranje...\n"
 
@@ -6087,6 +8565,10 @@ msgstr "Uklanjanje otklona DC...\n"
 #: src/effects/Normalize.cpp
 msgid "Normalizing without removing DC offset...\n"
 msgstr "Normaliziranje bez uklanjanja otklona DC...\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 #, c-format
@@ -6133,9 +8615,14 @@ msgstr "Stereo kanale neovisno normaliziraj"
 msgid "Paulstretch"
 msgstr "Paulovo rastezanje..."
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Čimbenik rastezanja:"
@@ -6144,9 +8631,43 @@ msgstr "Čimbenik rastezanja:"
 msgid "&Time Resolution (seconds):"
 msgstr "Vremenska razlučivost (s):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Faznik"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -6209,6 +8730,10 @@ msgid "Repair"
 msgstr "Popravi"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -6236,6 +8761,10 @@ msgid "Repeat"
 msgstr "Ponavljač"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "Broj ponova:"
 
@@ -6256,6 +8785,10 @@ msgstr "Nova dužina izbora: "
 #, c-format
 msgid "New selection length: %s"
 msgstr "Nova dužina izbora: "
+
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
@@ -6296,6 +8829,10 @@ msgstr "Katedrala"
 #: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "Pazvuk"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "&Room Size (%):"
@@ -6350,6 +8887,25 @@ msgstr "Obrni vodoravno"
 msgid "Reverses the selected audio"
 msgstr "Izvoz izabranoga zvuka kao %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Niskopropusni"
@@ -6359,12 +8915,35 @@ msgid "Highpass"
 msgstr "Visokopropusni"
 
 #: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "&Prenesi datoteku..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "Za crtanje spektra svi izabrani zapisi moraju imati istu uzorkovnu brzinu."
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
 msgstr "Filtar"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
@@ -6377,6 +8956,14 @@ msgstr "Rez:"
 #: src/effects/ScienFilter.cpp
 msgid "C&utoff:"
 msgstr "Rez:"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
@@ -6466,11 +9053,20 @@ msgstr "Rabi predzadanosti"
 msgid "Restore Defaults"
 msgstr "Obnovi predzadanosti"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Tišina"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -6495,6 +9091,10 @@ msgstr "Miješanje u &mono pri izvozu"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "Rastegni"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
 
 #: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
@@ -6553,6 +9153,14 @@ msgid "Tone"
 msgstr "Ton..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Valni oblik:"
 
@@ -6585,8 +9193,20 @@ msgid "Truncate Detected Silence"
 msgstr "Izreži tišinu"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "Izreži tišinu"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -6595,6 +9215,10 @@ msgstr "Razdvo&ji kod tišina"
 #: src/effects/TruncSilence.cpp
 msgid "Tr&uncate to:"
 msgstr "Izreži tišinu"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
@@ -6609,10 +9233,20 @@ msgid "VST Effects"
 msgstr "Učinci VST"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Scanning Shell VST"
 msgstr "Pregledavanje priključaka VST"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Neuspjelo otvaranje knjižnice za MP3 kodiranje!"
 
@@ -6620,17 +9254,44 @@ msgstr "Neuspjelo otvaranje knjižnice za MP3 kodiranje!"
 msgid "VST Effect Options"
 msgstr "Postavke učinka"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Dužina:"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Sažimanje tišine:"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Sažimanje tišine:"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Graphical Mode"
 msgstr "Grafički EQ"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 #, c-format
@@ -6642,11 +9303,17 @@ msgid "Save VST Preset As:"
 msgstr "Spremi program VST kao:"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Učitaj program VST:"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "Učitaj program VST:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacityjeve datoteke projekta"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -6673,9 +9340,15 @@ msgstr "Pogrješka pri učitavanju programa VST"
 msgid "Unable to load presets file."
 msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Postavke učinka"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
@@ -6685,6 +9358,20 @@ msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Ta datoteka parametara zadnji je put spremljena iz %s. Nastaviti?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -6712,6 +9399,11 @@ msgid "Audio Unit Effects"
 msgstr "Učinci zvučne jedinice"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Učinci zvučne jedinice"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "Pogrješka pri otvaranju datoteke"
 
@@ -6724,20 +9416,41 @@ msgid "Audio Unit Effect Options"
 msgstr "Učinci zvučne jedinice"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Sučelje"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Izaberite izlazni uređaj"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Višepojasni"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Stvori"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "Uvezi predzadanosti"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -6813,6 +9526,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Opis toka nedostupan"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "pretvorba uzorkovne brzine"
 
@@ -6820,6 +9538,21 @@ msgstr "pretvorba uzorkovne brzine"
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Uklanjanje %s nije uspjelo"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Opis toka nedostupan"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Opis toka nedostupan"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -6829,13 +9562,36 @@ msgstr "Zvučna jedinica"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Učinci VST"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "Učinci VST"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Postavke učinka"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -6843,6 +9599,7 @@ msgstr "Postavke učinka"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "Učinci VST"
@@ -6850,6 +9607,23 @@ msgstr "Učinci VST"
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
 msgstr "Postavke učinka"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
@@ -6865,13 +9639,27 @@ msgstr "%d krivulja izvezeno u %s\n"
 msgid "Generator"
 msgstr "Stvarač"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Učinci VST"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Učinci"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -6887,6 +9675,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Izlaz Nyquista:"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Poravnano s krajem izbora"
 
@@ -6899,12 +9705,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Oprostite, učinak nije moguće primijeniti na stereo zapise čiji se zasebni zapisi ne poklapaju."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Izlaz Nyquista:"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Obrađivanje: "
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -6984,6 +9808,19 @@ msgid "Could not determine language"
 msgstr "Pogrješka pri otvaranju datoteke:"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Unesite naredbu Nyquist:"
 
@@ -7000,6 +9837,22 @@ msgstr "Nyquistov upit"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Nyquistov upit"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Pogrješka pri otvaranju datoteke"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "Neizmjerene prednine"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -7020,13 +9873,18 @@ msgstr "Izaberite datoteku MIDI..."
 msgid "Save file as"
 msgstr "Spremi datoteke"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "neimenovano"
 
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Učinci VST"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -7043,6 +9901,22 @@ msgstr "Oprostite, inicijalizacija priključka Vamp nije uspjela."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Postavke priključka"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Glavne mogućnosti"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -7205,9 +10079,18 @@ msgstr ""
 "Želite li nastaviti?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "Modul \"%s\" nađen."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -7218,8 +10101,32 @@ msgstr ""
 "Postavite ga putem Postavke > Knjižnice."
 
 #: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Knjižnica FFmpeg:"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -7230,6 +10137,59 @@ msgid ""
 msgstr ""
 "FFmpeg ne može naći zvučni kodek 0x%x.\n"
 "Podrška za taj kodek vjerojatno nije prevedena."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -7250,7 +10210,8 @@ msgstr "Izvoz izabranoga zvuka kao %s"
 msgid "Invalid sample rate"
 msgstr "Nevaljana uzorkovna brzina"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Preuzorkuj"
 
@@ -7282,7 +10243,8 @@ msgstr "Uzorkovna brzina"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%i kb/s"
@@ -7302,6 +10264,45 @@ msgid "%.2f kbps"
 msgstr "%.2f kb/s"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
 msgstr "1"
 
@@ -7314,6 +10315,10 @@ msgid "Constrained"
 msgstr "stalni"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Zvuk..."
 
@@ -7322,8 +10327,44 @@ msgid "Low Delay"
 msgstr "Odgoda"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Osrednje"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -7394,8 +10435,17 @@ msgid "Replace preset '%s'?"
 msgstr "Želite izbrisati predzadanost '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Glavna"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -7503,6 +10553,10 @@ msgstr "Jezik:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Spremnik bitova (\"Bit Reservoir\")"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -7636,6 +10690,11 @@ msgstr ""
 "0 - zadano\n"
 "najmanje - 1\n"
 "najviše - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -7795,6 +10854,17 @@ msgstr "Nema oznaka za izvoz."
 msgid "Select xml file to export presets into"
 msgstr "Izaberite datoteku XML u koju će se izvesti predzadanosti"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Neuspjelo pogađanje formata"
@@ -7881,12 +10951,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(najkvalitetnije)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f kb/s"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(manje datoteke)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -7897,7 +11019,8 @@ msgstr "Ludo"
 msgid "Extreme"
 msgstr "Pretjerano"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Obično"
 
@@ -7922,6 +11045,11 @@ msgid "Joint Stereo"
 msgstr "Združeni stereo"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Mod bitove brzine:"
 
@@ -7934,14 +11062,19 @@ msgstr "Kakvoća"
 msgid "Channel Mode:"
 msgstr "Mod kanala:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Crta reza uklonjena"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Nađi Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity treba %s za stvaranje datoteke MP3."
 
 #: src/export/ExportMP3.cpp
@@ -7969,13 +11102,34 @@ msgid "Where is %s?"
 msgstr "Gdje je %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Poveznica usmjeruje na lame_enc.dll razl%d.%d. Ta inačica nije uskladiva s Audacityjem %d.%d.%d.\n"
 "Preuzmite najnoviju inačicu knjižnice LAME MP3."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Spremanje datoteka projekta"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -8079,6 +11233,10 @@ msgstr ""
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Mjesto izvoza:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -8219,6 +11377,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Nije moguće postaviti kakvoću renderiranja QuickTimeom"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
@@ -8229,6 +11407,10 @@ msgstr "Izvoz izabranoga zvuka kao Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Izvoz izabranoga zvuka kao Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -8247,8 +11429,28 @@ msgid "Other uncompressed files"
 msgstr "Druge nesažete datoteke"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Pogrješka pri uvozu"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -8276,11 +11478,11 @@ msgid "All supported files"
 msgstr "Sve datoteke|*|Sve podržane datoteke|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -8289,11 +11491,11 @@ msgstr ""
 "uređivati stiskom na Datoteka > Uvezi > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "je datoteka MIDI, a ne zvučna datoteka. \n"
@@ -8305,18 +11507,18 @@ msgid "Select stream(s) to import"
 msgstr "Izaberite tok(ove) za uvoz"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Podrška %s nije prevedena za ovu inačicu Audacityja."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je datoteka (zapis) glazbenoga CD-a.\n"
 "Tu vrstu datoteka Audacity izravno ne može otvoriti.\n"
@@ -8325,10 +11527,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" je datoteka popisa izvođenja.\n"
@@ -8337,10 +11539,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvučna datoteka Windows Media Audio. \n"
@@ -8349,10 +11551,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je datoteka Advanced Audio Coding. \n"
@@ -8361,12 +11563,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" je šifrirana zvučna datoteka. \n"
@@ -8377,10 +11579,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je medijska datoteka RealPlayer. \n"
@@ -8389,12 +11591,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" je datoteka notes-based, nije zvučna. \n"
 "Audacity ju ne može otvoriti.\n"
@@ -8403,10 +11605,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -8419,10 +11621,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvučna datoteka Wavpack. \n"
@@ -8431,10 +11633,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvučna datoteka Dolby Digital. \n"
@@ -8443,10 +11645,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvučna datoteka Ogg Speex. \n"
@@ -8455,10 +11657,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je video datoteka. \n"
@@ -8472,20 +11674,31 @@ msgstr "Modul \"%s\" nađen."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity nije prepoznao vrstu datoteke '%s'.\n"
 "Ako je sažeta, pokušajte ju uvesti rabeći \"Uvezi sirove podatke\"."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -8494,6 +11707,11 @@ msgstr ""
 "Uvoznici koji navodno podržavaju takve datoteke su:\n"
 "%s,\n"
 "ali nijedan ne razumije ovaj format."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Spremanje datoteka projekta"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8510,8 +11728,57 @@ msgid "Import Project"
 msgstr "Uvezi predzadanosti"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Postupak poravnanja javio je unutarnju pogrješku."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Nevaljana uzorkovna brzina"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8519,16 +11786,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Nije moguće naći mape s podatcima projekta: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Projekt"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Nevaljana uzorkovna brzina"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Nevaljana uzorkovna brzina"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8558,36 +11883,6 @@ msgstr "Kazalo[%02x], kodek[%s], jezik[%s], uzorkovna brzina[%s], kanali[%d], tr
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer (uskladive datoteke)"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Pogon GStreamera nije uspio"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "'%s' nemoguće preimenovati u '%s'"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Kazalo[%02x], kodek[%s], jezik[%s], uzorkovna brzina[%s], kanali[%d], trajanje[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer %s: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -8647,6 +11942,14 @@ msgstr "Pogrješka pri otvaranju datoteke"
 msgid "MP3 files"
 msgstr "MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis"
@@ -8681,8 +11984,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF i drugi nesažeti formati"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft), potpisano, 16-bitni PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bitni PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -8693,12 +12090,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-bitni PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bitni PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bitni PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-bitni brojevi"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-bitni brojevi"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft), potpisano, 16-bitni PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16-bitno"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -8709,12 +12150,20 @@ msgid "24 bit DWVW"
 msgstr "24-bitno"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bitni PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bitni PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -8763,6 +12212,19 @@ msgstr "Uvozi sirove podatke"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Bez 'endiannessa'"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Osrednje"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -8813,6 +12275,10 @@ msgstr "Uzorkovna brzina:"
 msgid "&Import"
 msgstr "&Uvezi"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -8833,6 +12299,7 @@ msgstr "desno"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -8858,6 +12325,7 @@ msgstr "Kraj"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -8881,15 +12349,35 @@ msgstr[2] ""
 msgstr[3] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Vremenski %s pomaknuti zapisi/isječci %.02f sekunda"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Vremenski %s pomaknuti zapisi/isječci %.02f sekunda"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Vremenski pomak"
 
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "Obreži gra&nice"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Obreži gra&nice"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "Obreži gra&nice"
 
 #: src/menus/ClipMenus.cpp
@@ -9010,7 +12498,8 @@ msgstr "Obreži izabrane snimke od %.2f sekunda do %.2f sekunda"
 msgid "Trim Audio"
 msgstr "Obreži zvuk"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Razdvoji"
 
@@ -9072,6 +12561,11 @@ msgstr "&Zalijepi"
 msgid "Duplic&ate"
 msgstr "&Udvostruči"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "&Izbriši sve zapise"
+
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
 msgid "Spl&it Cut"
@@ -9127,32 +12621,8 @@ msgid "Delete Key&2"
 msgstr "Tipka brisanja 2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Traka s k&lizačima"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Prilagodi brzinu izvođenja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Ubrzaj sviranje"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Uspori sviranje"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Snimanje završeno"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Ubrzaj sviranje"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Uspori sviranje"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -9177,6 +12647,13 @@ msgstr "Promijeni ulazni uređaj"
 #: src/menus/ExtraMenus.cpp
 msgid "&Full Screen (on/off)"
 msgstr "Cjelozaslonski da/ne"
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -9235,6 +12712,11 @@ msgstr "Uvezi oznake"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Izaberite datoteku MIDI..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Sve datoteke (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -9315,6 +12797,11 @@ msgid "&Labels..."
 msgstr "&Oznake..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Izvezi MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Sirovi podatci..."
 
@@ -9331,6 +12818,10 @@ msgstr "&Ispiši..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Izlaz"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -9363,6 +12854,10 @@ msgid "Nothing to do"
 msgstr "Ništa za vratiti"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Zatvori žarišni zapis"
 
@@ -9373,6 +12868,10 @@ msgstr "Nije moguće otvoriti datoteku projekta"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Snimanje započeto"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -9391,12 +12890,17 @@ msgid "&Getting Started"
 msgstr "Početak izbora:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacityjev dnevnik"
+#, fuzzy
+msgid "&Manual"
+msgstr "Upravljaj s krivuljama"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&Pomoć"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -9414,11 +12918,8 @@ msgstr "Po&datci o zvučnom uređaju..."
 msgid "Show &Log..."
 msgstr "Prikaži &dnevnik..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&O Audacityju..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Oznaka dodana"
 
@@ -9544,6 +13045,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "Zalijepi &tekst u novu oznaku"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "&Označen zvuk"
 
@@ -9608,6 +13113,18 @@ msgid "Label Join"
 msgstr "Uredi oznaku"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Idi nazad od alatnih traka do zapisa"
 
@@ -9648,8 +13165,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Mijenjaj žarišni zapis"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Novo..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -9664,6 +13189,10 @@ msgstr "Priključci %i do %i"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "&Stvori"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -9747,6 +13276,16 @@ msgid "Set Track Status..."
 msgstr "na &početak zapisa"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Stišaj zvuk"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&Razvrstaj zapise"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Postavke..."
 
@@ -9769,6 +13308,12 @@ msgstr "&Uredi oznake..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Spremi projekt &kao..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "promijenjivi"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -9845,6 +13390,11 @@ msgid "In All &Sync-Locked Tracks"
 msgstr "Na sve &zaključane zapise"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr " Zaključavanje odabrano"
+
+#: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "Svi&raj područje"
 
@@ -9913,8 +13463,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Linearna frekvencija"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Izbor do početka"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Mjesto sviranja:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -10051,6 +13610,14 @@ msgstr "Dug skok okomice lijevo"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "Dug skok okomice desno"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
@@ -10259,18 +13826,21 @@ msgid "Created new label track"
 msgstr "Napravljen novi oznakovni zapis"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Ova inačica Audacityja dopušta samo jedan vremenski zapis po prozoru."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Napravljen novi vremenski zapis"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nova uzorkovna brzina (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Unesena vrijednost nije valjana"
 
@@ -10350,6 +13920,11 @@ msgid "&Time Track"
 msgstr "&Vremenski zapis"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Traka s k&lizačima"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Razdvoji stereo u mo&no"
 
@@ -10388,6 +13963,10 @@ msgstr "&Unijemi sve zapise"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Odnijemi sve zapise"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -10519,7 +14098,9 @@ msgstr "Sviraj"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Snimanje"
 
@@ -10532,8 +14113,27 @@ msgid "no label track at or below focused track"
 msgstr "Nagni nalijevo na žarišnom zapisu"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Napravljen novi oznakovni zapis"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -10601,6 +14201,11 @@ msgid "&Timer Record..."
 msgstr "&Snimi sa štopericom... "
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Podraženo snimanje"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Svi&raj područje"
 
@@ -10629,16 +14234,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "&Podraženo snimanje (da/ne)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Snimanje završeno"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "Pre&krivaj (da/ne)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Pro&gramsko odsviravanje (da/ne)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomatsko prilagođivanje razine ulaza (da/ne)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -10648,6 +14254,11 @@ msgstr "&Upravljanje"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "Svi&raj"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -10765,6 +14376,11 @@ msgid "&Fit to Width"
 msgstr "Prilag&odi prozoru"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "Prilag&odi prozoru"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Stisni sve zapise"
 
@@ -10808,6 +14424,18 @@ msgstr "Učinci VST"
 msgid "&Window"
 msgstr "Prozor"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
@@ -10833,7 +14461,7 @@ msgstr "Postavke: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Ugasi Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -10880,7 +14508,8 @@ msgstr "&Poslužnik"
 msgid "Using:"
 msgstr "U uporabi:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Sviranje"
 
@@ -10900,7 +14529,8 @@ msgstr "Ka&nali"
 msgid "Latency"
 msgstr "Latencija"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisekunda"
 
@@ -10929,7 +14559,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Mape"
 
@@ -10942,8 +14573,22 @@ msgid "Default directories"
 msgstr "Mape"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Pretraži..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -11003,6 +14648,11 @@ msgstr "Izaberi mjesto za spremanje slika"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "Mapa %s ne postoji. Želite li ju stvoriti?"
 
@@ -11016,7 +14666,8 @@ msgid "Directory %s is not writable"
 msgstr "U mapi %s zapisivanje nije dopušteno"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Promjene privremene mape primjenit će se tek pri sljedećem pogonu Audacityja"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -11031,11 +14682,36 @@ msgstr "Postavke: "
 msgid "Sorted by Effect Name"
 msgstr "Razvrstaj po imenu"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Razvrstaj po imenu"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Razvrstaj po imenu"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "Učinci VST"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -11044,6 +14720,18 @@ msgstr "Učinci VST"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -11054,16 +14742,33 @@ msgid "Effect Options"
 msgstr "Postavke učinka"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Postavke priključka"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Pretraži učinke VST pri sljedećem pogonu Audacityja"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
 msgstr "Instrument"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
 
 #. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
 #. * audio file import options
@@ -11206,6 +14911,10 @@ msgid "Location of &Manual:"
 msgstr "Mjesto &priručnika:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "Opseg dB mje&rila/valna oblika:"
 
@@ -11218,6 +14927,10 @@ msgid "Show e&xtra menus"
 msgstr "Prikaži mrežu uzduž osi &Y"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "&Zapišti kad završiš s većim zadaćama"
 
@@ -11225,9 +14938,46 @@ msgstr "&Zapišti kad završiš s većim zadaćama"
 msgid "Re&tain labels if selection snaps to a label"
 msgstr "Za&drži oznake kad izbor skoči na njihov rub"
 
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Postavke priključka"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Ravnalo"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Uvozi/Izvozi"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Postavke: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -11240,6 +14990,10 @@ msgstr "Napredne mogućnosti miješanja"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Obično"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -11266,6 +15020,14 @@ msgstr "Zanemari tišinu na početku i kraju"
 msgid "Exported Label Style:"
 msgstr "Izvezi oznake kao:"
 
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
+
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Keyboard"
@@ -11284,6 +15046,10 @@ msgid "Open a new project to modify keyboard shortcuts."
 msgstr "Za promjenu tipkovnih prečaca otvorite novi projekt."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Tipkovni prečaci"
 
@@ -11292,8 +15058,35 @@ msgid "View by:"
 msgstr "&Prikaz"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Ime"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Prikaz"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Prikaz"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Prikaz"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
@@ -11302,6 +15095,12 @@ msgstr "Tipkovni prečaci"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Short cut"
 msgstr "Niski zapisi"
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Mogućnosti..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -11316,7 +15115,15 @@ msgid "&Defaults"
 msgstr "&Predzadano"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Izaberi datoteku XML s Audacityjevim tipkovnim prečacima..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11325,8 +15132,21 @@ msgstr "Pogrješka pri uvozu tipkovnih prečaca"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Učitano %d tipkovnih prečaca\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -11339,6 +15159,38 @@ msgstr "Izvezi tipkovne prečace kao:"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Pogrješka pri izvozu tipkovnih prečaca"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -11385,12 +15237,17 @@ msgid "Dow&nload"
 msgstr "&Preuzmi"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity je sam uočio valjane knjižnice FFmpeg.\n"
 "Želite li još uvijek potražiti ručno?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -11427,6 +15284,10 @@ msgstr "Latencija sintetizatora MIDI (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "Latencija sintetizatora MIDI mora biti cijeli broj"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -11437,13 +15298,30 @@ msgid "Preferences for Module"
 msgstr "Postavke: "
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr "Još u razvoju. Omogućite ih samo ako ste pročitali priručnik i znate što radite."
 
+#. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Promjene privremene mape primjenit će se tek pri sljedećem pogonu Audacityja"
 
 #: src/prefs/ModulePrefs.cpp
@@ -11461,6 +15339,10 @@ msgstr "Nema uređaja"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Moduli"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -11502,7 +15384,10 @@ msgstr "Lijeva povlaka"
 msgid "Set Selection Range"
 msgstr "Postavlja opseg izbora"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "SHIFT + lijevi klik"
 
@@ -11589,6 +15474,15 @@ msgstr "Lijeva povlaka"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Miče isječke među zapisima"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Lijeva povlaka"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -11700,8 +15594,21 @@ msgstr "&Kratak skok:"
 msgid "Lo&ng period:"
 msgstr "&Dugi skok:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Postavke Audacityja"
 
 #: src/prefs/PrefsDialog.cpp
@@ -11715,6 +15622,11 @@ msgstr "Postavke: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Postavke: "
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -11775,12 +15687,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "Natkrivanje: &sviraj druge zapise dok snimam novi"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "Pro&gramsko odsviravanje (da/ne)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Novi zapis"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Izaberite tok(ove) za uvoz"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -11821,41 +15743,37 @@ msgid "System &Date"
 msgstr "Započeto dana"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatsko prilagođivanje razine ulaza"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Omogući automatsko prilagođivanje razine ulaza."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Ciljni vršak:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Unutar:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Vrijeme analize:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisekunda (vrijeme jedne analize)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Broj uzastopnih analiza:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 znači beskonačno"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Započeto dana"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Podraženo snimanje"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Zabilježni zapis"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -11866,6 +15784,13 @@ msgstr "Razdoblje sličice"
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
+msgstr "Predzadano povećanje"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
 msgstr "Predzadano povećanje"
 
 #. i18n-hint: Grayscale color scheme for spectrograms
@@ -11883,6 +15808,11 @@ msgstr "&Linearno"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Frekvencija (Hz)"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -11943,12 +15873,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Naj&viša frekvencija (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "&Pojačanje (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "&Opseg (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -11971,12 +15909,21 @@ msgid "1024 - default"
 msgstr "256 - predzadano"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - najuže"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "V&rsta prozora"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Čimbenik raspada: "
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -12064,13 +16011,14 @@ msgid "Info"
 msgstr "Podatci"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -12158,6 +16106,18 @@ msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "Naredba \"Promijeni žarišni zapis\" &kruži kroz zapise"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Napredne mogućnosti miješanja"
 
@@ -12178,6 +16138,10 @@ msgid "Spectrogram"
 msgstr "Spektrogram"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "Prenacrtaj"
 
@@ -12192,6 +16156,10 @@ msgstr "&Povećaj na izbor"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Predzadano povećanje"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -12214,6 +16182,16 @@ msgid "50ths of Seconds"
 msgstr "sekunda"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "sekunda"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "sekunda"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "milisekunda"
 
@@ -12221,7 +16199,12 @@ msgstr "milisekunda"
 msgid "Samples"
 msgstr "obični uzorci"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Povećanost"
 
@@ -12230,8 +16213,29 @@ msgid "Preferences for Tracks"
 msgstr "Postavke: "
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "&Prikazuj ime zapisa u valnu obliku (u gornjem lijevom uglu)"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Snimanje završeno"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -12240,6 +16244,11 @@ msgstr "Predzadani način &prikaza:"
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Zadan &uzorkovni format:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "obični uzorci"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -12291,6 +16300,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "Miješanje u &stereo pri izvozu"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "Miješanje u &mono pri izvozu"
 
@@ -12315,16 +16328,24 @@ msgid "Stopped"
 msgstr "Zaustavi"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Zastani"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Skoči na početak"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Skoči na kraj"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Zastani"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Izbor do početka"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Izbor do kraja"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -12338,20 +16359,17 @@ msgstr "Novi zapis"
 msgid "Append Record"
 msgstr "Snimi na &kraj"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Izbor do kraja"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Izbor do početka"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Zastani"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -12431,11 +16449,17 @@ msgstr "Izbor tišine"
 msgid "Sync-Lock Tracks"
 msgstr "Vremenski zaključaj zapise"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Povećaj"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Umanji"
 
@@ -12502,50 +16526,23 @@ msgstr "Mjerilo snimljenoga"
 msgid "&Playback Meter Toolbar"
 msgstr "Mjerilo sviranoga"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Snimanje završeno"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Sviranje"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Jačina ulaza: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Jačina ulaza (nedostupno; uporabite miješač sustava)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Jačina ulaza: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Jačina ulaza: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Jačina ulaza (nedostupno; uporabite miješač sustava)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Traka s k&lizačima"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "Ravnalo"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Nyquistov upit"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Nyquistov upit"
@@ -12553,6 +16550,7 @@ msgstr "Nyquistov upit"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Nyquistov upit"
@@ -12560,9 +16558,24 @@ msgstr "Nyquistov upit"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Uključi nadzor"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Uključi nadzor"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Ravnalo"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -12610,7 +16623,9 @@ msgstr "Približno..."
 msgid "Length"
 msgstr "Dužina:"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "središte"
 
@@ -12618,6 +16633,14 @@ msgstr "središte"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "Odredite izbor s točnošću najmanje jedinice: \"%s\""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -12644,6 +16667,10 @@ msgstr "Pojačanje niskih frekvencija"
 msgid "Center Frequency"
 msgstr "Linearna frekvencija"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -12662,8 +16689,8 @@ msgstr "Traka za &uređaje"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacityjeva alatna traka - %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -12690,7 +16717,8 @@ msgstr "Vremenski pomak"
 msgid "Zoom Tool"
 msgstr "Povećalo"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Crtalo"
 
@@ -12766,17 +16794,24 @@ msgstr "Povucite jednu ili više granica oznaka"
 msgid "Drag label boundary."
 msgstr "Povucite granicu oznake"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Promijenjena oznaka"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Uredi oznaku"
 
 #: src/tracks/labeltrack/ui/LabelTextHandle.cpp
 msgid "Click to edit label text"
 msgstr "Skoči na početak"
+
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "&Font..."
+msgstr "&Ispiši..."
 
 #. i18n-hint: (noun) This is the font for the label track.
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
@@ -12821,31 +16856,42 @@ msgstr "Uređene oznake"
 msgid "New label"
 msgstr "Oznaka dodana"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Povisi za &oktavu"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Snizi za o&ktavu"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Kliknite za okomito povećanje, shift-kliknite za umanjenje. Vucite kako biste odredili područja povećanja."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Desni klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Umanji"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "SHIFT + lijevi klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "SHIFT + lijevi klik"
 
@@ -12868,6 +16914,14 @@ msgid "Stretch"
 msgstr "Rastegni"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Spojene snimke"
 
@@ -12879,7 +16933,8 @@ msgstr "Spoji"
 msgid "Expanded Cut Line"
 msgstr "Crta reza raširena"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Raširi"
 
@@ -12903,6 +16958,11 @@ msgstr "Premješten uzorak"
 msgid "Sample Edit"
 msgstr "Uređivanje uzoraka"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Povećaj točku"
@@ -12910,6 +16970,16 @@ msgstr "Povećaj točku"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "&Spektrogram"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -12935,7 +17005,8 @@ msgstr "Obrađivanje: "
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Promijenjeno: '%s' u %s"
@@ -12949,7 +17020,60 @@ msgid "Rat&e"
 msgstr "Postavi &brzinu"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 h 060 m 060>0100 s"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -12970,7 +17094,8 @@ msgstr "Promjena brzine"
 msgid "Set Rate"
 msgstr "Postavi brzinu"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Višekratno"
 
@@ -12989,6 +17114,11 @@ msgstr "Razdvoji s&tereo zapis"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Razdvoji stereo zapis u mono '%s'"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -13059,10 +17189,25 @@ msgid "Right, %dHz"
 msgstr "Desno, "
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "desno"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -13072,6 +17217,15 @@ msgstr "Kliknite i povucite za prilagođivanje omjer veličina stereo zapisa."
 msgid "Click and drag to rearrange sub-views"
 msgstr "Kliknite i povucite za pomicanje zapisa u vremenu"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Kliknite i povucite za pomicanje zapisa u vremenu"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Povećaj"
@@ -13079,6 +17233,10 @@ msgstr "Povećaj"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Povećanost"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -13165,9 +17323,8 @@ msgstr "Logaritamska &interpolacija"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Kliknite i povucite za pomicanje zapisa u vremenu"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -13218,6 +17375,21 @@ msgstr "Prilagođena omotnica."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "&Alatne trake"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Uključi nadzor"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Ravnalo"
@@ -13233,6 +17405,11 @@ msgstr "Zatvori žarišni zapis"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Pomakni zapis do&lje"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Nyquistov upit"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -13289,6 +17466,11 @@ msgstr "Kliknite i povucite za stvaranje područja izbora"
 msgid "Click and drag to select audio"
 msgstr "Kliknite i povucite za stvaranje područja izbora"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Kliknite i povucite za pomicanje zapisa u vremenu"
@@ -13310,6 +17492,10 @@ msgstr "Stišane izabrane snimke za %.2f sekunda pri %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Stišane izabrane snimke za %.2f sekunda pri %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -13336,6 +17522,12 @@ msgstr "Naredba"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "CTRL + lijevi klik"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Molimo izabrati radnju"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -13382,6 +17574,12 @@ msgstr "Pritisnite"
 msgid "Button"
 msgstr "Gumb"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
 #. i18n-hint: One-letter abbreviation for Right, in the Pan slider
 #. i18n-hint: One-letter abbreviation for Right, in VU Meter
 #: src/widgets/ASlider.cpp src/widgets/Meter.cpp
@@ -13393,6 +17591,14 @@ msgstr "D"
 #, c-format
 msgid "%.2fx"
 msgstr "%.1f dB"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" ne postoji.\n"
+"\n"
+"Želite li ju stvoriti?"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
@@ -13422,13 +17628,28 @@ msgstr "Prazno"
 msgid "Backwards"
 msgstr "Nazad"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Naprijed"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Mrežna pomoć"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Sve datoteke (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -13488,12 +17709,21 @@ msgid "Meter Style"
 msgstr "S mjerilima"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Filtar"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Trajanje"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Samoobnova pri urušenju"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -13508,9 +17738,22 @@ msgid " Monitoring "
 msgstr "Isključi nadzor"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Show Log for Details"
@@ -13527,6 +17770,29 @@ msgstr "Molimo izabrati radnju"
 msgid "01000,01000 seconds"
 msgstr "01000 01000 sekunda"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + uzorci"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 dana 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -13542,11 +17808,35 @@ msgstr "0100 dana 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + stotinke"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 uzoraka|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + milisekunde"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 uzoraka|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -13568,6 +17858,7 @@ msgstr "0100 h 060 m 060 s+># uzoraka"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "obični uzorci"
@@ -13729,6 +18020,15 @@ msgstr "01000,01000 uzoraka|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 h 060 m 060>0100 s"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -13736,6 +18036,10 @@ msgstr "0100 h 060 m 060>0100 s"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 h 060 m 060>0100 s"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -13751,17 +18055,47 @@ msgstr "u oktavu"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 uzoraka|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in semitones and cents
 #: src/widgets/NumericTextCtrl.cpp
 msgid "semitones + cents"
 msgstr "Polutoni"
 
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 uzoraka|24"
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
@@ -13770,6 +18104,11 @@ msgstr "(Kontekstni izbornik nudi druge formate.)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "stotinke sekunde"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -13813,6 +18152,11 @@ msgstr "Potvrdi"
 msgid "Unable to write files to directory: %s."
 msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -13831,6 +18175,10 @@ msgid "Don't show this warning again"
 msgstr "Više ne podsjećaj"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-beskonačnost"
 
@@ -13839,13 +18187,31 @@ msgid "-Infinity"
 msgstr "-beskonačnost"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Prazno"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Snimi na &kraj"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Povećaj područje"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Pogrješka LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -13863,11 +18229,20 @@ msgid "Value must not be greater than %s"
 msgstr "Početak i kraj moraju biti veći od 0."
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Napravljen novi projekt"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Mape"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Mape"
 
 #: src/xml/XMLFileReader.cpp
@@ -13888,16 +18263,49 @@ msgstr "Pogrješka pri otvaranju datoteke"
 msgid "Spectral edit multi tool"
 msgstr "Izbor"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtar"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Frekvencija (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Pogrješka"
@@ -13925,6 +18333,22 @@ msgstr "Do frekvencije (u sekundama)"
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Najmanja frekvencija mora biti barem 0 Hz"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "Izbor"
@@ -13937,9 +18361,27 @@ msgstr "Promjena glasnoće: Izblijedi"
 msgid "Applying Fade..."
 msgstr "Primjenjivanje..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "napravio Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -13966,8 +18408,16 @@ msgid "S-Curve Down"
 msgstr "Pomakni &dolje"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Početak"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -13976,6 +18426,14 @@ msgstr "Pojačanje"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Početak"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -13988,6 +18446,14 @@ msgstr "0-1"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "0-1"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -14036,6 +18502,14 @@ msgstr "Pojačanje frekvencije ne može biti negativno"
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "Pojačanje frekvencije ne može biti negativno"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Ponavljač"
@@ -14043,6 +18517,10 @@ msgstr "Ponavljač"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Nađi rezove..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacityjev dnevnik"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -14056,6 +18534,23 @@ msgstr "Rezanje"
 msgid "Reconstructing clips..."
 msgstr "Uklanjanje škljocaja i pucketaja..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Prag %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Zabilježni zapis"
@@ -14063,6 +18558,21 @@ msgstr "Zabilježni zapis"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Zabilježni zapis"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -14096,6 +18606,19 @@ msgstr "Ime zapisa"
 msgid "Fade direction"
 msgstr "Izravno čitaj"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Odgoda"
@@ -14111,6 +18634,19 @@ msgstr "Odgoda"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "Pravokutno"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Uklanjanje &šuma (dB):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -14136,6 +18672,14 @@ msgstr "Pret&poslušaj"
 msgid "Number of echoes"
 msgstr "Broj ponova:"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Ponovi zadnji učinak"
@@ -14147,6 +18691,10 @@ msgstr "Ekvalizacija"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -14161,10 +18709,24 @@ msgstr "Potvrda prekopisanja"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Datoteke žanra nije moguće otvoriti."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Pogrješka (datoteka možda nije zapisana): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Pogrješka (datoteka možda nije zapisana): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -14195,10 +18757,50 @@ msgstr "Dužina (u sekundama)"
 msgid "Length of label region (seconds)"
 msgstr "Dužina (u sekundama)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Uredi oznaku"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -14212,6 +18814,11 @@ msgstr "Otrgni"
 msgid "Warnings only"
 msgstr "Upozorenje"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -14220,6 +18827,12 @@ msgstr "Oznake spajanja"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Oznake spajanja"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -14238,13 +18851,46 @@ msgstr "Primjenjivanje ekvalizacije"
 msgid "Dominic Mazzoni"
 msgstr "napravio Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvencija (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Najmanja frekvencija mora biti barem 0 Hz"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -14292,6 +18938,11 @@ msgid "Point after sound"
 msgstr "Združeni stereo"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "Od dužine (u sekundama)"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "Od dužine (u sekundama)"
 
@@ -14299,11 +18950,41 @@ msgstr "Od dužine (u sekundama)"
 msgid "Maximum leading silence"
 msgstr "Izrezivanje tišine..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Izrezivanje tišine..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Ime ne smije biti prazno"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -14335,8 +19016,25 @@ msgid "Hard Clip"
 msgstr "Nađi porezano"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Desni kanal"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "&Razina (dB):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -14398,6 +19096,44 @@ msgstr "Vrijeme napada/raspada"
 msgid "Decay (ms)"
 msgstr "Vrijeme napada/raspada"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Ime ne smije biti prazno"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Dužina filtra"
@@ -14409,6 +19145,18 @@ msgstr "Primjenjivanje uravnavaoca..."
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "napravio Steve Daulton"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -14431,7 +19179,8 @@ msgstr "MP3"
 msgid "HTML file"
 msgstr "MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Imena datoteka:"
 
@@ -14448,9 +19197,24 @@ msgid "Disallow"
 msgstr "Nedopušteno"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Nedopušteno"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Uklanjanje %s nije uspjelo"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -14461,16 +19225,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Izaberite datoteku MIDI..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Neuporabljeni filtri:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Izaberite datoteku MIDI..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Stvaranje zvuka"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Filtar"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -14483,6 +19289,10 @@ msgstr "Ukloni zapis"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Stvaranje zujanja"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -14501,8 +19311,20 @@ msgid "Swing amount"
 msgstr "Izobličavalac"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Broj ponova:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -14525,12 +19347,54 @@ msgid "Beat sound"
 msgstr "Ponavljač"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Uklanjanje šuma"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Tlo šuma"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -14553,6 +19417,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Linearna frekvencija"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Frekvencija (Hz)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Amplituda (0-1)"
 
@@ -14563,6 +19436,10 @@ msgstr "Nemoguće izvoziti"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Primjenjivanje..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -14581,6 +19458,10 @@ msgid "HTML files"
 msgstr "MP3"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Uređivanje uzoraka"
 
@@ -14593,8 +19474,29 @@ msgid "Include header information"
 msgstr "Podatci o gradnji"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Sve"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -14609,6 +19511,11 @@ msgstr "\t-help (ovu poruku)"
 msgid "Errors Only"
 msgstr "Pogrješka:"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -14621,6 +19528,46 @@ msgstr "Desni kanal"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "obični uzorci"
 
@@ -14628,6 +19575,43 @@ msgstr "obični uzorci"
 #, lisp-format
 msgid "~a seconds."
 msgstr "sekunda"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -14646,6 +19630,10 @@ msgid "Value (dB)"
 msgstr "&Treble (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "0-1"
 
@@ -14662,6 +19650,14 @@ msgid "Right (dB)"
 msgstr "Desno, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "0-1"
 
@@ -14672,6 +19668,40 @@ msgstr "2 kanala (stereo)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 kanal (mono)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Pogrješka (datoteka možda nije zapisana): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -14686,8 +19716,40 @@ msgid "Select file"
 msgstr "Izaberite datoteku MIDI..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Pogrješka"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -14697,6 +19759,15 @@ msgstr "Datoteke žanra nije moguće otvoriti."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Izbor"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -14719,8 +19790,16 @@ msgid "Wet level (percent)"
 msgstr "2-razinski"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Primjenjivanje..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -14762,9 +19841,96 @@ msgstr "&Prouči"
 msgid "Strength"
 msgstr "Filtar"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Obrađivanje: "
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -14798,6 +19964,193 @@ msgstr "Frekvencija (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Frekvencija (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Ugasi Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Kanal"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Pogrješka pri otvaranju datoteke"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Pogrješka pri učitavanju metapodataka"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacityjeva alatna traka - %s"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Snimanje"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Naredba:"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "uvoz QuickTimeom"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automatsko prilagođivanje razine ulaza je stalo. Nije moguće bolje postaviti. Još uvijek previsoka."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Zbog automatskoga prilagođivanja razine ulaza, glasnoća se snizila na %f. "
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatsko prilagođivanje razine ulaza je stalo. Nije moguće bolje postaviti. Još uvijek preniska."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Zbog automatskoga prilagođivanja razine ulaza, glasnoća se povisila na %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automatsko prilagođivanje razine ulaza je stalo. Ukupan broj analiza prešao je granicu a da nije našao prihvatljivu glasnoću. Još uvijek previsoka."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automatsko prilagođivanje razine ulaza je stalo. Ukupan broj analiza prešao je granicu a da nije našao prihvatljivu glasnoću. Još uvijek preniska."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatsko prilagođivanje razine ulaza je stalo. %.2f izgleda kao prihvatljiva glasnoća."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Datoteke žanra nije moguće otvoriti.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Snimanje\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Sviranje\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Snimanje završeno\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Snimanje završeno\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Jačina ulaza: %.2f\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Jačina ulaza: %.2f\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer (uskladive datoteke)"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Pogon GStreamera nije uspio"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "'%s' nemoguće preimenovati u '%s'"
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Kazalo[%02x], kodek[%s], jezik[%s], uzorkovna brzina[%s], kanali[%d], trajanje[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer %s: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Prilagodi brzinu izvođenja"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Ubrzaj sviranje"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Uspori sviranje"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Snimanje završeno"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Ubrzaj sviranje"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Uspori sviranje"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacityjev dnevnik"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&O Audacityju..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomatsko prilagođivanje razine ulaza (da/ne)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatsko prilagođivanje razine ulaza"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Omogući automatsko prilagođivanje razine ulaza."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Ciljni vršak:"
+
+#~ msgid "Within:"
+#~ msgstr "Unutar:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Vrijeme analize:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisekunda (vrijeme jedne analize)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Broj uzastopnih analiza:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 znači beskonačno"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Snimanje završeno"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Sviranje"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Jačina ulaza: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Jačina ulaza (nedostupno; uporabite miješač sustava)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Jačina ulaza: %.2f"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Jačina ulaza: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Jačina ulaza (nedostupno; uporabite miješač sustava)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Traka s k&lizačima"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Kliknite i povucite za pomicanje zapisa u vremenu"
+
 #~ msgid "Program build date:"
 #~ msgstr "Nadnevak gradnje programa: "
 
@@ -14811,10 +20164,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "s"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Nemoguće otvoriti/stvoriti pokusne datoteke."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -15750,10 +21099,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgstr "Za prijepis"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "&Alatne trake"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "Naredba"
 
@@ -15864,10 +21209,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Start - Center - End"
 #~ msgstr "na kra&j izbora"
-
-#, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
 
 #, fuzzy
 #~ msgid "Show start time and end time"
@@ -16091,10 +21432,6 @@ msgstr "Frekvencija (Hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "Izreži tišinu"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Obrtanje vodoravno"
 
 #~ msgid "C&ategory:"
 #~ msgstr "R&azred:"
@@ -16637,9 +21974,6 @@ msgstr "Frekvencija (Hz)"
 #~ msgid "Cursor: %.4f sec (%d Hz) (%s) = %f,    Peak: %.4f sec (%d Hz) (%s) = %.3f"
 #~ msgstr "Okomica: %.4f s (%d Hz) (%s) = %f,    Vrh: %.4f s (%d Hz) (%s) = %.3f"
 
-#~ msgid "Plot Spectrum"
-#~ msgstr "Nacrtaj spektar"
-
 #~ msgid "Drawing Spectrum"
 #~ msgstr "Crtanje spektra"
 
@@ -16912,10 +22246,6 @@ msgstr "Frekvencija (Hz)"
 
 #~ msgid "Applying Reverb"
 #~ msgstr "Primjenjivanje pazvuka"
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "&Prenesi datoteku..."
 
 #~ msgid "Silence..."
 #~ msgstr "Tišina..."

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -12,53 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Hungarian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/hu/>\n"
+"Language-Team: Hungarian <https://hosted.weblate.org/projects/tenacity/tenacity/hu/>\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Kilépés az Audacity programból"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Csatorna"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Hiba a fájl visszafejtésekor"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Hiba a metaadatok betöltésekor"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s eszköztár"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Felvétel"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -68,6 +31,24 @@ msgstr "Nem lehet meghatározni"
 #, c-format
 msgid "%s bytes"
 msgstr "bájt"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -194,7 +175,8 @@ msgid "Script"
 msgstr "Parancsfájl"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Kimenet"
 
@@ -210,7 +192,12 @@ msgstr "Nyquist-parancsfájlok (*.ny)|*.ny|Lisp-parancsfájlok (*.lsp)|*.lsp|Min
 msgid "Script was not saved."
 msgstr "A parancsfájl nem lett elmentve."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
@@ -231,11 +218,17 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango ikongaléria (eszköztár ikonok)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "© Leland Lucius, 2009."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "© Leland Lucius, 2009."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Külső Audacity modul, amely egy egyszerű integrált fejlesztői környezetet biztosít a hatások írásához."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -258,7 +251,8 @@ msgstr "Névtelen"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist-hatás munkapad - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Új"
 
@@ -298,7 +292,8 @@ msgstr "Másolás"
 msgid "Copy to clipboard"
 msgstr "Másolás a vágólapra"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Kivágás"
 
@@ -306,7 +301,8 @@ msgstr "Kivágás"
 msgid "Cut to clipboard"
 msgstr "Kivágás a vágólapra"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Beillesztés"
 
@@ -331,7 +327,8 @@ msgstr "Összes kijelölése"
 msgid "Select all text"
 msgstr "Összes szöveg kijelölése"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Visszavonás"
 
@@ -339,7 +336,8 @@ msgstr "Visszavonás"
 msgid "Undo last change"
 msgstr "Legutóbbi változtatás visszavonása"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Ismétlés"
 
@@ -396,7 +394,8 @@ msgid "Go to next S-expr"
 msgstr "Ugrás a következő S-kifejezésre"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Kezdés"
 
@@ -404,7 +403,8 @@ msgstr "Kezdés"
 msgid "Start script"
 msgstr "Parancsfájl indítása"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Leállítás"
 
@@ -418,15 +418,23 @@ msgstr "Parancsfájl leállítása"
 msgid "About %s"
 msgstr "Névjegy"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Fordítási információ"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Letiltva"
 
@@ -436,8 +444,9 @@ msgid "The Build"
 msgstr "Hibakeresési változat"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Véglegesítés-azonosító:"
+#, fuzzy
+msgid "Version:"
+msgstr "Verzió"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -447,22 +456,28 @@ msgstr "Fordítás típusa:"
 msgid "Compiler:"
 msgstr "Tömörítő"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Telepítési előtag: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Beállítások mappa: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Beállítások mappa: "
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Fájlformátum támogatás"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Keresztplatformos GUI könyvtár"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -476,7 +491,6 @@ msgstr "Mintavételezési gyakoriság átalakítás"
 msgid "MP3 Importing"
 msgstr "MP3 importálás"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis importálás és exportálás"
@@ -485,7 +499,6 @@ msgstr "Ogg Vorbis importálás és exportálás"
 msgid "ID3 tag support"
 msgstr "ID3 címke támogatás"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC importálás és exportálás"
@@ -503,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg importálás és exportálás"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importálás GStreamer által"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Szolgáltatások"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Bővítmény támogatás"
 
@@ -525,6 +530,10 @@ msgstr "Hangmagasság és tempó változtatási támogatás"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Extrém hangmagasság- és a tempóváltoztatás támogatása"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Szolgáltatások"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -616,6 +625,12 @@ msgstr "zeneszerző"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "zeneszerző"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "Nyquist bővítmények"
@@ -632,6 +647,15 @@ msgstr "fejlesztő"
 msgid "%s, graphics"
 msgstr "&Grafika"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -641,6 +665,10 @@ msgstr "Szabad, nyílt forrású, keresztplatformos szoftver hangok felvételéh
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Köszönet"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -665,6 +693,12 @@ msgstr "Programkönyvtárak"
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s includes code from the following projects:"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s Team Members"
 msgstr "Audacity csapattagok"
 
@@ -676,11 +710,16 @@ msgstr "Visszavonult:"
 msgid "Contributors"
 msgstr "Közreműködők"
 
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
+
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -704,6 +743,22 @@ msgstr "Külön köszönet:"
 msgid "%s website: "
 msgstr "Az Audacity első indítása"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Közreműködők"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "Az idősávműveletek le vannak tiltva felvétel közben"
@@ -725,6 +780,7 @@ msgstr "Idővonal"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kattintás vagy húzás a tekerés elkezdéséhez"
@@ -732,6 +788,7 @@ msgstr "Kattintás vagy húzás a tekerés elkezdéséhez"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Kattintás vagy húzás a változó sebességű lejátszás elkezdéséhez"
@@ -739,6 +796,7 @@ msgstr "Kattintás vagy húzás a változó sebességű lejátszás elkezdéséh
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Kattintás és mozgatás a változó sebességű lejátszáshoz. Kattintás és húzás a tekeréshez."
@@ -746,6 +804,7 @@ msgstr "Kattintás és mozgatás a változó sebességű lejátszáshoz. Kattint
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Mozgatás a tekeréshez"
@@ -753,6 +812,7 @@ msgstr "Mozgatás a tekeréshez"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Mozgatás a változó sebességű lejátszáshoz"
@@ -809,7 +869,17 @@ msgstr ""
 "Nem zárolható terület\n"
 "a projekt végén túl"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Hiba"
 
@@ -833,7 +903,8 @@ msgstr ""
 "Ez egyszeri kérdés egy olyan „telepítés” után, ahol a beállítások visszaállítását kérték."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Audacity beállítások visszaállítása"
 
 #: src/AudacityApp.cpp
@@ -846,6 +917,10 @@ msgstr ""
 "%s nem található.\n"
 "\n"
 "Eltávolították a legutóbbi fájlok listájáról."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -870,7 +945,7 @@ msgstr "&Megnyitás…"
 msgid "Open &Recent..."
 msgstr "&Legutóbbi megnyitása…"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Audacity névjegye…"
@@ -884,9 +959,10 @@ msgid "&File"
 msgstr "&Fájl"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Az Audacity nem talált biztonságos helyet az átmeneti fájlok tárolására.\n"
@@ -895,20 +971,23 @@ msgstr ""
 "Adjon meg egy megfelelő könyvtárat a beállítások párbeszédablakban."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Az Audacity nem talált megfelelő helyet az átmeneti fájlok tárolására.\n"
 "Adjon meg egy megfelelő könyvtárat a beállítások párbeszédablakban."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Az Audacity most ki fog lépni. Indítsa el újra a programot az új átmeneti könyvtár használatához."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -917,15 +996,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Az Audacity nem tudta zárolni az átmeneti fájlok könyvtárát.\n"
 "Lehet, hogy ezt a könyvtárat az Audacity egy másik példánya használja.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Még mindig el szeretné indítani az Audacity programot?"
 
 #: src/AudacityApp.cpp
@@ -933,24 +1014,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "Hiba az átmeneti mappa zárolásakor"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "A rendszer azt észlelte, hogy az Audacity egy példánya már fut.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Használja az Új vagy a Megnyitás parancsot a már futó Audacity\n"
 "folyamatban több projekt egyidejű megnyitásához.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Az Audacity már fut"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity projektfájlok"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -970,7 +1099,8 @@ msgstr "öndiagnosztika futtatása"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Audacity verzió megjelenítése"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -980,9 +1110,10 @@ msgid "audio or project file name"
 msgstr "hang- vagy projektfájlnév"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -996,20 +1127,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity projektfájlok"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "Újra&mintavételezés…"
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Szabálytörlés megerősítése"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Súgó"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Kilépés az Audacity programból"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity napló"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1021,9 +1181,14 @@ msgstr "&Mentés…"
 msgid "Cl&ear"
 msgstr "Tör&lés"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Bezárás"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1072,47 +1237,33 @@ msgid "Error Initializing Midi"
 msgstr "Hiba a Midi előkészítésekor"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity napló"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Elfogyott a memória!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Az automatikus felvételi szint igazítás leállt. Nem volt lehetséges jobban optimalizálni. Még mindig túl magas."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Az automatikus felvételi szint igazítás %f értékre csökkentette a hangerőt."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Az automatikus felvételi szint igazítás leállt. Nem volt lehetséges jobban optimalizálni. Még mindig túl alacsony."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Az automatikus felvételi szint igazítás %.2f értékre növelte a hangerőt."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Az automatikus felvételi szint igazítás leállt. Az elemzések összesített számát túllépték elfogadható hangerő megtalálása nélkül. Még mindig túl magas."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Az automatikus felvételi szint igazítás leállt. Az elemzések összesített számát túllépték elfogadható hangerő megtalálása nélkül. Még mindig túl alacsony."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Az automatikus felvételi szint igazítás leállt. Úgy tűnik, %.2f az elfogadható hangerő."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Felvevőeszköz kiválasztása\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Felvevőeszköz kiválasztása\n"
 
 #: src/AudioIOBase.cpp
@@ -1155,8 +1306,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Felvétel vége:\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Felvétel vége:\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Felvétel vége:\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Felvétel vége:\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -1170,37 +1331,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Felvevőeszköz kiválasztása\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Felvevőeszköz kiválasztása\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Lejátszóeszköz kiválasztása\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Nem sikerült megnyitni a műfajfájlt.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Lejátszóeszköz kiválasztása\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Időzített felvétel\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Mintavételezési gyakoriságok\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Lejátszási hangerő\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Felvételi hangerő\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Felvételi hangerő\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Lejátszási hangerő: %%.2f%s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Lejátszási hangerő: %%.2f%s\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1208,8 +1372,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Felvevőeszköz kiválasztása\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Felvevőeszköz kiválasztása\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Lejátszóeszköz kiválasztása\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Lejátszóeszköz kiválasztása\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1217,8 +1391,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Összeomlás utáni automatikus helyreállítás"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1230,12 +1405,14 @@ msgid "Recoverable &projects"
 msgstr "Helyreállítható projektek"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Kijelölés"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Név"
 
@@ -1246,6 +1423,10 @@ msgstr "Kijelölés"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Kijelölés"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1282,6 +1463,11 @@ msgid "&Parameters"
 msgstr "&Paraméterek"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Leválasztás"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "Parancs &kiválasztása"
 
@@ -1316,6 +1502,22 @@ msgstr "Hatások"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Paraméterek &szerkesztése"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "Paraméterek &szerkesztése"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1363,6 +1565,10 @@ msgid "Apply %s"
 msgstr "%s alkalmazása"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "Görbék kezelése"
 
@@ -1371,6 +1577,17 @@ msgstr "Görbék kezelése"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Görbe kiválasztása"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Címkék…"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Lánc alkalmazása"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1438,7 +1655,8 @@ msgstr "Terület &helyreállítása"
 msgid "I&mport..."
 msgstr "&Importálás…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Exportálás…"
 
@@ -1479,9 +1697,15 @@ msgstr "Mozgatás &fel"
 msgid "Move &Down"
 msgstr "Mozgatás &le"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Mentés"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1527,11 +1751,38 @@ msgid "Benchmark"
 msgstr "&Teljesítményteszt futtatása…"
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Ismétlések száma"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Bezárás"
 
@@ -1546,8 +1797,23 @@ msgid "Export Benchmark Data as:"
 msgstr "Spektrális adatok exportálása másként:"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "A hangjegyek legnagyobb számának az 1…128 tartományban kell lennie"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "A hangjegyek legnagyobb számának az 1…128 tartományban kell lennie"
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "A hangjegyek legnagyobb számának az 1…128 tartományban kell lennie"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Preparing...\n"
@@ -1555,26 +1821,123 @@ msgstr "Előnézet előkészítése\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy, c-format
+msgid "Performing %d edits...\n"
+msgstr "Klasszikus szűrők"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Beillesztés\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Felvétel időtartama:\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Benchmark completed successfully.\n"
 msgstr "A fájl sikeresen visszafejtve\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Befejezési dátum és idő"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Kiadási változat"
 
 #: src/BuildInfo.h
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Kiadási változat"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1585,9 +1948,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Ennek a műveletnek a végrehajtásához először ki kell jelölnie némi hangot."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Nincs lánc kiválasztva"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1615,6 +2002,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Nem sikerült megtalálni a kodeket"
 
@@ -1632,10 +2024,24 @@ msgstr "Jelenlegi projekt"
 msgid "Checkpointing %s"
 msgstr "%s importálása"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Nem sikerült írni a fájlba: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Nem sikerült elmenteni a projektet. Talán %s \n"
+"nem írható, vagy a lemez megtelt."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1652,6 +2058,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "%s eltávolítása sikertelen"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1749,6 +2159,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Másolás a vágólapra"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Hiányzó fájlok"
 
@@ -1757,10 +2172,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ha folytatja, a projekt nem lesz lemezre mentve. Ezt szeretné?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1772,7 +2188,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Függőség-ellenőrzés"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nincs"
 
@@ -1780,7 +2199,7 @@ msgstr "Nincs"
 msgid "Rectangle"
 msgstr "Négyszög"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Háromszög"
 
@@ -1794,8 +2213,18 @@ msgstr "Négyszögletű"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Hamming"
 msgstr "Hamming, nincs"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
@@ -1812,14 +2241,30 @@ msgstr "Blackman, Hann"
 msgid "Welch"
 msgstr "Üdvözöljük!"
 
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Az FFmpeg támogatás nincs belefordítva"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1842,8 +2287,8 @@ msgid "Locate FFmpeg"
 msgstr "Az FFmpeg megkeresése"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Az Audacity a(z) %s fájlt igényli az FFmpeg program általi hang importálásához és exportálásához."
 
 #: src/FFmpeg.cpp
@@ -1856,7 +2301,8 @@ msgstr "„%s” helye:"
 msgid "To find '%s', click here -->"
 msgstr "„%s” kereséséhez kattintson ide -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Tallózás…"
 
@@ -1882,8 +2328,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg nem található"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1904,24 +2351,38 @@ msgstr "Ne jelenjen meg többet ez a figyelmeztetés"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Nem sikerült megfelelő FFmpeg programkönyvtárakat találni."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Az Audacity nem tudta írni a fájlt:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Az Audacity nem tudta írni a fájlt:\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Az Audacity nem tudta írni a fájlt:\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1958,7 +2419,9 @@ msgstr "&Ne másoljon semmilyen hangot"
 msgid "As&k"
 msgstr "&Kérdezze meg a felhasználót"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Minden fájl|*"
 
@@ -1967,6 +2430,11 @@ msgstr "Minden fájl|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Projekt adatfájlok mentése"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Programkönyvtárak"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1979,6 +2447,10 @@ msgstr "Fájlok elnevezése:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3-fájlok"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2020,6 +2492,14 @@ msgstr "Köbgyök autokorreláció"
 msgid "Enhanced Autocorrelation"
 msgstr "Részletes autokorreláció"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spektrum"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2036,6 +2516,18 @@ msgstr "Lineáris frekvencia"
 msgid "Log frequency"
 msgstr "Logaritmikus frekvencia"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Görgetés"
@@ -2043,6 +2535,15 @@ msgstr "Görgetés"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Nagyítás"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2109,6 +2610,18 @@ msgid "s"
 msgstr "mp"
 
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f mp (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f mp (%d Hz) (%s) = %.3f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
@@ -2123,10 +2636,16 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f mp (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Spektrum"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Spektrális adatok exportálása másként:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Nem sikerült írni a fájlba: "
@@ -2200,6 +2719,22 @@ msgstr "CD-re írás"
 #: src/HelpText.cpp
 msgid "No Local Help"
 msgstr "Nincs helyi súgó"
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2288,11 +2823,30 @@ msgstr "Eldobás"
 msgid "&Compact"
 msgstr "&Parancs"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "Elő&zmények…"
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2308,7 +2862,9 @@ msgid "Track"
 msgstr "Sáv"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Címke"
 
@@ -2368,18 +2924,25 @@ msgstr "Sávnév megadása"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Címkesáv"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Az Audacity első indítása"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Nyelv kiválasztása az Audacity használatához:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2389,7 +2952,8 @@ msgstr "Nyelv kiválasztása az Audacity használatához:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "A választott %s (%s) nyelv nem ugyanaz mint a rendszer nyelve: %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Megerősítés"
 
@@ -2407,8 +2971,14 @@ msgstr ""
 "A régi fájl a következő néven lett elmentve: „%s”"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity projekt megnyitása"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Külön köszönet:"
 
 #: src/LyricsWindow.cpp
 msgid "&Karaoke..."
@@ -2458,19 +3028,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Sávok keverése és megjelenítése"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity keverőpult%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Hangerő"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Sebesség"
 
@@ -2479,17 +3053,23 @@ msgid "Musical Instrument"
 msgstr "Zeneeszköz"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Görgetés"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Némítás"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Szóló"
 
@@ -2497,15 +3077,18 @@ msgstr "Szóló"
 msgid "Signal Level Meter"
 msgstr "Kivezérlésszint-kijelző"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Hangerőszabályzó áthelyezve"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Sebességcsúszka áthelyezve"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Görgetőcsúszka áthelyezve"
 
@@ -2536,9 +3119,9 @@ msgstr ""
 "Nem kerül betöltésre."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2571,16 +3154,19 @@ msgstr ""
 "\n"
 "Csak megbízható forrásokból használjon modulokat"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Igen"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nem"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacity modulbetöltő"
 
 #: src/ModuleManager.cpp
@@ -2610,8 +3196,33 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "D"
 msgstr "Db"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
@@ -2620,13 +3231,86 @@ msgstr "GB"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Meglévő fájlok felülírása"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2721,7 +3405,8 @@ msgstr "Ö&sszes kijelölése"
 msgid "C&lear All"
 msgstr "&Kijelölés törlése"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Engedélyezés"
 
@@ -2791,6 +3476,21 @@ msgstr "Hiba a hangeszköz megnyitásakor. Próbálja meg megváltoztatni a hang
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Egy szűrő alkalmazásához minden kijelölt sávnak azonos mintavételezési gyakorisággal kell rendelkeznie."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Hang felvéve"
@@ -2798,6 +3498,28 @@ msgstr "Hang felvéve"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "Felvétel"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2825,11 +3547,11 @@ msgid "Inspecting project file data"
 msgstr "Projektfájladatok vizsgálata"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2873,11 +3595,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Figyelmeztetés - Hiányzó álnevesített fájlok"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "A(z) „%s” mappa projektellenőrzése %lld hiányzó\n"
@@ -2902,12 +3624,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Figyelmeztetés - Hiányzó álnév összegző fájlok"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2965,7 +3687,8 @@ msgstr "Figyelmeztetés - Árva blokkfájlok"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Folyamat"
 
@@ -2990,6 +3713,11 @@ msgstr "Figyelmeztetés: probléma az automatikus helyreállításnál"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<névtelen>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projektek"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3028,11 +3756,96 @@ msgid ""
 msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "%s eltávolítása sikertelen"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Egy Audacity projekt mentése"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Nem sikerült előkészíteni az MP3 adatfolyamot"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3046,12 +3859,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Árva blokkfájl: „%s”"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "A(z) „%s” átnevezése „%s” névre nem sikerült."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Nem sikerült megtalálni a kodeket"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "%s eltávolítása sikertelen"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3062,9 +3896,9 @@ msgid "Error Writing to File"
 msgstr "Hiba a fájlba íráskor"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3075,6 +3909,19 @@ msgstr ""
 msgid "Compacting project"
 msgstr "&Projektek mentése"
 
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Sebesség"
+
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
@@ -3082,10 +3929,10 @@ msgstr "(Helyreállítva)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Ezt a fájlt az Audacity %s használatával mentették.\n"
 "Ön az Audacity %s verzióját használja. A fájl megnyitásához frissítenie kell egy újabb verzióra."
@@ -3093,6 +3940,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "A projektfájl nem nyitható meg"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3107,6 +3958,10 @@ msgid "Unable to parse project information."
 msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Projektek mentése"
 
@@ -3115,12 +3970,35 @@ msgid "Error Saving Project"
 msgstr "Hiba a projekt mentésekor"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Ü&res projekt mentése"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3128,8 +4006,24 @@ msgstr ""
 "futásakor. Szerencsére a következő projektek automatikusan helyreállíthatók:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Néhány projekt nem lett megfelelően elmentve az Audacity legutóbbi\n"
+"futásakor. Szerencsére a következő projektek automatikusan helyreállíthatók:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "A projekt helyreállítva"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Átmeneti fájlok könyvtára"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3160,6 +4054,17 @@ msgstr "Figyelmeztetés - Üres projekt"
 msgid "Insufficient Disk Space"
 msgstr "Lemezterület"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3179,12 +4084,26 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sA(z) „%s” projekt mentése másként…"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "A „Projekt mentése” Audacity-projekthez van, nem hangfájlhoz.\n"
 "Más alkalmazásban megnyitandó hangfájlhoz használja az „Exportálást”.\n"
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -3238,11 +4157,12 @@ msgid "Error Opening Project"
 msgstr "Hiba a projekt megnyitásakor"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Egy automatikusan létrehozott biztonsági mentés fájlt próbál megnyitni.\n"
 "Ez komoly adatvesztést eredményezhet.\n"
@@ -3275,6 +4195,12 @@ msgid "Error Opening File or Project"
 msgstr "Hiba a fájl vagy projekt megnyitásakor"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "A projekt helyreállítva"
 
@@ -3300,12 +4226,33 @@ msgid "Error Importing"
 msgstr "Hiba az importáláskor"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Projekt mentése"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "A projektfájl nem nyitható meg"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Parancs"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3316,8 +4263,8 @@ msgid "Automatic database backup failed."
 msgstr "Au"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Üdvözöli az Audacity %s verziója"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3375,6 +4322,12 @@ msgstr[1] ""
 msgid "%s and %s."
 msgstr "%d %s és %d %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3390,6 +4343,26 @@ msgstr "Vízszintes"
 msgid "Vertical Scrollbar"
 msgstr "Függőleges"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(Legjobb minőség)"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Minőség"
@@ -3401,6 +4374,18 @@ msgstr "Minőség"
 #: src/Resample.cpp
 msgid "Best Quality (Slowest)"
 msgstr "(Legjobb minőség)"
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bit PCM"
 
 #. i18n-hint: Audio data bit depth (precision): 32-bit floating point
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
@@ -3495,7 +4480,8 @@ msgstr "Beállítások: "
 msgid "SelectionBar"
 msgstr "Kijelöléssáv"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektrális kijelölés"
 
@@ -3503,46 +4489,55 @@ msgstr "Spektrális kijelölés"
 msgid "Timer"
 msgstr "Vonalidő:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Eszközök"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Átvitel"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Keverő"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Mérő"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Lejátszásmérő"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Felvételmérő"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Eszköz"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Lejátszás adott sebességgel"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Változó sebességű lejátszás"
 
@@ -3557,7 +4552,10 @@ msgstr "Vonalzó"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Sávok"
 
@@ -3609,6 +4607,15 @@ msgstr "Magas sávok"
 msgid "Choose a location to save screenshot images"
 msgstr "Válasszon egy helyet a képernyőképek mentéséhez"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "ez a súgó üzenet"
+
 #: src/Sequence.cpp
 #, c-format
 msgid ""
@@ -3659,7 +4666,8 @@ msgid "Activation level (dB):"
 msgstr "Aktivációs szint (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Üdvözöli az Audacity!"
 
 #: src/SplashDialog.cpp
@@ -3786,19 +4794,45 @@ msgstr "Hiba a címkefájl mentésekor"
 msgid "Unsuitable"
 msgstr "Alkalmatlan modul"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Átmeneti fájlok könyvtára"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Az Audacity nem tudta írni a fájlt:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3807,18 +4841,26 @@ msgstr ""
 "írásra."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Az Audacity nem tudta a képeket fájlba írni:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3828,9 +4870,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3839,8 +4881,9 @@ msgstr ""
 "Talán rossz png formátum?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Az Audacity nem tudta olvasni az alapértelmezett témáját.\n"
@@ -3877,9 +4920,9 @@ msgstr ""
 "már megvolt. Felülírja?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Az Audacity nem tudta elmenteni a fájlt:\n"
@@ -3896,11 +4939,21 @@ msgstr "Klasszikus szűrők"
 msgid "Light"
 msgstr "Enyhe"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Kontraszt…"
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Egyéni sáv&név használata"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3909,7 +4962,11 @@ msgstr "Kontraszt…"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Időtartam"
 
@@ -3920,7 +4977,8 @@ msgid "Time Track"
 msgstr "Idősáv"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity időzített felvétel"
 
 #: src/TimerRecordDialog.cpp
@@ -3966,6 +5024,17 @@ msgid "Error in Automatic Export"
 msgstr "Hiba az automatikus exportálásban"
 
 #: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
 msgid "Timer Recording Disk Space Warning"
 msgstr "Időzített felvétel lemezterület figyelmeztetés"
 
@@ -3977,7 +5046,8 @@ msgstr "Jelenlegi projekt"
 msgid "Recording start:"
 msgstr "Fe"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Időtartam:"
 
@@ -3998,7 +5068,8 @@ msgid "Action after Timer Recording:"
 msgstr "Művelet az időzített felvétel után:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity időzített felvétel folyamata"
 
 #: src/TimerRecordDialog.cpp
@@ -4033,6 +5104,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "Fe"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Hiba az időzített felvétel projekt mentésekor"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Időzített felvétel"
@@ -4052,6 +5147,7 @@ msgstr "099 nap 024 ó 060 p 060 mp"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Kezdési dátum és idő"
@@ -4096,7 +5192,8 @@ msgstr "Engedélyezi az automatikus &exportálást?"
 msgid "Export Project As:"
 msgstr "Projekt exportálása másként:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Beállítások"
 
@@ -4109,7 +5206,8 @@ msgid "Do nothing"
 msgstr "Ne tegyen semmit"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Kilépés az Audacity programból"
 
 #: src/TimerRecordDialog.cpp
@@ -4133,7 +5231,8 @@ msgid "Scheduled to stop at:"
 msgstr "Üt"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity időzített felvétel - Várakozás a kezdésre"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4141,6 +5240,14 @@ msgstr "Audacity időzített felvétel - Várakozás a kezdésre"
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "A felvétel ekkor fog kezdődni:"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -4151,12 +5258,18 @@ msgid "Recording Exported:"
 msgstr "Fe"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity időzített felvétel - Várakozás"
 
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "Sztereó, 999999Hz"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -4272,6 +5385,10 @@ msgstr "Sáv mozgatása &fel"
 msgid "Move Track Down"
 msgstr "Sáv mozgatása &le"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4317,6 +5434,11 @@ msgstr "Nincs elég elérhető hely a kijelölés beillesztéséhez"
 msgid "There is not enough room available to expand the cut line"
 msgstr "Nincs elég elérhető hely a metszésvonal kibővítéséhez"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid ""
@@ -4333,20 +5455,61 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s alkalmazása…"
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Parancs"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Parancs"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ismétlés: %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4361,12 +5524,20 @@ msgid "Compares a range on two tracks."
 msgstr "Tömörítés a csúcsok alapján"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Késleltetési idő (másodperc):"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Lecsengési tényező:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -4388,6 +5559,11 @@ msgstr "Sáv"
 msgid "Track 1"
 msgstr "Sáv"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Ablakméret:"
@@ -4399,6 +5575,22 @@ msgstr "Percenkénti fordulatszámtól"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Percenkénti fordulatszámtól"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -4424,17 +5616,41 @@ msgstr "Levágás"
 msgid "Envelopes"
 msgstr "Burkológörbe"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Címkék"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Típus:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formátum:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -4444,6 +5660,10 @@ msgstr "Sáv mozgatása &le"
 msgid "Types:"
 msgstr "Típus:"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Megjegyzések"
@@ -4451,6 +5671,18 @@ msgstr "Megjegyzések"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Parancs:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4469,6 +5701,11 @@ msgid "Number of Channels:"
 msgstr "Ismétlések száma"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Több exportálása"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Több exportálása"
 
@@ -4476,13 +5713,27 @@ msgstr "Több exportálása"
 msgid "Builtin Commands"
 msgstr "Parancs kiválasztása"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Az Audacity csapat"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Beépített hatásokat biztosít az Audacity programhoz"
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Befejezési dátum és idő"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -4524,11 +5775,22 @@ msgstr "&Projekt mentése"
 msgid "Saves a copy of current project."
 msgstr "&Projekt mentése"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "&Beállítások használata"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Név"
 
@@ -4539,6 +5801,15 @@ msgstr "&Beállítások használata"
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Érték"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+#, fuzzy
+msgid "Gets the value of a single preference."
+msgstr "Beállítja egy vagy több sáv csúcsamplitúdóját"
 
 #: src/commands/PreferenceCommands.h
 msgid "Sets the value of a single preference."
@@ -4568,7 +5839,8 @@ msgstr "Teljes képernyő be/ki"
 msgid "Toolbars"
 msgstr "E&szköztárak"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Hatások"
 
@@ -4612,6 +5884,10 @@ msgstr "Magas sávok"
 msgid "All Tracks Plus"
 msgstr "Magas sávok"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -4623,13 +5899,26 @@ msgid "Path:"
 msgstr "Útvonal"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "&Háttér:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Hiba a fájlmentés kísérleténél: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Képernyőkép eszközök…"
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -4676,6 +5965,10 @@ msgid "High:"
 msgstr "Felüláteresztő"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "Sávok &rendezése"
 
@@ -4688,7 +5981,8 @@ msgstr "Beállítás"
 msgid "Add"
 msgstr "&Hozzáadás"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Eltávolítás"
 
@@ -4706,6 +6000,11 @@ msgstr "Közepes"
 
 #: src/commands/SelectCommand.h
 msgid "Selects a time range."
+msgstr "Válasszon egy MIDI fájlt…"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
 msgstr "Válasszon egy MIDI fájlt…"
 
 #: src/commands/SelectCommand.h
@@ -4736,6 +6035,10 @@ msgstr "Színek"
 msgid "Color 3"
 msgstr "Színek"
 
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Color:"
 msgstr "Színek"
@@ -4743,6 +6046,10 @@ msgstr "Színek"
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Kezdés"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4761,9 +6068,14 @@ msgid "Edited Envelope"
 msgstr "Burkológörbe"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Burkológörbe"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4773,6 +6085,10 @@ msgstr "Címke &törlése"
 msgid "Label Index"
 msgstr "Címkeszerkesztés"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Kijelölés"
@@ -4780,6 +6096,10 @@ msgstr "Kijelölés"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Címkék szerkesztve"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4794,12 +6114,25 @@ msgid "Resize:"
 msgstr "Csökken&tés"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Szélesség"
 
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Enyhe"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Projekt mentése"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4830,16 +6163,32 @@ msgid "Gain:"
 msgstr "Hangerő"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Sávok &rendezése"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineáris"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "&Visszaállítás"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Vonalidő:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4869,9 +6218,20 @@ msgstr "Felhasználói előbeállítások"
 msgid "Spectral Select"
 msgstr "Spektrális kijelölés"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Új sáv"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Válasszon egy hangsávot."
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
@@ -4919,12 +6279,18 @@ msgstr "Olyan sávot jelölt ki, amely nem tartalmaz hangot. Az automatikus leha
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Az automatikus lehalkítás egy vezérlősávot igényel, amelyet a kijelölt sáv(ok) alá kell tenni."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Lehalkítás mértéke:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "másodperc"
 
@@ -4948,7 +6314,8 @@ msgstr "Belső lehalkítás hossza:"
 msgid "Inner &fade up length:"
 msgstr "Belső felerősítés hossza:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Küszöbszint:"
 
@@ -5075,6 +6442,10 @@ msgid "from (Hz)"
 msgstr "innen (Hz):"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "eddig (Hz):"
 
@@ -5082,11 +6453,13 @@ msgstr "eddig (Hz):"
 msgid "t&o"
 msgstr "eddig:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Változás százalékban:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Változás százalékban"
 
@@ -5095,12 +6468,24 @@ msgid "&Use high quality stretching (slow)"
 msgstr "Jó minőségű nyújtás használata (lassú)"
 
 #: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
 msgid "45"
 msgstr "4"
 
 #: src/effects/ChangeSpeed.cpp
 msgid "78"
 msgstr "8"
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -5126,6 +6511,7 @@ msgstr "Szabványos bakelitlemez fordulat:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Percenkénti fordulatszámtól"
@@ -5138,6 +6524,7 @@ msgstr "innen:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Percenkénti fordulatszámig"
@@ -5280,6 +6667,12 @@ msgstr "Tömörítő"
 msgid "Compresses the dynamic range of audio"
 msgstr "Tömöríti a hang dinamikatartományát"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -5288,6 +6681,20 @@ msgstr "%.2f mp"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f mp"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f mp"
 
 #: src/effects/Compressor.cpp
@@ -5405,7 +6812,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Kontrasztelemző a hang két kijelölése közti RMS hangerő különbségének méréséhez."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Befejezés"
 
@@ -5464,6 +6872,18 @@ msgstr "&Különbség:"
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&Súgó"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "zero"
@@ -5533,6 +6953,12 @@ msgstr "Jelenlegi különbség"
 msgid "Measured foreground level"
 msgstr "Mért előtérszint"
 
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
+
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
 msgstr "Nincs mért előtér"
@@ -5601,6 +7027,12 @@ msgstr "WCAG 2.0 sikerfeltételek 1.4.7: sikertelen"
 msgid "Data gathered"
 msgstr "Adatok begyűjtve"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Kontrasztelemzés (WCAG 2 szerint)"
@@ -5662,6 +7094,10 @@ msgstr "Kemény vágás -12dB, 80% helyrehozó erősítés"
 #, no-c-format
 msgid "Soft clip -12dB, 80% make-up gain"
 msgstr "Puha vágás -12dB, 80% helyrehozó erősítés"
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
 
 #: src/effects/Distortion.cpp src/effects/Equalization.cpp
 msgid "Walkie-talkie"
@@ -5860,6 +7296,12 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "Olyan kéttónusú, többfrekvenciás (DTMF) hangokat állít elő, mint például amilyeneket a telefonokon lévő billentyűzet hoz létre"
 
 #: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "DTMF sorozat:"
 
@@ -5867,7 +7309,9 @@ msgstr "DTMF sorozat:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitúdó (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "I&dőtartam:"
 
@@ -5912,7 +7356,8 @@ msgstr "Visszhang"
 msgid "Repeats the selected audio again and again"
 msgstr "Újra és újra ismétli a kijelölt hangot"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "A kért érték meghaladja a memóriakapacitást."
 
@@ -5936,7 +7381,8 @@ msgstr "Előbeállítás"
 msgid "Export Effect Parameters"
 msgstr "Paraméterek &szerkesztése"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Nem sikerült megnyitni a fájlt: „%s”"
@@ -5973,6 +7419,15 @@ msgstr "Előnézet előkészítése"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Előnézet"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -6285,12 +7740,32 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "Beállítja az egyes frekvenciák hangerőszintjeit"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Basszus (dB):"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Basszus"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -6325,9 +7800,41 @@ msgid "Effect Unavailable"
 msgstr "A hatás nem érhető el"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 #, c-format
 msgid "%d dB"
 msgstr "%3d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -6402,8 +7909,16 @@ msgid "D&efault"
 msgstr "Ala&pértelmezett"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &menetes"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -6648,12 +8163,25 @@ msgid "Builtin Effects"
 msgstr "Beépített hatások"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Beépített hatásokat biztosít az Audacity programhoz"
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Legnagyobb amplitúdó normalizálása erre:"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Sets the loudness of one or more tracks"
@@ -6677,9 +8205,26 @@ msgstr "Feldolgozás: "
 msgid "&Normalize"
 msgstr "Normalizálás"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Sztereócsatornák független normalizálása"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -6741,7 +8286,17 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (alapértelmezett)"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "Blackman, Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, nincs"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, nincs"
 
 #: src/effects/NoiseReduction.cpp
@@ -6841,8 +8396,9 @@ msgid "Step 1"
 msgstr "1. lépés"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Jelöljön ki pár másodpercnyi zajt, hogy az Audacity megtudja, mit kell\n"
@@ -6894,13 +8450,63 @@ msgstr "&Ablaktípusok"
 msgid "Window si&ze:"
 msgstr "Ablak&méret"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (alapértelmezett)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Ablakonkénti &lépések"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -6971,6 +8577,10 @@ msgid "Normalizing without removing DC offset...\n"
 msgstr "Normalizálás DC-eltolás eltávolítása nélkül…\n"
 
 #: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 #, c-format
 msgid "Analyzing first track of stereo pair: %s"
 msgstr "A sztereópár első sávjának elemzése: "
@@ -7012,12 +8622,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Sztereócsatornák független normalizálása"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Nyújtás"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch használata kizárólag egy extrém időnyújtás vagy „megrekedés” hatásnál"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Nyújtási tényező:"
@@ -7299,6 +8915,11 @@ msgstr "Megfordítja a kijelölt hangot"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS idő / hangmagasság nyújtás"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -7454,6 +9075,11 @@ msgstr "Alapértékek használata"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Alapértékek visszaállítása"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -7613,6 +9239,10 @@ msgstr "Csend felismerése"
 msgid "Tr&uncate to:"
 msgstr "Csonkítás eddig:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Tömörítés eddig:"
@@ -7626,7 +9256,8 @@ msgid "VST Effects"
 msgstr "VST-hatások"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Hozzáadja a VST-hatások használatának képességét az Audacity programhoz."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -7638,7 +9269,8 @@ msgstr "Héj VST vizsgálata"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "%d / %d regisztrálása: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Nem sikerült megnyitni az MP3-kódoló programkönyvtárat!"
 
@@ -7650,15 +9282,25 @@ msgstr "VST-hatás beállításai"
 msgid "Buffer Size"
 msgstr "Pufferméret"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Pufferméret (8-tól 1048576 mintáig):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Késleltetési kompenzáció"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "&Kompenzáció engedélyezése"
 
@@ -7684,7 +9326,18 @@ msgid "Save VST Preset As:"
 msgstr "VST-előbeállítás mentése másként:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Hangegység előbeállítások exportálása"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Hangegység előbeállítások exportálása"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity projektfájlok"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -7711,7 +9364,8 @@ msgstr "Hiba a VST-előbeállítások betöltésekor"
 msgid "Unable to load presets file."
 msgstr "Az előbeállítás-fájl nem tölthető be."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Hatásbeállítások"
 
@@ -7727,6 +9381,16 @@ msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Ez a paraméterfájl innen lett elmentve: %s. Folytatja?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -7758,7 +9422,8 @@ msgid "Audio Unit Effects"
 msgstr "Hangegység hatások"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Hangegység hatások támogatását biztosítja az Audacity programhoz"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -7774,8 +9439,16 @@ msgid "Audio Unit Effect Options"
 msgstr "Hangegység hatás beállításai"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Felhasználói felület"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -7829,6 +9502,14 @@ msgid "Unable to store preset in config file"
 msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not import \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "Nem található a projektadatokat tartalmazó mappa: „%s”"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Export Audio Unit Preset As %s:"
 msgstr "Hangegység előbeállítások exportálása"
@@ -7836,6 +9517,14 @@ msgstr "Hangegység előbeállítások exportálása"
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Standard Audio Unit preset file"
 msgstr "Hangegység előbeállítások exportálása"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not export \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "Nem található a projektadatokat tartalmazó mappa: „%s”"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Export Audio Unit Presets"
@@ -7855,6 +9544,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Nem lehet lekérni az adatfolyam leírását"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Mintavételezési gyakoriság átalakítás"
 
@@ -7862,6 +9556,21 @@ msgstr "Mintavételezési gyakoriság átalakítás"
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "%s eltávolítása sikertelen"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Nem lehet lekérni az adatfolyam leírását"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Nem lehet lekérni az adatfolyam leírását"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -7871,6 +9580,7 @@ msgstr "Hangegység"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA-hatások"
@@ -7880,8 +9590,25 @@ msgid "Provides LADSPA Effects"
 msgstr "LADSPA-hatásokat biztosít"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "LADSPA-hatás beállításai"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -7889,6 +9616,7 @@ msgstr "Hatáskimenet"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "LADSPA-hatások"
@@ -7903,8 +9631,16 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Pufferméret (8-tól 1048576 mintáig):"
 
 #: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
 msgstr "Az LV2 hatásoknak lehet grafikus felületük a paraméterértékek beállításához."
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
@@ -7920,12 +9656,19 @@ msgstr "%d görbe exportálva ide: %s\n"
 msgid "Generator"
 msgstr "Előállító"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-hatások"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "LV2-hatások támogatását biztosítja az Audacity programhoz"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -7933,7 +9676,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist-hatások"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Nyquist-hatások támogatását biztosítja az Audacity programhoz"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -7951,6 +9695,12 @@ msgstr "Nyquist bővítmények"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
 "To use 'Spectral effects', enable 'Spectral Selection'\n"
 "in the track Spectrogram settings and select the\n"
 "frequency range for the effect to act on."
@@ -7958,6 +9708,11 @@ msgstr ""
 "A „Spektrális hatások” használatához engedélyezze a „Spektrális\n"
 "kijelölést” a sáv spektrogram beállításaiban, és válassza a\n"
 "frekvenciatartományt a hatásnál, hogy hasson rá."
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
@@ -7989,6 +9744,16 @@ msgstr "Nyquist-kimenet: "
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Feldolgozás kész."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -8068,6 +9833,19 @@ msgid "Could not determine language"
 msgstr "Nem sikerült visszafejteni a fájlt: "
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Az előbeállítás-fájl nem tölthető be.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Nyquist-parancs megadása: "
 
@@ -8120,7 +9898,8 @@ msgstr "Válasszon egy MIDI fájlt…"
 msgid "Save file as"
 msgstr "Fájlok mentése"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "névtelen"
 
@@ -8129,7 +9908,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-hatások"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Vamp-hatások támogatását biztosítja az Audacity programhoz"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -8147,6 +9927,17 @@ msgstr "Elnézést, nem sikerült a Vamp-bővítmény előkészítése."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Bővítmény-beállítások"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -8303,15 +10094,28 @@ msgid "Command Output"
 msgstr "Parancskimenet"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
 "Egy felismerhetetlen fájlkiterjesztéssel rendelkező fájlnevet jelölt ki.\n"
 "Szeretné folytatni?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "A(z) „%s” modul található."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Az előbeállítás-fájl nem tölthető be."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -8358,6 +10162,14 @@ msgid ""
 msgstr ""
 "Az FFmpeg nem találja a 0x%x hangkodeket.\n"
 "A kodekhez támogatása valószínűleg nincs belefordítva."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -8423,7 +10235,8 @@ msgstr "A kijelölt hang exportálása mint %s"
 msgid "Invalid sample rate"
 msgstr "Érvénytelen mintavételezési gyakoriság"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Újramintavételezés"
 
@@ -8455,7 +10268,8 @@ msgstr "Mintavételezési gyakoriságok"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -8467,6 +10281,49 @@ msgstr "Bitsebesség:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Minőség:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%i kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -8481,6 +10338,10 @@ msgid "Constrained"
 msgstr "Állandó"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Hang…"
 
@@ -8489,8 +10350,44 @@ msgid "Low Delay"
 msgstr "Késleltetés"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Közepes"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -8561,8 +10458,17 @@ msgid "Replace preset '%s'?"
 msgstr "Lecseréli a(z) „%s” előbeállítást?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Fő"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -8670,6 +10576,10 @@ msgstr "Nyelv:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bit tartály"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -8803,6 +10713,11 @@ msgstr ""
 "0 - alapértelmezett\n"
 "min - 1\n"
 "max - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -8962,6 +10877,17 @@ msgstr "Nincsenek exportálandó címkék."
 msgid "Select xml file to export presets into"
 msgstr "Válasszon xml-fájlt, amelybe az előbeállításokat exportálja"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Nem sikerült kitalálni a formátumot"
@@ -8970,6 +10896,16 @@ msgstr "Nem sikerült kitalálni a formátumot"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to find the codec"
 msgstr "Nem sikerült megtalálni a kodeket"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "24 bit"
 
 #: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
@@ -9040,12 +10976,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(Legjobb minőség)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(Kisebb fájlok)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -9056,7 +11044,8 @@ msgstr "Megszállott"
 msgid "Extreme"
 msgstr "Extrém"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Szabványos"
 
@@ -9107,8 +11096,8 @@ msgid "Locate LAME"
 msgstr "LAME keresése"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Az Audacity programnak szüksége van a(z) %s fájlra az MP3-fájlok létrehozásához."
 
 #: src/export/ExportMP3.cpp
@@ -9136,13 +11125,34 @@ msgid "Where is %s?"
 msgstr "Hol van: %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "A lame_enc.dll v%d.%d fájlhoz csatlakozik. Ez a verzió nem kompatibilis az Audacity %d.%d.%d. verziójával.\n"
 "Töltse le a LAME MP3 programkönyvtár legújabb verzióját."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Projekt adatfájlok mentése"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -9392,6 +11402,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Nem lehet beállítani a QuickTime megjelenítő minőségét"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Az előbeállítás-fájl nem tölthető be."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Az előbeállítás-fájl nem tölthető be."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Az előbeállítás-fájl nem tölthető be."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Az előbeállítás-fájl nem tölthető be."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Az előbeállítás-fájl nem tölthető be."
 
@@ -9402,6 +11432,10 @@ msgstr "A kijelölt hang exportálása Ogg Vorbis formátumba"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "A kijelölt hang exportálása Ogg Vorbis formátumba"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -9420,8 +11454,28 @@ msgid "Other uncompressed files"
 msgstr "Egyéb tömörítetlen fájlok"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Hiba az importáláskor"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -9449,11 +11503,11 @@ msgid "All supported files"
 msgstr "Minden fájl|*|Minden támogatott fájl|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "„%s”\n"
@@ -9462,11 +11516,11 @@ msgstr ""
 "szerkesztheti a Fájl > Importálás > MIDI menüpontra kattintva."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "„%s”\n"
 "egy MIDI-fájl, nem hangfájl.\n"
@@ -9478,18 +11532,18 @@ msgid "Select stream(s) to import"
 msgstr "Az importálandó adatfolyamok kiválasztása"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Az Audacity ezen verziója %s támogatás nélkül lett lefordítva."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "„%s” egy hang-CD száma.\n"
 "Az Audacity nem tudja közvetlenül megnyitni a hang-CD-ket.\n"
@@ -9498,10 +11552,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "„%s” egy lejátszólista fájl.\n"
@@ -9511,10 +11565,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s” egy Windows Media Audio fájl.\n"
@@ -9523,10 +11577,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s” egy Advanced Audio Coding fájl.\n"
@@ -9535,12 +11589,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "„%s” egy titkosított hangfájl.\n"
@@ -9552,10 +11606,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s” egy RealPlayer médiafájl.\n"
@@ -9564,12 +11618,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "„%s” egy hangjegyeken alapuló fájl, nem hangfájl.\n"
 "Az Audacity nem tudja megnyitni az ilyen típusú fájlt.\n"
@@ -9578,10 +11632,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -9594,10 +11648,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s” egy Wavpack hangfájl.\n"
@@ -9606,10 +11660,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s” egy Dolby Digital hangfájl.\n"
@@ -9618,10 +11672,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s” egy Ogg Speex hangfájl.\n"
@@ -9630,10 +11684,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "„%s” egy videofájl.\n"
@@ -9647,20 +11701,31 @@ msgstr "A(z) „%s” modul található."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Az Audacity nem ismerte fel a(z) „%s” fájl típusát.\n"
 "Próbálja meg telepíteni az FFmpeg programot. Tömörítetlen fájloknál próbálja meg ezt is: Fájl > Importálás > Nyers adatok."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -9669,6 +11734,11 @@ msgstr ""
 "Az importálók állítólag támogatják az ilyen fájlokat:\n"
 "%s,\n"
 "azonban egyikük sem értette meg ezt a fájlformátumot."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Projekt adatfájlok mentése"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -9683,8 +11753,57 @@ msgid "Import Project"
 msgstr "Előbeállítás importálása"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Az igazítási folyamat belső hibát jelentett."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -9692,16 +11811,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Nem található a projektadatokat tartalmazó mappa: „%s”"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Projektek"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Érvénytelen mintavételezési gyakoriság"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Érvénytelen mintavételezési gyakoriság"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -9731,31 +11908,6 @@ msgstr "Index[%02x] kodek[%s], nyelv[%s], bitsebesség[%s], csatornák[%d], idő
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC-fájlok"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-kompatibilis fájlok"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Az előbeállítás-fájl nem tölthető be."
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Bővített importálás"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "A(z) „%s” átnevezése „%s” névre nem sikerült."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index[%02x] kodek[%s], nyelv[%s], bitsebesség[%s], csatornák[%d], időtartam[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Nem lehet megnyitni vagy létrehozni a tesztfájlt."
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -9813,6 +11965,14 @@ msgstr "A fájl nem nyitható meg "
 msgid "MP3 files"
 msgstr "MP3-fájlok"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis fájlok"
@@ -9847,8 +12007,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF és egyéb tömörítetlen típusok"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) 32-bit lebegőpontos PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -9859,12 +12113,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-bit lebegőpontos"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-bit lebegőpontos"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) 32-bit lebegőpontos PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bit"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -9875,12 +12173,20 @@ msgid "24 bit DWVW"
 msgstr "24 bit"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -9991,6 +12297,10 @@ msgstr "Mintavételezési gyakoriság:"
 msgid "&Import"
 msgstr "&Importálás"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -10011,6 +12321,7 @@ msgstr "jobbra"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -10034,6 +12345,7 @@ msgstr "Befejezés"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -10053,10 +12365,16 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Sávok/klipek időben eltolva %s %.02f másodperccel"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Sávok/klipek időben eltolva %s %.02f másodperccel"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Időeltolás"
 
@@ -10066,6 +12384,16 @@ msgstr "A parancsfájl nem lett elmentve."
 
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "Határ&ok levágása"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Határ&ok levágása"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "Határ&ok levágása"
 
 #: src/menus/ClipMenus.cpp
@@ -10186,7 +12514,8 @@ msgstr "A kijelölt hangsávok levágása %.2f másodperctől %.2f másodpercig"
 msgid "Trim Audio"
 msgstr "Hang levágása"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Szétvágás"
 
@@ -10307,32 +12636,8 @@ msgid "Delete Key&2"
 msgstr "Törlésgomb2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Ke&verő eszköztár"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Lejátszás hangerejének igazítása"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Lejátszás hangerejének növelése"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Lejátszás hangerejének csökkentése"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Felvételi hangerő igazítása"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Felvételi hangerő növelése"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Felvételi hangerő csökkentése"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -10357,6 +12662,13 @@ msgstr "Felvételi csatornák változtatása"
 #: src/menus/ExtraMenus.cpp
 msgid "&Full Screen (on/off)"
 msgstr "Teljes képernyő be/ki"
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -10415,6 +12727,11 @@ msgstr "Címkék importálása"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Válasszon egy MIDI fájlt…"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Minden fájl|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -10517,6 +12834,10 @@ msgid "E&xit"
 msgstr "&Kilépés"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "Címkék exportálása másként:"
 
@@ -10547,6 +12868,10 @@ msgid "Nothing to do"
 msgstr "Nincs mit visszavonni"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "A kiválasztott sáv bezárása"
 
@@ -10557,6 +12882,10 @@ msgstr "A projektfájl nem nyitható meg"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Fe"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -10575,8 +12904,9 @@ msgid "&Getting Started"
 msgstr "Kijelölés kezdete:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Kézikönyv"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -10602,11 +12932,8 @@ msgstr "&Hangeszköz információk…"
 msgid "Show &Log..."
 msgstr "&Napló megjelenítése…"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Audacity névjegye…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Címke hozzáadva"
 
@@ -10808,6 +13135,10 @@ msgid "Move Forward Through Active Windows"
 msgstr "Előre mozgatás az aktív ablakokon keresztül"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Visszafelé mozgatás az eszköztárakból a sávokba"
 
@@ -10959,6 +13290,16 @@ msgid "Set Track Status..."
 msgstr "a &sáv elejére"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Hang csenddé alakítása"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Sávok &rendezése"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "&Beállítások…"
 
@@ -10981,6 +13322,12 @@ msgstr "Címkék szerkesz&tése…"
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "P&rojekt mentése másként…"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Parancsfájl"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -11055,6 +13402,11 @@ msgstr "Minden &sávban"
 #: src/menus/SelectMenus.cpp
 msgid "In All &Sync-Locked Tracks"
 msgstr "M&inden szinkronsávban"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr " Szinkronizációs zár kiválasztva"
 
 #: src/menus/SelectMenus.cpp
 msgid "R&egion"
@@ -11275,6 +13627,7 @@ msgstr "Hosszú kurzorugrás jobbra"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Tekerés"
@@ -11486,18 +13839,21 @@ msgid "Created new label track"
 msgstr "Új címkesáv létrehozva"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Az Audacity ezen verziója projektablakonként csak egyetlen idősávot engedélyez."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Új idősáv létrehozva"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Új mintavételezési gyakoriság (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "A megadott érték érvénytelen"
 
@@ -11577,6 +13933,11 @@ msgid "&Time Track"
 msgstr "&Idősáv"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Ke&verő eszköztár"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Sztereó felosztása mo&nóra"
 
@@ -11615,6 +13976,10 @@ msgstr "Minden sáv el&némítása"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "Minden sáv &visszahangosítása"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -11746,7 +14111,9 @@ msgstr "Lejátszás"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Felvétel"
 
@@ -11757,6 +14124,11 @@ msgstr "nincs címkesáv"
 #: src/menus/TransportMenus.cpp
 msgid "no label track at or below focused track"
 msgstr "nincs címkesáv a kiválasztott sávnál vagy alatta"
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
@@ -11848,6 +14220,11 @@ msgid "&Timer Record..."
 msgstr "&Időzített felvétel…"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Hangvezérelt felvétel"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Terület lejátszás&a"
 
@@ -11888,10 +14265,6 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "S&zoftveres átjátszás (be/ki)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Auto&matikus felvételiszint-szabályozás (be/ki)"
-
-#: src/menus/TransportMenus.cpp
 msgid "T&ransport"
 msgstr "Á&tvitel"
 
@@ -11899,6 +14272,11 @@ msgstr "Á&tvitel"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "&Lejátszás/leállítás"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -12016,6 +14394,11 @@ msgid "&Fit to Width"
 msgstr "A&blakhoz igazítás"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "A&blakhoz igazítás"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "Minden sáv össze&csukása"
 
@@ -12096,7 +14479,7 @@ msgstr "Beállítások: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Kilépés az Audacity programból"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -12143,7 +14526,8 @@ msgstr "&Gép:"
 msgid "Using:"
 msgstr "Használva:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Lejátszás"
 
@@ -12163,7 +14547,8 @@ msgstr "&Csatornák:"
 msgid "Latency"
 msgstr "Késleltetés"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "ezredmásodperc"
 
@@ -12192,7 +14577,8 @@ msgid "2 (Stereo)"
 msgstr "2 (sztereó)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Könyvtárak"
 
@@ -12205,8 +14591,22 @@ msgid "Default directories"
 msgstr "Könyvtárak"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Tallózás…"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -12284,7 +14684,8 @@ msgid "Directory %s is not writable"
 msgstr "A(z) %s könyvtár nem írható"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Az átmeneti könyvtár megváltoztatása az Audacity újraindításakor lép életbe"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -12317,9 +14718,16 @@ msgstr "Típus szerint csoportosítva"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "LADSPA-hatások"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -12328,6 +14736,18 @@ msgstr "LADSPA-hatások"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -12338,6 +14758,10 @@ msgid "Effect Options"
 msgstr "Hatásbeállítások"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "&Maximum effects per group (0 to disable):"
 msgstr "Maximális hatások csoportonként (0 - kikapcsolás):"
 
@@ -12346,11 +14770,13 @@ msgid "Plugin Options"
 msgstr "Bővítmény beállítások"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Frissített bővítmények keresése az Audacity indításakor"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Bővítmények újraolvasása az Audacity következő indításakor"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -12502,6 +14928,10 @@ msgid "Location of &Manual:"
 msgstr "&Kézikönyv helye:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "Mérő dB &tartománya:"
 
@@ -12514,12 +14944,29 @@ msgid "Show e&xtra menus"
 msgstr "&Rácsvonalak megjelenítése"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "&Rendszerhang a hosszabb tevékenységek befejezésekor"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Re&tain labels if selection snaps to a label"
 msgstr "Címkék meg&tartása, ha a kijelölés egy címke széléhez illeszkedik"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -12534,9 +14981,18 @@ msgstr "Változó sebességű lejátszás vonalzó megjelenítése"
 msgid "Language \"%s\" is unknown"
 msgstr "A(z) „%s” nyelv ismeretlen"
 
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Importálás / exportálás"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Beállítások: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -12549,6 +15005,10 @@ msgstr "Speciális keverési beállítások"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Szabványos"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -12574,6 +15034,14 @@ msgstr "Csend mellőzése a kezdeteken és a végeken"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Címkék exportálása másként:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -12658,7 +15126,15 @@ msgid "&Defaults"
 msgstr "&Alapértékek"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Válasszon egy Audacity gyorsbillentyűket tartalmazó XML-fájlt…"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -12667,8 +15143,21 @@ msgstr "Hiba a gyorsbillentyűk importálásakor"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d gyorsbillentyű betöltve\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -12689,6 +15178,15 @@ msgstr "Ehhez a bejegyzéshez nem rendelhet hozzá billentyűt"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "Ki kell választania egy kötést a gyorsbillentyű hozzárendelése előtt"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -12759,12 +15257,17 @@ msgid "Dow&nload"
 msgstr "Le&töltés"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Az Audacity automatikusan felismerte a megfelelő FFmpeg programkönyvtárakat.\n"
 "Ennek ellenére szeretné azokat kézzel megkeresni?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -12801,6 +15304,10 @@ msgstr "MIDI-szintetizátor késleltetés (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "A MIDI-szintetizátor késleltetésnek egész számnak kell lennie"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -12811,19 +15318,22 @@ msgid "Preferences for Module"
 msgstr "Beállítások: "
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr "Ezek kísérleti modulok. Csak akkor engedélyezze azokat, ha elolvasta az Audacity kézikönyvét, és tudja, hogy mit tesz."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "A „Kérdés” azt jelenti, hogy az Audacity minden indításkor meg fogja kérdezni, hogy be szeretné-e tölteni a modult."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "A „Sikertelen” azt jelenti, hogy az Audacity úgy gondolja, hogy a modul törött, és nem fogja futtatni."
 
 #. i18n-hint preserve the leading spaces
@@ -12832,7 +15342,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "Az „Új” azt jelenti, hogy még nem történt választás."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Ezen beállítások változtatásai csak az Audacity következő indításakor lépnek életbe."
 
 #: src/prefs/ModulePrefs.cpp
@@ -12850,6 +15361,10 @@ msgstr "Nem találhatók modulok"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modulok"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -12891,7 +15406,10 @@ msgstr "Bal húzás"
 msgid "Set Selection Range"
 msgstr "Kijelölési tartomány beállítása"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift + bal kattintás"
 
@@ -12978,6 +15496,15 @@ msgstr " + bal húzás"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Klip áthelyezése fel/le a sávok között"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr " + bal húzás"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -13089,8 +15616,21 @@ msgstr "&Rövid szakasz:"
 msgid "Lo&ng period:"
 msgstr "&Hosszú szakasz:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity beállítások"
 
 #: src/prefs/PrefsDialog.cpp
@@ -13104,6 +15644,11 @@ msgstr "Beállítások: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Beállítások: "
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -13164,12 +15709,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "Rájátszás: más sávok &lejátszása az új felvétel közben"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "S&zoftveres átjátszás (be/ki)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Új sáv"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Az importálandó adatfolyamok kiválasztása"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -13214,41 +15769,32 @@ msgid "System T&ime"
 msgstr "Rendszer&idő hozzáadása"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatikus felvételi szint beállítás"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Automatikus felvételi szint beállítás engedélyezése."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Cél csúcs:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Ezen belül:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Elemzési idő:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "ezredmásodperc (egy elemzés ideje)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Egymást követő elemzések száma:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 jelentése végtelen"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Hangvezérelt felvétel"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Jegyzetsáv"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -13359,6 +15905,10 @@ msgid "&Range (dB):"
 msgstr "&Tartomány (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
 msgstr "Algoritmus"
 
@@ -13377,6 +15927,10 @@ msgstr "8 - leginkább széles sávú"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "256 - alapérték"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -13476,13 +16030,14 @@ msgid "Info"
 msgstr "Információ"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -13574,6 +16129,10 @@ msgid "&Type to create a label"
 msgstr "&Gépelés egy címke létrehozásához"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Enable scrolling left of &zero"
 msgstr "Görgetés engedélyezése &nullától balra"
 
@@ -13597,6 +16156,14 @@ msgstr "Hullámforma"
 msgid "Spectrogram"
 msgstr "Spektrogram"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "A&blakhoz igazítás"
@@ -13608,6 +16175,10 @@ msgstr "N&agyítás a kijelölésre"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Alapértelmezett nagyítás"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -13630,6 +16201,16 @@ msgid "50ths of Seconds"
 msgstr "másodperc"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "másodperc"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "másodperc"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "ezredmásodperc"
 
@@ -13637,7 +16218,12 @@ msgstr "ezredmásodperc"
 msgid "Samples"
 msgstr "minta"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Nagyítás"
 
@@ -13646,12 +16232,28 @@ msgid "Preferences for Tracks"
 msgstr "Beállítások: "
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "Hangsávnév megjelenítése &rátétként"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "&Pinned Recording/Playback head"
 msgstr "&Rögzített felvevő- vagy lejátszófej"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -13660,6 +16262,11 @@ msgstr "Alapértelmezett &nézetmód:"
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Alapé&rtelmezett mintaformátum:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "minta"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -13739,16 +16346,24 @@ msgid "Stopped"
 msgstr "Leállítva"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Szünet"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Kihagyás az elejéig"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Kihagyás a végéig"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Szünet"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Kijelölés a kezdetéig"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Kijelölés a végéig"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -13762,20 +16377,17 @@ msgstr "Új sáv"
 msgid "Append Record"
 msgstr "Felvétel hozzáfűzése"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Kijelölés a végéig"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Kijelölés a kezdetéig"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Szüneteltetve"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -13855,11 +16467,17 @@ msgstr "Hangkijelölés csenddé alakítása"
 msgid "Sync-Lock Tracks"
 msgstr "Sávok szinkronba tartása"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Nagyítás"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Kicsinyítés"
 
@@ -13926,43 +16544,6 @@ msgstr "&Felvételmérő eszköztár"
 msgid "&Playback Meter Toolbar"
 msgstr "&Lejátszásmérő eszköz"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Felvételi hangerő"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Lejátszási hangerő"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Felvételi hangerő: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Felvételi hangerő (nem érhető el; rendszerkeverő használata.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Lejátszási hangerő: %%.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Lejátszási hangerő: %%.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Lejátszási hangerő (nem érhető el; rendszerkeverő használata.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Ke&verő eszköztár"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Tekerés"
@@ -13978,6 +16559,7 @@ msgstr "Változó sebességű lejátszás"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Változó sebességű lejátszás leállítása"
@@ -13985,6 +16567,7 @@ msgstr "Változó sebességű lejátszás leállítása"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Változó sebességű lejátszás indítása"
@@ -13992,6 +16575,7 @@ msgstr "Változó sebességű lejátszás indítása"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Tekerés leállítása"
@@ -13999,6 +16583,7 @@ msgstr "Tekerés leállítása"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Tekerés indítása"
@@ -14053,7 +16638,9 @@ msgstr "Igazítás"
 msgid "Length"
 msgstr "Hossz"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Közép"
 
@@ -14061,6 +16648,14 @@ msgstr "Közép"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "Kattintások / kijelölések illesztése ehhez: %s"
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -14109,8 +16704,8 @@ msgstr "&Eszköz eszköztár"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %s eszköztár"
 
 #: src/toolbars/ToolBar.cpp
@@ -14137,7 +16732,8 @@ msgstr "Időeltolódás eszköz"
 msgid "Zoom Tool"
 msgstr "Nagyítás eszköz"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Rajzeszköz"
 
@@ -14213,11 +16809,13 @@ msgstr "Egy vagy több címkehatár húzása."
 msgid "Drag label boundary."
 msgstr "Címkehatár húzása."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Címke módosítva"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Címkeszerkesztés"
 
@@ -14272,31 +16870,42 @@ msgstr "Címkék szerkesztve"
 msgid "New label"
 msgstr "Címke hozzáadva"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Egy &oktávval feljebb"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Egy oktá&vval lejjebb"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Kattintás a függőleges nagyításhoz. Shift + kattintás a kicsinyítéshez. Húzás egy nagyítási terület megadásához."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Jobb kattintás"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Kicsinyítés"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift + bal kattintás"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift + bal húzás"
 
@@ -14319,6 +16928,14 @@ msgid "Stretch"
 msgstr "Nyújtás"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Klipek egyesítve"
 
@@ -14330,7 +16947,8 @@ msgstr "Egyesítés"
 msgid "Expanded Cut Line"
 msgstr "Metszésvonal kibővítve"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Kibővítés"
 
@@ -14353,6 +16971,11 @@ msgstr "Áthelyezett minták"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Mintaszerkesztés"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -14398,7 +17021,8 @@ msgstr "Feldolgozás: "
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "„%s” módosítva erre: %s"
@@ -14412,7 +17036,60 @@ msgid "Rat&e"
 msgstr "Se&besség"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100000>0100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100000>0100 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -14433,7 +17110,8 @@ msgstr "Frekvencia változtatása"
 msgid "Set Rate"
 msgstr "Frekvencia beállítása"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Több"
 
@@ -14526,10 +17204,25 @@ msgid "Right, %dHz"
 msgstr "Jobb, "
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "jobbra"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -14539,6 +17232,15 @@ msgstr "Kattintás és húzás a sztereó sávok relatív méretének változtat
 msgid "Click and drag to rearrange sub-views"
 msgstr "Kattintás és húzás a sáv áthelyezéséhez az időben"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Kattintás és húzás a sáv áthelyezéséhez az időben"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Nagyítás"
@@ -14546,6 +17248,10 @@ msgstr "Nagyítás"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Nagyítás"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -14632,9 +17338,8 @@ msgstr "Logaritmikus &interpoláció"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Kattintás és húzás a sáv áthelyezéséhez az időben"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -14685,6 +17390,7 @@ msgstr "Beállított burkológörbe."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Változó sebességű lejátszás"
@@ -14696,6 +17402,7 @@ msgstr "Tekerés"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Változó sebességű lejátszás vonalzó"
@@ -14771,6 +17478,11 @@ msgstr "Kattintás és húzás a frekvencia-sávszélesség beállításához."
 msgid "Click and drag to select audio"
 msgstr "Kattintás és húzás a hang kiválasztásához"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Kattintás és húzás a sáv áthelyezéséhez az időben"
@@ -14792,6 +17504,10 @@ msgstr "Kijelölt sávok csenddé alakítva %.2f másodpercnél itt: %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Kijelölt sávok csenddé alakítva %.2f másodpercnél itt: %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -14921,9 +17637,19 @@ msgstr "Üres"
 msgid "Backwards"
 msgstr "Vissza"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Előre"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -15137,6 +17863,7 @@ msgstr "0100 ó 060 p 060 m+># minta"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "minta"
@@ -15298,6 +18025,15 @@ msgstr "01000,01000 képkocka|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000>0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -15305,6 +18041,10 @@ msgstr "0100000>0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100.01000 kHz|0.001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -15370,6 +18110,11 @@ msgstr "(Használja a helyi menüt a formátum változtatásához.)"
 msgid "centiseconds"
 msgstr "századmásodperc"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Eltelt idő:"
@@ -15412,6 +18157,11 @@ msgstr "Bezárás megerősítése"
 msgid "Unable to write files to directory: %s."
 msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -15428,6 +18178,10 @@ msgstr "Beállítások: "
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Ne jelenjen meg többet ez a figyelmeztetés"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -15478,6 +18232,11 @@ msgid "Value must not be greater than %s"
 msgstr "Az érték nem lehet nagyobb mint %s"
 
 #: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Dialog"
+msgstr "Keresés párbeszédablak"
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Összes szöveg kijelölése"
 
@@ -15507,16 +18266,49 @@ msgstr "A fájl nem nyitható meg "
 msgid "Spectral edit multi tool"
 msgstr "Spektrális kijelölés"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Szűrőhossz"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Frekvenciák"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Hiba"
@@ -15531,8 +18323,34 @@ msgstr "Nö&velés (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "A legkisebb frekvenciának legalább 0 Hz-nek kell lennie"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -15546,9 +18364,22 @@ msgstr "Lekeverés"
 msgid "Applying Fade..."
 msgstr "Alkalmazás…"
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Beállítás ala&pértelmezettként"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -15580,8 +18411,16 @@ msgid "S-Curve Down"
 msgstr "Mozgatás le"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Kezdés"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -15590,6 +18429,14 @@ msgstr "Hangerő"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Kezdés"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -15602,6 +18449,14 @@ msgstr "Lineáris"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Lineáris"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -15650,9 +18505,26 @@ msgstr "A frekvencianövelés nem lehet negatív"
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "A frekvencianövelés nem lehet negatív"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Ismétlődés"
+
+#: plug-ins/beat.ny
+msgid "Finding beats..."
+msgstr ""
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Audacity napló"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -15661,6 +18533,27 @@ msgstr "Küszöbszint szabályzók"
 #: plug-ins/clipfix.ny
 msgid "Clip Fix"
 msgstr "Levágás"
+
+#: plug-ins/clipfix.ny
+msgid "Reconstructing clips..."
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Küszöbszint %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
 
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
@@ -15683,6 +18576,11 @@ msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
 msgstr ""
 "Érvénytelen hangkijelölés.\n"
 "Győződjön meg arról, hogy a hang ki van-e jelölve."
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -15716,6 +18614,19 @@ msgstr "Egyéni sáv&név használata"
 msgid "Fade direction"
 msgstr "közvetlen olvasás"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Késleltetés"
@@ -15731,6 +18642,19 @@ msgstr "Késleltetés"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "Négyszögletű"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "&Zajcsökkentés (dB):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -15756,6 +18680,14 @@ msgstr "Hatás előnézete"
 msgid "Number of echoes"
 msgstr "Ismétlések száma"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Utolsó hatás ismétlése"
@@ -15767,6 +18699,10 @@ msgstr "Kiegyenlítés"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3-fájlok"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -15781,10 +18717,24 @@ msgstr "Felülírás megerősítése"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Nem sikerült megnyitni a műfajfájlt."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Hiba (esetleg a fájl nem lett kiírva): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Hiba (esetleg a fájl nem lett kiírva): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -15815,10 +18765,50 @@ msgstr "Hossz (másodperc)"
 msgid "Length of label region (seconds)"
 msgstr "Hossz (másodperc)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Címkeszerkesztés"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -15832,6 +18822,11 @@ msgstr "Leválasztás"
 msgid "Warnings only"
 msgstr "Figyelmeztetések"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -15841,6 +18836,17 @@ msgstr "Terü&let mentése"
 msgid "point labels"
 msgstr "Címkék szerkesztve"
 
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
 msgstr "Klasszikus szűrők"
@@ -15849,13 +18855,50 @@ msgstr "Klasszikus szűrők"
 msgid "Performing High-Pass Filter..."
 msgstr "Klasszikus szűrők"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvencia (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "A legkisebb frekvenciának legalább 0 Hz-nek kell lennie"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -15902,11 +18945,53 @@ msgstr "Joint sztereó"
 msgid "Point after sound"
 msgstr "Joint sztereó"
 
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "Joint sztereó"
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum leading silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum trailing silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "A kijelölésnek nagyobbnak kell lennie %d mintánál."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -15938,8 +19023,25 @@ msgid "Hard Clip"
 msgstr "Kemény levágás"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Jobb csatorna"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "&Szoprán (dB):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -15960,6 +19062,10 @@ msgstr "Zajtípus:"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Kijelölés"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -15997,6 +19103,44 @@ msgstr "Válasz-/lecsengési idő"
 msgid "Decay (ms)"
 msgstr "Válasz-/lecsengési idő"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "A kijelölésnek nagyobbnak kell lennie %d mintánál."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Szűrő hossza"
@@ -16008,6 +19152,18 @@ msgstr "Nyquist-hatás alkalmazása…"
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Beállítás ala&pértelmezettként"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -16030,7 +19186,8 @@ msgstr "MP3-fájlok"
 msgid "HTML file"
 msgstr "MP3-fájlok"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Fájlok elnevezése:"
 
@@ -16047,9 +19204,24 @@ msgid "Disallow"
 msgstr "Nem engedélyezett"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Nem engedélyezett"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "%s eltávolítása sikertelen"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -16060,12 +19232,59 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Válasszon egy MIDI fájlt…"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Nem használt szűrők:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Válasszon egy MIDI fájlt…"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Generating pluck sound..."
+msgstr "Hang gyorsítótárazása"
+
+#: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Fájltípus:"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -16076,16 +19295,44 @@ msgid "Rhythm Track"
 msgstr "Sáv eltávolítása"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Generating Rhythm..."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Beats per bar"
 msgstr "Percenkénti ütem"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Torzítás mértéke"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Ismétlések száma"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -16108,12 +19355,62 @@ msgid "Beat sound"
 msgstr "Ismétlődés"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Rezonancia"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Zajszint padló"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Risset Drum"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Generating Risset Drum..."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Steven Jones"
@@ -16128,6 +19425,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Középfrekvencia és szélesség"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Frekvencia (Hz):"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Amplitúdó (0-1):"
 
@@ -16138,6 +19444,10 @@ msgstr "Nem exportálható"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Alkalmazás…"
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -16154,6 +19464,10 @@ msgstr "FLAC-fájlok"
 #: plug-ins/sample-data-export.ny
 msgid "HTML files"
 msgstr "MP3-fájlok"
+
+#: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Count"
@@ -16175,6 +19489,23 @@ msgstr "Minimum"
 msgid "All"
 msgstr "Összes"
 
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
+
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
 msgid "L Channel First"
@@ -16188,6 +19519,11 @@ msgstr "ez a súgó üzenet"
 msgid "Errors Only"
 msgstr "Hiba: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -16200,6 +19536,46 @@ msgstr "Jobb csatorna"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "minta"
 
@@ -16207,6 +19583,43 @@ msgstr "minta"
 #, lisp-format
 msgid "~a seconds."
 msgstr "másodperc"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -16225,6 +19638,10 @@ msgid "Value (dB)"
 msgstr "&Hangerő (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Lineáris"
 
@@ -16241,6 +19658,14 @@ msgid "Right (dB)"
 msgstr "Jobb, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Lineáris"
 
@@ -16251,6 +19676,40 @@ msgstr "2 csatorna (sztereó)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 csatorna (monó)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Hiba (esetleg a fájl nem lett kiírva): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -16265,8 +19724,40 @@ msgid "Select file"
 msgstr "Válasszon egy MIDI fájlt…"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Hiba"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -16276,6 +19767,15 @@ msgstr "Nem sikerült megnyitni a műfajfájlt."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Spektrális kijelölés"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -16298,8 +19798,16 @@ msgid "Wet level (percent)"
 msgstr "Nedves szint"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Alkalmazás…"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -16341,9 +19849,96 @@ msgstr "Ele&mzés"
 msgid "Strength"
 msgstr "Szűrőhossz"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Feldolgozás kész."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -16377,6 +19972,192 @@ msgstr "Frekvencia (Hz):"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Frekvencia (Hz):"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Kilépés az Audacity programból"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Csatorna"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Hiba a fájl visszafejtésekor"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Hiba a metaadatok betöltésekor"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s eszköztár"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Felvétel"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Véglegesítés-azonosító:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Keresztplatformos GUI könyvtár"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importálás GStreamer által"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Az automatikus felvételi szint igazítás leállt. Nem volt lehetséges jobban optimalizálni. Még mindig túl magas."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Az automatikus felvételi szint igazítás %f értékre csökkentette a hangerőt."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Az automatikus felvételi szint igazítás leállt. Nem volt lehetséges jobban optimalizálni. Még mindig túl alacsony."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Az automatikus felvételi szint igazítás %.2f értékre növelte a hangerőt."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Az automatikus felvételi szint igazítás leállt. Az elemzések összesített számát túllépték elfogadható hangerő megtalálása nélkül. Még mindig túl magas."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Az automatikus felvételi szint igazítás leállt. Az elemzések összesített számát túllépték elfogadható hangerő megtalálása nélkül. Még mindig túl alacsony."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Az automatikus felvételi szint igazítás leállt. Úgy tűnik, %.2f az elfogadható hangerő."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Nem sikerült megnyitni a műfajfájlt.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Időzített felvétel\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Lejátszási hangerő\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Felvételi hangerő\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Felvételi hangerő\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Lejátszási hangerő: %%.2f%s\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Lejátszási hangerő: %%.2f%s\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-kompatibilis fájlok"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Az előbeállítás-fájl nem tölthető be."
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Bővített importálás"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "A(z) „%s” átnevezése „%s” névre nem sikerült."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index[%02x] kodek[%s], nyelv[%s], bitsebesség[%s], csatornák[%d], időtartam[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Nem lehet megnyitni vagy létrehozni a tesztfájlt."
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Lejátszás hangerejének igazítása"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Lejátszás hangerejének növelése"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Lejátszás hangerejének csökkentése"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Felvételi hangerő igazítása"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Felvételi hangerő növelése"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Felvételi hangerő csökkentése"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Audacity névjegye…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Auto&matikus felvételiszint-szabályozás (be/ki)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatikus felvételi szint beállítás"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Automatikus felvételi szint beállítás engedélyezése."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Cél csúcs:"
+
+#~ msgid "Within:"
+#~ msgstr "Ezen belül:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Elemzési idő:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "ezredmásodperc (egy elemzés ideje)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Egymást követő elemzések száma:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 jelentése végtelen"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Felvételi hangerő"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Lejátszási hangerő"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Felvételi hangerő: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Felvételi hangerő (nem érhető el; rendszerkeverő használata.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Lejátszási hangerő: %%.2f%s"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Lejátszási hangerő: %%.2f%s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Lejátszási hangerő (nem érhető el; rendszerkeverő használata.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Ke&verő eszköztár"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Kattintás és húzás a sáv áthelyezéséhez az időben"
+
 #~ msgid "Program build date:"
 #~ msgstr "Program készítésének dátuma: "
 
@@ -16394,10 +20175,6 @@ msgstr "Frekvencia (Hz):"
 #, fuzzy
 #~ msgid "Unknown error"
 #~ msgstr "Ismeretlen"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Nem sikerült olvasni az előbeállítás-fájlt."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -16856,10 +20633,6 @@ msgstr "Frekvencia (Hz):"
 #, fuzzy
 #~ msgid "Sound Finder"
 #~ msgstr "Csend"
-
-#, fuzzy
-#~ msgid "Gating audio..."
-#~ msgstr "Hang gyorsítótárazása"
 
 #, fuzzy
 #~ msgid "Apply Low-Cut filter"
@@ -17546,10 +21319,6 @@ msgstr "Frekvencia (Hz):"
 #~ msgstr "Kez&dettől a kijelölés végéig"
 
 #, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
-
-#, fuzzy
 #~ msgid "Show start time and end time"
 #~ msgstr "Kezdési dátum és idő"
 
@@ -17773,9 +21542,6 @@ msgstr "Frekvencia (Hz):"
 
 #~ msgid "Offset"
 #~ msgstr "Eltolás"
-
-#~ msgid "Version"
-#~ msgstr "Verzió"
 
 #~ msgid "C&ategory:"
 #~ msgstr "&Kategória:"

--- a/locale/hy.po
+++ b/locale/hy.po
@@ -3,11 +3,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Armenian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/hy/>\n"
+"Language-Team: Armenian <https://hosted.weblate.org/projects/tenacity/tenacity/hy/>\n"
 "Language: hy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,42 +14,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Փակել Աուդասիթին"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Ալիք"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Ֆայլի բացումը անհաջող էր"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Ժամաչափի բեռնման սխալ"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Աուդասիթի %s գործիքադարակ"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Ձայնագրում"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -60,6 +23,24 @@ msgstr "Անհնար է որոշել"
 #, c-format
 msgid "%s bytes"
 msgstr "բիթեր"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -82,12 +63,63 @@ msgid "&Nyquist Workbench..."
 msgstr "Nyquist հրահանգ..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "Տեղադրել"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "Տեղադրել"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "Տեղադրել"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "Տեղադրել"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Նշել &բոլորը"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -114,15 +146,34 @@ msgid "&Large Icons"
 msgstr "Մեծ տարածք"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Small Icons"
+msgstr "Մեծ տարածք"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "Գործիքադարակներ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Դադարեցնել"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Փոփոխական"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Էֆեկտի կարգավորումներ"
 
@@ -130,13 +181,50 @@ msgstr "Էֆեկտի կարգավորումներ"
 msgid "Load Nyquist script"
 msgstr "Nyquist հրահանգ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Ուշադրություն"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Nyquist հրահանգ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -147,6 +235,10 @@ msgid "No matches found"
 msgstr "Սարքեր չեն գտնվել"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
 msgstr "անվերնագիր"
 
@@ -154,9 +246,15 @@ msgstr "անվերնագիր"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist էֆեկտի հաստատում..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Նոր"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Բացել նախկիններից"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -190,7 +288,8 @@ msgstr "Պատճենել"
 msgid "Copy to clipboard"
 msgstr "Կտրել ժամանակավոր փոխանցողի մեջ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Կտրել"
 
@@ -198,7 +297,8 @@ msgstr "Կտրել"
 msgid "Cut to clipboard"
 msgstr "Կտրել ժամանակավոր փոխանցողի մեջ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Տեղադրել"
 
@@ -223,7 +323,8 @@ msgstr "Նշել &բոլորը"
 msgid "Select all text"
 msgstr "Նշել &բոլորը"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Քայլ հետ"
 
@@ -231,9 +332,20 @@ msgstr "Քայլ հետ"
 msgid "Undo last change"
 msgstr "Ֆորմատի փոխում"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Քայլ առաջ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Ֆորմատի փոխում"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "Գտնել գրառում"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -244,23 +356,46 @@ msgid "Match"
 msgstr "Կապոց"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "Մեջտեղ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Չկան նշումներ վերցման համար:"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Վերև"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Նախորդը գործիք"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Փոխել կենտրոնացումը նախորդ և ընտրել"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Հաջորդը գործիք"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Սկսել"
 
@@ -268,7 +403,8 @@ msgstr "Սկսել"
 msgid "Start script"
 msgstr "Nyquist հրահանգ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Դադարեցնել"
 
@@ -276,8 +412,15 @@ msgstr "Դադարեցնել"
 msgid "Stop script"
 msgstr "Nyquist հրահանգ"
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Լավ"
 
@@ -285,11 +428,13 @@ msgstr "Լավ"
 msgid "Build Information"
 msgstr "Ստեղծման տեղեկություն"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Միացված է"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Անջատված է"
 
@@ -299,8 +444,9 @@ msgid "The Build"
 msgstr "Մասնավոր օգտագործման"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Հրահանգ՝"
+#, fuzzy
+msgid "Version:"
+msgstr "Հետդարձում"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -310,13 +456,23 @@ msgstr "Տեսակը՝"
 msgid "Compiler:"
 msgstr "Խտացնող"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Նստեցված նախագծեր՝"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Կարգավորումների թղթապանակ՝"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Կարգավորումների թղթապանակ՝"
 
 #: src/AboutDialog.cpp
@@ -335,7 +491,6 @@ msgstr "Հաճախականության փոփոխում"
 msgid "MP3 Importing"
 msgstr "MP3 ներմուծում"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "OGG Vorbis ֆայլի ներմուծում և վերցնում"
@@ -344,7 +499,6 @@ msgstr "OGG Vorbis ֆայլի ներմուծում և վերցնում"
 msgid "ID3 tag support"
 msgstr "ID3 տեգի աջակցում"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC ֆայլի ներմուծում և վերցնում"
@@ -362,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg ֆայլի ներմուծում/վերցնում"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Ներմուծում GStreamer-ի միջոցով"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Նկարագրություն"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Պլագինի աջակցում"
 
@@ -384,6 +530,10 @@ msgstr "Տեմպի և տոնի փոփոխման աջակցում"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Զվարճալի տեմպի և տոնի փոփոխման աջակցում"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Նկարագրություն"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -410,6 +560,18 @@ msgstr "Պատիչ"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Պատիչ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Պատիչ"
 
@@ -421,6 +583,24 @@ msgstr "Պատիչ"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Պատիչ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Պատիչ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Պատիչ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "Որակի ապահովում"
@@ -428,8 +608,26 @@ msgstr "Որակի ապահովում"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, graphic artist"
 msgstr "Գրաֆիկ տատանում"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Պատիչ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Պատիչ"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -449,6 +647,15 @@ msgstr "Պատիչ"
 msgid "%s, graphics"
 msgstr "Գրաֆիկ տատանում"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -458,6 +665,10 @@ msgstr "Անվճար, բաց կոդով, խաչաձև հարթակ ունեցո�
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Հեղինակներ"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -492,14 +703,23 @@ msgid "%s Team Members"
 msgstr "Պատվավոր թիմի մասնակիցներ"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Այլ ներդրողներ"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Ծրագրի հայաֆիկացում — Արամ բլոգ (www.aramblog.yn.lt - aramvardanyan@gmx.com)"
@@ -518,6 +738,26 @@ msgstr "Հատուկ շնորհակալություն"
 msgid "%s website: "
 msgstr "Աուդասիթի առաջին մուտք"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Այլ ներդրողներ"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Սեղմեք և քաշեք, հարմարեցնելով ստերեո ձայնագրությունների հարաբերական չափերը:"
@@ -535,6 +775,7 @@ msgstr "Ժամատարածքի փոխող"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփոխելու համար:"
@@ -542,17 +783,66 @@ msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփո
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփոխելու համար:"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Փոխել կենտրոնացումը հաջորդ և ընտրել"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Տեղափոխել ֆայլը &ցած"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Փակել կենտրոնացված ձայն. ֆայլը"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr " (անջատված)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr " (անջատված)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "Պլագին կարգավորումներ"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -570,7 +860,23 @@ msgstr "Նվագարկել մասը"
 msgid "Pinned Play Head"
 msgstr "Ձայնագրումն ավարտված է"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Եղավ սխալ"
 
@@ -594,7 +900,8 @@ msgstr ""
 "Սա միայն մեկ անգամվա երկխոսություն է, 'նստեցումից' հետո, որտեղ որ հրահանգել եք Կարգավորումների վերնշում:"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Վերնշել Աուդասիթի կարգավորումները"
 
 #: src/AudacityApp.cpp
@@ -607,6 +914,14 @@ msgstr ""
 "%s գոյություն չունի:\n"
 "\n"
 "Այն հեռացվել է նախկին ֆայլերի ցանկից:"
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -627,7 +942,7 @@ msgstr "&Բացել..."
 msgid "Open &Recent..."
 msgstr "Բացել &նախկիններից..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Աուդասիթիի մասին..."
@@ -641,29 +956,33 @@ msgid "&File"
 msgstr "&Ֆայլ"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Աուդասիթին չի գտնում տեղ պահելու համար ժամանակավոր ֆայլերը:\n"
 "Խնդրում ենք մուտքագրել կարգավորումների համապատասխան վայրում այդ տեղը:"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Աուդասիթին չի գտնում տեղ պահելու համար ժամանակավոր ֆայլերը:\n"
 "Խնդրում ենք մուտքագրել կարգավորումների համապատասխան վայրում այդ տեղը:"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Աուդասիթին պատրաստվում է փակվել: Խնդրում ենք կրկին բացել Աուդասիթին օգտվելու համար պահպանման վայրից:"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -672,15 +991,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Աուդասիթին չի կարողանում բացել ժամանակավոր ֆայլերի տեղը:\n"
 "Այս թղթապանակը հնարավոր է զբաղեցված լինի այլ Աուդասիթիի պատճենի կողմից:\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Իսկապե՞ս ցանկանում եք, որ սկսվի Աուդասիթին:"
 
 #: src/AudacityApp.cpp
@@ -688,24 +1009,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "Եղավ սխալ, ժամանակավոր թղթապանակ բացելիս"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Համակարգը գտնում է, որ Աուդասիթիի այլ պատճեն է բացված:\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Օգտագործեք նոր կամ բացված հրահանգների կետերը, ներկայիս բացված Աուդասիթիում\n"
 "ընթացք բացելու համար մի քանի պրոեկտ միաժամանակ:\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Աուդասիթին արդեն բացված է"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Աուդասիթի պրոեկտ ֆայլեր"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -725,7 +1094,8 @@ msgstr "\t-test (ինքնամիացող հետազոտում)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (ցուցադրել Աուդասիթիի տարբերակը)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -735,9 +1105,10 @@ msgid "audio or project file name"
 msgstr "Չի հաջողվում բացել պրոեկտ ֆայլը"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -750,20 +1121,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Աուդասիթի պրոեկտ ֆայլեր"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "Վերկտրում..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Կանոնի ջնջման հաստատում"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Օգնություն"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Փակել Աուդասիթին"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Աուդասիթի պատմության գրքույկ"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -775,9 +1175,14 @@ msgstr "&Պահպանել..."
 msgid "Cl&ear"
 msgstr "Մա&քրել"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Փակել"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -824,7 +1229,8 @@ msgid "Error Initializing Midi"
 msgstr "Եղավ սխալ Midi-ն մեկնարկելիս"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Աուդասիթի պատմության գրքույկ"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -838,40 +1244,18 @@ msgstr "Սխալ, երբ բացվում է ձայնի սարքը:"
 msgid "Out of memory!"
 msgstr "Հիշողությունից բարձր է"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Հնարավոր չէր այն ավելի օպտիմալացնել: Շատ բարձր է:"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը հատեց ձայնի մակարդաչափը %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Հնարավոր չէր այն ավելի օպտիմալացնել: Շատ ցածր է:"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը մինչ %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Վերլուծությունների ընդհանուր թիվը գերազանցել է, չգտնելով ձայնաչափը: Կրկին բարձր է:"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Վերլուծությունների ընդհանուր թիվը գերազանցել է, չգտնելով ձայնաչափը: Կրկին ցածր է:"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: %.2f թվաց ընդհանուր ձայնաչափ:"
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Նշել ձայնագրման սարք\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Նշել ձայնագրման սարք\n"
 
 #: src/AudioIOBase.cpp
@@ -914,8 +1298,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Ձայնագրումն ավարտված է\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Ձայնագրումն ավարտված է\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Ձայնագրումն ավարտված է\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Ձայնագրումն ավարտված է\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -929,37 +1323,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Նշել ձայնագրման սարք\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Նշել ձայնագրման սարք\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Նշել նվագարկման սարք\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Չի հաջողվում բացել ոճի ֆայլը:\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Նշել նվագարկման սարք\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Փոփոխվող ձայնագրում\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Ձայնի բաժին\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Նվագարկման ձայնաչափ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Ձայնագրման ձայնաչափ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Ձայնագրման ձայնաչափ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Նվագարկման ձայնաչափ՝ %.2f%s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Նվագարկման ձայնաչափ՝ %.2f%s\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -967,8 +1364,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Նշել ձայնագրման սարք\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Նշել ձայնագրման սարք\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Նշել նվագարկման սարք\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Նշել նվագարկման սարք\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -976,8 +1383,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Ավտոմատ հետ բերում վթարային իրավիճակից հետո:"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -989,12 +1397,14 @@ msgid "Recoverable &projects"
 msgstr "Վերականգնվող պրոեկտներ"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Ընտրել"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Անուն"
 
@@ -1005,6 +1415,10 @@ msgstr "Ընտրել"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Ընտրել"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1041,6 +1455,11 @@ msgid "&Parameters"
 msgstr "&Կարգավորել"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Բաժանել"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "Ը&նտրել հրահանգ"
 
@@ -1075,6 +1494,22 @@ msgstr "Էֆեկտներ"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Փոխել կարգավորումները"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Փոխել կարգավորումները"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1122,6 +1557,10 @@ msgid "Apply %s"
 msgstr "Հաստատել %s"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "Փոփոխել կորերը"
 
@@ -1130,6 +1569,17 @@ msgstr "Փոփոխել կորերը"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Նշել կոր"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "Նշումներ..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Հաստատել շղթան"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1197,7 +1647,8 @@ msgstr "Մասի հետ բերում"
 msgid "I&mport..."
 msgstr "Ներմուծել..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "Ներմուծել..."
 
@@ -1238,9 +1689,15 @@ msgstr "Տեղափոխել &վերև"
 msgid "Move &Down"
 msgstr "Տեղափոխել &ներգև"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Պահպանել"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1286,11 +1743,38 @@ msgid "Benchmark"
 msgstr "Բացել հենանիշը..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Ժամաքանակ կրկնելու՝"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Փակել"
 
@@ -1305,12 +1789,32 @@ msgid "Export Benchmark Data as:"
 msgstr "Վերցնել սպեկտրալ ինֆորմացիան որպես՝"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "Նշման առավելագույն քանակը պետք է լինի"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "Նշման առավելագույն քանակը պետք է լինի"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "Նշման առավելագույն քանակը պետք է լինի"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Կարճ դիտման պատրաստում\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1319,17 +1823,104 @@ msgstr "Կատարելով կրկնում\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Տեղադրել\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Աուդիոյի ձայնագրում\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Վերջի ամսաթիվ և ժամ"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Ազատ օգտագործման"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1350,9 +1941,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Դուք պետք է առաջինը ընտրեք որևէ աուդիո սրանից օգտվելու համար:"
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Շղթան ընտրված չէ"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1380,6 +1995,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Չհաջողվեց գտնել կոդեկը"
 
@@ -1397,10 +2017,24 @@ msgstr "Հաստատել ընթացիկ &պրոեկտում"
 msgid "Checkpointing %s"
 msgstr "Ներմուծվում են՝ %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Չի գրվում որպես ֆայ՝\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Չի հաջողվում պահպանել պրոեկտը: Հնարավոր է %s \n"
+"չգրվող է կամ սկավառակում տեղ չկա:"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1417,6 +2051,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "Անհաջող հեռացում %s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1514,6 +2152,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Կտրել ժամանակավոր փոխանցողի մեջ"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Ֆայլերը բացակայում են"
 
@@ -1522,10 +2165,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Եթե սկսեք, ձեր պրոեկտը չի պահպանվի սկավառակում: Դուք դա ուզու՞մ եք:"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1537,7 +2181,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Կախվածության ստուգում"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ոչինչ"
 
@@ -1545,7 +2192,7 @@ msgstr "Ոչինչ"
 msgid "Rectangle"
 msgstr "Ուղղանկյուն"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Եռանկյուն"
 
@@ -1559,17 +2206,58 @@ msgstr "Ողղանկյուն"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Բարի գալուստ"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg աջակցումը կազմված չէ"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1591,8 +2279,8 @@ msgid "Locate FFmpeg"
 msgstr "տեղադրում FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Աուդասիթիին պետք է ֆայլ '%s' ներմուծման և աուդիո ֆայլի վերցման համար FFmpeg-ի միջոցով:"
 
 #: src/FFmpeg.cpp
@@ -1605,7 +2293,8 @@ msgstr "Տեղը '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Գտնելու համար '%s', սեղմեք այստեղ -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Ընտրել..."
 
@@ -1631,8 +2320,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg-ն գոյություն չունի"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1652,24 +2342,38 @@ msgstr "Չցուցադրել այս զգուշացումը կրկին"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Ձախողվեց գտնել աջակցող FFmpeg գրադարանը:"
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Աուդասիթին չի կարողանում գրել ֆայլը՝\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Աուդասիթին չի կարողանում գրել ֆայլը՝\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Աուդասիթին չի կարողանում գրել ֆայլը՝\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1706,7 +2410,9 @@ msgstr "Չպատճենել որևէ աուդիո"
 msgid "As&k"
 msgstr "Հարցնել օգտվողին"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Բոլոր ֆայլերը (*)|*"
 
@@ -1715,6 +2421,11 @@ msgstr "Բոլոր ֆայլերը (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Պրոեկտի ժամանակավոր ֆայլերի պահպանում"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Գրադարաններ"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1727,6 +2438,10 @@ msgstr "Անուն ֆայլեր՝"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3 ֆայլեր"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1793,9 +2508,18 @@ msgstr "Մուտքային հաճախականություն"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "դԲ"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
 
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
@@ -1804,7 +2528,9 @@ msgstr "Խոշորացնել"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "Հց"
 
@@ -1821,6 +2547,10 @@ msgstr "Հորիզոնական ստերեո"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Նշման գիծը ձախ"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1863,11 +2593,49 @@ msgstr "Շատ աուդիո է ընտրված:  Միայն առաջին %.1f վ�
 msgid "Not enough data selected."
 msgstr "Քիչ տվյալ է ընտրված:"
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "s"
+msgstr "մվ"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Սպեկտր"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Վերցնել սպեկտրալ ինֆորմացիան որպես՝"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Չի գրվում որպես ֆայ՝"
@@ -1943,6 +2711,26 @@ msgid "No Local Help"
 msgstr "Ընդհանուր օգնություն չկա"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "These are our support methods:"
 msgstr "Սրանք մեր օգնության մեթոդներն են՝"
 
@@ -1997,6 +2785,10 @@ msgid "Used Space"
 msgstr "Սկավառակի հիշողությունը"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "Հետ բերման փուլ կա"
 
@@ -2010,6 +2802,10 @@ msgid "&Discard"
 msgstr "Հրաժարվել"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "Հրաժարվել"
 
@@ -2017,11 +2813,30 @@ msgstr "Հրաժարվել"
 msgid "&Compact"
 msgstr "&Կառավարում"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "Պատմություն..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2037,7 +2852,9 @@ msgid "Track"
 msgstr "Ձայնային ֆայլ"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Նշիչ"
 
@@ -2097,18 +2914,25 @@ msgstr "Մուտքագրեք ձայնային ֆայլի անունը"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Նշիչ ձայնային ֆայլ"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Աուդասիթի առաջին մուտք"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Ընտրել լեզու Աուդասիթին օգտագործելու համար՝"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2118,7 +2942,8 @@ msgstr "Ընտրել լեզու Աուդասիթին օգտագործելու հ
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Ձեր ընտրած լեզուն, %s (%s), չի համապատասխանում որպես համակարգի լեզու, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Հաստատել"
 
@@ -2136,12 +2961,13 @@ msgstr ""
 "Հին ֆայլը պահպանվեց որպես '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Բացված Աուդասիթի պրոեկտ"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Աուդասիթի Կարաոկե%s"
 
 #: src/LyricsWindow.cpp
@@ -2192,19 +3018,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Միախառնված և ստեղծված ձայնագրություններ"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Աուդասիթի միախառնման տարածք%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Որակի ամրապնդում"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Արագություն"
 
@@ -2213,17 +3043,23 @@ msgid "Musical Instrument"
 msgstr "Երաժշտական գործիք"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Պան"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Լուռ"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Սոլո"
 
@@ -2231,15 +3067,18 @@ msgstr "Սոլո"
 msgid "Signal Level Meter"
 msgstr "Ազդանշանային մետրի փուլ"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Տեղափոխվել է ամրապնդման սլայդ"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Տեղափոխված արագագործ սլայդ"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Տեղափոխվել է պան սլայդ"
 
@@ -2270,9 +3109,9 @@ msgstr ""
 "Այն չի կարող բեռնվել:"
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2305,16 +3144,19 @@ msgstr ""
 "\n"
 "Միշտ օգտվել վստահելի աղբյուրների մոդուլներից"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Այո"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ոչ"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Մոդուլի բեռնող"
 
 #: src/ModuleManager.cpp
@@ -2344,18 +3186,121 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "ԳԲ"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "դԲ"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Վերագրել առկա ֆայլերը"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2384,6 +3329,16 @@ msgstr "Nyquist հրահանգ"
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Միացնել պլագինի բեռնման համար %s"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Ցուցադրել բոլոր կոդեկները"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -2415,6 +3370,21 @@ msgstr "Միացված է"
 msgid "E&nabled"
 msgstr "Միացված է"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Միացված է"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Path"
 msgstr "Ճանապարհը"
@@ -2427,7 +3397,8 @@ msgstr "Նշել &բոլորը"
 msgid "C&lear All"
 msgstr "Մաքրե&լ բոլորը"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Միացված է"
 
@@ -2493,6 +3464,21 @@ msgstr "Կա սխալ երբ բացվում է ձայնի սարքը: Խնդրո
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Զտման հաստատման համար, բոլոր նշված ձայնագրությունները պետք է լինեն նույն ձայնաչափի բաժնի:"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Ձայնագրված աուդիո"
@@ -2500,6 +3486,28 @@ msgstr "Ձայնագրված աուդիո"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "Ձայնագրել"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2527,11 +3535,11 @@ msgid "Inspecting project file data"
 msgstr "Ստուգելով պրոեկտ ֆայլի ծամանակը"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2574,11 +3582,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Ուշադրություն - Բացակայող կեղծված ֆայլ(եր)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Պրոեկտը ստուգում է \"%s\" թղթապանակ \n"
@@ -2603,12 +3611,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Ուշադրություն - Բացակայող կեղծ համառոտ ֆայլ(եր)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2666,7 +3674,8 @@ msgstr "Ուշադրություն - Առանձնացած բլոկ ֆայլ(եր
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Սանդղակ"
 
@@ -2687,6 +3696,16 @@ msgstr ""
 #: src/ProjectFSCK.cpp
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Ուշադրություն՝ Կա խնդիր ավտոմատ հետ բերման ժամանակ"
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "<untitled>"
+msgstr "անվերնագիր"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Պրոեկտներ"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2725,11 +3744,96 @@ msgid ""
 msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Անհաջող հեռացում %s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Պահպանում որպես Աուդասիթի պրոեկտ"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Չի ստացվում մեկանարկել MP3 հոսքը"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2743,12 +3847,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Առանձնացած բլոկ ֆայլ: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Անհնար է անվանափոխել '%s' ից '%s'."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Չհաջողվեց գտնել կոդեկը"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Անհաջող հեռացում %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2759,9 +3884,9 @@ msgid "Error Writing to File"
 msgstr "Ֆայլի գրման սխալ"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2772,8 +3897,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Պրոեկտների պահպանում"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Աուդասիթի պատմության գրքույկ"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2783,10 +3917,10 @@ msgstr "(Հետ բերված)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Ֆայլը պահպանվել է նշված Աուդասիթի %s. -ի կողմից\n"
 "Դուք օգտագործում եք Աուդասիթի %s: Պետք է թարմացնեք նոր տարբերակի, բացելու համար այս ֆայլը:"
@@ -2794,6 +3928,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Չի հաջողվում բացել պրոեկտ ֆայլը"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2808,6 +3946,10 @@ msgid "Unable to parse project information."
 msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Պրոեկտների պահպանում"
 
@@ -2816,12 +3958,35 @@ msgid "Error Saving Project"
 msgstr "Պրոեկտի պահպանումը անհաջող էր"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Դատարկ պրոեկտի պահպանում"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2829,8 +3994,24 @@ msgstr ""
 "Բարեբախտաբար հետևյալ պրոեկտները կարող են վերականգնվել:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Որոշ պրոեկտներ պահպանված չեն, վերջին անգամ Աուդասիթիի բաց լինելու պատճառով:\n"
+"Բարեբախտաբար հետևյալ պրոեկտները կարող են վերականգնվել:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Պրոեկտը հետ բերվեց"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Ժամանակավոր ֆայլերի ճանապարհներ"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2860,6 +4041,17 @@ msgstr "Ուշադրություն - Դատարկ պրոեկտ"
 msgid "Insufficient Disk Space"
 msgstr "Սկավառակի հիշողությունը"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -2879,12 +4071,26 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "Պահպանել պրոեկտը \"%s\" որպես..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Պահպանել պրոեկտը' Աուդասիթի պրոեկտի համար չի լինի աուդի ֆայլ:\n"
 "Աուդիո ֆայլի համար, որը պետք է բացվի այլ ծրագրերի միջոցով, ընտրեք 'Վերցնել':\n"
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2938,11 +4144,12 @@ msgid "Error Opening Project"
 msgstr "Պրոեկտի բացումը անհաջող էր"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Դուք փորձում եք բացել ավտոմատ ստեղծված հետ բերման ֆայլ:\n"
 "Այս արդյունքի հետևանքով որոշ ինֆորմացիա կարող է անհետանալ:\n"
@@ -2975,6 +4182,12 @@ msgid "Error Opening File or Project"
 msgstr "Պրոեկտի կամ ֆայլի բացումն անհաջող էր"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Պրոեկտը հետ բերվեց"
 
@@ -3000,12 +4213,33 @@ msgid "Error Importing"
 msgstr "Ներմուծման սխալ"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Պահպանել պրոեկտը"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Չի հաջողվում բացել պրոեկտ ֆայլը"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Կառավարում"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3016,8 +4250,8 @@ msgid "Automatic database backup failed."
 msgstr "Ավտոմատ հետ բերում վթարային իրավիճակից հետո:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Բարի գալուստ Աուդասիթի տարբերակ %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3052,6 +4286,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "Սկավառակի հիշողության մնացորդ ձայնագրման համար %d րոպե:"
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -3064,6 +4302,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -3079,6 +4329,26 @@ msgstr "Հորիզոնական ստերեո"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Ուղղահայաց ստերեո"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(Լավագույն որակ)"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -3106,6 +4376,10 @@ msgstr "24-բիթ Պրոց. հիշ."
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
 msgstr "32-բիթ վերբեռն."
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -3191,7 +4465,8 @@ msgstr "Կարգավորումներ՝"
 msgid "SelectionBar"
 msgstr "ՆշվածԲար"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Տեղավորել նշվածը"
 
@@ -3199,44 +4474,58 @@ msgstr "Տեղավորել նշվածը"
 msgid "Timer"
 msgstr "Ժամ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Գործիքներ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Շարժ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Միախառնող"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Մետր"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Նվագարկել հաշվիչով"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Ձայնագրել հաշվիչով"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Փոխել"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Սարք"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Նվագարկել արագությամբ"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "Գործիքադարակներ"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -3249,7 +4538,10 @@ msgstr "Քանոն"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Ձայնագրություններ"
 
@@ -3301,6 +4593,15 @@ msgstr "Մեծ ձայնագրություններ"
 msgid "Choose a location to save screenshot images"
 msgstr "Ընտրեք վայր պահպանելու համար նկարված նկարները"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (Տ-Օգնություն)"
+
 #: src/Sequence.cpp
 #, c-format
 msgid ""
@@ -3351,7 +4652,8 @@ msgid "Activation level (dB):"
 msgstr "Ակտիվացման փուլ (դԲ)՝"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Բարի գալուստ Աուդասիթի:"
 
 #: src/SplashDialog.cpp
@@ -3478,19 +4780,45 @@ msgstr "Տեգ ֆայլի պահպանման սխալ"
 msgid "Unsuitable"
 msgstr "Մոդուլը անընդունելի է"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Ժամանակավոր ֆայլերի ճանապարհներ"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Աուդասիթին չի կարողանում գրել ֆայլը՝\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3499,18 +4827,26 @@ msgstr ""
 "գրման համար:"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Աուդասիթին չի կարողանում գրել նկարը որպես ֆայլ՝\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3520,9 +4856,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3531,8 +4867,9 @@ msgstr ""
 "Վատ png ֆորմա՞տ է միգուցե:"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Աուդասիթին չի կարող կարդալ, սա լռելյայն տեսք է:\n"
@@ -3570,9 +4907,9 @@ msgstr ""
 "արդեն ներկայացված են:"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Աուդասիթին չի կարող պահպանել ֆայլը՝\n"
@@ -3589,11 +4926,21 @@ msgstr "Դասական զտումներ"
 msgid "Light"
 msgstr "Լույս"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Հակադրում..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Ձայնագրության անունը"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3602,7 +4949,11 @@ msgstr "Հակադրում..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Ժամաչափը"
 
@@ -3613,7 +4964,8 @@ msgid "Time Track"
 msgstr "Ժամ ֆայլի"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Աուդասիթի ժամային ձայնագրում"
 
 #: src/TimerRecordDialog.cpp
@@ -3642,12 +4994,38 @@ msgid "Error in Duration"
 msgstr "Ժամաչափի սխալ"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Ավտոմատ հետ բերում վթարային իրավիճակից հետո:"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Ժամաչափի սխալ"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Ընտրովի FFmpeg վերցնում"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "Ժամաչափի սխալ"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "Ժամային ձայնագրում..."
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3657,7 +5035,8 @@ msgstr "Հաստատել ընթացիկ &պրոեկտում"
 msgid "Recording start:"
 msgstr "Ձայնագրումը սկսված է"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Ժամաչափ՝"
 
@@ -3678,7 +5057,8 @@ msgid "Action after Timer Recording:"
 msgstr "Աուդասիթի ժամային ձայնագրում"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Աուդասիթի ժամային ձայնագրման սանդղակ"
 
 #: src/TimerRecordDialog.cpp
@@ -3713,6 +5093,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "Ձայնագրումն ավարտված է"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Պրոեկտի պահպանումը անհաջող էր"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Փոփոխվող ձայնագրում"
@@ -3732,6 +5136,7 @@ msgstr "099 օր 024 ժ 060 ր 060 վ"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Սկզբի ամսաթիվ և ժամ"
@@ -3776,7 +5181,8 @@ msgstr "Չի ստացվում վերցնել"
 msgid "Export Project As:"
 msgstr "Վերցնել վերագրումները"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Կարգավորել..."
 
@@ -3785,8 +5191,21 @@ msgid "After Recording completes:"
 msgstr "Ձայնագրել հաշվիչով"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Փակել Աուդասիթին"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3801,7 +5220,8 @@ msgid "Scheduled to stop at:"
 msgstr "Սկզբի նշումը"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Աուդասիթի ժամային ձայնագրում - Սպասել սկսման"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3809,6 +5229,14 @@ msgstr "Աուդասիթի ժամային ձայնագրում - Սպասել ս
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Ձայնագրման սարք"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3819,12 +5247,18 @@ msgid "Recording Exported:"
 msgstr "Ձայնագրումն ավարտված է"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Աուդասիթի ժամային ձայնագրում - Սպասել սկսման"
 
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "Ստերեո, 999999Հց"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3940,6 +5374,10 @@ msgstr "Տեղափոխել ֆայլը &վերև"
 msgid "Move Track Down"
 msgstr "Տեղափոխել ֆայլը &ներգև"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3985,25 +5423,79 @@ msgstr "Բավարար տարածք չկա նշվածի տեղադրման հա�
 msgid "There is not enough room available to expand the cut line"
 msgstr "Բավարար տարածք չկա կտրված ֆայլի տարածման համար"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Հաստատվում է..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Կատարող"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Կատարող"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Կրկնել %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4018,12 +5510,20 @@ msgid "Compares a range on two tracks."
 msgstr "Խտացում պիկի բազայի վրա"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Դանդաղեցման ժամ (վարկյան)՝"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Քայքայման գործոն՝"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -4045,6 +5545,11 @@ msgstr "Ձայնային ֆայլ"
 msgid "Track 1"
 msgstr "Ձայնային ֆայլ"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Պատուհանի չափ"
@@ -4056,6 +5561,22 @@ msgstr "Պտույտ րոպեից"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Պտույտ րոպեից"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -4081,11 +5602,36 @@ msgstr "Կտրում"
 msgid "Envelopes"
 msgstr "Պատիչ"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Նշումներ"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "&Զտման տեսակը՝"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Ֆորմատ՝"
 
@@ -4101,6 +5647,10 @@ msgstr "Տեղափոխել ֆայլը &ներգև"
 msgid "Types:"
 msgstr "&Զտման տեսակը՝"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Նկարագրություն"
@@ -4108,6 +5658,18 @@ msgstr "Նկարագրություն"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Հրահանգ՝"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4126,6 +5688,11 @@ msgid "Number of Channels:"
 msgstr "Ժամաքանակ կրկնելու՝"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Վերցնել բազմակի"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Վերցնել բազմակի"
 
@@ -4133,9 +5700,26 @@ msgstr "Վերցնել բազմակի"
 msgid "Builtin Commands"
 msgstr "Ընտրել հրահանգ"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Աուդասիթի աջակցող թիմ"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Վերջի ամսաթիվ և ժամ"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -4177,11 +5761,22 @@ msgstr "Պահպանել պրոեկտը"
 msgid "Saves a copy of current project."
 msgstr "Պահպանել պրոեկտը"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Կարգավորումներ՝"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Անուն"
 
@@ -4192,6 +5787,18 @@ msgstr "Կարգավորումներ՝"
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Արժեք"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -4217,7 +5824,8 @@ msgstr "Լիաէկրան միացնել/անջատել"
 msgid "Toolbars"
 msgstr "Գործիքադարակներ"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Էֆեկտներ"
 
@@ -4261,6 +5869,10 @@ msgstr "Մեծ ձայնագրություններ"
 msgid "All Tracks Plus"
 msgstr "Մեծ ձայնագրություններ"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -4272,13 +5884,26 @@ msgid "Path:"
 msgstr "Ճանապարհը"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Հետևի պլան ֆոն:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Ֆայլի պահպանման սխալ"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "Պատկերող գործիքներ..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -4325,6 +5950,10 @@ msgid "High:"
 msgstr "Ուժեղ հաճախությամբ"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "Ձայնային ֆայլի ֆիլտր"
 
@@ -4337,7 +5966,8 @@ msgstr "Նշել"
 msgid "Add"
 msgstr "Ավելացնել"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Հեռացնել"
 
@@ -4358,6 +5988,11 @@ msgid "Selects a time range."
 msgstr "Ընտրել MIDI ֆայլ..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Ընտրել MIDI ֆայլ..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
 
@@ -4369,9 +6004,37 @@ msgstr "Նշել աուդիո հոսթ"
 msgid "Set Clip"
 msgstr "Հաջորդը գործիք"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Սկսել"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4390,9 +6053,14 @@ msgid "Edited Envelope"
 msgstr "Պատիչ"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Պատիչ"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4402,6 +6070,10 @@ msgstr "&Ջնջել նշումը"
 msgid "Label Index"
 msgstr "Փոխել նշում"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Ընտրել"
@@ -4409,6 +6081,10 @@ msgstr "Ընտրել"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Փոփոխված մասեր"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4422,9 +6098,26 @@ msgstr "Նշել ձայնաչափի բաժին"
 msgid "Resize:"
 msgstr "Փոխել փոքրի"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Լույս"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "Պահպանել պրոեկտը"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4455,10 +6148,17 @@ msgid "Gain:"
 msgstr "Որակի ամրապնդում"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Ձայնային ֆայլի ֆիլտր"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Գծային"
 
@@ -4469,6 +6169,10 @@ msgstr "Վեր&նշել"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "Ժամ"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4498,13 +6202,28 @@ msgstr "Սպեկտրալ պրոցեսոր"
 msgid "Spectral Select"
 msgstr "Տեղավորել նշվածը"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Նոր ձայնագրություն"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Ընդլայնել"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -4526,6 +6245,10 @@ msgstr "Թույլատրում հատման"
 msgid "Auto Duck"
 msgstr "Ինքնախուսափում"
 
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -4540,12 +6263,18 @@ msgstr "Դուք ընտրել եք ֆայլ, որը աուդիո չէ: Ավտո�
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Ավտո խուսափմանն անհրաժեշտ է վերահսկել ձայնագրությունները, որը ներգևում պիտի տեղադրվի, նշված ձայնագրությունը (ները):"
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Ամբողջական խուսափում՝"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "վարկյան"
 
@@ -4569,7 +6298,8 @@ msgstr "Ներքին մթացում ներգևի երկարությամբ՝"
 msgid "Inner &fade up length:"
 msgstr "Ներքին մթացում վերևի երկարությամբ՝"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Մուտք՝"
 
@@ -4584,6 +6314,11 @@ msgstr "Բաս և եռատակ"
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Ընտրություն մգացնել ձախ"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Շեմ"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -4613,6 +6348,10 @@ msgstr "Եռատակ (դԲ)՝"
 msgid "Level"
 msgstr "Փուլ"
 
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "Փոխել տոնի բարձրությունը"
@@ -4620,6 +6359,11 @@ msgstr "Փոխել տոնի բարձրությունը"
 #: src/effects/ChangePitch.cpp
 msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Փոխել տոնի բարձրությունը տեմպի հետ"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Վերջնական տեմպի փոխում (%)"
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
@@ -4684,6 +6428,10 @@ msgid "from (Hz)"
 msgstr "(Հց) -ից"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "մինչ (Հց)"
 
@@ -4691,13 +6439,23 @@ msgstr "մինչ (Հց)"
 msgid "t&o"
 msgstr "դեպի"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Տոկոս փոխում՝"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Տոկոս փոխում"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -4706,6 +6464,14 @@ msgstr "4"
 #: src/effects/ChangeSpeed.cpp
 msgid "78"
 msgstr "7"
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -4731,6 +6497,7 @@ msgstr "Ստանդարտ վինիլային պտույտ րոպեում՝"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Պտույտ րոպեից"
@@ -4740,6 +6507,14 @@ msgstr "Պտույտ րոպեից"
 msgctxt "change speed"
 msgid "&from"
 msgstr "ից"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "Պտույտ րոպեից"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4843,6 +6618,10 @@ msgid "Click Removal"
 msgstr "Սեղմել հեռացման"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
 msgid "Algorithm not effective on this audio. Nothing changed."
 msgstr "Այս աուդիոյի համար ալգորիթմը էֆեկտիվ չէ: Չփոխվեց:"
 
@@ -4871,6 +6650,10 @@ msgstr "Առավելագ. ծայրի լայնությունը"
 msgid "Compressor"
 msgstr "Խտացնող"
 
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
 #. i18n-hint: usually leave this as is as dB doesn't get translated
 #: src/effects/Compressor.cpp
 #, c-format
@@ -4885,6 +6668,20 @@ msgstr "%.1f վարկյ."
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f վարկյ."
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f վարկյ."
 
 #: src/effects/Compressor.cpp
@@ -4982,6 +6779,12 @@ msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
 
 #: src/effects/Contrast.cpp
 msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid ""
 "Nothing to measure.\n"
 "Please select a section of a track."
 msgstr ""
@@ -4994,7 +6797,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Մթացման անալիզ միջին քառակուսային ձայնաչափի տարբերության համար, երկու աուդիոների արանքում:"
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Ավարտ"
 
@@ -5054,6 +6858,18 @@ msgstr "Տարբերություն՝"
 msgid "&Help"
 msgstr "Օգնություն"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "զրո"
@@ -5098,6 +6914,10 @@ msgstr "Առաջին պլանի ֆոն ավարտի ժամանակ"
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "Հետևի պլանի ֆոն ավարտի ժամանակ"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -5192,6 +7012,12 @@ msgstr "Հաջող կրիտերիա 1.4.7 ից WCAG 2.0: դուրս"
 msgid "Data gathered"
 msgstr "Ինֆորացիոն հավաքված"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Մթացման անալիզ (WCAG 2 համապատասխանություն)"
@@ -5217,6 +7043,19 @@ msgid "Medium Overdrive"
 msgstr "Վերագրման հաստատում"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Վերագրման հաստատում"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Դինամիկ շարային խտացում"
 
@@ -5227,6 +7066,96 @@ msgstr "Կայունարար"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Այլակերպում"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Սահմանափակիչ"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Վերագրման հաստատում"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Վերագրման հաստատում"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Վերագրման հաստատում"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -5249,8 +7178,16 @@ msgid "Distortion"
 msgstr "Այլակերպում"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Այլակերպում"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -5265,8 +7202,21 @@ msgid "Clipping level"
 msgstr "Կտրում"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Հաստատել շղթան"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Աղմուկի շեմը՝"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -5281,6 +7231,14 @@ msgid "Repeat processing"
 msgstr "նվազեցնել մշակման ժամանակը:"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Փուլավորման աստիչան՝"
 
@@ -5291,6 +7249,15 @@ msgstr "Սահմանափակիչ"
 #: src/effects/Distortion.cpp
 msgid "Wet level"
 msgstr "2 փուլ"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2 փուլ"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -5317,6 +7284,16 @@ msgid "DTMF Tones"
 msgstr "Հեռ. տոնի ազդանշաններ..."
 
 #: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Հեռ. տոնի ազդանշանի հերթականություն՝"
 
@@ -5324,7 +7301,9 @@ msgstr "Հեռ. տոնի ազդանշանի հերթականություն՝"
 msgid "&Amplitude (0-1):"
 msgstr "Լայնք (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Ժամաչափ՝"
 
@@ -5369,6 +7348,11 @@ msgstr "Կրկնում"
 msgid "Repeats the selected audio again and again"
 msgstr "Վերցնում նշված աուդիոն որպես %s"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "Դանդաղեցման ժամ (վարկյան)՝"
@@ -5389,7 +7373,8 @@ msgstr "Վերնշել՝"
 msgid "Export Effect Parameters"
 msgstr "&Փոխել կարգավորումները"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Չի ստացվում բացել ֆայլը՝ \"%s\""
@@ -5413,6 +7398,12 @@ msgstr "&Փոխել կարգավորումները"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Կարճ դիտման պատրաստում"
@@ -5420,6 +7411,15 @@ msgstr "Կարճ դիտման պատրաստում"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Կարճ դիտում"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -5456,10 +7456,30 @@ msgid "Factory Defaults"
 msgstr "Դնել լռ&ելյայն"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr ""
 "FLAC կոդավորման անհաջող մեկնարկ\n"
 "Կարգավիճակ՝ %d"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -5484,6 +7504,23 @@ msgid "&Bypass"
 msgstr "Բենդ հաճախությամբ"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Հավասարեցնել %s/Տեղափոխել"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Տեղափոխել &վերև"
 
@@ -5500,6 +7537,24 @@ msgid "Move effect down in the rack"
 msgstr "Տեղափոխվածը միացնել այլ ձայնագրության"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Տեղափոխվածը միացնել այլ ձայնագրության"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Նշեք նոր շղթայի անունը"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Թաքնված"
@@ -5509,8 +7564,17 @@ msgid "Some Command"
 msgstr "Ընտրել հրահանգ"
 
 #: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "&Manage"
 msgstr "Փոփոխել կորերը"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Փոփոխվող նվագարկում"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -5525,6 +7589,16 @@ msgstr "Դիտում"
 #: src/effects/EffectUI.cpp
 msgid "&Preview effect"
 msgstr "Ցուցադրում մինչ մասի կտրումը՝"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Անցնել սկիզբ"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Անցնել սկիզբ"
 
 #: src/effects/EffectUI.cpp
 msgid "Skip forward"
@@ -5563,14 +7637,33 @@ msgid "Options..."
 msgstr "Կարգավորել..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "&Զտման տեսակը՝"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Անուն"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Հետդարձում"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Եղավ սխալ՝"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "Արտագրում"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -5632,12 +7725,36 @@ msgid "Graphic EQ"
 msgstr "Գրաֆիկ տատանում"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Բաս (դԲ)՝"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Բաս"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -5672,6 +7789,10 @@ msgid "Effect Unavailable"
 msgstr "Կարճ դիտում չի աջակցում"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Առավելագույն դԲ"
 
@@ -5684,6 +7805,26 @@ msgstr "%3d դԲ"
 msgid "Min dB"
 msgstr "Ամենաքիչ դԲ"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "&Զտման տեսակը՝"
@@ -5691,6 +7832,11 @@ msgstr "&Զտման տեսակը՝"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Գծման կորեր"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Գծող գործիք"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -5937,6 +8083,17 @@ msgstr "Կորերը վերցվեց"
 msgid "No curves exported"
 msgstr "Չկա կոր վերցման համար"
 
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
+
 #: src/effects/Fade.cpp
 msgid "Fade In"
 msgstr "Ավելացնել"
@@ -5945,9 +8102,23 @@ msgstr "Ավելացնել"
 msgid "Fade Out"
 msgstr "Քչացնել"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-in to the selected audio"
+msgstr "Վերցնում նշված աուդիոն որպես %s"
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Վերցնում նշված աուդիոն որպես %s"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Գտնել անջատում"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -5969,13 +8140,37 @@ msgstr "Բավարար տարածք չկա ստեղծելու համար աու�
 msgid "Invert"
 msgstr "Շրջել"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Աուդիո յունիթ էֆեկտներ"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Կարգավորում առավելագույն ամպլիտուդ"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -5995,9 +8190,26 @@ msgstr "Ընթացքի մեջ է"
 msgid "&Normalize"
 msgstr "Կարգավորել"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Կարգավորում ստերեո ալիքները առանձին"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -6027,6 +8239,10 @@ msgid "Noise"
 msgstr "Աղմուկ՝"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Աղմուկի տեսակ՝"
 
@@ -6039,16 +8255,73 @@ msgid "Second greatest"
 msgstr "Երկրորդ ձայնագրություն"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Խոշորացնել լռելյայն"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Խոշորացնել լռելյայն"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Աղմուկի կրճատում"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Զտման հաստատման համար, բոլոր նշված ձայնագրությունները պետք է լինեն նույն ձայնաչափի բաժնի:"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -6107,8 +8380,9 @@ msgid "Step 1"
 msgstr "Քայլ 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Նշել մի քանի վարկյան աղմուկի համար, որ Աուդասիթին իմանա, որ մասը զտի հանի,\n"
@@ -6134,9 +8408,20 @@ msgstr ""
 msgid "Noise:"
 msgstr "Աղմուկ՝"
 
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Isolate"
 msgstr "&Մեկուսացում"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Փոխել փոքրի"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -6150,6 +8435,11 @@ msgstr "Պատուհանի տեսակ"
 msgid "Window si&ze:"
 msgstr "Պատուհանի չափ"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
+
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
 msgstr "1"
@@ -6162,17 +8452,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - լռելյայն"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "Խոշորացնել լռելյայն"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Աղմուկի հեռացում"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -6211,6 +8547,10 @@ msgid "Normalize"
 msgstr "Կարգավորել"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
 msgstr "Հեռացում DC ճյուղի և կարգավորում...\n"
 
@@ -6221,6 +8561,10 @@ msgstr "Հեռացում DC ճյուղի...\n"
 #: src/effects/Normalize.cpp
 msgid "Normalizing without removing DC offset...\n"
 msgstr "Կարգավորում հեռացնելով DC ճյուղը...\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 #, c-format
@@ -6267,9 +8611,14 @@ msgstr "Կարգավորում ստերեո ալիքները առանձին"
 msgid "Paulstretch"
 msgstr "Paulstretch..."
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Ձգվող գործակից՝"
@@ -6278,9 +8627,43 @@ msgstr "Ձգվող գործակից՝"
 msgid "&Time Resolution (seconds):"
 msgstr "Ժամաչափ (վարկյան)՝"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Փուլապտտիչ"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -6343,6 +8726,10 @@ msgid "Repair"
 msgstr "Նորոգել"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -6371,6 +8758,10 @@ msgid "Repeat"
 msgstr "Կրկնել"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "Ժամաքանակ կրկնելու՝"
 
@@ -6391,6 +8782,10 @@ msgstr "Նոր ընտրվածի երկարություն՝"
 #, c-format
 msgid "New selection length: %s"
 msgstr "Նոր ընտրվածի երկարություն՝"
+
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
@@ -6431,6 +8826,10 @@ msgstr "Տաճար"
 #: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "Արտացոլում"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "&Room Size (%):"
@@ -6485,6 +8884,10 @@ msgstr "Հակառակ"
 msgid "Reverses the selected audio"
 msgstr "Վերցնում նշված աուդիոն որպես %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
 #. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Butterworth"
@@ -6511,6 +8914,11 @@ msgstr "Ուժեղ հաճախությամբ"
 #: src/effects/ScienFilter.cpp
 msgid "Classic Filters"
 msgstr "Դասական զտումներ"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
@@ -6562,6 +8970,11 @@ msgid "Frame Period:"
 msgstr "Շրջանակ՝"
 
 #: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Շրջանակ՝"
+
+#: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
 msgstr "Պատուհանի չափ"
 
@@ -6570,12 +8983,38 @@ msgid "Window Size"
 msgstr "Պատուհանի չափ"
 
 #: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
 msgstr "Աղմուկի շեմը՝"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold"
 msgstr "Աղմուկի շեմը՝"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time:"
+msgstr "Առանձնացնել ժամանակի տեսակետից"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
+msgstr "Առանձնացնել ժամանակի տեսակետից"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
 #. This is a NEW experimental effect, and until we have it documented in the user
@@ -6613,11 +9052,20 @@ msgstr "&Նախնական"
 msgid "Restore Defaults"
 msgstr "Դնել լռ&ելյայն"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Լռելյայն"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -6642,6 +9090,10 @@ msgstr "Միախառնում մոնոյի վերցման ժամանակ"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "Ձգել"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
 
 #: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
@@ -6700,6 +9152,14 @@ msgid "Tone"
 msgstr "Տոն..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Ալիքաձև՝"
 
@@ -6740,12 +9200,24 @@ msgid "Truncate Silence"
 msgstr "Ընդհատել լռություն"
 
 #: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Գտնել լռություն"
 
 #: src/effects/TruncSilence.cpp
 msgid "Tr&uncate to:"
 msgstr "Ընդհատել ից՝"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
@@ -6760,10 +9232,20 @@ msgid "VST Effects"
 msgstr "VST էֆեկտներ"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Scanning Shell VST"
 msgstr "VST պլագինների հետազոտում"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Չի ստացվում բացել MP3 կոդավորման գրադարանը:"
 
@@ -6775,15 +9257,25 @@ msgstr "VST էֆեկտ կարգավորումներ"
 msgid "Buffer Size"
 msgstr "Բուֆեր չափը"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Բուֆեր չափ (8 ից 1048576 նմուշներ)՝"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Միացնել &հատուցումը"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Միացնել &հատուցումը"
 
@@ -6809,7 +9301,18 @@ msgid "Save VST Preset As:"
 msgstr "Պահպանել VST սկզբնաբերումը որպես՝"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Վերցնել վերագրումները"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Վերցնել վերագրումները"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Աուդասիթի պրոեկտ ֆայլեր"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -6836,9 +9339,15 @@ msgstr "VST նշումների բեռնման սխալ"
 msgid "Unable to load presets file."
 msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Էֆեկտի կարգավորումներ"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
@@ -6848,6 +9357,20 @@ msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Այս պարամետր ֆայլը պահպանված է %s -ից: Շարունակե՞լ: "
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -6875,6 +9398,11 @@ msgid "Audio Unit Effects"
 msgstr "Աուդիո յունիթ էֆեկտներ"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Աուդիո յունիթ էֆեկտներ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "Չի ստացվում բեռնել ֆայլը կամ աջակցող ծավալը:"
 
@@ -6887,20 +9415,41 @@ msgid "Audio Unit Effect Options"
 msgstr "Աուդիո յունիթ էֆեկտներ"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Տեսք"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Ընտրություն մգացնել ձախ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Բազմաբենդ"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "Արտադրել"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "Ներմուծել վերագրումներ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -6976,6 +9525,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Անհնար է ստանալ հոսքի նկարագրությունը"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Հաճախականության փոփոխում"
 
@@ -6983,6 +9537,21 @@ msgstr "Հաճախականության փոփոխում"
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Անհաջող հեռացում %s"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Անհնար է ստանալ հոսքի նկարագրությունը"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Անհնար է ստանալ հոսքի նկարագրությունը"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -6992,13 +9561,36 @@ msgstr "Աուդիո յունիթ"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "VST էֆեկտներ"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "VST էֆեկտներ"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "VST էֆեկտ կարգավորումներ"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -7006,6 +9598,7 @@ msgstr "Էֆեկտի կարգավորումներ"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "VST էֆեկտներ"
@@ -7020,8 +9613,16 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Բուֆեր չափ (8 ից 1048576 նմուշներ)՝"
 
 #: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
 msgstr "Շատ VST էֆեկտներ ունեն գրաֆիկական ինտերֆեյսի, կարգավորման պարամերտ արժեքների համար:"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
@@ -7037,13 +9638,27 @@ msgstr "%d կորերը վերցվեցին դեպի %s\n"
 msgid "Generator"
 msgstr "Ստեղծող"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "VST էֆեկտներ"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Nyquist էֆեկտի հաստատում..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -7059,6 +9674,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Nyquist ելք՝ "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Շղթան ընտրված չէ"
 
@@ -7071,12 +9704,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Ներեցեք, չի կարող հաստատվել էֆեկտը ստերեո ձայնագրությունների վրա,  ուր ձայնագրությունները անհավասար են:"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Nyquist ելք՝ "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Ընթացքի մեջ է"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -7156,6 +9807,19 @@ msgid "Could not determine language"
 msgstr "Չի հաջողվում բացել ֆայլը՝ "
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Մուտք Nyquist կատարող՝ "
 
@@ -7172,6 +9836,22 @@ msgstr "Nyquist հրահանգ"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Nyquist հրահանգ"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Չի ստացվում բացել ֆայլը"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "Չկա առաջին պլանի ֆոնի հավասարված"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -7192,13 +9872,18 @@ msgstr "Ընտրել MIDI ֆայլ..."
 msgid "Save file as"
 msgstr "Պահպանել ֆայլերը"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "անվերնագիր"
 
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "VST էֆեկտներ"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -7219,6 +9904,17 @@ msgstr "Պլագին կարգավորումներ"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Ծրագիր"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Գլխավոր կարգավորումներ"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -7381,9 +10077,18 @@ msgstr ""
 "Ցանկանու՞մ եք շարունակել:"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "Մոդուլ \"%s\" -ը գտնված է:"
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -7394,8 +10099,32 @@ msgstr ""
 "Կարող եք կարգավորել այն մտնելով՝ Կարգավորումներ> Գրադարան:"
 
 #: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "FFmpeg գրադարան՝"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -7406,6 +10135,59 @@ msgid ""
 msgstr ""
 "FFmpeg-ն չգտավ աուդիո կոդեկը 0x%x.\n"
 "Հավանաբար այս կոդեկը չի աջակցում:"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -7426,7 +10208,8 @@ msgstr "Վերցնել նշված աուդիոն որպես %s"
 msgid "Invalid sample rate"
 msgstr "Սխալ ձայնաչափի բաժին"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Վերահաճախավորել"
 
@@ -7458,7 +10241,8 @@ msgstr "Ձայնի բաժին"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -7470,6 +10254,51 @@ msgstr "Բիթի չափ՝"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Որակը՝"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%i kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -7484,6 +10313,10 @@ msgid "Constrained"
 msgstr "Հաստատուն"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Աուդիո..."
 
@@ -7492,8 +10325,44 @@ msgid "Low Delay"
 msgstr "Ուշացնող"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Միջին"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -7564,8 +10433,17 @@ msgid "Replace preset '%s'?"
 msgstr "Ջնջե՞լ վերագրումը '%s':"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Գլխավոր"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -7673,6 +10551,10 @@ msgstr "Լեզու՝"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Բիթ ամբար"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -7806,6 +10688,11 @@ msgstr ""
 "0 - լռելյայն\n"
 "նվազ - 1\n"
 "առավ - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -7965,6 +10852,17 @@ msgstr "Չկան նշումներ վերցման համար:"
 msgid "Select xml file to export presets into"
 msgstr "Նշել xml ֆայլ, վերցնելու վերագրումը -ից"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Չհաջողվեց կռահել ֆորմատը"
@@ -8051,12 +10949,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(Լավագույն որակ)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(Փոքր ֆայլեր)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -8067,7 +11017,8 @@ msgstr "ահռելի"
 msgid "Extreme"
 msgstr "Ծայրահեղ"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Ստանդարտ"
 
@@ -8108,14 +11059,19 @@ msgstr "Որակ"
 msgid "Channel Mode:"
 msgstr "Ալիքի ռեժիմ՝"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Հեռացված կտրման գիծ"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Տեղադրել անունը"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Աուդասիթիին պետք է %s  ֆայլը, որպեսզի ստեղծի MP3-ները:"
 
 #: src/export/ExportMP3.cpp
@@ -8143,13 +11099,34 @@ msgid "Where is %s?"
 msgstr "Որտե՞ղ է %s -ը:"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Դուք նշել եք՝ lame_enc.dll v%d.%d. Այս տարբերակը չի աջակցում Աուդասիթիին %d.%d.%d.\n"
 "Խնդրում ենք, բեռնլ LAME MP3 գրադարան-ի վերջին տարբերակը:"
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Պրոեկտի ժամանակավոր ֆայլերի պահպանում"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -8255,6 +11232,10 @@ msgstr ""
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Վերցման տեղ՝"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -8395,6 +11376,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Անհնար է նշել QuickTime պատրաստման որակ"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
@@ -8405,6 +11406,10 @@ msgstr "Վերցնել նշված աուդիոն որպես Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Վերցնել նշված աուդիոն որպես Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -8423,8 +11428,28 @@ msgid "Other uncompressed files"
 msgstr "Այլ չխտացված ֆայլեր"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Ներմուծման սխալ"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -8452,11 +11477,11 @@ msgid "All supported files"
 msgstr "Բոլոր ֆայլերը|*|Բոլոր աջակցող ֆայլերը|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -8465,11 +11490,11 @@ msgstr ""
 "փոփոխել այն սեղմելով՝ Ֆայլ > Ներմուծել > MIDI:"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "MIDI ֆայլ է, ոչ աուդիո ֆայլ: \n"
@@ -8481,18 +11506,18 @@ msgid "Select stream(s) to import"
 msgstr "Նշել հոսք(եր) ներմուծման համար"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Այս Աուդասիթի տարբերակը չի աջակցում %s օգնություն:"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" աուդիո CD ձայնագրություն է: \n"
 "Աուդասիթին չի կարող բացել CD-ները անմիջապես: \n"
@@ -8501,10 +11526,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" երգացանկի ֆայլ է: \n"
@@ -8513,10 +11538,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Windows Media աուդիո ֆայլ է: \n"
@@ -8525,10 +11550,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Ընդլայնված Աուդիո Կոդավորման ֆայլ է (AAC): \n"
@@ -8537,12 +11562,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" կոդավորված աուդիո ֆայլ է: \n"
@@ -8553,10 +11578,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" RealPlayer-ի մեդիա ֆայլ է: \n"
@@ -8565,12 +11590,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" նշման բազայի ֆայլ է, ոչ աուդիո ֆայլ: \n"
 "Աուդասիթին չի կարող բացել այս տեսակի ֆայլը: \n"
@@ -8579,10 +11604,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -8595,10 +11620,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is a Wavpack աուդիո ֆայլ է: \n"
@@ -8607,10 +11632,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Դոլբի Թվային աուդիո ֆայլ է: \n"
@@ -8619,10 +11644,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Ogg Speex աուդիո ֆայլ է: \n"
@@ -8631,10 +11656,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" վիդեո ֆայլ է: \n"
@@ -8648,20 +11673,31 @@ msgstr "Մոդուլ \"%s\" -ը գտնված է:"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Աուդասիթին չի ճանաչել '%s' ֆայլի տեսակը:\n"
 "Եթե դա խտացված չէ, փորձե՛ք ներմուծել \"Անմշակ ներմուծման\" միջոցով:"
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -8670,6 +11706,11 @@ msgstr ""
 "Ներմուծողները ենթադրաբար աջակցում են այնպիսի ֆայլերի, ինչպիսիք են՝\n"
 "%s,\n"
 "բայց դրանցից ոչ մեկը չհասկացավ ֆայլի ֆորմատը:"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Պրոեկտի ժամանակավոր ֆայլերի պահպանում"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8686,8 +11727,57 @@ msgid "Import Project"
 msgstr "Ներմուծել վերագրումներ"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Ներքին սխալ է հաղորդվում հավասարման գործընթացից:"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8695,16 +11785,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Չի գտնվում պրոեկտի ինֆորմացիոն թղթապանակը՝ \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Պրոեկտներ"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Սխալ ձայնաչափի բաժին"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Սխալ ձայնաչափի բաժին"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8734,31 +11882,6 @@ msgstr "Ինդեքս[%02x] Կոդեկ[%S], Լեզու[%S], Բիթաչափ[%S], �
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC ֆայլեր"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "FFmpeg համատեղելի ֆայլեր"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Ընդլայնված ներմուծում"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Անհնար է անվանափոխել '%s' ից '%s'."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Ինդեքս[%02x] Կոդեկ[%S], Լեզու[%S], Բիթաչափ[%S], Ալիքներ[%d], Տևողություն[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -8816,6 +11939,14 @@ msgstr "Չի ստացվում բացել ֆայլը"
 msgid "MP3 files"
 msgstr "MP3 ֆայլեր"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis ֆայլեր"
@@ -8850,8 +11981,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, և այլ ոչ խտացված տեսակներ"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) միացված 16 բիթ PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-բիթ Պրոց. հիշ."
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -8862,12 +12087,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-բիթ Պրոց. հիշ."
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-բիթ Պրոց. հիշ."
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-բիթ Պրոց. հիշ."
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-բիթ վերբեռն."
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-բիթ վերբեռն."
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) միացված 16 բիթ PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 բիթ"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -8878,12 +12147,20 @@ msgid "24 bit DWVW"
 msgstr "24 բիթ"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-բիթ Պրոց. հիշ."
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-բիթ Պրոց. հիշ."
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -8994,6 +12271,10 @@ msgstr "Ձայնաչափի բաժին՝"
 msgid "&Import"
 msgstr "Ներմուծել"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -9014,6 +12295,7 @@ msgstr "Աջ"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -9037,6 +12319,7 @@ msgstr "Ավարտ"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -9056,15 +12339,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Ժամափոխված ձայնագրություններ/ամրացումներ %s %.02f վարկյան"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Ժամափոխված ձայնագրություններ/ամրացումներ %s %.02f վարկյան"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Ժամափոխում"
 
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "Կտրել սահմանները"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Կտրել սահմանները"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "Կտրել սահմանները"
 
 #: src/menus/ClipMenus.cpp
@@ -9185,7 +12488,8 @@ msgstr "Հատում նշված աուդիո տարածությունները %.
 msgid "Trim Audio"
 msgstr "Հատել աուդիո"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Անջատել"
 
@@ -9306,32 +12610,8 @@ msgid "Delete Key&2"
 msgstr "ՋնջելԲանալի2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Միախառնող գործիքադարակ"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Կարգավորել նվագարկման ձայնաչափը"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Նվագարկման ձայնաչափի ավելացում"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Նվագարկման ձայնաչափի նվազեցում"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Կարգավորել ձայնագրման ձայնաչափը"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Ձայնագրման ձայնաչափի ավելացում"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Ձայնագրման ձայնաչափի նվազեցում"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -9358,8 +12638,21 @@ msgid "&Full Screen (on/off)"
 msgstr "Լիաէկրան միացնել/անջատել"
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Վերցնել նշված աուդիոն"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Փոխել նշում"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -9409,6 +12702,11 @@ msgstr "Ներմուծել նշումներ"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Ընտրել MIDI ֆայլ..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Բոլոր ֆայլերը (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -9511,6 +12809,10 @@ msgid "E&xit"
 msgstr "Դուրս գալ"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "Վերցնել նշումները որպես՝"
 
@@ -9541,6 +12843,10 @@ msgid "Nothing to do"
 msgstr "Ոչինչ հետ չբերել"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Փակել կենտրոնացված ձայն. ֆայլը"
 
@@ -9551,6 +12857,10 @@ msgstr "Չի հաջողվում բացել պրոեկտ ֆայլը"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Ձայնագրումը սկսված է"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -9569,12 +12879,17 @@ msgid "&Getting Started"
 msgstr "Ընտրված սկիզբ՝"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Աուդասիթի պատմության գրքույկ"
+#, fuzzy
+msgid "&Manual"
+msgstr "Փոփոխել կորերը"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "Օգնություն"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -9592,11 +12907,8 @@ msgstr "Աուդիո սարքի մասին..."
 msgid "Show &Log..."
 msgstr "Ցուցադրել &պատմության ֆայլերը..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Աուդասիթիի մասին..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Ավելացված նշում"
 
@@ -9722,6 +13034,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "Տեղադրել տեքստը նոր նշումում"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Նշված աուդիո"
 
@@ -9786,6 +13102,18 @@ msgid "Label Join"
 msgstr "Փոխել նշում"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Տեղափոխել հետ բերումը գործիքադարակից ֆայլ"
 
@@ -9826,8 +13154,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Փոխանջատել կենտրոնացված ձայն. ֆայլը"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Նոր..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -9842,6 +13178,10 @@ msgstr "Պլագիններ %i ից %i"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "Արտադրել"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -9925,6 +13265,16 @@ msgid "Set Track Status..."
 msgstr "Ձայնային ֆայլի սկիզբ"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Լռեցված աուդիո"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Ձայնային ֆայլի ֆիլտր"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Կարգավորումներ..."
 
@@ -9947,6 +13297,12 @@ msgstr "Փոխել նշումները..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Պահպանել պրոեկտը &որպես..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Փոփոխական"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -10023,6 +13379,11 @@ msgid "In All &Sync-Locked Tracks"
 msgstr "Բոլոր Սինք-փակված ձայնային ֆայլերը"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Սինք-փակ նշված"
+
+#: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "Նվագարկել մասը"
 
@@ -10091,8 +13452,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Մուտքային հաճախականություն"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Սկզբի նշումը"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Աուդիո արանք՝"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -10229,6 +13599,14 @@ msgstr "Նշման գծի երկար թռիչք դեպի ձախ"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "Նշման գծի երկար թռիչք դեպի աջ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
@@ -10437,18 +13815,21 @@ msgid "Created new label track"
 msgstr "Ստեղծվել է նոր նշում ձայնագրություն"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Աուդասիթիի այս տարբերակը միայն աջակցում է մեկ ժամի ձայն. ֆայլ, պրեկտի ոշոր պատուհաններում:"
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Ստեղծված նոր ժամ. ձայնագրություն"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Նոր հաճախություն (Հց)՝"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Նշված արժեքը թերի է"
 
@@ -10528,6 +13909,11 @@ msgid "&Time Track"
 msgstr "Ժամ ձայնագրություն"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Միախառնող գործիքադարակ"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Անջատել ստերեոն մոնոի"
 
@@ -10566,6 +13952,10 @@ msgstr "Անջատել բոլորի ձայնը"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "Միացնել բոլորի ձայները"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -10697,7 +14087,9 @@ msgstr "Նվագարկել"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Ձայնագրում"
 
@@ -10710,8 +14102,27 @@ msgid "no label track at or below focused track"
 msgstr "Պան ձախ կենտրոնացված ձայն. ֆայլի վրա"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Ստեղծվել է նոր նշում ձայնագրություն"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -10779,6 +14190,11 @@ msgid "&Timer Record..."
 msgstr "Ժամային ձայնագրում..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Ձայնի ակտիվացվավ ձայնագրում"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Նվագարկել մասը"
 
@@ -10807,16 +14223,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "Ձայնագրման ակտիվացում ջայնաչափի փուլով (միացնել/անջատել)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Ձայնագրումն ավարտված է"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "Ձայնագրում ձայնին հավասար (միացնել/անջատել)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Ծրագրային ձայնագրման մոնիտորինգ (միացնել/անջատել)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Ա&վտոմատ ձայնագրման փուլի հարմարեցում (միացնել/անջատել)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -10826,6 +14243,11 @@ msgstr "ՇարԺ"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "Նվագարկում/Դադարեցում"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -10943,6 +14365,11 @@ msgid "&Fit to Width"
 msgstr "Էկրանի չափով"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "Էկրանի չափով"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "Ամբողջացնել բոլոր ձայնային ֆայլերը"
 
@@ -10986,6 +14413,18 @@ msgstr "VST էֆեկտներ"
 msgid "&Window"
 msgstr "պատուհան"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
@@ -11011,7 +14450,7 @@ msgstr "Կարգավորումներ՝"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Փակել Աուդասիթին"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -11058,7 +14497,8 @@ msgstr "Հոսթ"
 msgid "Using:"
 msgstr "Օգտագործված՝"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Նվագարկում"
 
@@ -11078,7 +14518,8 @@ msgstr "Ալիքներ"
 msgid "Latency"
 msgstr "Թաքնված"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "միլիվարկյաններ"
 
@@ -11107,7 +14548,8 @@ msgid "2 (Stereo)"
 msgstr "2 (Ստերեո-երկու դինամիկ)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Ճանապարհներ"
 
@@ -11120,8 +14562,22 @@ msgid "Default directories"
 msgstr "Ճանապարհներ"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Ընտրել..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -11181,6 +14637,11 @@ msgstr "Ընտրեք վայր ֆայլերի պահպանման համար"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "%s Ճանապարհը գոյություն չունի: Ստեղծե՞լ այն:"
 
@@ -11194,7 +14655,8 @@ msgid "Directory %s is not writable"
 msgstr "%s ճանապարհը գրման անհասանելի է"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Ժամանակավոր ֆայլերի փոփոխումը էֆեկտ չի տա, մինչև չվերբեռնվի Աուդասիթին"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -11209,11 +14671,36 @@ msgstr "Կարգավորումներ՝"
 msgid "Sorted by Effect Name"
 msgstr "Առանձնացնել անվան տեսակետից"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Առանձնացնել անվան տեսակետից"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Առանձնացնել անվան տեսակետից"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "VST էֆեկտներ"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -11222,6 +14709,18 @@ msgstr "VST էֆեկտներ"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -11232,11 +14731,24 @@ msgid "Effect Options"
 msgstr "Էֆեկտի կարգավորումներ"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Պլագին կարգավորումներ"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "VST էֆեկտների վերստուգում հաջորդ Աուդասիթի մեկնարկին"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -11388,6 +14900,10 @@ msgid "Location of &Manual:"
 msgstr "Ձեռքով կառավարման տեղ՝"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "Մետր/Ալիքաձև դԲ դիապազոն՝"
 
@@ -11400,6 +14916,10 @@ msgid "Show e&xtra menus"
 msgstr "Ցուցադրել ցանցը Y առանցքի երկայնքով"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "Ազդանշան երկար գործունեություն ավարտելիս"
 
@@ -11407,9 +14927,46 @@ msgstr "Ազդանշան երկար գործունեություն ավարտե�
 msgid "Re&tain labels if selection snaps to a label"
 msgstr "Պահպանել նշումները, եթե ընրությունը գտնվում է նշման եզրին"
 
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Պլագին կարգավորումներ"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Քանոն"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Ներմուծել / Վերցնել"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Կարգավորումներ՝"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -11422,6 +14979,10 @@ msgstr "Հավելյալ միախառնման կարգավորում"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Ստանդարտ"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -11439,9 +15000,22 @@ msgstr "Երբ վերցվում են ձայնագրություններ որպե
 msgid "S&how Metadata Tags editor before export"
 msgstr "Ցուցադրել մետա տվյալների փոփոխիչը վերցման քայլի ժամանակ"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Վերցնել նշումները որպես՝"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11526,7 +15100,15 @@ msgid "&Defaults"
 msgstr "&Նախնական"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Ընտրել XML ստեղնաշարի նշաններ պարունակող ֆայլ, Աուդասիթիի համար..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11535,8 +15117,21 @@ msgstr "Եղավ սխալ՝ ստեղնաշարի նշաններ ներմուծե
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Բեռնված %d ստեղնաշարի իկոններ\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -11557,6 +15152,15 @@ msgstr "Դուք չեք կարող նշել բանալի այս գրառման �
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "Առաջինը պետք է նշեք պարտադիրը, մինչև նշանների նշելը"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -11627,12 +15231,17 @@ msgid "Dow&nload"
 msgstr "Բեռնել"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Աուդասիթին ավտոմատ գտավ լավ FFmpeg գրադարաններ:\n"
 "Վստա՞հ եք, որ ցանկաում եք դրանք կարգավորել ձոռքվ:"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -11669,6 +15278,10 @@ msgstr "MIDI սինթեզատոր ուշացում (ms)՝"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "MIDI սինթեզատոր ուշացումը պետք է լինի ամբողջական թվով"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -11679,23 +15292,32 @@ msgid "Preferences for Module"
 msgstr "Կարգավորումներ՝"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr "Սրանք փորձնական մոդուլներ են: Միացնել դրանք միայն, երբ դուք կարդացել եք ձեռնարկը և տեղյակ եք ձեր անելիքից:"
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "'Հարցնել' նշանակում է, որ Աուդասիթին կհարցնի, երբ ցանկանում եք բեռնել պլագին ամեն անգամ ծրագիրը մեկնարկելիս:"
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "'Չհաջողվեց' նշանակում է, որ Աուդասիթին կարծում է, թե պլագինը կոտրված է և չի աշխատելու դրա հետ:"
 
+#. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Ժամանակավոր ֆայլերի փոփոխումը էֆեկտ չի տա, մինչև չվերբեռնվի Աուդասիթին"
 
 #: src/prefs/ModulePrefs.cpp
@@ -11713,6 +15335,10 @@ msgstr "Սարքեր չեն գտնվել"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Մոդուլներ"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -11754,7 +15380,10 @@ msgstr "Ձախ քաշում"
 msgid "Set Selection Range"
 msgstr "Նշել ընտրման դիապազոն "
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift և ձախ սեղմում"
 
@@ -11841,6 +15470,15 @@ msgstr "Ձախ քաշում"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Մասի տեղափոխում վերև/ցած ձայնագրությունների միջև"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Ձախ քաշում"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -11952,8 +15590,21 @@ msgstr "Կարճ հատված՝"
 msgid "Lo&ng period:"
 msgstr "Երկար հատված՝"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Աուդասիթի կարգավորումներ"
 
 #: src/prefs/PrefsDialog.cpp
@@ -11967,6 +15618,11 @@ msgstr "Կարգավորումներ՝"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Կարգավորումներ՝"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -12027,12 +15683,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "Վերանայում՝ Նվագարկել մյուս երգերը, երբ ձայնագրվում է մեկը"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "Ծրագրային ձայնագրման մոնիտորինգ (միացնել/անջատել)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Նոր ձայնագրություն"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Նշել հոսք(եր) ներմուծման համար"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -12073,41 +15739,37 @@ msgid "System &Date"
 msgstr "Սկզբի ամսաթիվ"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Ավտոմատ ձայնագրման փուլի ճշգրտում"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Միացնել ավտոմատ ձայնագրման փուլի ճշգրտումը"
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Նշանակետի գագաթ՝"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Ընթացքում՝"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Անալիզի ժամ՝"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "միլիվարկյաններ (մեկ անալիզի ժամանակ)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Անընդմեջ վերլուծության քանակ՝"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 նշանակված անվերջություն"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Սկզբի ամսաթիվ"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Ձայնի ակտիվացվավ ձայնագրում"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Հավելում ձայնագրություն"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -12141,6 +15803,11 @@ msgstr "&Գծային"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Հաճախություն"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -12201,12 +15868,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Առավելագույն ձայնաչափի բաժին (Հց)՝"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "Հզորացում (դԲ)՝"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "Դիապազոն (դԲ)՝"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -12229,12 +15904,21 @@ msgid "1024 - default"
 msgstr "256 - լռելյայն"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - ամենանեղ խումբ"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "Պատուհանի տեսակ"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Քայքայման գործոն՝"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -12322,13 +16006,14 @@ msgid "Info"
 msgstr "Տեղեկություն"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -12416,6 +16101,18 @@ msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "\"Ձայնագրության տեղափոխման հավասարություն\" բազմակի ցիկլեր ձայնագրություններով"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Հավելյալ միախառնման կարգավորում"
 
@@ -12436,6 +16133,10 @@ msgid "Spectrogram"
 msgstr "Տատանման ցուցիչ"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "Վերագրաֆիկավորում"
 
@@ -12450,6 +16151,10 @@ msgstr "Մեծացնել ընտրվածը"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Խոշորացնել լռելյայն"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -12472,6 +16177,16 @@ msgid "50ths of Seconds"
 msgstr "վարկյան"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "վարկյան"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "վարկյան"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "միլիվարկյաններ"
 
@@ -12479,7 +16194,12 @@ msgstr "միլիվարկյաններ"
 msgid "Samples"
 msgstr "նմուշներ"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Խոշորացնել"
 
@@ -12488,8 +16208,29 @@ msgid "Preferences for Tracks"
 msgstr "Կարգավորումներ՝"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "Ցուցադրել ձայնագրության անունը ալիքաձև էկրանին"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Ձայնագրումն ավարտված է"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -12498,6 +16239,11 @@ msgstr "Լռելյայն դիտման ռեժիմ"
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Լռելյայն ձայնաչափի ֆորմատ՝"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "նմուշներ"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -12549,6 +16295,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "Միախառնում ստերեոյի վերցման ժամանակ"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "Միախառնում մոնոյի վերցման ժամանակ"
 
@@ -12573,16 +16323,24 @@ msgid "Stopped"
 msgstr "Դադարեցնել"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Դադար"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Անցնել սկիզբ"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Անցնել վերջ"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Դադար"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Սկզբի նշումը"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Վերջի նշումը"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -12596,20 +16354,17 @@ msgstr "Նոր ձայնագրություն"
 msgid "Append Record"
 msgstr "Կցվող ձայնագրում"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Վերջի նշումը"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Սկզբի նշումը"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Դադար"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -12689,11 +16444,17 @@ msgstr "Լռեցնել նշված աուդիոն"
 msgid "Sync-Lock Tracks"
 msgstr "Սինք-բանալի ձայնագրություններ"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Խոշորացնել"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Փոքրացնել"
 
@@ -12760,50 +16521,23 @@ msgstr "Մետրի գործիքադարակ"
 msgid "&Playback Meter Toolbar"
 msgstr "Մետրի գործիքադարակ"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Ձայնագրման ձայնաչափ"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Նվագարկման ձայնաչափ"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Ձայնագրման ձայնաչափ՝ %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Ձայնագրման ձայնաչափ (Անհասանելի է; օգտվե՛ք համակարգի միախառնումից)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Նվագարկման ձայնաչափ՝ %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Նվագարկման ձայնաչափ՝ %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Նվագարկման ձայնաչափ (Անհասանելի է; օգտվե՛ք համակարգի միախառնումից)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Միախառնող գործիքադարակ"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "Քանոն"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Nyquist հրահանգ"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Nyquist հրահանգ"
@@ -12811,6 +16545,7 @@ msgstr "Nyquist հրահանգ"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Nyquist հրահանգ"
@@ -12818,9 +16553,24 @@ msgstr "Nyquist հրահանգ"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Սկսել մոնիտորինգը"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Սկսել մոնիտորինգը"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Քանոն"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -12868,7 +16618,9 @@ msgstr "Ճաքեցում"
 msgid "Length"
 msgstr "Երկարություն"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Կենտրոն"
 
@@ -12876,6 +16628,14 @@ msgstr "Կենտրոն"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "Իսկույ նսեղմում/Ընտրվածը %s"
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -12895,8 +16655,17 @@ msgid "Center frequency and Width"
 msgstr "Գծային հաճախականություն"
 
 #: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Low and High Frequencies"
+msgstr "Հաճախություն"
+
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Center Frequency"
 msgstr "Գծային հաճախականություն"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
@@ -12916,8 +16685,8 @@ msgstr "Սարքի գործիքադարակ"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Աուդասիթի %s գործիքադարակ"
 
 #: src/toolbars/ToolBar.cpp
@@ -12944,7 +16713,8 @@ msgstr "Ժամի որոշման գործիք"
 msgid "Zoom Tool"
 msgstr "Խոշորացնող գործիք"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Գծող գործիք"
 
@@ -13020,11 +16790,13 @@ msgstr "Քաշել մեկ և ավելի նշման տարածություննե�
 msgid "Drag label boundary."
 msgstr "Քաշել նշման տարածություններ"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Փոփոխված նշում"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Փոխել նշում"
 
@@ -13079,31 +16851,42 @@ msgstr "Փոփոխված մասեր"
 msgid "New label"
 msgstr "Ավելացված նշում"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Բարձր է &օկտավայից"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Ցածր օկտավ&ա"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Սեղմեք հորիզոնական մեծացման համար: Shift-սեղմում փոքրացման համար: Քաշելով գցել հատուկ մեծացված մաս:"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Աջ սեղմում"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Փոքրացնել"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift և ձախ սեղմում"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift և ձախ սեղմում"
 
@@ -13126,6 +16909,14 @@ msgid "Stretch"
 msgstr "Ձգել"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Միացված ֆայլեր"
 
@@ -13137,7 +16928,8 @@ msgstr "Միացնել"
 msgid "Expanded Cut Line"
 msgstr "Տարածված կտրման գիծ"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Տարածել"
 
@@ -13161,6 +16953,11 @@ msgstr "Տեղափոխված նմուշ"
 msgid "Sample Edit"
 msgstr "Փոխել նմուշ"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Խոշորացնել բաժնում"
@@ -13168,6 +16965,16 @@ msgstr "Խոշորացնել բաժնում"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Սպեկտրոգրամ"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -13193,7 +17000,8 @@ msgstr "Ընթացքի մեջ է"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Փոխված '%s' ից %s"
@@ -13207,7 +17015,60 @@ msgid "Rat&e"
 msgstr "Նշել ձայնի &բաժին"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 ժ 060 ր 060>0100 վ"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -13228,7 +17089,8 @@ msgstr "Ձայնաչափի բաժնի փոխում"
 msgid "Set Rate"
 msgstr "Նշել ձայնաչափի բաժին"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Բազմակողմանի"
 
@@ -13321,10 +17183,25 @@ msgid "Right, %dHz"
 msgstr "Աջ"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f դԲ"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "Աջ"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -13334,6 +17211,15 @@ msgstr "Սեղմեք և քաշեք, հարմարեցնելով ստերեո ձա
 msgid "Click and drag to rearrange sub-views"
 msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփոխելու համար:"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփոխելու համար:"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Խոշորացնել"
@@ -13341,6 +17227,10 @@ msgstr "Խոշորացնել"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Խոշորացնել"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -13427,9 +17317,8 @@ msgstr "Լոգարիթմային &միջարկում"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփոխելու համար:"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -13480,6 +17369,21 @@ msgstr "Հարմարեցված պատիչ"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Գործիքադարակներ"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Սկսել մոնիտորինգը"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Քանոն"
@@ -13495,6 +17399,11 @@ msgstr "Փակել կենտրոնացված ձայն. ֆայլը"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Տեղափոխել ֆայլը &ցած"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Nyquist հրահանգ"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -13551,6 +17460,11 @@ msgstr "Սեղմեք և քաշեք, ձգելու համար նշված տարա�
 msgid "Click and drag to select audio"
 msgstr "Սեղմեք և քաշեք, ձգելու համար նշված տարածքը:"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփոխելու համար:"
@@ -13572,6 +17486,10 @@ msgstr "Լռելյայն նշված ձայնագրությունները %.2f վ
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Լռելյայն նշված ձայնագրությունները %.2f վարկյանի մինչ %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -13601,6 +17519,12 @@ msgstr "Ctrl և ձախ սեղմում"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track."
 msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
@@ -13620,6 +17544,18 @@ msgstr "Տեղափոխված '%s' %s"
 msgid "Move Track"
 msgstr "Տեղափոխել ձայնագրություն"
 
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Click to Zoom In, Shift-Click to Zoom Out"
+msgstr ""
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Drag to Zoom Into Region, Right-Click to Zoom Out"
+msgstr ""
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Left=Zoom In, Right=Zoom Out, Middle=Normal"
+msgstr ""
+
 #: src/widgets/AButton.cpp
 msgid "(disabled)"
 msgstr " (անջատված)"
@@ -13632,11 +17568,36 @@ msgstr "Սեղմել"
 msgid "Button"
 msgstr "Կոճակ"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
 #. i18n-hint: "x" suggests a multiplicative factor
 #: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.2fx"
 msgstr "%.1f դԲ"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" գոյություն չունի:\n"
+"\n"
+"Ցանկանու՞մ եք ստեղծել այն:"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy
+msgid "Please choose an existing file."
+msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
 
 #: src/widgets/FileDialog/mac/FileDialogPrivate.mm
 msgid "File type:"
@@ -13661,6 +17622,21 @@ msgstr "Դատարկ"
 #: src/widgets/HelpSystem.cpp
 msgid "Backwards"
 msgstr "Հետևի պլանի ֆոն"
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Անցնել սկիզբ"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -13729,12 +17705,21 @@ msgid "Meter Style"
 msgstr "Մետր"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "&Զտման տեսակը՝"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Ժամաչափը"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Ավտոմատ հետ բերում վթարային իրավիճակից հետո:"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -13749,9 +17734,22 @@ msgid " Monitoring "
 msgstr "Դադարեցնել մոնիտորինգը"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f դԲ"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f դԲ"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Show Log for Details"
@@ -13768,6 +17766,13 @@ msgstr "Խնդրում ենք ընտրել որևէ գործողություն"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 վարկյան"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + մասեր"
+
 #. i18n-hint: Format string for displaying time in hours, minutes and
 #. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
@@ -13777,6 +17782,12 @@ msgstr "01000,01000 վարկյան"
 msgid "0100 h 060 m 060 s"
 msgstr "0100 ժ 060 ր 060 վ"
 
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -13785,6 +17796,13 @@ msgstr "0100 ժ 060 ր 060 վ"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 օր 024 ժ 060 ր 060 վ"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "hh:mm:ss + մասեր"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
@@ -13834,6 +17852,7 @@ msgstr "0100 ժ 060 ր 060 վ+># նմուշներ"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "նմուշներ"
@@ -13995,6 +18014,10 @@ msgstr "01000,01000 կադրեր|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 ժ 060 ր 060>0100 վ"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows frequency in kilohertz
 #: src/widgets/NumericTextCtrl.cpp
 msgid "kHz"
@@ -14007,6 +18030,10 @@ msgstr "կՀց"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 ժ 060 ր 060>0100 վ"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -14022,6 +18049,49 @@ msgstr "Օկտավա"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 կադրեր|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "10>01000 decades|0.434294482"
+msgstr "01000,01000 կադրեր|24"
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "(Օգտագործե՛ք համատեքստային մենյուն, ֆորմատի փոխման համար)"
@@ -14029,6 +18099,11 @@ msgstr "(Օգտագործե՛ք համատեքստային մենյուն, ֆո�
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "ցենտիվարկյաններ"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -14072,6 +18147,11 @@ msgstr "Հաստատել"
 msgid "Unable to write files to directory: %s."
 msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -14090,6 +18170,10 @@ msgid "Don't show this warning again"
 msgstr "Չցուցադրել այս զգուշացումը կրկին"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-Անվերջություն"
 
@@ -14098,13 +18182,31 @@ msgid "-Infinity"
 msgstr "-Անվերջություն"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Դատարկ"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Կցվող ձայնագրում"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Խոշորացնել դիապազոնում"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "LOF Սխալ"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -14122,11 +18224,20 @@ msgid "Value must not be greater than %s"
 msgstr "Սկիզբն ու դադարը պետք է լինի լավ քան 0:"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Ստեղծված նոր պրոեկտ"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Ճանապարհներ"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Ճանապարհներ"
 
 #: src/xml/XMLFileReader.cpp
@@ -14147,16 +18258,49 @@ msgstr "Չի ստացվում բացել ֆայլը"
 msgid "Spectral edit multi tool"
 msgstr "Տեղավորել նշվածը"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Զտիչ"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Հաճախություն"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Եղավ սխալ"
@@ -14171,8 +18315,34 @@ msgstr "Հզորացում (դԲ)՝"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Նվազագույն հաճախությունը պետք է լինի առնվազն 0 Հց"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -14186,9 +18356,22 @@ msgstr "Քչացնել"
 msgid "Applying Fade..."
 msgstr "Հաստատվում է..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Դնել լռ&ելյայն"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -14220,8 +18403,16 @@ msgid "S-Curve Down"
 msgstr "Տեղափոխել &ներգև"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Սկսել"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -14230,6 +18421,14 @@ msgstr "Որակի ամրապնդում"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Սկսել"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -14242,6 +18441,14 @@ msgstr "Գծային"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Գծային"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -14290,6 +18497,14 @@ msgstr "Հաճախության ավելացումը չպետք է լինի բա�
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "Հաճախության ավելացումը չպետք է լինի բացասական"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Կրկնել"
@@ -14297,6 +18512,10 @@ msgstr "Կրկնել"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Գտնել մասնատված..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Աուդասիթի պատմության գրքույկ"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -14310,6 +18529,23 @@ msgstr "Կտրում"
 msgid "Reconstructing clips..."
 msgstr "Հեռացվող սեմղմումներ և խցաններ..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Շեմը %d դԲ"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Հավելում ձայնագրություն"
@@ -14317,6 +18553,21 @@ msgstr "Հավելում ձայնագրություն"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Հավելում ձայնագրություն"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -14350,6 +18601,19 @@ msgstr "Ձայնագրության անունը"
 msgid "Fade direction"
 msgstr "կարդալ անմիջապես"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Ուշացնող"
@@ -14365,6 +18629,19 @@ msgstr "Ուշացնող"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "Ողղանկյուն"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Աղմուկի կր&ճատում (դԲ)՝"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -14390,6 +18667,14 @@ msgstr "Դիտում"
 msgid "Number of echoes"
 msgstr "Ժամաքանակ կրկնելու՝"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Կրկնել վերջին էֆեկտը"
@@ -14401,6 +18686,10 @@ msgstr "Տատանումների կառուցում"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3 ֆայլեր"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -14415,10 +18704,24 @@ msgstr "Վերագրման հաստատում"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Չի հաջողվում բացել ոճի ֆայլը:"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Սխալ (ֆայլը կարող է չգրվել)՝ %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Սխալ (ֆայլը կարող է չգրվել)՝ %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -14449,10 +18752,50 @@ msgstr "Երկարություն (վարկյան)"
 msgid "Length of label region (seconds)"
 msgstr "Երկարություն (վարկյան)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Փոխել նշում"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -14466,6 +18809,11 @@ msgstr "Բաժանել"
 msgid "Warnings only"
 msgstr "Զգուշացումներ"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -14474,6 +18822,12 @@ msgstr "Մասի պահպանում"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Փոփոխված մասեր"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -14488,13 +18842,50 @@ msgstr "Դասական զտումներ"
 msgid "Performing High-Pass Filter..."
 msgstr "Դասական զտման կատարում"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Հաճախականություն (Հց)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Նվազագույն հաճախությունը պետք է լինի առնվազն 0 Հց"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -14542,6 +18933,11 @@ msgid "Point after sound"
 msgstr "Համատեղ ստերեո"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "Երկարությունից վարկյանում"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "Երկարությունից վարկյանում"
 
@@ -14549,11 +18945,41 @@ msgstr "Երկարությունից վարկյանում"
 msgid "Maximum leading silence"
 msgstr "Լռության ընդհատում..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Լռության ընդհատում..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Նշվածը պետք է մեծ լինի քան %d նշումները:"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -14585,8 +19011,25 @@ msgid "Hard Clip"
 msgstr "Գտնել անջատում"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Աջ ալիք"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Փուլ (դԲ)՝"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -14648,6 +19091,44 @@ msgstr "Հարձակման/հետ քաշման ժամ"
 msgid "Decay (ms)"
 msgstr "Հարձակման/հետ քաշման ժամ"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Նշվածը պետք է մեծ լինի քան %d նշումները:"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Ֆիլտրերի երկարությամբ"
@@ -14659,6 +19140,18 @@ msgstr "Փուլավորման հաստատում..."
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Դնել լռ&ելյայն"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -14681,7 +19174,8 @@ msgstr "MP3 ֆայլեր"
 msgid "HTML file"
 msgstr "MP3 ֆայլեր"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Անուն ֆայլեր՝"
 
@@ -14698,9 +19192,24 @@ msgid "Disallow"
 msgstr "Արգելված"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Արգելված"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Անհաջող հեռացում %s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -14711,16 +19220,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Ընտրել MIDI ֆայլ..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Չվերցված զտումներ՝"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Ընտրել MIDI ֆայլ..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Տոնի ստեղծում"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "&Զտման տեսակը՝"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -14733,6 +19284,10 @@ msgstr "Հեռացնել ձայնագրությունը"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Ձայնի ստեղծում"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -14751,8 +19306,20 @@ msgid "Swing amount"
 msgstr "Այլակերպում"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Ժամաքանակ կրկնելու՝"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -14775,12 +19342,54 @@ msgid "Beat sound"
 msgstr "Կրկնել"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Աղմուկի հեռացում"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Աղմուկի ծածկ"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -14803,6 +19412,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Գծային հաճախականություն"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Հաճախականություն (Հց)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Լայնք (0-1)"
 
@@ -14813,6 +19431,10 @@ msgstr "Չի ստացվում վերցնել"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Հաստատվում է..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -14831,6 +19453,10 @@ msgid "HTML files"
 msgstr "MP3 ֆայլեր"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Փոխել նմուշ"
 
@@ -14843,8 +19469,29 @@ msgid "Include header information"
 msgstr "Ստեղծման տեղեկություն"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Բոլորը"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -14859,6 +19506,11 @@ msgstr "\t-help (Տ-Օգնություն)"
 msgid "Errors Only"
 msgstr "Եղավ սխալ՝"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -14871,6 +19523,46 @@ msgstr "Աջ ալիք"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "նմուշներ"
 
@@ -14878,6 +19570,43 @@ msgstr "նմուշներ"
 #, lisp-format
 msgid "~a seconds."
 msgstr "վարկյան"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -14896,6 +19625,10 @@ msgid "Value (dB)"
 msgstr "Եռատակ (դԲ)՝"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Գծային"
 
@@ -14912,6 +19645,14 @@ msgid "Right (dB)"
 msgstr "Աջ"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Գծային"
 
@@ -14922,6 +19663,40 @@ msgstr "2 Ալիքներ (Ստերեո-երկու դինամիկ)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 Ալիք (Մոնո-մեկ դինամիկ)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Սխալ (ֆայլը կարող է չգրվել)՝ %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -14936,8 +19711,40 @@ msgid "Select file"
 msgstr "Ընտրել MIDI ֆայլ..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Եղավ սխալ"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -14947,6 +19754,15 @@ msgstr "Չի հաջողվում բացել ոճի ֆայլը:"
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Տեղավորել նշվածը"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -14969,8 +19785,16 @@ msgid "Wet level (percent)"
 msgstr "2 փուլ"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Հաստատվում է..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -15012,9 +19836,96 @@ msgstr "Ստուգել"
 msgid "Strength"
 msgstr "Զտիչ"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Ընթացքի մեջ է"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -15048,6 +19959,189 @@ msgstr "Հաճախականություն (Հց)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Հաճախականություն (Հց)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Փակել Աուդասիթին"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Ալիք"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Ֆայլի բացումը անհաջող էր"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Ժամաչափի բեռնման սխալ"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Աուդասիթի %s գործիքադարակ"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Ձայնագրում"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Հրահանգ՝"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Ներմուծում GStreamer-ի միջոցով"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Հնարավոր չէր այն ավելի օպտիմալացնել: Շատ բարձր է:"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը հատեց ձայնի մակարդաչափը %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Հնարավոր չէր այն ավելի օպտիմալացնել: Շատ ցածր է:"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը մինչ %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Վերլուծությունների ընդհանուր թիվը գերազանցել է, չգտնելով ձայնաչափը: Կրկին բարձր է:"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: Վերլուծությունների ընդհանուր թիվը գերազանցել է, չգտնելով ձայնաչափը: Կրկին ցածր է:"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Ավտոմատ ձայնագրման փուլի սանդղակը դադարեց: %.2f թվաց ընդհանուր ձայնաչափ:"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Չի հաջողվում բացել ոճի ֆայլը:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Փոփոխվող ձայնագրում\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Նվագարկման ձայնաչափ\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Ձայնագրման ձայնաչափ\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Ձայնագրման ձայնաչափ\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Նվագարկման ձայնաչափ՝ %.2f%s\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Նվագարկման ձայնաչափ՝ %.2f%s\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "FFmpeg համատեղելի ֆայլեր"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Ընդլայնված ներմուծում"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Անհնար է անվանափոխել '%s' ից '%s'."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Ինդեքս[%02x] Կոդեկ[%S], Լեզու[%S], Բիթաչափ[%S], Ալիքներ[%d], Տևողություն[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Կարգավորել նվագարկման ձայնաչափը"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Նվագարկման ձայնաչափի ավելացում"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Նվագարկման ձայնաչափի նվազեցում"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Կարգավորել ձայնագրման ձայնաչափը"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Ձայնագրման ձայնաչափի ավելացում"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Ձայնագրման ձայնաչափի նվազեցում"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Աուդասիթի պատմության գրքույկ"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Աուդասիթիի մասին..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Ա&վտոմատ ձայնագրման փուլի հարմարեցում (միացնել/անջատել)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Ավտոմատ ձայնագրման փուլի ճշգրտում"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Միացնել ավտոմատ ձայնագրման փուլի ճշգրտումը"
+
+#~ msgid "Target Peak:"
+#~ msgstr "Նշանակետի գագաթ՝"
+
+#~ msgid "Within:"
+#~ msgstr "Ընթացքում՝"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Անալիզի ժամ՝"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "միլիվարկյաններ (մեկ անալիզի ժամանակ)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Անընդմեջ վերլուծության քանակ՝"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 նշանակված անվերջություն"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Ձայնագրման ձայնաչափ"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Նվագարկման ձայնաչափ"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Ձայնագրման ձայնաչափ՝ %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Ձայնագրման ձայնաչափ (Անհասանելի է; օգտվե՛ք համակարգի միախառնումից)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Նվագարկման ձայնաչափ՝ %.2f%s"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Նվագարկման ձայնաչափ՝ %.2f%s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Նվագարկման ձայնաչափ (Անհասանելի է; օգտվե՛ք համակարգի միախառնումից)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Միախառնող գործիքադարակ"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Սեղմեք և քաշեք, ձայնագրության չափը փոփոխելու համար:"
+
 #~ msgid "Program build date:"
 #~ msgstr "Ծրագրի ստեղծման ամսաթիվը՝"
 
@@ -15061,10 +20155,6 @@ msgstr "Հաճախականություն (Հց)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "Ան"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Անհնար է բացել/ստեղծել թեստային ֆայլ:"
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -15714,9 +20804,6 @@ msgstr "Հաճախականություն (Հց)"
 #~ msgid "Selected:"
 #~ msgstr "Ընտրել"
 
-#~ msgid "ms"
-#~ msgstr "մվ"
-
 #~ msgid "xml files (*.xml;*.XML)|*.xml;*.XML"
 #~ msgstr "xml ֆայլեր (*.xml;*.XML)|*.xml;*.XML"
 
@@ -16108,10 +21195,6 @@ msgstr "Հաճախականություն (Հց)"
 #~ msgstr "Արտագրում"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "Գործիքադարակներ"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "Կատարող"
 
@@ -16217,10 +21300,6 @@ msgstr "Հաճախականություն (Հց)"
 #, fuzzy
 #~ msgid "S-E"
 #~ msgstr "Հոսքային ՍԻՄԴ հավելում"
-
-#, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
 
 #, fuzzy
 #~ msgid "Show start time and end time"
@@ -16449,10 +21528,6 @@ msgstr "Հաճախականություն (Հց)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "Ընդհատել ից՝"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Հետդարձում"
 
 #~ msgid "C&ategory:"
 #~ msgstr "Տեսակ՝"

--- a/locale/id.po
+++ b/locale/id.po
@@ -9,82 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-04 21:06+0000\n"
 "Last-Translator: liimee <alt3753.7@gmail.com>\n"
-"Language-Team: Indonesian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/id/>\n"
+"Language-Team: Indonesian <https://hosted.weblate.org/projects/tenacity/tenacity/id/>\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.8-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Perbarui Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Lewati"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Pasang pembaruan"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Saluran"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Baca lebih lanjut di GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Terjadi kesalahan ketika memeriksa pembaruan"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Tidak dapat menghubungi server pembaruan Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Data pembaruan rusak."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Terjadi kesalahan ketika mengunduh pembaruan."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Tidak dapat membuka tautan unduhan Tenacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s tersedia!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Rekam"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -100,6 +34,18 @@ msgstr "%s bita"
 #, c-format
 msgid "%s KB"
 msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -122,12 +68,63 @@ msgid "&Nyquist Workbench..."
 msgstr "Prompt Nyquist..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Tempel\tCtrl+V"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Tempel\tCtrl+V"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Tempel\tCtrl+V"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Tempel\tCtrl+V"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Pilih"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -150,15 +147,37 @@ msgid "Show &Output"
 msgstr "Tunjukkan output"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "&Toolbar"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "&Berhenti"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Variabel"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Meter Output"
 
@@ -166,13 +185,38 @@ msgstr "Meter Output"
 msgid "Load Nyquist script"
 msgstr "Prompt Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Perhatian"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Prompt Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -183,12 +227,20 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "dari Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Efek"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "No matches found"
 msgstr "Tidak ada perangkat"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
@@ -198,9 +250,15 @@ msgstr "tak berjudul"
 msgid "Nyquist Effect Workbench - "
 msgstr "Efek"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Baru"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Buka yang Sebelumnya"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -234,7 +292,8 @@ msgstr "Salin"
 msgid "Copy to clipboard"
 msgstr "Potong ke Clipboard"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Potong"
 
@@ -242,7 +301,8 @@ msgstr "Potong"
 msgid "Cut to clipboard"
 msgstr "Potong ke Clipboard"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Tempel"
 
@@ -267,7 +327,8 @@ msgstr "Pilih"
 msgid "Select all text"
 msgstr "Pilih"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Batalkan"
 
@@ -275,9 +336,20 @@ msgstr "Batalkan"
 msgid "Undo last change"
 msgstr "Perubahan Format"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Lakukan Kembali"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Perubahan Format"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "&Cari Nada"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -288,23 +360,46 @@ msgid "Match"
 msgstr "Batch"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "Ke:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Tidak ada label untuk diekspor."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Atas"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Alat Sebelumnya"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Pindahkan Fokus ke Trek Sebelumnya dan Pilih"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Alat Selanjutnya"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Awal"
 
@@ -312,7 +407,8 @@ msgstr "Awal"
 msgid "Start script"
 msgstr "Prompt Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Berhenti"
 
@@ -320,15 +416,29 @@ msgstr "Berhenti"
 msgid "Stop script"
 msgstr "Prompt Nyquist..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informasi Perubahan"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Dibolehkan"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Dilarang"
 
@@ -338,8 +448,9 @@ msgid "The Build"
 msgstr "Versi Debug"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Perintah:"
+#, fuzzy
+msgid "Version:"
+msgstr "Menukar Balik"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -349,13 +460,23 @@ msgstr "Tipe perubahan:"
 msgid "Compiler:"
 msgstr "Kompresor"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Awalan Instalasi:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Folder pengaturan:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Folder pengaturan:"
 
 #: src/AboutDialog.cpp
@@ -374,7 +495,6 @@ msgstr "Konversi sample rate"
 msgid "MP3 Importing"
 msgstr "Mengimpor MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Impor dan Ekspor Ogg Vorbis"
@@ -383,7 +503,6 @@ msgstr "Impor dan Ekspor Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Dukungan Tag ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Impor dan Ekspor FLAC"
@@ -401,14 +520,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Referensi Impor/Ekspor FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Impor melalui QuickTime"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Fitur"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Dukungan Plug-in"
 
@@ -423,6 +534,10 @@ msgstr "Dukungan Perubahan Pitch dan Tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Dukungan Perubahan Pitch dan Tempo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Fitur"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -449,6 +564,18 @@ msgstr "Amplop"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Amplop"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Amplop"
 
@@ -460,9 +587,51 @@ msgstr "Amplop"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Amplop"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Amplop"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Amplop"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "Grafik EQ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Amplop"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Amplop"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -483,8 +652,26 @@ msgid "%s, graphics"
 msgstr "Grafik EQ"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Orang-Orang yang Berjasa"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -519,14 +706,23 @@ msgid "%s Team Members"
 msgstr "Anggota Tim Emeritus Lainnya"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Kontributor Lainnya"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Bahasa Indonesia: Lukmanul Hakim (lukmanul.hakim91@ui.ac.id)"
@@ -545,6 +741,26 @@ msgstr "Terima kasih untuk:"
 msgid "%s website: "
 msgstr "Pengoperasian Pertama Audacity"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Kontributor Lainnya"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Klik dan dorong untuk mengubah ukuran relatif trek stereo."
@@ -562,6 +778,7 @@ msgstr "Pengubah Nama"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kik dan dorong untuk mengedit sampel"
@@ -569,17 +786,66 @@ msgstr "Kik dan dorong untuk mengedit sampel"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klik dan dorong untuk mengubah ukuran trek"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Pindahkan Fokus ke Trek Selanjutnya dan Pilih"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Pindahkan Trek ke Bawah"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Tutup trek yang terfokus"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr " (dilarang)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr " (dilarang)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "Aturan Plugin"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -597,13 +863,46 @@ msgstr "Mai&nkan Wilayah"
 msgid "Pinned Play Head"
 msgstr "Selesai merekam"
 
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Error"
+msgstr "Error"
+
 #: src/AudacityApp.cpp
 #, c-format
 msgid "Failed to remove %s"
 msgstr "Tidak bisa membuang '%s'"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Preferensi Audacity"
 
 #: src/AudacityApp.cpp
@@ -616,6 +915,14 @@ msgstr ""
 "%s tidak bisa ditemukan.\n"
 "\n"
 "Ini sudah dibuang dari daftar file terkini."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -636,7 +943,7 @@ msgstr "B&uka..."
 msgid "Open &Recent..."
 msgstr "Buka yang &Sebelumnya..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Tentang Audacity"
@@ -650,29 +957,33 @@ msgid "&File"
 msgstr "&Berkas"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity tidak bisa mencari tempat untuk meletakkan file temporary.\n"
 "Tolong masukkan direktori yang benar ke dalam dialog preferensi."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity tidak bisa mencari tempat untuk meletakkan file temporary.\n"
 "Tolong masukkan direktori yang benar ke dalam dialog preferensi."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity sekarang ingin keluar. Tolong aktifkan Audacity kembali untuk menggunakan direktori file temporary yang baru."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -681,15 +992,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity tidak bisa mengunci direktori file temporary.\n"
 "Folder ini mungkin digunakan oleh program Audacity yang Lain.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Anda ingin tetap menjalankan Audacity?"
 
 #: src/AudacityApp.cpp
@@ -697,24 +1010,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "Error dalam mengunci folder temporary"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Sistem telah mendeteksi bahwa Audacity yang lainnya sedang berjalan.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Gunakan komando Baru atau Buka waktu menjalankan\n"
 "Audacity untuk membuka beberapa proyek sekaligus.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity sudah berjalan"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "File Proyek Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -734,7 +1095,8 @@ msgstr "\t-test (jalankan diagnosa otomatis)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-versi (tampilan versi Audacity)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -744,9 +1106,10 @@ msgid "audio or project file name"
 msgstr "Tidak bisa membuka file proyek"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -759,20 +1122,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "File Proyek Audacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&Sampel Ulang..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Informasi Perubahan"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Bantuan"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Keluar dari Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Proyek Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -784,9 +1176,14 @@ msgstr "Sim&pan..."
 msgid "Cl&ear"
 msgstr "Hap&us"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Tutup"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -835,7 +1232,8 @@ msgid "Error Initializing Midi"
 msgstr "Error Menginisialisasi Midi"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Proyek Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -846,39 +1244,21 @@ msgid ""
 msgstr "Error ketika membuka perangkat suara."
 
 #: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Perubahan Level Input Otomatis dihentikan. Tidak mungkin membenahi lebih jauh. Tetap terlalu tinggi."
+msgid "Out of memory!"
+msgstr ""
 
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Perubahan Level Input Otomatis mengurangi volume ke %f"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Perubahan Level Input Otomatis dihentikan. Tidak mungkin membenahi lebih jauh. Tetap terlalu rendah."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Perubahan Level Input Otomatis menaikkan volume ke %f"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Perubahan Level Input Otomatis dihentikan. Angka total analisis telah melebihi batas tanpa menemukan volume yang cocok. tetap terlalu tinggi."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Perubahan Level Input Otomatis dihentikan. Angka total analisis telah melebihi batas tanpa menemukan volume yang cocok. tetap terlalu rendah."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Perubahan Level Input Otomatis dihentikan. %.2f sepertinya volume yang cocok."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Pilih Sumber Input\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Pilih Sumber Input\n"
 
 #: src/AudioIOBase.cpp
@@ -921,8 +1301,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Selesai merekam\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Selesai merekam\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Selesai merekam\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Selesai merekam\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -936,37 +1326,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Pilih Sumber Input\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Pilih Sumber Input\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Pilih Sumber Input\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Tidak bisa membuka file genre.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Pilih Sumber Input\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Merekam\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Rate Sampel\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Memainkan\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Selesai merekam\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Selesai merekam\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Memainkan\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Memainkan\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -974,8 +1367,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Pilih Sumber Input\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Pilih Sumber Input\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Pilih Sumber Input\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Pilih Sumber Input\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -983,8 +1386,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Pengembalian Otomatis Akibat Crash"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -996,12 +1400,14 @@ msgid "Recoverable &projects"
 msgstr "Proyek yang dipindahkan"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Pilih"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nama"
 
@@ -1012,6 +1418,11 @@ msgstr "Pilih"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Pilih"
+
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Skip"
+msgstr "&Lewati"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1045,6 +1456,11 @@ msgstr "Simpan Aturan Lanjut"
 #: src/BatchCommandDialog.cpp
 msgid "&Parameters"
 msgstr "&Parameter"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Lepas"
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
@@ -1081,6 +1497,22 @@ msgstr "Efek"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Edit Parameter"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Edit Parameter"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1127,11 +1559,30 @@ msgstr "Mode Percobaan"
 msgid "Apply %s"
 msgstr "Mengaplikasikan %s"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Pilih kurva:"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Label..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Mengaplikasikan Untaian"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1199,7 +1650,8 @@ msgstr "Wila&yah Pengembalian"
 msgid "I&mport..."
 msgstr "&Impor..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Ekspor"
 
@@ -1240,9 +1692,15 @@ msgstr "Pindah ke &Atas"
 msgid "Move &Down"
 msgstr "Pindak ke &Bawah"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Simpan"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1288,11 +1746,38 @@ msgid "Benchmark"
 msgstr "&Jalankan Benchmark..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Number of times to repeat:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Tutup"
 
@@ -1307,12 +1792,32 @@ msgid "Export Benchmark Data as:"
 msgstr "Ekspor data spektral sebagai:"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "Jumlah Nada Maksimum harus berupa angka dan diantara 1..128"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "Jumlah Nada Maksimum harus berupa angka dan diantara 1..128"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "Jumlah Nada Maksimum harus berupa angka dan diantara 1..128"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Meyiapkan preview\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1321,22 +1826,113 @@ msgstr "Mengulang\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Tempel\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Merekam Audio\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Tanggal dan Waktu selesai"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Versi Rilis"
 
 #: src/BuildInfo.h
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Versi Rilis"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1347,9 +1943,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Anda harus pilih beberapa audio terlebih dahulu."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Tidak ada untaian yang dipilih"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1377,6 +1997,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Gagal mencari codec"
 
@@ -1394,10 +2019,24 @@ msgstr "Aplikasikan ke proyek yang tersedia"
 msgid "Checkpointing %s"
 msgstr "Mengimpor %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Tidak bisa menulis file:\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Tidak bisa menyimpan proyek. Mungkin %s \n"
+"tidak bisa ditulis atau disk penuh."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1414,6 +2053,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "Tidak bisa membuang '%s'"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1436,6 +2079,14 @@ msgstr ""
 "Ini membutuhkan ruang lebih banyak, tetapi lebih aman."
 
 #: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Project Dependencies"
 msgstr "Ketergantungan Proyek"
 
@@ -1454,6 +2105,11 @@ msgstr "Menyalin Audio yang Dipilih ke dalam Proyek"
 #: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "Batalkan Penyimpanan"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Label"
 
 #: src/Dependencies.cpp
 msgid "Do Not Copy"
@@ -1486,8 +2142,18 @@ msgid "Never copy any files"
 msgstr "Tidak pernah menyalin audio apapun"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Potong ke Clipboard"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1498,10 +2164,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Proyek Anda tidak akan disimpad di disk. Itukan yang Anda mau?"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "Cek ketergantungan"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Tidak Ada"
 
@@ -1509,7 +2187,7 @@ msgstr "Tidak Ada"
 msgid "Rectangle"
 msgstr "Persegi"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Segitiga"
 
@@ -1523,17 +2201,58 @@ msgstr "Bersiku"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Selamat Datang!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Dukungan FFMpeg tidak terkompilasi"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1547,12 +2266,17 @@ msgid "FFmpeg startup failed"
 msgstr "Awalan FFMpeg gagal"
 
 #: src/FFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg library not found"
+msgstr "FFmpeg tidak ada"
+
+#: src/FFmpeg.cpp
 msgid "Locate FFmpeg"
 msgstr "Tempatkan FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity memerlukan file %s untuk menegkspor dan mengimpor dengan FFmpeg.."
 
 #: src/FFmpeg.cpp
@@ -1565,7 +2289,8 @@ msgstr "Lokasi %s:"
 msgid "To find '%s', click here -->"
 msgstr "Untuk mencari %s, click here -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Jelajah..."
 
@@ -1591,8 +2316,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg tidak ada"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1612,24 +2338,38 @@ msgstr "Jangan tunjukkan peringatan ini lagi"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Gagal untuk mencari referensi FFMpeg yang kompetibel"
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity tidak bisa menulis file:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Audacity tidak bisa menulis file:\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Audacity tidak bisa menulis file:\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1666,7 +2406,9 @@ msgstr "Ja&ngan salin audio apapiun"
 msgid "As&k"
 msgstr "Tan&ya pengguna"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Semua File (*)|*"
 
@@ -1675,6 +2417,11 @@ msgstr "Semua File (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Menyimpan file data proyek"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Referensi"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1687,6 +2434,10 @@ msgstr "Nama file:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "File MP3"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1751,6 +2502,36 @@ msgstr "Frekuensi linier"
 msgid "Log frequency"
 msgstr "Frekuensi logaritma"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoom"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
+
 #: src/FreqWindow.cpp
 #, fuzzy
 msgid "Scroll Horizontal"
@@ -1764,6 +2545,10 @@ msgstr "Stereo Horizontal"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Kursor Kiri"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1811,6 +2596,32 @@ msgstr "Data yang dipilih tidak cukup"
 msgid "s"
 msgstr "d"
 
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "spektrum.txt"
@@ -1819,7 +2630,8 @@ msgstr "spektrum.txt"
 msgid "Export Spectral Data As:"
 msgstr "Ekspor data spektral sebagai:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Tidak bisa menulis file:"
@@ -1895,6 +2707,26 @@ msgid "No Local Help"
 msgstr "Tidak Ada Bantuan lokal"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "These are our support methods:"
 msgstr "Ini adalah metode dukungan kami:"
 
@@ -1916,6 +2748,22 @@ msgstr " <a href=\"http://forum.audacityteam.org/\">Forum</a> (tanyakan secara l
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
 msgstr " [[http://wiki.audacityteam.org/index.php|Wiki]] (tips, trik dan tutorial terbaru di internet)"
 
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
 #: src/HistoryWindow.cpp
 msgid "History"
 msgstr "&History..."
@@ -1933,6 +2781,10 @@ msgid "Used Space"
 msgstr "Ruang disk"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Dibolehkan Pembatalan Level"
 
@@ -1946,12 +2798,42 @@ msgid "&Discard"
 msgstr "&Larang"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Larang"
 
 #: src/HistoryWindow.cpp
 msgid "&Compact"
 msgstr "&Komando"
+
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the various editing steps
+#. that have been taken.
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&History..."
+msgstr "&History..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -1965,6 +2847,14 @@ msgstr "Edit Label"
 #: src/LabelDialog.cpp
 msgid "Track"
 msgstr "Trek"
+
+#. i18n-hint: (noun)
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#, fuzzy
+msgid "Label"
+msgstr "Label"
 
 #. i18n-hint: (noun) of a label
 #: src/LabelDialog.cpp src/TimerRecordDialog.cpp
@@ -2022,18 +2912,25 @@ msgstr "Masukkan nama trek"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Trek Label"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Pengoperasian Pertama Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Pilih Bahasa untuk digunakan pada Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2043,7 +2940,8 @@ msgstr "Pilih Bahasa untuk digunakan pada Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Bahasa yang Anda gunakan, %s (%s), tidak sama dengan bahasa sistem, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Konfirmasi"
 
@@ -2061,13 +2959,19 @@ msgstr ""
 "File lama telah disimpan sebagai '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Membuka Proyek Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke%s Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Jelajah..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2099,6 +3003,12 @@ msgstr ""
 msgid "Disallowed"
 msgstr "Tidak Diperbolehkan"
 
+#. i18n-hint: noun, means a track, made by mixing other tracks
+#: src/Mix.cpp
+#, fuzzy
+msgid "Mix"
+msgstr "Mix"
+
 #: src/Mix.cpp src/menus/TrackMenus.cpp
 msgid "Mix and Render"
 msgstr "Mix dan Render"
@@ -2108,19 +3018,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Trek Mix dan Render"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Mixer Board%s Audacity"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Kekuatan"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Kecepatan nada"
 
@@ -2128,24 +3042,45 @@ msgstr "Kecepatan nada"
 msgid "Musical Instrument"
 msgstr "Instrumen Musikal"
 
+#. i18n-hint: Title of the Pan slider, used to move the sound left or right
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Pan"
+msgstr "Panel Trek"
+
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Diam"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Pengukur Level Signal"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Pindahkan slider kekuatan"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Pindahkan slider kekuatan"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Pindahkan slider pan"
 
@@ -2161,13 +3096,73 @@ msgid ""
 "Error: %s"
 msgstr "Tidak bisa membuka atau membuat file tes"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Dibolehkan"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy, c-format
+msgid "Module \"%s\" found."
+msgstr "FFmpeg tidak ada"
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Tidak Ada"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Modulator"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -2182,18 +3177,121 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Meniban file yang sudah ada"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2221,6 +3319,16 @@ msgstr "Prompt Nyquist"
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Kelola Plug-in"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Tunjukkan Semua Codec"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -2252,6 +3360,25 @@ msgstr "Dibolehkan"
 msgid "E&nabled"
 msgstr "Dibolehkan"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Dibolehkan"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Pilih"
@@ -2260,7 +3387,8 @@ msgstr "Pilih"
 msgid "C&lear All"
 msgstr "&Hapus"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Dibolehkan"
 
@@ -2326,6 +3454,21 @@ msgstr "Error ketika membuka perangkat suara. Tolong cek pengaturan perangkat ou
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Untuk memplot spektrum, semua trek yang dipilih harus mempunyai rate sampel yang sama."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Rekaman Audio"
@@ -2333,6 +3476,28 @@ msgstr "Rekaman Audio"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "Rekam"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2348,23 +3513,61 @@ msgid "Close project immediately with no changes"
 msgstr "Tutup proyek secepatnya tanpa perubahan"
 
 #: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
 msgid "Inspecting project file data"
 msgstr "Memeriksa data file proyek..."
+
+#: src/ProjectFSCK.cpp
+#, fuzzy, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+"Pengecekan menemukan file data blok audio %lld yang menghilang (.au), \n"
+"mungkin karena bug, crash, atau ketidaksengajaan. \n"
+"Tidak ada jalan lain selain mengembalikan data yang hilang\n"
+"secara otomatis; Anda bisa memilih untuk tetap mengosongkan data tadi\n"
+"atau secara sementara atau tutup proyek dan mencoba mengembalikannya sendiri."
 
 #: src/ProjectFSCK.cpp
 msgid "Treat missing audio as silence (this session only)"
 msgstr "Mengembalikan data yang hilang diam-diam secara sementara [hanya sesi ini saja]"
 
 #: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr "Kosongkan data yang hilang [permanen]"
+
+#: src/ProjectFSCK.cpp
 msgid "Warning - Missing Aliased File(s)"
 msgstr "File alias menghilang: (%s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Pengecekan menemukan file rangkuman %lld yang hilang (.auf).\n"
@@ -2387,12 +3590,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "File rangkuman menghilang: (%s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2411,6 +3614,11 @@ msgstr ""
 #: src/ProjectFSCK.cpp
 msgid "Replace missing audio with silence (permanent immediately)"
 msgstr "Kosongkan data yang hilang [permanen]"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr "File alias menghilang: (%s)"
 
 #: src/ProjectFSCK.cpp
 #, c-format
@@ -2438,7 +3646,8 @@ msgstr "Anak file blok: (%s)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Kemajuan"
 
@@ -2446,9 +3655,26 @@ msgstr "Kemajuan"
 msgid "Cleaning up unused directories in project data"
 msgstr "Membersihkan direktori yang tak berguna apda data proyek..."
 
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning: Problems in Automatic Recovery"
+msgstr "Error dalam Durasi"
+
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "tak berjudul"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Proyek"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2487,11 +3713,96 @@ msgid ""
 msgstr "Tidak bisa membuka atau membuat file tes"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Tidak bisa membuang '%s'"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Menyimpan Proyek Audacity"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Tidak bisa menginisialisasi strim MP3"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tidak bisa menginisialisasi strim MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tidak bisa menginisialisasi strim MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tidak bisa menginisialisasi strim MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tidak bisa menginisialisasi strim MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tidak bisa menginisialisasi strim MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Tidak bisa menginisialisasi strim MP3"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Tidak bisa menginisialisasi strim MP3"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2505,12 +3816,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Anak file blok: (%s)"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Tidak bisa meganti nama '%s' ke '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Gagal mencari codec"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Tidak bisa membuang '%s'"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2521,9 +3853,9 @@ msgid "Error Writing to File"
 msgstr "Error menulis ke file"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2534,8 +3866,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Menyimpan &proyek"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2545,10 +3886,10 @@ msgstr "(Terkembalikan)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "File ini disimpan dengan Audacity %s.\n"
 "Anda menggunakan Audacity %s - anda diharuskan untuk\n"
@@ -2557,6 +3898,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Tidak bisa membuka file proyek"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2571,6 +3916,10 @@ msgid "Unable to parse project information."
 msgstr "Tidak bisa membuka atau membuat file tes"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Menyimpan &proyek"
 
@@ -2579,12 +3928,35 @@ msgid "Error Saving Project"
 msgstr "Error Meyimpan Proyek"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "M&enyimpan proyek kosong"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2592,8 +3964,24 @@ msgstr ""
 "Pada yang akan datang, proyek-proyek ini bisa dikembalikan secara otomatis:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Beberapa proyek tidak disimpan sebelumnya waktu Audacity terakhir dijalankan.\n"
+"Pada yang akan datang, proyek-proyek ini bisa dikembalikan secara otomatis:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Proyek telah dikembalikan"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Direktori file sementara"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2623,6 +4011,17 @@ msgstr "Peringatan proyek kosong"
 msgid "Insufficient Disk Space"
 msgstr "Ruang disk"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -2640,6 +4039,25 @@ msgstr ""
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Simpan Proyek Sebagai..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2693,11 +4111,12 @@ msgid "Error Opening Project"
 msgstr "Error dalam membuka proyek"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Anda mencoba membuka file backup yang dibuat otomatis.\n"
 "Melakukannya memungkinkan beberapa data hilang.\n"
@@ -2730,6 +4149,12 @@ msgid "Error Opening File or Project"
 msgstr "Error dalam membuka file atau proyek"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Proyek telah dikembalikan"
 
@@ -2755,12 +4180,33 @@ msgid "Error Importing"
 msgstr "Error menginpor"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Simpan Proyek"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Tidak bisa membuka file proyek"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Komando"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2771,8 +4217,8 @@ msgid "Automatic database backup failed."
 msgstr "Pengembalian Otomatis Akibat Crash"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Selamat datang di Audacity versi %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2807,6 +4253,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "Ruang disk tinggal %d menit waktu rekaman."
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -2819,6 +4269,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2835,6 +4297,26 @@ msgstr "Stereo Horizontal"
 msgid "Vertical Scrollbar"
 msgstr "Stereo Vertikal"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(Kualitas Terbaik)"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Kualitas"
@@ -2846,6 +4328,28 @@ msgstr "Kualitas"
 #: src/Resample.cpp
 msgid "Best Quality (Slowest)"
 msgstr "(Kualitas Terbaik)"
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "32-bit float"
+msgstr "32-bit float"
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -2931,7 +4435,8 @@ msgstr "Preferensi..."
 msgid "SelectionBar"
 msgstr "BarSeleksi"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Pilihan"
 
@@ -2939,31 +4444,61 @@ msgstr "Pilihan"
 msgid "Timer"
 msgstr "Waktu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Alat"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "T&ransportasi"
 
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Mixer"
+msgstr "Panel Mixer"
+
+#. i18n-hint: Noun (the meter is used for playback or record level monitoring)
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter"
+msgstr "Pengukur Permainan"
+
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Pengukur Permainan"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Pengukur Rekaman"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "E&dit..."
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Perangkat"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Memainkan berkecepatan"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "&Toolbar"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -2976,7 +4511,10 @@ msgstr "Penggaris"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Trek"
 
@@ -3028,6 +4566,22 @@ msgstr "Trek Panjang"
 msgid "Choose a location to save screenshot images"
 msgstr "Pilih lokasi untuk menyimpan gambar hasil screenshot"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-bantuan (pesan ini)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
 #: src/Sequence.cpp
 msgid "Warning - Truncating Overlong Block File"
 msgstr "Anak file blok: (%s)"
@@ -3048,6 +4602,19 @@ msgstr "&Opsi..."
 msgid "Debu&g"
 msgstr "&Benah"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "Hidupkan Patokan"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
 #: src/SoundActivatedRecord.cpp
 msgid "Sound Activated Record"
 msgstr "Rekam dengan Suara Diaktifkan"
@@ -3057,7 +4624,8 @@ msgid "Activation level (dB):"
 msgstr "Level Aktivasi (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Selamat datang di Audacity!"
 
 #: src/SplashDialog.cpp
@@ -3088,6 +4656,11 @@ msgstr "Nomor Trek"
 msgid "Year"
 msgstr "Tahun"
 
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genre"
+msgstr "Genre"
+
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Kommentar"
@@ -3095,6 +4668,10 @@ msgstr "Kommentar"
 #: src/Tags.cpp
 msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
 msgstr "Gunakan tombol arah (atau tombol RETURN setelah mengedit) untuk navigasi."
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Value"
@@ -3111,6 +4688,11 @@ msgstr "&Buang"
 #: src/Tags.cpp
 msgid "Genres"
 msgstr "Genre"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "E&dit..."
 
 #: src/Tags.cpp
 msgid "Rese&t..."
@@ -3172,19 +4754,45 @@ msgstr "Error menyimpan file tags"
 msgid "Unsuitable"
 msgstr "Dibolehkan"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Direktori file sementara"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity tidak bisa menulis file:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3193,18 +4801,26 @@ msgstr ""
 "untuk ditulis."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity tidak bisa menulis gambar ke file:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3214,9 +4830,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3225,8 +4841,9 @@ msgstr ""
 "Format png yang buruk mungkin?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity tidak bisa membaca tema normalnya.\n"
@@ -3264,24 +4881,40 @@ msgstr ""
 "sudah ada."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity tidak bisa menyimpan file:\n"
 "  %s"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "Cahaya"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Kontras..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Nama Trek"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3290,7 +4923,11 @@ msgstr "Kontras..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Durasi"
 
@@ -3301,7 +4938,8 @@ msgid "Time Track"
 msgstr "Trek Waktu"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Pencatat Waktu Rekaman Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -3330,12 +4968,38 @@ msgid "Error in Duration"
 msgstr "Error dalam Durasi"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Pengembalian Otomatis Akibat Crash"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Error dalam Durasi"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Pengeksporan FFmpeg Pilihan Sendiri"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "Error dalam Durasi"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "Pen&catat waktu rekaman..."
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3345,7 +5009,8 @@ msgstr "Aplikasikan ke proyek yang tersedia"
 msgid "Recording start:"
 msgstr "Mulai merekam"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Durasi"
 
@@ -3366,7 +5031,8 @@ msgid "Action after Timer Recording:"
 msgstr "Pencatat Waktu Rekaman Audacity"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Peningkatan Pencatat Waktu Rekaman Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -3401,6 +5067,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "Selesai merekam"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Error Meyimpan Proyek"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Merekam"
@@ -3420,6 +5110,7 @@ msgstr "0100 hari 024 jam 060 mnt 060 dtk"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Tanggal dan Waktu mulai"
@@ -3464,7 +5155,8 @@ msgstr "Tidak bisa mengekspor"
 msgid "Export Project As:"
 msgstr "Ekspor Aturan Lanjut"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opsi"
 
@@ -3473,8 +5165,21 @@ msgid "After Recording completes:"
 msgstr "Pengukur Rekaman"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Keluar dari Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3489,7 +5194,8 @@ msgid "Scheduled to stop at:"
 msgstr "Pilih ke Awal"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Pencatat Waktu Rekaman Audacity - Menunggu untuk mulai"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3497,6 +5203,14 @@ msgstr "Pencatat Waktu Rekaman Audacity - Menunggu untuk mulai"
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Selesai merekam"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3507,8 +5221,19 @@ msgid "Recording Exported:"
 msgstr "Selesai merekam"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Pencatat Waktu Rekaman Audacity - Menunggu untuk mulai"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo,"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3538,6 +5263,15 @@ msgstr "Solo"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Pilih"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "Pilih Diam"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -3616,6 +5350,10 @@ msgstr "Pindahkan Trek ke Atas"
 msgid "Move Track Down"
 msgstr "Pindahkan Trek ke Bawah"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3661,25 +5399,79 @@ msgstr "Tidak ada ruang cukup untuk menempel itu"
 msgid "There is not enough room available to expand the cut line"
 msgstr "Tidak ada ruang yang tersedia untuk menyebarkan garis potong"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Mengaplikasikan..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Perintah"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Perintah"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ulangi %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -3694,12 +5486,20 @@ msgid "Compares a range on two tracks."
 msgstr "Pengompresan didasari oleh banyaknya Pik"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Waktu tenggang (detk):"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Faktor kekurangan:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -3721,6 +5521,11 @@ msgstr "Trek"
 msgid "Track 1"
 msgstr "Trek"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "&Ukuran jendela"
@@ -3732,6 +5537,22 @@ msgstr "Dari:"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Dari:"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -3757,9 +5578,43 @@ msgstr "Clipping"
 msgid "Envelopes"
 msgstr "Amplop"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Label"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Penyaring"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Format:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -3769,6 +5624,10 @@ msgstr "Pindahkan Trek ke Bawah"
 msgid "Types:"
 msgstr "Penyaring"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Kommentar"
@@ -3776,6 +5635,18 @@ msgstr "Kommentar"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Perintah:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -3794,6 +5665,11 @@ msgid "Number of Channels:"
 msgstr "Number of times to repeat:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Ekspor Banyak"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Ekspor Banyak"
 
@@ -3801,9 +5677,26 @@ msgstr "Ekspor Banyak"
 msgid "Builtin Commands"
 msgstr "Pilih Komando"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tim Pendukung Audacity %s"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Tanggal dan Waktu selesai"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -3845,11 +5738,22 @@ msgstr "&Simpan Proyek"
 msgid "Saves a copy of current project."
 msgstr "&Simpan Proyek"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Preferensi..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nama"
 
@@ -3860,6 +5764,18 @@ msgstr "Preferensi..."
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Nilai"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3885,7 +5801,8 @@ msgstr "Layar penuh hidup/mati"
 msgid "Toolbars"
 msgstr "&Toolbar"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efek"
 
@@ -3929,6 +5846,10 @@ msgstr "Trek Panjang"
 msgid "All Tracks Plus"
 msgstr "Trek Panjang"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -3936,13 +5857,30 @@ msgid "White"
 msgstr "Putih"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Latar Belakang:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "error dalam menyimpan file:"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Alat Screenshot..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -3989,6 +5927,10 @@ msgid "High:"
 msgstr "Batas Atas"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "Trek Kecil"
 
@@ -4001,7 +5943,8 @@ msgstr "Atur"
 msgid "Add"
 msgstr "&Tambah"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Buang"
 
@@ -4022,6 +5965,11 @@ msgid "Selects a time range."
 msgstr "Pilih file MIDI..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Pilih file MIDI..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Silahkan pilih aksinya"
 
@@ -4033,9 +5981,37 @@ msgstr "Pilihan"
 msgid "Set Clip"
 msgstr "Alat Selanjutnya"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Awal"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4054,9 +6030,14 @@ msgid "Edited Envelope"
 msgstr "Amplop"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Amplop"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4066,6 +6047,10 @@ msgstr "Labelkan Sekaligus"
 msgid "Label Index"
 msgstr "Label Edit"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Pilih"
@@ -4073,6 +6058,10 @@ msgstr "Pilih"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Label yang diedit"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4086,9 +6075,26 @@ msgstr "Atur Rate"
 msgid "Resize:"
 msgstr "Ubah ukuran lebih kecil"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Cahaya"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Simpan Proyek"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4103,6 +6109,10 @@ msgid "Set Track Status"
 msgstr "ke &Awal Trek"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "Pause"
 
@@ -4115,10 +6125,17 @@ msgid "Gain:"
 msgstr "Kekuatan"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Trek Kecil"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linier"
 
@@ -4129,6 +6146,10 @@ msgstr "Ulang"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "Waktu"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4158,9 +6179,29 @@ msgstr "Pemroses Spektral"
 msgid "Spectral Select"
 msgstr "Pilihan"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Trek Baru"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Silahkan pilih aksinya"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplify"
+msgstr "Mengamplifikasikan"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -4178,6 +6219,14 @@ msgstr "Amplitudo yang baru (dB):"
 msgid "Allo&w clipping"
 msgstr "Dibolehkan clipping"
 
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -4192,12 +6241,18 @@ msgstr "Anda memilih trek yang tidak ada suaranya. AutoDuck hanya bisa memproses
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck membutuhkan trek pengendali yang harus ditempatkan dibawah trek yang dipilih."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Banyak Duck:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "detik"
 
@@ -4221,7 +6276,8 @@ msgstr "Panjang fade down dalam: "
 msgid "Inner &fade up length:"
 msgstr "Panjang fade up dalam: "
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Ambang Batas:"
 
@@ -4230,8 +6286,17 @@ msgid "Preview not available"
 msgstr "Preview tidak tersedia"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Pilih yang di Kiri"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Ambang Batas untuk Bising:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -4242,8 +6307,18 @@ msgid "Ba&ss (dB):"
 msgstr "Boost (dB):"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "Bass Boost"
+
+#: src/effects/BassTreble.cpp
 msgid "&Treble (dB):"
 msgstr "Ja&rak (dB):"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Label Edit"
 
 #: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
@@ -4252,6 +6327,10 @@ msgstr "Ja&rak (dB):"
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Tingkat:"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -4262,8 +6341,18 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Mengubah Pitch Tanpa Mengubah Tempo"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Perubahan Tempo Final (%)"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Mengubah Pitch Tanpa Mengubah Tempo"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
@@ -4318,17 +6407,36 @@ msgstr "Frekuensi (Hz)"
 msgid "from (Hz)"
 msgstr "dari"
 
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "to (Hz)"
+msgstr "Potong:"
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "ke"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Presentase Perubahan:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Presentase Perubahan"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -4340,7 +6448,9 @@ msgstr "48"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "tidak ada"
 
@@ -4368,6 +6478,7 @@ msgstr "Vinyl RPM Standar:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Dari RPM"
@@ -4377,6 +6488,14 @@ msgstr "Dari RPM"
 msgctxt "change speed"
 msgid "&from"
 msgstr "dari"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "Dari RPM"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4476,6 +6595,24 @@ msgid "Length in seconds from %s, to"
 msgstr "Ke panjang dalam detik"
 
 #: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Pembuang Klik..."
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Nama seharusnya tidak kosong"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "Pilih ambang batas (lebih rendah, lebih sensitif):"
 
@@ -4495,6 +6632,16 @@ msgstr "Ketebalan Maksimal"
 msgid "Compressor"
 msgstr "Kompresor"
 
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -4503,6 +6650,20 @@ msgstr "%.1f detik"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f detik"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f detik"
 
 #: src/effects/Compressor.cpp
@@ -4591,7 +6752,25 @@ msgid "Release Time %.1f secs"
 msgstr "Waktu Kekurangan %.1f dtk"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Silahkan pilih aksinya"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
+msgstr "Silahkan pilih aksinya"
+
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
 msgstr "Silahkan pilih aksinya"
 
 #. i18n-hint: RMS abbreviates root mean square, a certain averaging method
@@ -4600,7 +6779,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Penganalisis kontras, untuk mengukur perbedaan volume rms diantara dua audio yang dipilih."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Akhir"
 
@@ -4660,6 +6840,18 @@ msgstr "Perbedaan:"
 msgid "&Help"
 msgstr "&Bantuan"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nol"
@@ -4705,6 +6897,10 @@ msgstr "Waktu selesai latar depan"
 msgid "Background level too high"
 msgstr "Waktu akhir latar belakang"
 
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
 msgid "WCAG2 Pass"
@@ -4731,12 +6927,22 @@ msgid "%.2f dB"
 msgstr "%.1f dB"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "No foreground measured"
+msgstr "No foreground measured"
+
+#: src/effects/Contrast.cpp
 msgid "Foreground not yet measured"
 msgstr "No foreground measured"
 
 #: src/effects/Contrast.cpp
 msgid "Measured background level"
 msgstr "Tingkat latar belakang yang terhitung"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "No background measured"
+msgstr "No background measured"
 
 #: src/effects/Contrast.cpp
 msgid "Background not yet measured"
@@ -4790,6 +6996,12 @@ msgstr "Kesuksesan Kriteria 1.4.7 dari WCAG 2.0: Gagal"
 msgid "Data gathered"
 msgstr "Data Terkumpul"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Analisis Kontras (Permasalahan WCAG 2)"
@@ -4815,12 +7027,120 @@ msgid "Medium Overdrive"
 msgstr "Konfirmasi Penibanan"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Konfirmasi Penibanan"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Pengompresan Dinamis"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Leveller"
+msgstr "Leveller..."
+
+#: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Distorsi"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Pembatas"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Konfirmasi Penibanan"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Konfirmasi Penibanan"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Konfirmasi Penibanan"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -4843,8 +7163,16 @@ msgid "Distortion"
 msgstr "Distorsi"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Distorsi"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -4859,8 +7187,21 @@ msgid "Clipping level"
 msgstr "Clipping"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Mengaplikasikan Untaian"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Pilih Ambang Batas"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -4875,6 +7216,14 @@ msgid "Repeat processing"
 msgstr "Proses Batch CleanSpeech"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Derajat Leveller"
 
@@ -4886,9 +7235,48 @@ msgstr "Pembatas"
 msgid "Wet level"
 msgstr "2 level"
 
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2 level"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "Nada DTMF..."
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -4898,7 +7286,9 @@ msgstr "Urutan DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitudo (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Durasi"
 
@@ -4936,8 +7326,17 @@ msgid "%0.f ms"
 msgstr "%.0f:1"
 
 #: src/effects/Echo.cpp
+msgid "Echo"
+msgstr ""
+
+#: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Mengekspor audio terpilih sebagai %s"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -4959,7 +7358,8 @@ msgstr "Aturan Lanjut:"
 msgid "Export Effect Parameters"
 msgstr "&Edit Parameter"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Tidak bisa membuka file:\"%s\""
@@ -4983,6 +7383,12 @@ msgstr "&Edit Parameter"
 msgid "%s: is not a valid presets file.\n"
 msgstr "Tidak bisa membuka atau membuat file tes\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Meyiapkan preview"
@@ -4990,6 +7396,15 @@ msgstr "Meyiapkan preview"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Melihat preview"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Prompt Nyquist..."
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -5026,10 +7441,30 @@ msgid "Factory Defaults"
 msgstr "Atur Nor&mal"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr ""
 "Encoder FLAC gagal menginisialisasi\n"
 "Status: %d"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -5054,6 +7489,23 @@ msgid "&Bypass"
 msgstr "Batas Band"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Diratakan"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Pindah ke &Atas"
 
@@ -5070,6 +7522,24 @@ msgid "Move effect down in the rack"
 msgstr "Telah dipindah ke trek yang lain"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Telah dipindah ke trek yang lain"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Masukkan nama untaian baru"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Laten"
@@ -5077,6 +7547,20 @@ msgstr "Laten"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Pilih Komando"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "Atur History"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Memainkan"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -5137,14 +7621,33 @@ msgid "Options..."
 msgstr "Opsi..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Penyaring"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Nama"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Menukar Balik"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Error:"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "Transkrispi"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -5176,6 +7679,11 @@ msgstr "File bernama \"%s\" telah ada. Ganti?"
 msgid "Stop &Playback"
 msgstr "Memainkan"
 
+#: src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Play"
+msgstr "Play"
+
 #. i18n-hint: Technical term for a kind of curve.
 #: src/effects/Equalization.cpp
 msgid "B-spline"
@@ -5202,8 +7710,37 @@ msgid "Graphic EQ"
 msgstr "Grafik EQ"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Boost"
+msgstr "Bass Boost"
+
+#: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Bass Boost"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -5236,6 +7773,10 @@ msgid "Effect Unavailable"
 msgstr "Preview tidak tersedia"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "dB Maks"
 
@@ -5248,6 +7789,26 @@ msgstr "%3d dB"
 msgid "Min dB"
 msgstr "dB Min"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "Penyaring"
@@ -5255,6 +7816,11 @@ msgstr "Penyaring"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Gambar kurva"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Alat Menggambar"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -5317,6 +7883,42 @@ msgid "D&efault"
 msgstr "&Normal"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Jalankan Benchmark..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Error Loading EQ Curves"
 msgstr "Error mengambil kurva EQ"
 
@@ -5325,12 +7927,26 @@ msgid "Error Saving Equalization Curves"
 msgstr "Error dalam menyimpan equalizer"
 
 #: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Curve not found"
 msgstr "FFmpeg tidak ada"
 
 #: src/effects/Equalization.cpp
 msgid "Manage Curves List"
 msgstr "Atur History"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Atur History"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Gambar kurva"
 
 #: src/effects/Equalization.cpp
 msgid "Curve Name"
@@ -5349,6 +7965,20 @@ msgid "De&faults"
 msgstr "Se&mula"
 
 #: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s' to..."
 msgstr "Diubah nama '%s' ke '%s'"
@@ -5361,6 +7991,10 @@ msgstr "&Sampel Ulang..."
 #, c-format
 msgid "Rename '%s'"
 msgstr "&Ganti Nama"
+
+#: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Same name"
@@ -5380,6 +8014,11 @@ msgid "You cannot delete the 'unnamed' curve."
 msgstr "Anda tidak bisa menghapus preset tanpa nama"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Tidak dapat mengekspor audio ke %s"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Hapus"
@@ -5392,6 +8031,11 @@ msgstr "Konfirmasi Penghapusan"
 #, c-format
 msgid "Delete %d items?"
 msgstr "Diulang %d kali"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr "Anda tidak bisa menghapus preset tanpa nama"
 
 #: src/effects/Equalization.cpp
 msgid "Choose an EQ curve file"
@@ -5410,8 +8054,29 @@ msgid "Cannot Export 'unnamed'"
 msgstr "Tidak dapat mengekspor audio ke %s"
 
 #: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Tidak ada label untuk diekspor."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "Tidak ada label untuk diekspor."
+
+#: src/effects/Equalization.cpp
 msgid "No curves exported"
 msgstr "Tidak ada label untuk diekspor."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -5425,8 +8090,22 @@ msgstr "Fade Keluar"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Klik dan dorong untuk memilih audio"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Klik dan dorong untuk memilih audio"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
+msgstr "Mencari Clipping"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
 msgstr "Mencari Clipping"
 
 #: src/effects/FindClipping.cpp
@@ -5445,13 +8124,37 @@ msgstr "Tidak ada ruang cukup untuk membuat audio"
 msgid "Invert"
 msgstr "Tukar"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Efek Unit Audio"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Menormalkan amplitudo maksimum ke:"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -5470,6 +8173,27 @@ msgstr "Memproses Auto Duck..."
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normalize"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -5499,6 +8223,10 @@ msgid "Noise"
 msgstr "Bising..."
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Tpie Bising"
 
@@ -5511,16 +8239,73 @@ msgid "Second greatest"
 msgstr "Trek Kedua"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Normalkan"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Normalkan"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Pengurangan bising"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Semua trek harus mempunyai rate sampel yang sama"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -5579,8 +8364,9 @@ msgid "Step 1"
 msgstr "Tahap 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Pilih beberapa detik bising agar Audacity tahu apa yang harus dibuang,\n"
@@ -5606,6 +8392,22 @@ msgstr ""
 msgid "Noise:"
 msgstr "Bising..."
 
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "Rekaman Audio"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Ubah ukuran lebih kecil"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "Opsi Mixing Lanjut"
@@ -5622,17 +8424,74 @@ msgstr "&Ukuran jendela"
 msgid "8"
 msgstr "48"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - normal"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "Normalkan"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Pembuang Bising"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -5667,8 +8526,56 @@ msgid "Re&move"
 msgstr "Buang"
 
 #: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalize"
+msgstr "Normalize"
+
+#: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Membuang Bising\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Membuang Bising\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Membuang Bising\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Remove DC offset (center on 0.0 vertically)"
@@ -5682,13 +8589,22 @@ msgstr "Menormalkan amplitudo maksimum ke:"
 msgid "Peak amplitude dB"
 msgstr "Amplitudo yang baru (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
 #: src/effects/Paulstretch.cpp
 msgid "Paulstretch"
 msgstr "Awal"
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Faktor kekurangan:"
@@ -5696,6 +8612,45 @@ msgstr "Faktor kekurangan:"
 #: src/effects/Paulstretch.cpp
 msgid "&Time Resolution (seconds):"
 msgstr "Waktu tenggang (detk):"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Phaser"
+msgstr "Phaser"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -5758,6 +8713,10 @@ msgid "Repair"
 msgstr "Perbaiki"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -5786,6 +8745,10 @@ msgid "Repeat"
 msgstr "Ulang"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "Number of times to repeat:"
 
@@ -5807,6 +8770,10 @@ msgstr "Panjang yang baru:"
 msgid "New selection length: %s"
 msgstr "Panjang yang baru:"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
 msgstr "Lokal"
@@ -5816,8 +8783,51 @@ msgid "Vocal II"
 msgstr "Lokal"
 
 #: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "Sedang"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Reverb"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Ukuran"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Waktu baru/usang"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -5828,12 +8838,30 @@ msgid "Da&mping (%):"
 msgstr "Kedalaman (%):"
 
 #: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Kedalaman (%):"
+
+#: src/effects/Reverb.cpp
 msgid "Wet &Gain (dB):"
 msgstr "Pen&guatan (dB):"
 
 #: src/effects/Reverb.cpp
 msgid "Dr&y Gain (dB):"
 msgstr "Pen&guatan (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Stereo"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -5848,6 +8876,25 @@ msgstr "Tukar Balik"
 msgid "Reverses the selected audio"
 msgstr "Mengekspor audio terpilih sebagai %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Batas Bawah"
@@ -5857,12 +8904,35 @@ msgid "Highpass"
 msgstr "Batas Atas"
 
 #: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "&Upload File..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "Untuk memplot spektrum, semua trek yang dipilih harus mempunyai rate sampel yang sama."
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
 msgstr "Penyaring"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
@@ -5875,6 +8945,14 @@ msgstr "Potong:"
 #: src/effects/ScienFilter.cpp
 msgid "C&utoff:"
 msgstr "Potong:"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
@@ -5895,6 +8973,14 @@ msgstr "&Ukuran jendela"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "&Ukuran jendela"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -5967,6 +9053,10 @@ msgctxt "generator"
 msgid "Silence"
 msgstr "Diam"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "Stereo ke Mono"
@@ -5992,6 +9082,10 @@ msgid "Sliding Stretch"
 msgstr "Awal"
 
 #: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
 msgstr "Perubahan Tempo Inisial (%)"
 
@@ -6006,6 +9100,10 @@ msgstr "Penyingkat Pitch"
 #: src/effects/TimeScale.cpp
 msgid "(&semitones) [-12 to 12]:"
 msgstr "Pitch Shift Total (seminada) [-12 to 12]:"
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
 
 #: src/effects/TimeScale.cpp
 msgid "Final Pitch Shift"
@@ -6044,6 +9142,14 @@ msgid "Tone"
 msgstr "Nada..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Waveform:"
 
@@ -6076,8 +9182,20 @@ msgid "Truncate Detected Silence"
 msgstr "Pangkas Diam"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "Pangkas Diam"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -6087,19 +9205,37 @@ msgstr "Membuat tugas di Diam"
 msgid "Tr&uncate to:"
 msgstr "Pangkas Diam"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Kompresi:"
+
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST Effects"
 msgstr "Efek VST"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Scanning Shell VST"
 msgstr "Memindai Plugin VST"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Tidak bisa membuka referensi encoding MP3!"
 
@@ -6107,17 +9243,44 @@ msgstr "Tidak bisa membuka referensi encoding MP3!"
 msgid "VST Effect Options"
 msgstr "Aturan Efek"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Panjang"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Kompresi diam:"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Kompresi diam:"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Graphical Mode"
 msgstr "Grafik EQ"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 #, c-format
@@ -6129,12 +9292,22 @@ msgid "Save VST Preset As:"
 msgstr "Simpan Program VST sebagai:"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Mengambil Program VST:"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "Mengambil Program VST:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "File Proyek Audacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Error Saving VST Presets"
@@ -6156,9 +9329,15 @@ msgstr "Error memulai program"
 msgid "Unable to load presets file."
 msgstr "Tidak bisa membuka atau membuat file tes"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Aturan Efek"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Tidak bisa membuka atau membuat file tes"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
@@ -6174,6 +9353,14 @@ msgstr "parameter ini disimpan dari %s. Lanjutkan?"
 #: src/effects/VST/VSTEffect.h
 msgid "VST"
 msgstr "V&ST"
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -6201,6 +9388,11 @@ msgid "Audio Unit Effects"
 msgstr "Efek Unit Audio"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Efek Unit Audio"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "Tidak bisa membuka file"
 
@@ -6213,20 +9405,41 @@ msgid "Audio Unit Effect Options"
 msgstr "Efek Unit Audio"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Tampilan"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "PErangkat Output"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Banyak band"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Buat"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "Impor Aturan Lajut"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -6302,6 +9515,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Tidak bisa menerima deskripsi aliran"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Tidak bisa membuka atau membuat file tes"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Konversi sample rate"
 
@@ -6309,6 +9527,21 @@ msgstr "Konversi sample rate"
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Tidak bisa membuang '%s'"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Tidak bisa menerima deskripsi aliran"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Tidak bisa menerima deskripsi aliran"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Tidak bisa membuka atau membuat file tes"
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -6318,13 +9551,36 @@ msgstr "Unit Audio"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efek VST"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "Efek VST"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Aturan Efek"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -6332,6 +9588,7 @@ msgstr "Aturan Efek"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "&LADSPA"
@@ -6340,13 +9597,59 @@ msgstr "&LADSPA"
 msgid "LV2 Effect Settings"
 msgstr "Aturan Efek"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "Pembuat Nada"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efek VST"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Efek"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -6362,6 +9665,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Output Nyquist:"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Diratakan dengan akhir pilihan"
 
@@ -6374,12 +9695,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Maaf, efek tidak bisa dipakai padatrek stereo yang trek-terknya tidak cocok."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Output Nyquist:"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Memproses Auto Duck..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -6422,6 +9761,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist tidak menghasilkan audio.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Versi Audacity ini tidak di-compile dengan dukungan %s."
@@ -6431,6 +9774,16 @@ msgid "Could not open file"
 msgstr "Tidak bisa membuka file"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Error in Nyquist code"
 msgstr "Error dalam Durasi"
 
@@ -6438,6 +9791,19 @@ msgstr "Error dalam Durasi"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Tidak bisa membuka file:"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Tidak bisa membuka atau membuat file tes\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -6458,6 +9824,22 @@ msgid "Lisp scripts"
 msgstr "Prompt Nyquist..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Tidak bisa membuka file"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "No foreground measured"
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -6476,13 +9858,18 @@ msgstr "Pilih file MIDI..."
 msgid "Save file as"
 msgstr "Simpan File"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "tak berjudul"
 
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Efek VST"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -6499,6 +9886,22 @@ msgstr "Maaf, Plug-in Vamp gagal diinstall."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Aturan Plugin"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Opsi General"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -6569,6 +9972,11 @@ msgstr "Opsi Mixing Lanjut"
 msgid "Format Options"
 msgstr "Opsi General"
 
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Channel: %2d"
+msgstr "Saluran:"
+
 #. i18n-hint: track name and L abbreviating Left channel
 #: src/export/Export.cpp
 #, c-format
@@ -6617,6 +10025,11 @@ msgid "Executables"
 msgstr "Variabel"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Perintah"
+
+#: src/export/ExportCL.cpp
 msgid "(external program)"
 msgstr "(program eksternal)"
 
@@ -6642,15 +10055,28 @@ msgid "Command Output"
 msgstr "Output Perintah"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
 "Anda memilih nama file yang ekstensinya tidak bisa dibaca.\n"
 " Anda ingin meneruskan?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "FFmpeg tidak ada"
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Tidak bisa membuka atau membuat file tes"
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -6661,8 +10087,32 @@ msgstr ""
 "Anda bisa mengaturnya di Preferensi > referensi."
 
 #: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Referensi FFmpeg:"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -6675,9 +10125,67 @@ msgstr ""
 "Pendukuk codec ini mungkin belum dibuat."
 
 #: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
 msgstr "Sedang mengekspor %d saluran, tapi saluran maksimal untuk format ini adalah %d"
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Mengekspor audio terpilih sebagai %s"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -6688,7 +10196,8 @@ msgstr "Exporting selected audio as %s"
 msgid "Invalid sample rate"
 msgstr "Rate sampel tidak valid"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Sampel Ulang"
 
@@ -6720,10 +10229,16 @@ msgstr "Rate Sampel"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#, fuzzy
+msgid "Bit Rate:"
+msgstr "Mode Bit Rate:"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
@@ -6738,6 +10253,34 @@ msgstr "kbps"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "0"
 msgstr "60"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "120"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "145"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "145"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "48"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "9"
@@ -6756,6 +10299,10 @@ msgid "Constrained"
 msgstr "Konstan"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Audio..."
 
@@ -6764,8 +10311,44 @@ msgid "Low Delay"
 msgstr "Pembeda"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Sedang"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -6836,8 +10419,17 @@ msgid "Replace preset '%s'?"
 msgstr "Hapus aturan lanjut '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Utama"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -6907,6 +10499,12 @@ msgstr "Impor Aturan Lajut"
 msgid "Export Presets"
 msgstr "Ekspor Aturan Lanjut"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Aplikasikan ke proyek yang tersedia"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
 msgstr "Tidak semua format dan codec kompetibel. Begitu pula kombinasi opsi yang belum tentu kompetibel dengan semua codec."
@@ -6941,6 +10539,10 @@ msgstr "Bahasa:"
 msgid "Bit Reservoir"
 msgstr "Penampung Bit"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -6951,6 +10553,10 @@ msgstr ""
 "Tag codec (FOURCC)\n"
 "Opsi\n"
 "kosong - otomatis"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -7071,6 +10677,11 @@ msgstr ""
 "maks - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -7178,6 +10789,14 @@ msgstr ""
 "Opsi\n"
 "0 - biasa"
 
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Atur Rate"
+
 #. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
 #. compression.  It measures how big a chunk of audio is compressed in one piece.
 #: src/export/ExportFFmpegDialogs.cpp
@@ -7221,6 +10840,17 @@ msgstr "Tidak ada label untuk diekspor."
 msgid "Select xml file to export presets into"
 msgstr "Pilih file xml untuk mengekspor aturan lanjut ke dalam"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Gagal menebak format"
@@ -7229,6 +10859,16 @@ msgstr "Gagal menebak format"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to find the codec"
 msgstr "Gagal mencari codec"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "24 bit"
 
 #: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
@@ -7299,12 +10939,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(Kualitas Terbaik)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(File yang lebih kecil)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -7315,7 +11007,8 @@ msgstr "Parah"
 msgid "Extreme"
 msgstr "Ekstrim"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standar"
 
@@ -7340,6 +11033,11 @@ msgid "Joint Stereo"
 msgstr "Stereo yang Telah Digabung"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Buat Stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Mode Bit Rate:"
 
@@ -7352,14 +11050,19 @@ msgstr "Kualitas"
 msgid "Channel Mode:"
 msgstr "Mode Channel:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Garis Pemisah yang Dibuang"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Tempatkan Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity memerlukan file %s untuk membuat MP3."
 
 #: src/export/ExportMP3.cpp
@@ -7387,13 +11090,34 @@ msgid "Where is %s?"
 msgstr "Dimana %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Anda menghubungkan lame_enc.dll v%d.%d. Viersi ini tidak cocok dengan Audacity %d.%d.%d.\n"
 "Silahkan download versi akhir referensi LAME MP3."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Menyimpan file data proyek"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -7489,8 +11213,18 @@ msgid "Cannot Export Multiple"
 msgstr "Ekspor Banyak"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Lokasi ekspor:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -7631,6 +11365,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Tidak bisa mengatur kualitas render Quicktime"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Tidak bisa membuka atau membuat file tes"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Tidak bisa membuka atau membuat file tes"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Tidak bisa membuka atau membuat file tes"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Tidak bisa membuka atau membuat file tes"
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Tidak bisa membuka atau membuat file tes"
 
@@ -7643,6 +11397,10 @@ msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Mengekspor audio terpilih sebagai Ogg Vorbis"
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
 msgstr "WAV (Microsoft) tertanda 16 bit PCM"
 
@@ -7650,13 +11408,38 @@ msgstr "WAV (Microsoft) tertanda 16 bit PCM"
 msgid "Header:"
 msgstr "Catatan Kepala:"
 
+#: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Encoding:"
+msgstr "Merekam"
+
 #: src/export/ExportPCM.cpp
 msgid "Other uncompressed files"
 msgstr "File tanpa terkompres lainnya"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Error menginpor"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -7684,11 +11467,11 @@ msgid "All supported files"
 msgstr "Semua file|*|Semua file yang terdukung|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -7697,11 +11480,11 @@ msgstr ""
 "mengeditnya dengan mengklik Berkas > Impor > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "adalah file MIDI, buka file audio. \n"
@@ -7713,18 +11496,18 @@ msgid "Select stream(s) to import"
 msgstr "Pilih stream untuk diimpor"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Versi Audacity ini tidak di-compile dengan dukungan %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah trek CD audio. \n"
 "Audacity tidak bisa membuka CD audio secara langsung. \n"
@@ -7733,10 +11516,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" adalah file playlist. \n"
@@ -7745,10 +11528,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah file Windows Media Audio. \n"
@@ -7757,10 +11540,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah file Advanced Audio Coding. \n"
@@ -7769,12 +11552,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah file audio terenkripsi. \n"
@@ -7785,10 +11568,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is a file media RealPlayer. \n"
@@ -7797,12 +11580,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" adalah file berbasis nada, bukan file audio. \n"
 "Audacity tidak bisa membuka tipe file ini. \n"
@@ -7811,10 +11594,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -7827,10 +11610,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah file audio Wavpack. \n"
@@ -7839,10 +11622,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah file audio Dolby Digital. \n"
@@ -7851,10 +11634,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah file audio Ogg Speex. \n"
@@ -7863,10 +11646,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" adalah file video. \n"
@@ -7880,20 +11663,31 @@ msgstr "FFmpeg tidak ada"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity tidak dapat membaca tipe file '%s'.\n"
 "Jika ini tidak dikompres, coba mengimpornya dengan menggunakan \"Import Raw\""
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -7902,6 +11696,11 @@ msgstr ""
 "Pengimpor yang mendukung file-file ini adalah:\n"
 "%s,\n"
 "tapi tidak ada yang mengerti format ini."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Menyimpan file data proyek"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7918,21 +11717,132 @@ msgid "Import Project"
 msgstr "Impor Aturan Lajut"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Tidak bisa menemukan folder data proyek: \"%s\""
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Proyek"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "Rate sampel tidak valid"
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Rate sampel tidak valid"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7962,36 +11872,6 @@ msgstr "Indeks[%02x] Codec[%s], Bahasa[%s], Bitrate[%s], Saluran[%d], Durasi[%d]
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "File FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "File GSteramer yang kompetibel"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Tidak bisa membuka atau membuat file tes"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Awalan GStreamer gagal"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Tidak bisa meganti nama '%s' ke '%s'"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indeks[%02x] Codec[%s], Bahasa[%s], Bitrate[%s], Saluran[%d], Durasi[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Tidak bisa membuka atau membuat file tes"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer %s: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -8051,6 +11931,14 @@ msgstr "Tidak bisa membuka file"
 msgid "MP3 files"
 msgstr "File MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "File Ogg Vorbis"
@@ -8085,8 +11973,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, dan tipe tanpa terkompres lainnya"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) tertanda 16 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -8097,12 +12079,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-bit float"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-bit float"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) tertanda 16 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bit"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -8113,12 +12139,20 @@ msgid "24 bit DWVW"
 msgstr "24 bit"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -8229,6 +12263,10 @@ msgstr "Rate sampel:"
 msgid "&Import"
 msgstr "&Impor"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -8249,6 +12287,7 @@ msgstr "kanan"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -8272,6 +12311,7 @@ msgstr "Akhir"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -8291,8 +12331,38 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Waktu trek/klip %s dipersingkat %.02f seconds"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Waktu trek/klip %s dipersingkat %.02f seconds"
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Time-Shift"
+msgstr "Alat Menyingkat Waktu"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Clip B&oundaries"
+msgstr "Atur Batas Kiri"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Atur Batas Kiri"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "Atur Batas Kiri"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -8309,6 +12379,11 @@ msgstr "Alat Selanjutnya"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Alat Selanjutnya"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "Atur Batas Kiri"
 
 #: src/menus/ClipMenus.cpp
 msgid "Cursor to Prev Clip Boundary"
@@ -8408,7 +12483,8 @@ msgstr "Telah didiamkan trek terpilih pada %.2f seconds at %.2f"
 msgid "Trim Audio"
 msgstr "Merekam Audio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Sekaligus"
 
@@ -8441,6 +12517,11 @@ msgstr "Lepas"
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
 msgstr "Edit Tag Metadata"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "&Edit"
+msgstr "E&dit..."
 
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
@@ -8525,32 +12606,8 @@ msgid "Delete Key&2"
 msgstr "KunciHapus2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Toolbar Mi&xer"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Ubah kecepatan bermain"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Tingkatkan kecepatan bermain"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Turunkan kecepatan bermain"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Selesai merekam"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Tingkatkan kecepatan bermain"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Turunkan kecepatan bermain"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -8575,6 +12632,13 @@ msgstr "Mengubah Pitch"
 #: src/menus/ExtraMenus.cpp
 msgid "&Full Screen (on/off)"
 msgstr "Layar penuh hidup/mati"
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -8633,6 +12697,11 @@ msgstr "Impor label"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Pilih file MIDI..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Semua File (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -8705,8 +12774,18 @@ msgid "Export MI&DI..."
 msgstr "Ekspor MIDI..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "&Ekspor"
+
+#: src/menus/FileMenus.cpp
 msgid "&Labels..."
 msgstr "&Label..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Ekspor MIDI..."
 
 #: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
@@ -8725,6 +12804,10 @@ msgstr "P&rint..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "Ke&luar"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -8757,6 +12840,10 @@ msgid "Nothing to do"
 msgstr "Tidak mungkin membatalkan"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Tutup trek yang terfokus"
 
@@ -8767,6 +12854,10 @@ msgstr "Tidak bisa membuka file proyek"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Mulai merekam"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -8785,7 +12876,8 @@ msgid "&Getting Started"
 msgstr "Awal Pilihan:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "Proyek Audacity"
 
 #: src/menus/HelpMenus.cpp
@@ -8793,8 +12885,17 @@ msgid "&Quick Help..."
 msgstr "&Bantuan"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
 msgstr "\t-test (jalankan diagnosa otomatis)"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Au&dio Device Info..."
+msgstr "Info Perangkat Audio"
 
 #: src/menus/HelpMenus.cpp
 msgid "&MIDI Device Info..."
@@ -8804,11 +12905,8 @@ msgstr "Perangkat MIDI"
 msgid "Show &Log..."
 msgstr "Tunjukkan &Log..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Tentang Audacity"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Label telah dibuat"
 
@@ -8934,6 +13032,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "Tempel Tek&s ke Label Baru"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "&Wilayah Terlabel"
 
@@ -8998,6 +13100,18 @@ msgid "Label Join"
 msgstr "Label Edit"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Maju ke belakang dari toolbar ke Trek"
 
@@ -9038,8 +13152,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Fokuskan ke Trek Terpilih"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Baru..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -9054,6 +13176,10 @@ msgstr "Plugin %i ke %i"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "&Buat"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -9137,6 +13263,16 @@ msgid "Set Track Status..."
 msgstr "ke &Awal Trek"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "&Diamkan Audio"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Trek Kecil"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Preferensi..."
 
@@ -9159,6 +13295,12 @@ msgstr "&Edit Label"
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Simpan &Proyek Sebagai..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Variabel"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -9307,8 +13449,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Frekuensi linier"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Pilih ke Awal"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Posisi Audio:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -9446,6 +13597,14 @@ msgstr "Kursor Kiri Lompatan Tinggi"
 msgid "Cursor Long Ju&mp Right"
 msgstr "Kursor Kanan Lompatan Tinggi"
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
 msgstr "Coba periode pendek di kiri selama bermain"
@@ -9479,6 +13638,13 @@ msgstr "&Kembalikan Toolbar"
 #, c-format
 msgid "Rendered all audio in track '%s'"
 msgstr "Semua audio di trek '%s' telah di-render"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Render"
+msgstr "Mix dan Render"
 
 #: src/menus/TrackMenus.cpp
 #, c-format
@@ -9647,10 +13813,21 @@ msgid "Created new label track"
 msgstr "Trek label baru telah dibuat"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Dibuat trek waktu yang baru"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Rate sampel:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Nilai yang Anda masukkan tidak valid"
 
@@ -9672,8 +13849,22 @@ msgid "Please select at least one audio track and one MIDI track."
 msgstr "Silahkan pilih aksinya"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Sync MIDI with Audio"
 msgstr "Sinkronisasi MIDI dengan Audio"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -9696,6 +13887,11 @@ msgid "Can't delete track with active audio"
 msgstr "Tidak bisa menghapus trek yang sedang aktif"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&Baru"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "Pindahkan Trek"
 
@@ -9710,6 +13906,11 @@ msgstr "&Trek Label"
 #: src/menus/TrackMenus.cpp
 msgid "&Time Track"
 msgstr "Trek &Waktu"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Toolbar Mi&xer"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
@@ -9750,6 +13951,10 @@ msgstr "&Diamkan Semua Trek"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Matikan Diam ke Semua Trek"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -9881,7 +14086,9 @@ msgstr "Play"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Merekam"
 
@@ -9894,8 +14101,27 @@ msgid "no label track at or below focused track"
 msgstr "Pan-kan di kiri trek terfokus"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Trek label baru telah dibuat"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -9938,6 +14164,11 @@ msgid "&Loop Play"
 msgstr "Maikan Be&rkali-kali"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Pause"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "Merekam"
 
@@ -9957,6 +14188,11 @@ msgstr "&Buang Trek"
 #: src/menus/TransportMenus.cpp
 msgid "&Timer Record..."
 msgstr "Pen&catat waktu rekaman..."
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Meream dengan Suara Diaktifkan"
 
 #: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
@@ -9987,16 +14223,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "Merekam dengan Suara Diaktifkan (nyala/mati)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Selesai merekam"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "Overdub (nyala/mati)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Selama bermainpada software (nyala/mati)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Perubahan Level Input Otomatis (nyala/mati)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -10006,6 +14243,11 @@ msgstr "T&ransportasi"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "Mulai/Berhenti"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -10123,6 +14365,11 @@ msgid "&Fit to Width"
 msgstr "&Samakan Dengan Jendela"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&Samakan Dengan Jendela"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Sederhanakan Semua Trek"
 
@@ -10166,6 +14413,18 @@ msgstr "Efek VST"
 msgid "&Window"
 msgstr " jendela"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
@@ -10191,13 +14450,18 @@ msgstr "Preferensi..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Keluar dari Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
 msgid "&Check for Updates"
 msgstr "Ce&k Ketergantungan..."
+
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+#, fuzzy
+msgid "Batch"
+msgstr "Batch"
 
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
@@ -10234,7 +14498,8 @@ msgstr "&Host"
 msgid "Using:"
 msgstr "Menggunakan:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Memainkan"
 
@@ -10254,7 +14519,8 @@ msgstr "Salura&n"
 msgid "Latency"
 msgstr "Laten"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milidetik"
 
@@ -10274,8 +14540,19 @@ msgstr "Tidak ada pengolah audio"
 msgid "No devices found"
 msgstr "Tidak ada perangkat"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Saluran (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 Saluran (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Direktori"
 
@@ -10288,8 +14565,22 @@ msgid "Default directories"
 msgstr "Direktori"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Jelajah..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -10349,6 +14640,11 @@ msgstr "Pilih lokasi untuk menyimpan file"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "Direktori %s belum ada. Buat dulu?"
 
@@ -10362,7 +14658,8 @@ msgid "Directory %s is not writable"
 msgstr "Direktori %s tidak bisa ditulis"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Pengubahan direktori temporer tidak berefek sampai Audacity dihidupkan ulang"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -10378,6 +14675,59 @@ msgid "Sorted by Effect Name"
 msgstr "Urutkan dari Nama"
 
 #: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Urutkan dari Nama"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Urutkan dari Nama"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "&LADSPA"
+msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Prompt Nyquist..."
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Bolehkan efek"
 
@@ -10386,20 +14736,56 @@ msgid "Effect Options"
 msgstr "Aturan Efek"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Aturan Plugin"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Pindai ulang efek VST sewaktu Audacity dimulai"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
 msgstr "Instrumen"
 
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Impor"
+
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Preferensi..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Mime-types"
@@ -10426,12 +14812,20 @@ msgid "Move &filter down"
 msgstr "Pindak ke &Bawah"
 
 #: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
 msgid "De&lete selected rule"
 msgstr "Wilayah berlabel dihapus"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Unused filters:"
 msgstr "Nama file:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -10512,6 +14906,10 @@ msgid "Location of &Manual:"
 msgstr "Lokasi &Manual:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "Jangkauan dB meter/Wavefo&rm:"
 
@@ -10524,12 +14922,57 @@ msgid "Show e&xtra menus"
 msgstr "Lihat batas sepanjang sumbu &Y"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "&Beep pada penyelesaian aktivitas lama"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Aturan Plugin"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Penggaris"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Impor / Ekspor"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Preferensi..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -10542,6 +14985,10 @@ msgstr "Opsi Mixing Lanjut"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Standar"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -10559,9 +15006,27 @@ msgstr "Ketike mengekspor ke file audio"
 msgid "S&how Metadata Tags editor before export"
 msgstr "&Tunjukkan Editor Metadata dahulu dalam langkah mengekspor"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Ekspor label sebagai:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
+
+#. i18n-hint: as in computer keyboard (not musical!)
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Preferences for KeyConfig"
@@ -10576,6 +15041,10 @@ msgid "Open a new project to modify keyboard shortcuts."
 msgstr "Buka Proyek Baru untuk mengubah jalan pintas keyboard"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Kunci-kunci Keyboard"
 
@@ -10584,8 +15053,35 @@ msgid "View by:"
 msgstr "&Lihat"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Nama"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Lihat"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Lihat"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Lihat"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
@@ -10594,6 +15090,12 @@ msgstr "Kunci-kunci Keyboard"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Short cut"
 msgstr "Trek Kecil"
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Opsi..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -10608,7 +15110,15 @@ msgid "&Defaults"
 msgstr "&Normal"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Pilih file XML yang mengandung jalan pintas keyboard Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -10617,8 +15127,21 @@ msgstr "Error mengambil jalan pintas keyboard"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Diambil %d jalan pintas keyboard\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -10631,6 +15154,38 @@ msgstr "Ekspor Jalan Pintas Keyboard Sebagai:"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Error mengambil jalan pintas keyboard"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -10669,16 +15224,26 @@ msgid "FFmpeg Library:"
 msgstr "Referensi FFmpeg:"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "&Tempatkan..."
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "Dow&nload"
 msgstr "U&nduh"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity telah mendeteksi referensi FFmpeg yang valid.\n"
 "Apakah Anda tetap ingin meletakkannya sendiri?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -10704,8 +15269,20 @@ msgid "Interface"
 msgstr "Tampilan"
 
 #: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "Frekuensi minmum harus berupa angka"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
 
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
@@ -10717,12 +15294,38 @@ msgid "Preferences for Module"
 msgstr "Preferensi..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Pengubahan direktori temporer tidak berefek sampai Audacity dihidupkan ulang"
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "Tanya saya"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
 
 #: src/prefs/ModulePrefs.cpp
 msgid "No modules were found"
@@ -10731,6 +15334,14 @@ msgstr "Tidak ada perangkat"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modulator"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
+msgid "Mouse"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp
 msgid "Preferences for Mouse"
@@ -10768,7 +15379,10 @@ msgstr "Klik Kiri dan Dorong"
 msgid "Set Selection Range"
 msgstr "Atur Range yang Dipilih"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Klik Kiri dengan Shift"
 
@@ -10855,6 +15469,15 @@ msgstr "Klik Kiri dan Dorong"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Pindahkan klik ke atas/bawah diantara trek"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Klik Kiri dan Dorong"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -10966,8 +15589,21 @@ msgstr "Periode pen&dek:"
 msgid "Lo&ng period:"
 msgstr "Periode pan&jang:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferensi Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -10981,6 +15617,11 @@ msgstr "Preferensi..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferensi..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -11006,6 +15647,11 @@ msgstr "Konversi Real-time"
 msgid "Sample Rate Con&verter:"
 msgstr "Pengkon&versi Rate Sampel:"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
 #: src/prefs/QualityPrefs.cpp
 msgid "High-quality Conversion"
 msgstr "Konversi Berkualitas Tinggi"
@@ -11013,6 +15659,11 @@ msgstr "Konversi Berkualitas Tinggi"
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "Pen&gkonversi Rate Sampel:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -11031,12 +15682,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "OverDub: &Mainkan trek lain ketika merekam"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "Selama bermainpada software (nyala/mati)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Trek Baru"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Pilih stream untuk diimpor"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -11077,41 +15738,37 @@ msgid "System &Date"
 msgstr "Tanggal Mulai"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Perubahan Level Input Otomatis"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Hidupkan Perubahan Level Input Otomatis."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Target Pik:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Dengan:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Waktu Analisis:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milidetik (waku satu analisis)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Angka analisis:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 berarti tak hingga"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Tanggal Mulai"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Meream dengan Suara Diaktifkan"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Trek Nada"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -11122,6 +15779,13 @@ msgstr "Ukuran Bingkai:"
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
+msgstr "Normalkan"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
 msgstr "Normalkan"
 
 #. i18n-hint: Grayscale color scheme for spectrograms
@@ -11139,6 +15803,17 @@ msgstr "Linier"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Frekuensi (Hz)"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
+#. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Pitch (EAC)"
+msgstr "Pitch (EAC)"
 
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Maximum frequency must be 100 Hz or above"
@@ -11194,12 +15869,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Frekuensi Mak&simum (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "Pen&guatan (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "Ja&rak (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -11222,12 +15905,21 @@ msgid "1024 - default"
 msgstr "256 - normal"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - jangkauan terkecil"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "&Tipe jendela"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Faktor kekurangan:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -11311,13 +16003,19 @@ msgid "Preferences for Theme"
 msgstr "Preferensi..."
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Info"
+msgstr "Info"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -11405,6 +16103,18 @@ msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "\"Move track focus\" memutar terus-menerus pada trek"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Opsi Mixing Lanjut"
 
@@ -11416,9 +16126,18 @@ msgstr "Tombol &Solo:"
 msgid "Logarithmic (dB)"
 msgstr "Logaritmik"
 
+#: src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.h
+#, fuzzy
+msgid "Waveform"
+msgstr "Waveform"
+
 #: src/prefs/TracksPrefs.cpp
 msgid "Spectrogram"
 msgstr "Spektrogram"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
@@ -11435,6 +16154,10 @@ msgstr "Perbesar Ter&pilih"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Normalkan"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -11457,6 +16180,16 @@ msgid "50ths of Seconds"
 msgstr "detik"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "detik"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "detik"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "milidetik"
 
@@ -11464,7 +16197,12 @@ msgstr "milidetik"
 msgid "Samples"
 msgstr "sampel"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom"
 
@@ -11473,12 +16211,42 @@ msgid "Preferences for Tracks"
 msgstr "Preferensi..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Selesai merekam"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "Mode &View Normal:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "&Format Sampel Normal:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "sampel"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -11530,6 +16298,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "Mix-kan ke &stereo waktu mengekspor"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "Mix-kan ke &mono waktu mengekspor"
 
@@ -11562,6 +16334,19 @@ msgid "Skip to End"
 msgstr "Langsung ke akhir"
 
 #: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Pause"
+msgstr "Pause"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Pilih ke Awal"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Pilih ke Akhir"
+
+#: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
 msgstr "Maikan Be&rkali-kali"
 
@@ -11573,20 +16358,17 @@ msgstr "Trek Baru"
 msgid "Append Record"
 msgstr "Tambah Rekaman"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Pilih ke Akhir"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Pilih ke Awal"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pause"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -11666,11 +16448,17 @@ msgstr "Pilihan diam"
 msgid "Sync-Lock Tracks"
 msgstr "Link Trek"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Perbesar"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Perkecil"
 
@@ -11737,50 +16525,23 @@ msgstr "Pengukur Rekaman"
 msgid "&Playback Meter Toolbar"
 msgstr "Pengukur Permainan"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Selesai merekam"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Memainkan"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Selesai merekam"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Tak dapat mengendalikan level input; gunakan mixer sistem."
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Memainkan"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Memainkan"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Tak dapat mengendalikan level input; gunakan mixer sistem."
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Toolbar Mi&xer"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "Penggaris"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Prompt Nyquist..."
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Prompt Nyquist..."
@@ -11788,6 +16549,7 @@ msgstr "Prompt Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Prompt Nyquist..."
@@ -11795,9 +16557,24 @@ msgstr "Prompt Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Mulai Pemantauan"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Mulai Pemantauan"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Penggaris"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -11845,9 +16622,24 @@ msgstr "Patokan"
 msgid "Length"
 msgstr "Panjang"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Tengah"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -11874,6 +16666,10 @@ msgstr "Memboosting Frekuensi Bass"
 msgid "Center Frequency"
 msgstr "Frekuensi linier"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -11892,8 +16688,8 @@ msgstr "Toolbar &Perangkat"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Toolbar Audacity %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -11920,7 +16716,8 @@ msgstr "Alat Menyingkat Waktu"
 msgid "Zoom Tool"
 msgstr "Alat Memperbesar"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Alat Menggambar"
 
@@ -11996,9 +16793,16 @@ msgstr "Dorong satu atau lebih batasan label"
 msgid "Drag label boundary."
 msgstr "Borong batasan label"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Label yang Telah Diubah"
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Label Edit"
+msgstr "Label Edit"
 
 #: src/tracks/labeltrack/ui/LabelTextHandle.cpp
 msgid "Click to edit label text"
@@ -12051,31 +16855,42 @@ msgstr "Label yang diedit"
 msgid "New label"
 msgstr "Label telah dibuat"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Oktaf Atas"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Oktaf Bawah"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klik untuk perbesar secara vertikal, klik dengan Shift untuk perkecil, Dorong untuk membuat wilayah zoom kecil."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Klik Kanan"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Perkecil"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Klik Kiri dengan Shift"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Klik Kiri dengan Shift"
 
@@ -12098,6 +16913,14 @@ msgid "Stretch"
 msgstr "Awal"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Klip Tergabung"
 
@@ -12109,7 +16932,8 @@ msgstr "Gabung"
 msgid "Expanded Cut Line"
 msgstr "Garis Potong yng Tersebar"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Sebar"
 
@@ -12133,6 +16957,11 @@ msgstr "Dipindahkan Sampel"
 msgid "Sample Edit"
 msgstr "Sampel Edit"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Perbesar pada Titik"
@@ -12140,6 +16969,16 @@ msgstr "Perbesar pada Titik"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Spektrogram"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -12165,7 +17004,8 @@ msgstr "Memproses Auto Duck..."
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Diubah '%s' ke %s"
@@ -12179,7 +17019,60 @@ msgid "Rat&e"
 msgstr "Atur Rate"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 j 060 m 060>0100 d"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 j 060 m 060>0100 d"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -12200,7 +17093,8 @@ msgstr "Perubahan Rate"
 msgid "Set Rate"
 msgstr "Atur Rate"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Banyak"
 
@@ -12219,6 +17113,11 @@ msgstr "Gabung Trek Stereo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Pisah Stereo ke Mono '%s'"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -12289,10 +17188,25 @@ msgid "Right, %dHz"
 msgstr "Kanan,"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "kanan"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -12302,6 +17216,15 @@ msgstr "Klik dan dorong untuk mengubah ukuran relatif trek stereo."
 msgid "Click and drag to rearrange sub-views"
 msgstr "Klik dan dorong ubtuk memindahkan trek ke waktu tertentu"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Klik dan dorong ubtuk memindahkan trek ke waktu tertentu"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Perbesar"
@@ -12309,6 +17232,10 @@ msgstr "Perbesar"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Zoom"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -12354,12 +17281,28 @@ msgid "Set Range"
 msgstr "Atur Jarak"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "Tampilan"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Interpolasi:"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
@@ -12379,9 +17322,8 @@ msgstr "Interpolasi Sinc yang Cepat"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klik dan dorong ubtuk memindahkan trek ke waktu tertentu"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -12432,6 +17374,21 @@ msgstr "Amplop diubah."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "&Toolbar"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Mulai Pemantauan"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Penggaris"
@@ -12447,6 +17404,11 @@ msgstr "Tutup trek yang terfokus"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Pindahkan Trek ke Bawah"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Prompt Nyquist..."
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -12503,6 +17465,11 @@ msgstr "Klik dan dorong untuk memilih audio"
 msgid "Click and drag to select audio"
 msgstr "Klik dan dorong untuk memilih audio"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Klik dan dorong ubtuk memindahkan trek ke waktu tertentu"
@@ -12524,6 +17491,10 @@ msgstr "Telah didiamkan trek terpilih pada %.2f seconds at %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Telah didiamkan trek terpilih pada %.2f seconds at %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -12550,6 +17521,12 @@ msgstr "Perintah"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Klik Kiri dengan Ctrl"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Silahkan pilih aksinya"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -12596,11 +17573,31 @@ msgstr "Tekan"
 msgid "Button"
 msgstr "Tombol"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
 #. i18n-hint: "x" suggests a multiplicative factor
 #: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.2fx"
 msgstr "%.1f dB"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" tidak ada.\n"
+"\n"
+"Apakah Anda mingin membuatnya?"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
@@ -12630,13 +17627,28 @@ msgstr "Kosong"
 msgid "Backwards"
 msgstr "Percepat ke Awal"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Percepat ke Akhir"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Bantuan di Internet"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Semua File (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -12697,12 +17709,21 @@ msgid "Meter Style"
 msgstr "Meter"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Penyaring"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Durasi"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Pengembalian Otomatis Akibat Crash"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -12717,9 +17738,26 @@ msgid " Monitoring "
 msgstr "Hentikan Pemantauan"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Please select an action"
@@ -12816,6 +17854,7 @@ msgstr "0100 jam 060 mnt 060 dtk+># sampel"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "sampel"
@@ -12977,6 +18016,15 @@ msgstr "01000,01000 bingkai|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 j 060 m 060>0100 d"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -12984,6 +18032,10 @@ msgstr "0100 j 060 m 060>0100 d"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 j 060 m 060>0100 d"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -12999,17 +18051,47 @@ msgstr "Oktaf Bawah"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 bingkai|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in semitones and cents
 #: src/widgets/NumericTextCtrl.cpp
 msgid "semitones + cents"
 msgstr "Seminada dalam separuh langkah"
 
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 bingkai|24"
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
@@ -13018,6 +18100,11 @@ msgstr "Gunakan tombol kanan mouse atau kunci konteks untuk mengubah format"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "sentidetik"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -13061,6 +18148,11 @@ msgstr "Konfirmasi"
 msgid "Unable to write files to directory: %s."
 msgstr "Tidak bisa membuka atau membuat file tes"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -13079,6 +18171,10 @@ msgid "Don't show this warning again"
 msgstr "Jangan perlihatkan peringatan lagi"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-tak terhingga"
 
@@ -13087,13 +18183,31 @@ msgid "-Infinity"
 msgstr "-tak terhingga"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Kosong"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Tambah Rekaman"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Perbesar pada Wilayah"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Error LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -13111,11 +18225,20 @@ msgid "Value must not be greater than %s"
 msgstr "Awal dan akhir harus lebih dari 0."
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Membuat proyek baru"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Direktori"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Direktori"
 
 #: src/xml/XMLFileReader.cpp
@@ -13136,16 +18259,49 @@ msgstr "Tidak bisa membuka file"
 msgid "Spectral edit multi tool"
 msgstr "Pilihan"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Penyaring"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Frekuensi (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Error"
@@ -13173,6 +18329,22 @@ msgstr "Ke Frekuensi dalam Detik"
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Frekuensi minimum harus lebih atau sama dengan 0 Hz"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "Pilihan"
@@ -13185,9 +18357,27 @@ msgstr "Fade Keluar"
 msgid "Applying Fade..."
 msgstr "Mengaplikasikan..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Atur Nor&mal"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -13214,8 +18404,16 @@ msgid "S-Curve Down"
 msgstr "Pindak ke &Bawah"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Awal"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -13224,6 +18422,14 @@ msgstr "Kekuatan"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Awal"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -13236,6 +18442,14 @@ msgstr "Linier"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Linier"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -13284,6 +18498,14 @@ msgstr "Penguatan frekuensi tidak boleh negatif"
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "Penguatan frekuensi tidak boleh negatif"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Ulang"
@@ -13291,6 +18513,10 @@ msgstr "Ulang"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Mencari Clipping..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -13304,6 +18530,23 @@ msgstr "Clipping"
 msgid "Reconstructing clips..."
 msgstr "Membuang klik dan pop..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Ambang Batas %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Trek Nada"
@@ -13311,6 +18554,21 @@ msgstr "Trek Nada"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Trek Nada"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -13344,6 +18602,19 @@ msgstr "Nama Trek"
 msgid "Fade direction"
 msgstr "Pengurangan bising"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Pembeda"
@@ -13359,6 +18630,19 @@ msgstr "Kunci Ketikan"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "Bersiku"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Reduksi bising (dB):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -13384,6 +18668,14 @@ msgstr "Pre&view"
 msgid "Number of echoes"
 msgstr "Number of times to repeat:"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Ulangi Efek Terakhir"
@@ -13395,6 +18687,10 @@ msgstr "Ekualisasi"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "File MP3"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -13409,10 +18705,24 @@ msgstr "Konfirmasi Penibanan"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Tidak bisa membuka file genre."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Error (file tidak mungkin ditulis): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Error (file tidak mungkin ditulis): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -13443,10 +18753,50 @@ msgstr "Panjang (detik)"
 msgid "Length of label region (seconds)"
 msgstr "Panjang (detik)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Label Edit"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -13460,6 +18810,11 @@ msgstr "Lepas"
 msgid "Warnings only"
 msgstr "Peringatan"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -13468,6 +18823,12 @@ msgstr "Gabungkan Label"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Gabungkan Label"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -13486,13 +18847,46 @@ msgstr "Mengekualisasi"
 msgid "Dominic Mazzoni"
 msgstr "dari Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekuensi (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Frekuensi minimum harus lebih atau sama dengan 0 Hz"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -13540,6 +18934,11 @@ msgid "Point after sound"
 msgstr "Stereo yang Telah Digabung"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "Dari panjang dalam detik"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "Dari panjang dalam detik"
 
@@ -13547,11 +18946,41 @@ msgstr "Dari panjang dalam detik"
 msgid "Maximum leading silence"
 msgstr "Memangkas Diam.."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Memangkas Diam.."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Nama seharusnya tidak kosong"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -13583,8 +19012,25 @@ msgid "Hard Clip"
 msgstr "Mencari Clipping"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Bagian Kanan"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Ja&rak (dB):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -13646,6 +19092,44 @@ msgstr "Waktu baru/usang"
 msgid "Decay (ms)"
 msgstr "Waktu baru/usang"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Nama seharusnya tidak kosong"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Panjang filter:"
@@ -13657,6 +19141,18 @@ msgstr "Mengaplikasikan Leveller..."
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Atur Nor&mal"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -13679,7 +19175,8 @@ msgstr "File MP3"
 msgid "HTML file"
 msgstr "File MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Nama file:"
 
@@ -13696,9 +19193,24 @@ msgid "Disallow"
 msgstr "Tidak Diperbolehkan"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Tidak Diperbolehkan"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Tidak bisa membuang '%s'"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -13709,16 +19221,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Pilih file MIDI..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Nama file:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Pilih file MIDI..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Membuat Nada"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Penyaring"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -13731,6 +19285,10 @@ msgstr "Buang Trek"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Membuat Chirp"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -13749,8 +19307,20 @@ msgid "Swing amount"
 msgstr "Distorsi"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Number of times to repeat:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -13773,12 +19343,54 @@ msgid "Beat sound"
 msgstr "Ulang"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Membuang Bising"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Dasar Bising"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -13801,6 +19413,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Frekuensi linier"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Frekuensi (Hz)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Amplitudo (0-1)"
 
@@ -13811,6 +19432,10 @@ msgstr "Tidak bisa mengekspor"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Mengaplikasikan..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -13829,6 +19454,10 @@ msgid "HTML files"
 msgstr "File MP3"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Sampel Edit"
 
@@ -13841,8 +19470,29 @@ msgid "Include header information"
 msgstr "Informasi Perubahan"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Semua"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -13857,6 +19507,11 @@ msgstr "\t-bantuan (pesan ini)"
 msgid "Errors Only"
 msgstr "Error:"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -13869,6 +19524,46 @@ msgstr "Bagian Kanan"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "sampel"
 
@@ -13876,6 +19571,43 @@ msgstr "sampel"
 #, lisp-format
 msgid "~a seconds."
 msgstr "detik"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -13894,6 +19626,10 @@ msgid "Value (dB)"
 msgstr "Ja&rak (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Linier"
 
@@ -13910,6 +19646,14 @@ msgid "Right (dB)"
 msgstr "Kanan,"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Linier"
 
@@ -13920,6 +19664,40 @@ msgstr "2 Saluran (Stereo)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 Saluran (Mono)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Error (file tidak mungkin ditulis): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -13934,8 +19712,40 @@ msgid "Select file"
 msgstr "Pilih file MIDI..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Error"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -13945,6 +19755,15 @@ msgstr "Tidak bisa membuka file genre."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Pilihan"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -13967,8 +19786,16 @@ msgid "Wet level (percent)"
 msgstr "2 level"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Mengaplikasikan..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -14010,9 +19837,96 @@ msgstr "&Analisa"
 msgid "Strength"
 msgstr "Penyaring"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Memproses Auto Duck..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -14046,6 +19960,209 @@ msgstr "Frekuensi (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Frekuensi (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Perbarui Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Pasang pembaruan"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Saluran"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Baca lebih lanjut di GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Terjadi kesalahan ketika memeriksa pembaruan"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Tidak dapat menghubungi server pembaruan Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Data pembaruan rusak."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Terjadi kesalahan ketika mengunduh pembaruan."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Tidak dapat membuka tautan unduhan Tenacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s tersedia!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Rekam"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Perintah:"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Impor melalui QuickTime"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Perubahan Level Input Otomatis dihentikan. Tidak mungkin membenahi lebih jauh. Tetap terlalu tinggi."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Perubahan Level Input Otomatis mengurangi volume ke %f"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Perubahan Level Input Otomatis dihentikan. Tidak mungkin membenahi lebih jauh. Tetap terlalu rendah."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Perubahan Level Input Otomatis menaikkan volume ke %f"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Perubahan Level Input Otomatis dihentikan. Angka total analisis telah melebihi batas tanpa menemukan volume yang cocok. tetap terlalu tinggi."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Perubahan Level Input Otomatis dihentikan. Angka total analisis telah melebihi batas tanpa menemukan volume yang cocok. tetap terlalu rendah."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Perubahan Level Input Otomatis dihentikan. %.2f sepertinya volume yang cocok."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Tidak bisa membuka file genre.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Merekam\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Memainkan\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Selesai merekam\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Selesai merekam\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Memainkan\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Memainkan\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "File GSteramer yang kompetibel"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Tidak bisa membuka atau membuat file tes"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Awalan GStreamer gagal"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Tidak bisa meganti nama '%s' ke '%s'"
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indeks[%02x] Codec[%s], Bahasa[%s], Bitrate[%s], Saluran[%d], Durasi[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Tidak bisa membuka atau membuat file tes"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer %s: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Ubah kecepatan bermain"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Tingkatkan kecepatan bermain"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Turunkan kecepatan bermain"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Selesai merekam"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Tingkatkan kecepatan bermain"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Turunkan kecepatan bermain"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Tentang Audacity"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Perubahan Level Input Otomatis (nyala/mati)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Perubahan Level Input Otomatis"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Hidupkan Perubahan Level Input Otomatis."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Target Pik:"
+
+#~ msgid "Within:"
+#~ msgstr "Dengan:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Waktu Analisis:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milidetik (waku satu analisis)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Angka analisis:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 berarti tak hingga"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Selesai merekam"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Memainkan"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Selesai merekam"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Tak dapat mengendalikan level input; gunakan mixer sistem."
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Memainkan"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Memainkan"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Tak dapat mengendalikan level input; gunakan mixer sistem."
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Toolbar Mi&xer"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klik dan dorong ubtuk memindahkan trek ke waktu tertentu"
+
 #~ msgid "Program build date:"
 #~ msgstr "Tangga perubahan program:"
 
@@ -14059,10 +20176,6 @@ msgstr "Frekuensi (Hz)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "Op"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Tidak bisa membuka atau membuat file tes"
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -14110,13 +20223,6 @@ msgstr "Frekuensi (Hz)"
 
 #~ msgid "LAME MP3 Library:"
 #~ msgstr "Referensi LAME MP3"
-
-#~ msgid "&Locate..."
-#~ msgstr "&Tempatkan..."
-
-#, fuzzy
-#~ msgid "Error.n"
-#~ msgstr "Error"
 
 #, fuzzy
 #~ msgid "Failed to copy tags"
@@ -14860,10 +20966,6 @@ msgstr "Frekuensi (Hz)"
 #~ msgstr "Transkrispi"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "&Toolbar"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "Perintah"
 
@@ -14961,10 +21063,6 @@ msgstr "Frekuensi (Hz)"
 #, fuzzy
 #~ msgid "Start - Center - End"
 #~ msgstr "ke A&khiran yang Dipilih"
-
-#, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
 
 #, fuzzy
 #~ msgid "Show start time and end time"
@@ -15100,20 +21198,12 @@ msgstr "Frekuensi (Hz)"
 #~ msgstr "Frekuensi (Hz)"
 
 #, fuzzy
-#~ msgid "Phase"
-#~ msgstr "Phaser"
-
-#, fuzzy
 #~ msgid "Depth"
 #~ msgstr "Kedalaman:"
 
 #, fuzzy
 #~ msgid "Feedback"
 #~ msgstr "Tanggapan (%):"
-
-#, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Ukuran"
 
 #, fuzzy
 #~ msgid "Reverberance"
@@ -15130,10 +21220,6 @@ msgstr "Frekuensi (Hz)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Kekuatan"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Stereo"
 
 #, fuzzy
 #~ msgid "FilterType"
@@ -15178,10 +21264,6 @@ msgstr "Frekuensi (Hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "Pangkas Diam"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Menukar Balik"
 
 #~ msgid "C&ategory:"
 #~ msgstr "K&ategori:"
@@ -15230,10 +21312,6 @@ msgstr "Frekuensi (Hz)"
 
 #~ msgid "Stereo Trac&k to Mono"
 #~ msgstr "Tre&k Stereo ke Mono"
-
-#, fuzzy
-#~ msgid "&Mono"
-#~ msgstr "Mono"
 
 #, fuzzy
 #~ msgid "&Left Channel"
@@ -15538,10 +21616,6 @@ msgstr "Frekuensi (Hz)"
 #~ msgstr "Pilihan"
 
 #, fuzzy
-#~ msgid "Pitc&h (EAC)"
-#~ msgstr "Pitch (EAC)"
-
-#, fuzzy
 #~ msgid "Set Sample &Format"
 #~ msgstr "Atur Format Sampel"
 
@@ -15552,10 +21626,6 @@ msgstr "Frekuensi (Hz)"
 #, fuzzy
 #~ msgid "Plug-ins %i to %i"
 #~ msgstr "Plugin %i ke %i"
-
-#, fuzzy
-#~ msgid "&Draw Curves"
-#~ msgstr "Gambar kurva"
 
 #, fuzzy
 #~ msgid "Save and Manage Curves"
@@ -15717,9 +21787,6 @@ msgstr "Frekuensi (Hz)"
 #~ msgid "Applied effect: %s %.1f dB"
 #~ msgstr "Efek traplikasi: %s %.1f dB"
 
-#~ msgid "Amplifying"
-#~ msgstr "Mengamplifikasikan"
-
 #~ msgid "Please enter valid values."
 #~ msgstr "Tolong masukkan nilai yang valid."
 
@@ -15758,9 +21825,6 @@ msgstr "Frekuensi (Hz)"
 
 #~ msgid "Change Tempo..."
 #~ msgstr "Ubah Tempo..."
-
-#~ msgid "Click Removal..."
-#~ msgstr "Pembuang Klik..."
 
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "Mengaplikasikan Pengompresan Dinamis"
@@ -15847,10 +21911,6 @@ msgstr "Frekuensi (Hz)"
 #~ msgid "Inverting"
 #~ msgstr "Menukar"
 
-#, fuzzy
-#~ msgid "Leveler..."
-#~ msgstr "Leveller..."
-
 #~ msgid "Noise Generator"
 #~ msgstr "Pembuat Bising"
 
@@ -15913,16 +21973,8 @@ msgstr "Frekuensi (Hz)"
 #~ msgstr "Ubah nama trek ke:"
 
 #, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "Reverb"
-
-#, fuzzy
 #~ msgid "Applying Reverb"
 #~ msgstr "Mengaplikasikan Leveller..."
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "&Upload File..."
 
 #~ msgid "Silence..."
 #~ msgstr "Diam..."
@@ -15947,9 +21999,6 @@ msgstr "Frekuensi (Hz)"
 
 #~ msgid "Chirp Generator"
 #~ msgstr "Pembuat Chirp"
-
-#~ msgid "Tone Generator"
-#~ msgstr "Pembuat Nada"
 
 #~ msgid "Truncate Silence..."
 #~ msgstr "Pangkas Diam..."
@@ -16545,15 +22594,3 @@ msgstr "Frekuensi (Hz)"
 
 #~ msgid "Calibrate"
 #~ msgstr "Kalibrasi"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"

--- a/locale/it.po
+++ b/locale/it.po
@@ -8,83 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-27 11:11+0000\n"
 "Last-Translator: J. Lavoie <j.lavoie@net-c.ca>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/it/>\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/tenacity/tenacity/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Aggiorna Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "Trala&scia"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Installa aggiornamento"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Registro modifiche"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Ulteriori informazioni su GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Errore durante la verifica di aggiornamenti"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Non è stato possibile collegarsi al server degli aggiornamenti di Audacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "I dati dell'aggiornamento sono danneggiati."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Errore durante lo scaricamento dell'aggiornamento."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Non è stato possibile aprire il collegamento al download di Audacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "È disponibile Audacity %s!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Registrazione"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -100,6 +33,18 @@ msgstr "%s byte"
 #, c-format
 msgid "%s KB"
 msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -221,8 +166,14 @@ msgstr "&Ferma\tF6"
 msgid "&About"
 msgstr "&Info"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Script"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Uscita"
 
@@ -238,7 +189,12 @@ msgstr "Script Nyquist (*.ny)|*.ny|Script Lisp (*.lsp)|*.lsp|Tutti i file|*"
 msgid "Script was not saved."
 msgstr "Lo script non è stato salvato."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Attenzione"
 
@@ -251,15 +207,25 @@ msgid "Find dialog"
 msgstr "Finestra di dialogo trova"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango Icon Gallery (icone barra degli strumenti)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Modulo esterno per Audacity che fornisce un semplice IDE per scrivere effetti."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -282,7 +248,8 @@ msgstr "Senza titolo"
 msgid "Nyquist Effect Workbench - "
 msgstr "Spazio di lavoro degli effetti di Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nuovo"
 
@@ -322,7 +289,8 @@ msgstr "Copia"
 msgid "Copy to clipboard"
 msgstr "Copia negli appunti"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Taglia"
 
@@ -330,7 +298,8 @@ msgstr "Taglia"
 msgid "Cut to clipboard"
 msgstr "Taglia negli appunti"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Incolla"
 
@@ -355,7 +324,8 @@ msgstr "Seleziona tutto"
 msgid "Select all text"
 msgstr "Seleziona tutto il testo"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Annulla"
 
@@ -363,7 +333,8 @@ msgstr "Annulla"
 msgid "Undo last change"
 msgstr "Annulla ultima modifica"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Ripristina"
 
@@ -420,7 +391,8 @@ msgid "Go to next S-expr"
 msgstr "Vai a S-expr successiva"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Inizia"
 
@@ -428,7 +400,8 @@ msgstr "Inizia"
 msgid "Start script"
 msgstr "Inizia script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Ferma"
 
@@ -442,15 +415,23 @@ msgstr "Ferma script"
 msgid "About %s"
 msgstr "Info su %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informazioni sulla versione"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Disabilitato"
 
@@ -460,8 +441,9 @@ msgid "The Build"
 msgstr "La compilazione"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "ID commit:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versione: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -471,22 +453,28 @@ msgstr "Tipo di versione:"
 msgid "Compiler:"
 msgstr "Compilatore:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefisso installazione: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Cartella impostazioni:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Cartella impostazioni:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Supporto formato file"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Libreria GUI multi-piattaforma"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -500,7 +488,6 @@ msgstr "Conversione frequenza di campionamento"
 msgid "MP3 Importing"
 msgstr "Importazione MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importazione ed esportazione Ogg Vorbis"
@@ -509,7 +496,6 @@ msgstr "Importazione ed esportazione Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Supporto tag ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importazione ed esportazione FLAC"
@@ -527,14 +513,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importazione/esportazione FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importazione tramite GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Caratteristiche"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Supporto estensioni"
 
@@ -549,6 +527,10 @@ msgstr "Supporto intonazione e cambio tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Supporto intonazione estrema e cambio tempo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Caratteristiche"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -640,6 +622,12 @@ msgstr "%s, compositore"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "%s, compositore"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, estensioni Nyquist"
@@ -661,6 +649,10 @@ msgstr "%s, grafica"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (contenente %s, %s, %s, %s e %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -670,6 +662,10 @@ msgstr "%s il software libero, open source, multi-piattaforma per registrare ed 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Crediti"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -720,6 +716,7 @@ msgstr "Sito web e grafica"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Traduzione italiana di Carmelo Battaglia e Michele Locati"
@@ -738,6 +735,22 @@ msgstr "Ringraziamenti particolari:"
 msgid "%s website: "
 msgstr "Sito web di %s: "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Collaboratori"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "Azioni nella timeline disabilitate durante la registrazione"
@@ -752,9 +765,15 @@ msgstr "Fare clic e trascinare per regolare, doppio clic per azzerare"
 msgid "Record/Play head"
 msgstr "Registra/esegui intestazione"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Opzioni sequenza temporale"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Fare clic o trascinare per iniziare la ricerca"
@@ -762,6 +781,7 @@ msgstr "Fare clic o trascinare per iniziare la ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Fare clic o trascinare per iniziare lo scorrimento"
@@ -769,6 +789,7 @@ msgstr "Fare clic o trascinare per iniziare lo scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Fare clic e spostarsi per scorrere. Fare clic e trascinare per ricercare."
@@ -776,6 +797,7 @@ msgstr "Fare clic e spostarsi per scorrere. Fare clic e trascinare per ricercare
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Spostarsi per ricercare"
@@ -783,6 +805,7 @@ msgstr "Spostarsi per ricercare"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Spostarsi per scorrere"
@@ -839,7 +862,17 @@ msgstr ""
 "Impossibile bloccare la regione oltre\n"
 "la fine del progetto."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Errore"
 
@@ -863,7 +896,8 @@ msgstr ""
 "Questa domanda viene posta una sola volta, dopo una 'installazione' in cui è stato chiesto di azzerare le preferenze."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Azzera le preferenze di Audacity"
 
 #: src/AudacityApp.cpp
@@ -878,7 +912,8 @@ msgstr ""
 "È stato rimosso dall'elenco dei file recenti."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "L'inizializzazione della libreria SQLite è fallita. Audacity non può procedere."
 
 #: src/AudacityApp.cpp
@@ -904,7 +939,7 @@ msgstr "&Apri..."
 msgid "Open &Recent..."
 msgstr "Apri &recenti..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "Informazioni su &Audacity..."
@@ -913,10 +948,16 @@ msgstr "Informazioni su &Audacity..."
 msgid "&Preferences..."
 msgstr "&Preferenze..."
 
+#: src/AudacityApp.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&File"
+msgstr "&File..."
+
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Non è stato possibile trovare una posizione sicura dove salvare i file temporanei.\n"
@@ -924,20 +965,23 @@ msgstr ""
 "Specificare un'appropriata cartella nella finestra di dialogo delle preferenze."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Impossibile trovare una posizione dove salvare i file temporanei.\n"
 "Specificare una cartella adatta nella finestra di dialogo delle preferenze."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Si sta uscendo da Audacity. Riavviare Audacity per usare la nuova cartella temporanea."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -946,15 +990,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Non è stato possibile bloccare la cartella dei file temporanei.\n"
 "Questa cartella potrebbe essere in uso in un'altra copia di Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Si desidera ancora avviare Audacity?"
 
 #: src/AudacityApp.cpp
@@ -962,19 +1008,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Errore bloccando la cartella dei file temporanei"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Il sistema ha rilevato che un'altra copia di Audacity è in esecuzione.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Usa i comandi Nuovo o Apri nel processo di Audacity attualmente\n"
 "in esecuzione per aprire più progetti contemporaneamente.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity è già in esecuzione"
 
 #: src/AudacityApp.cpp
@@ -990,7 +1039,8 @@ msgstr ""
 "e potrebbe essere necessario un riavvio."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Avvio di Audacity fallito"
 
 #: src/AudacityApp.cpp
@@ -1030,8 +1080,9 @@ msgstr ""
 "e potrebbe essere necessario un riavvio."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1063,7 +1114,8 @@ msgstr "avvia autodiagnosi"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "mostra versione Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1073,9 +1125,10 @@ msgid "audio or project file name"
 msgstr "nome file audio o progetto"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1088,16 +1141,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "File di progetto di Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Messaggio"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Errore di configurazione di Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1107,7 +1162,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Non è stato possibile accedere al seguente file di configurazione:\n"
 "\n"
@@ -1119,12 +1174,15 @@ msgstr ""
 "\n"
 "Se si seleziona \"Esci da Audacity\", il progetto potrebbe rimanere in uno stato non salvato che verrà ripristinato la prossima volta che verrà aperto."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Aiuto"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "E&sci da Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1132,7 +1190,8 @@ msgid "&Retry"
 msgstr "&Riprova"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Registro di Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1144,7 +1203,8 @@ msgstr "&Salva..."
 msgid "Cl&ear"
 msgstr "Az&zera"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Chiudi"
 
@@ -1174,6 +1234,11 @@ msgstr ""
 "\n"
 
 #: src/AudioIO.cpp
+#, fuzzy, c-format
+msgid "Error: %s"
+msgstr "Errore"
+
+#: src/AudioIO.cpp
 msgid "Error Initializing Audio"
 msgstr "Errore nell'inizializzazione dell'audio"
 
@@ -1194,7 +1259,8 @@ msgid "Error Initializing Midi"
 msgstr "Errore durante l'inizializzazione del MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audio di Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1209,37 +1275,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Memoria esaurita!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Ottimizzazione ulteriore impossibile. Livello ancora troppo alto."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "La regolazione automatica del livello di registrazione ha ridotto il volume a %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Ottimizzazione ulteriore impossibile. Livello ancora troppo basso."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "La regolazione automatica del livello di registrazione ha aumentato il volume a %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Il numero totale di analisi è stato superato senza trovare un volume accettabile. Livello ancora troppo alto."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Il numero totale di analisi è stato superato senza trovare un volume accettabile. Livello ancora troppo basso."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Sembra che %.2f sia un volume accettabile."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1338,43 +1373,6 @@ msgstr "Nessun dispositivo di riproduzione trovato per '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Impossibile verificare le frequenze di campionamento reciproche senza entrambi i dispositivi.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Ricevuto %d durante l'apertura dei dispositivi\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Non è stato possibile aprire Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Mixer disponibili:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Fonti di registrazione disponibili:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volumi di riproduzione disponibili:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Il volume di registrazione è simulato\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Il volume di registrazione è nativo\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Il volume di riproduzione è simulato\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Il volume di riproduzione è nativo\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1417,8 +1415,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Ripristino automatico da crash"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1431,12 +1430,14 @@ msgid "Recoverable &projects"
 msgstr "Progetti ri&pristinabili"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Seleziona"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nome"
 
@@ -1523,6 +1524,11 @@ msgstr "Effetto"
 msgid "Menu Command (With Parameters)"
 msgstr "Comando di menu (con parametri)"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
 msgstr "Comando di menu (senza parametri)"
@@ -1592,6 +1598,12 @@ msgstr "Gestisci macro"
 msgid "Select Macro"
 msgstr "Seleziona macro"
 
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Macro..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
 msgstr "Applica macro a:"
@@ -1639,6 +1651,11 @@ msgid "Applying..."
 msgstr "Applicazione in corso..."
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "File"
+msgstr "&File..."
+
+#: src/BatchProcessDialog.cpp
 msgid "&Cancel"
 msgstr "&Annulla"
 
@@ -1658,13 +1675,19 @@ msgstr "Ripri&stina"
 msgid "I&mport..."
 msgstr "I&mporta..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&sporta..."
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Modifica passi"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1694,7 +1717,8 @@ msgstr "Sposta &su"
 msgid "Move &Down"
 msgstr "Sposta &giù"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Salva"
 
@@ -1741,6 +1765,12 @@ msgstr "I nomi non devono contenere '%c' o '%c'"
 msgid "Are you sure you want to delete %s?"
 msgstr "Eliminare %s?"
 
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Benchmark"
+msgstr "Avvia benchmar&k..."
+
 #: src/Benchmark.cpp
 msgid "Disk Block Size (KB):"
 msgstr "Dimensione blocco disco (KB):"
@@ -1772,9 +1802,17 @@ msgid "Run"
 msgstr "Avvia"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Chiudi"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "Avvia benchmar&k..."
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1912,11 +1950,6 @@ msgid "No revision identifier was provided"
 msgstr "Non è stato fornito alcun identificativo di revisione"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Data e ora di fine"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Versione di debug (livello di debug %d)"
@@ -2001,6 +2034,11 @@ msgid ""
 msgstr ""
 "Prima di eseguire questa azione è necessario selezionare un audio.\n"
 "(La selezione di altri tipi di tracce non va bene)."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2163,6 +2201,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Copia nomi negli appunti"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Mancante"
 
@@ -2171,10 +2214,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Se si procede il progetto non verrà salvato su disco. Si è sicuri di voler procedere?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2188,7 +2232,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Controlla dipendenze"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nessuno"
 
@@ -2196,7 +2243,7 @@ msgstr "Nessuno"
 msgid "Rectangle"
 msgstr "Rettangolo"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triangolo"
 
@@ -2207,6 +2254,38 @@ msgstr "Sagomata"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Rettangolare"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, nessuno"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Benvenuto!"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2228,9 +2307,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Supporto FFmpeg non compilato"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2252,8 +2332,8 @@ msgid "Locate FFmpeg"
 msgstr "Individua FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Ad Audacity serve il file '%s' per importare ed esportare l'audio tramite FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2266,7 +2346,8 @@ msgstr "Posizione di '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Per cercare '%s', fare clic qui -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Sfoglia..."
 
@@ -2292,8 +2373,9 @@ msgid "FFmpeg not found"
 msgstr "Impossibile trovare FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2324,24 +2406,24 @@ msgid "Only libavformat.so"
 msgstr "Solo libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity non è riuscito ad aprire il file in %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity non è riuscito a leggere un file in %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity ha scritto con successo un file in %s ma non è riuscito a rinominarlo in %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2379,7 +2461,9 @@ msgstr "Non &copiare l'audio"
 msgid "As&k"
 msgstr "Chie&di"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Tutti i file"
 
@@ -2404,6 +2488,10 @@ msgstr "File di testo"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "File XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2445,6 +2533,14 @@ msgstr "Autocorrelazione radice cubica"
 msgid "Enhanced Autocorrelation"
 msgstr "Autocorrelazione avanzata"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spettro"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2461,9 +2557,35 @@ msgstr "Frequenza lineare"
 msgid "Log frequency"
 msgstr "Frequenza logaritmica"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "Si"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Scorri"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoom vert:"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2524,6 +2646,23 @@ msgstr "È stato selezionato troppo audio. Saranno analizzati solo i primi %.1f 
 msgid "Not enough data selected."
 msgstr "I dati selezionati non sono sufficienti."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f s (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f s (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2546,7 +2685,8 @@ msgstr "spettro.txt"
 msgid "Export Spectral Data As:"
 msgstr "Esporta dati spettrali come:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Impossibile scrivere nel file: %s"
@@ -2738,19 +2878,19 @@ msgid "&History..."
 msgstr "&Cronologia..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Errore interno in %s nel file %s alla linea %d.\n"
 "Si invita a informare il team di Audacity all'indirizzo https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Errore interno nel file %s alla linea %d.\n"
 "Si invita a informare il team di Audacity all'indirizzo https://forum.audacityteam.org/."
@@ -2769,7 +2909,9 @@ msgid "Track"
 msgstr "Traccia"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etichetta"
 
@@ -2829,7 +2971,8 @@ msgstr "Inserire nome traccia"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Traccia etichette"
 
@@ -2840,11 +2983,13 @@ msgstr "Impossibile leggere una o più etichette salvate."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Primo avvio di Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Selezionare la lingua da usare per Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2854,7 +2999,8 @@ msgstr "Selezionare la lingua da usare per Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "La lingua selezionata, %s (%s), non corrisponde alla lingua di sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Conferma"
 
@@ -2872,13 +3018,19 @@ msgstr ""
 "Il vecchio file è stato salvato come '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Apertura progetto di Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke di Audacity%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "S&foglia..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2924,19 +3076,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mixaggio e renderizzazione delle tracce"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Pannello mixer di Audacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Guadagno"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocità"
 
@@ -2945,28 +3101,43 @@ msgid "Musical Instrument"
 msgstr "Strumento musicale"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Bilanciamento"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Muto"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr " Reso solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Monitor livello segnale"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Cursore guadagno spostato"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Cursore velocità spostato"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Cursore bilanciamento spostato"
 
@@ -3001,9 +3172,9 @@ msgstr ""
 "Non verrà caricato."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3037,12 +3208,20 @@ msgstr ""
 "\n"
 "Usare solo moduli da fonti attendibili"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Sì"
 
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
+#, fuzzy
+msgid "No"
+msgstr "Nessuno"
+
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Caricatore di moduli di Audacity"
 
 #: src/ModuleManager.cpp
@@ -3284,7 +3463,8 @@ msgstr "&Seleziona tutto"
 msgid "C&lear All"
 msgstr "Cance&lla tutto"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Abilita"
 
@@ -3364,9 +3544,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Frequenze di campionamento non corrispondenti"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Sono state selezionate troppo poche tracce a questa frequenza di campionamento.\n"
@@ -3395,10 +3576,11 @@ msgid "Dropouts"
 msgstr "Perdite"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3438,11 +3620,11 @@ msgid "Inspecting project file data"
 msgstr "Analisi dei dati del file del progetto"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3485,11 +3667,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Attenzione - File alias mancanti"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Il controllo del progetto nella cartella \"%s\" \n"
@@ -3514,12 +3696,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Attenzione - File alias di riepilogo mancanti"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3577,7 +3759,8 @@ msgstr "Attenzione - File di blocco orfani"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Avanzamento"
 
@@ -3602,6 +3785,11 @@ msgstr "Attenzione: problemi nel recupero automatico"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<senza titolo>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Progetto %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3671,12 +3859,14 @@ msgstr ""
 "(impossibile creare i file temporanei richiesti)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Questo non è un file di progetto di Audacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3808,9 +3998,9 @@ msgid "Error Writing to File"
 msgstr "Errore scrittura file"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3825,9 +4015,16 @@ msgstr "Compressione del progetto"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Progetto %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Velocità"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3836,10 +4033,10 @@ msgstr "(Recuperato)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Questo file è stato salvato usando Audacity %s.\n"
 "Ora si sta usando Audacity %s. È necessario aggiornare a una nuova versione per aprire questo file."
@@ -3911,8 +4108,9 @@ msgid "Backing up project"
 msgstr "Copia di backup del progetto in corso"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3922,8 +4120,9 @@ msgstr ""
 "È stato ripristinato l'ultimo snapshot."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4002,8 +4201,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sSalva progetto \"%s\" con nome..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Salva progetto' è per un progetto di Audacity, non per un file audio.\n"
@@ -4080,11 +4280,12 @@ msgid "Error Opening Project"
 msgstr "Errore durante l'apertura del progetto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Si sta cercando di aprire un file di backup creato automaticamente.\n"
 "In questo modo si può avere una grave perdita di dati.\n"
@@ -4193,8 +4394,8 @@ msgid "Automatic database backup failed."
 msgstr "Backup automatico del database fallito."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Benvenuto nella versione %s di Audacity"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4306,6 +4507,18 @@ msgstr "Qualità alta"
 msgid "Best Quality (Slowest)"
 msgstr "Qualità migliore (la più lenta)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "PCM a 16 bit "
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "PCM a 8 bit"
+
 #. i18n-hint: Audio data bit depth (precision): 32-bit floating point
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
@@ -4399,46 +4612,66 @@ msgstr "Tutte le preferenze"
 msgid "SelectionBar"
 msgstr "Barra di selezione"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Selezione spettrale"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Timer"
+msgstr "Tempo"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Strumenti"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Attività"
 
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Mixer"
+msgstr "Pannello mixer"
+
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Monitor"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Monitor riproduzione"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Monitor registrazione"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Modifica"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Dispositivo"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Riproduci a velocità"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Scorri"
 
@@ -4453,7 +4686,10 @@ msgstr "Righello"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Tracce"
 
@@ -4563,7 +4799,8 @@ msgid "Activation level (dB):"
 msgstr "Livello attivazione (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Benvenuto in Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4605,6 +4842,10 @@ msgstr "Commenti"
 #: src/Tags.cpp
 msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
 msgstr "Usare i tasti freccia (o il tasto INVIO dopo la modifica) per spostarsi tra i campi."
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Value"
@@ -4706,9 +4947,9 @@ msgstr ""
 "Per consigli sui dischi idonei fare clic sul pulsante di aiuto."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity non può scrivere il file:\n"
@@ -4728,9 +4969,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4739,9 +4980,9 @@ msgstr ""
 "per la scrittura."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity non può scrivere immagini nel file:\n"
@@ -4758,9 +4999,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4770,9 +5011,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4781,8 +5022,9 @@ msgstr ""
 "Probabile formato png non valido?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity non può leggere il tema predefinito.\n"
@@ -4820,9 +5062,9 @@ msgstr ""
 "sono già presenti. Sovrascriverli?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity non può salvare il file:\n"
@@ -4861,7 +5103,11 @@ msgstr "Personalizzato"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Durata"
 
@@ -4872,7 +5118,8 @@ msgid "Time Track"
 msgstr "Traccia tempo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Programma registrazione"
 
 #: src/TimerRecordDialog.cpp
@@ -4946,7 +5193,8 @@ msgstr "Progetto corrente"
 msgid "Recording start:"
 msgstr "Inizio registrazione:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Durata:"
 
@@ -4967,7 +5215,8 @@ msgid "Action after Timer Recording:"
 msgstr "Azione al termine della registrazione programmata:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Avanzamento registrazione programmata di Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5048,6 +5297,12 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Registrazione programmata"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 giorni 024 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -5058,6 +5313,7 @@ msgstr "099 giorni 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data e ora di inizio"
@@ -5102,7 +5358,8 @@ msgstr "Abilitare l'&esportazione automatica?"
 msgid "Export Project As:"
 msgstr "Esporta progetto con nome:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opzioni"
 
@@ -5115,7 +5372,8 @@ msgid "Do nothing"
 msgstr "Non fare nulla"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Chiudi Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5139,7 +5397,8 @@ msgid "Scheduled to stop at:"
 msgstr "Arresto pianificato il:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Registrazione programmata di Audacity - In attesa di iniziare"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5165,8 +5424,13 @@ msgid "Recording Exported:"
 msgstr "Registrazione esportata:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Registrazione programmata di Audacity - In attesa"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5357,6 +5621,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Applicazione di %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "FALLITO"
@@ -5375,13 +5649,15 @@ msgstr "%s non è un parametro accettato da %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Valore non valido per il parametro '%s': dovrebbe essere %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Comando"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ripeti %s"
@@ -5416,6 +5692,10 @@ msgid "Compares a range on two tracks."
 msgstr "Confronta un intervallo in due tracce."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Ritardo temporale (secondi):"
 
@@ -5446,6 +5726,11 @@ msgstr "Traccia 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Traccia 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5499,13 +5784,24 @@ msgstr "Clip"
 msgid "Envelopes"
 msgstr "Inviluppi"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etichette"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Riquadri"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5515,7 +5811,8 @@ msgstr "Breve"
 msgid "Type:"
 msgstr "Tipo:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formato:"
 
@@ -5542,6 +5839,10 @@ msgstr "Commento"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Comando:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5579,12 +5880,17 @@ msgstr "Esporta in un file."
 msgid "Builtin Commands"
 msgstr "Comandi incorporati"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Il team di Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Fornisce ad Audacity i comandi incorporati"
 
 #: src/commands/LoadCommands.cpp
@@ -5647,7 +5953,10 @@ msgstr "Svuota il contenuto del registro."
 msgid "Get Preference"
 msgstr "Ottieni preferenza"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nome:"
 
@@ -5695,7 +6004,8 @@ msgstr "Schermo intero"
 msgid "Toolbars"
 msgstr "Barre degli strumenti"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effetti"
 
@@ -5835,7 +6145,8 @@ msgstr "Imposta"
 msgid "Add"
 msgstr "Aggiungi"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Rimuovi"
 
@@ -5920,7 +6231,8 @@ msgid "Edited Envelope"
 msgstr "Busta modificata"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Inviluppo"
 
@@ -5963,6 +6275,14 @@ msgstr "Frequenza:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Ridimensiona:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -6012,7 +6332,10 @@ msgstr "Bilanciamento:"
 msgid "Set Track Visuals"
 msgstr "Imposta aspetto traccia"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineare"
 
@@ -6116,12 +6439,18 @@ msgstr "La traccia selezionata non contiene audio. L'effetto Riduci volume autom
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "La funzione di riduzione automatica del volume necessita di una traccia di controllo che deve essere posizionata al di sotto delle tracce selezionate."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Quantità &volume:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "secondi"
 
@@ -6145,7 +6474,8 @@ msgstr "Lunghezza della dissolvenza in entrata &verso il basso:"
 msgid "Inner &fade up length:"
 msgstr "Lunghezza della dissolvenza in entrata vers&o l'alto:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Soglia:"
 
@@ -6184,6 +6514,11 @@ msgstr "&Alti (dB):"
 #: src/effects/BassTreble.cpp
 msgid "Treble"
 msgstr "Alti"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Volume (dB):"
+msgstr "Valore (dB)"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
@@ -6279,11 +6614,13 @@ msgstr "a (Hz)"
 msgid "t&o"
 msgstr "&a"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Percentuale di cam&biamento:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Percentuale di cambiamento"
 
@@ -6291,9 +6628,23 @@ msgstr "Percentuale di cambiamento"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Usa allungamento ad alta qualità (lento)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n/d"
 
@@ -6321,6 +6672,7 @@ msgstr "Giri/minuto vinile:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Da g/m"
@@ -6333,6 +6685,7 @@ msgstr "&da"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "A g/m"
@@ -6475,6 +6828,12 @@ msgstr "Compressione"
 msgid "Compresses the dynamic range of audio"
 msgstr "Comprime l'intervallo dinamico dell'audio"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6484,6 +6843,20 @@ msgstr "%.2f sec"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f sec"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6600,9 +6973,14 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analizzatore contrasto, per misurare differenze RMS di volume tra due selezioni di audio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Fine"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Foreground:"
@@ -6656,9 +7034,32 @@ msgstr "&Differenza:"
 msgid "&Help"
 msgstr "&Aiuto"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "indeterminata"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6712,6 +7113,12 @@ msgstr "Differenza attuale"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Livello di primo piano misurato"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f sec"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6853,6 +7260,10 @@ msgstr "Clip morbida -12dB, composizione guadagno 80%"
 msgid "Fuzz Box"
 msgstr "Fuzz box"
 
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
 #: src/effects/Distortion.cpp
 msgid "Blues drive sustain"
 msgstr "Drive sustain blues"
@@ -6962,6 +7373,10 @@ msgid "Clipping level"
 msgstr "Livello clipping"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Make-up Gain"
 msgstr "Guadagno composizione"
 
@@ -7057,7 +7472,9 @@ msgstr "&Sequenza DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Ampiezza (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Durata:"
 
@@ -7070,12 +7487,29 @@ msgid "Duty cycle:"
 msgstr "Ciclo di lavoro:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f sec"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Durata tono:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Durata silenzio:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7085,7 +7519,8 @@ msgstr "Eco"
 msgid "Repeats the selected audio again and again"
 msgstr "Ripeti l'audio selezionato più e più volte"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Il valore richiesto supera la capacità della memoria."
 
@@ -7109,7 +7544,8 @@ msgstr "Preset"
 msgid "Export Effect Parameters"
 msgstr "Esporta parametri effetto"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Impossibile aprire il file: \"%s\""
@@ -7146,6 +7582,15 @@ msgstr "Generazione dell'anteprima"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Anteprima"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Errore Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7232,6 +7677,10 @@ msgstr "&Applica"
 #: src/effects/EffectUI.cpp
 msgid "Latency: 0"
 msgstr "Latenza: 0"
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Active State"
@@ -7426,6 +7875,11 @@ msgstr "Arresta &riproduzione"
 msgid "Play"
 msgstr "Riproduci"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Coseno"
@@ -7471,6 +7925,10 @@ msgid "Low rolloff for speech"
 msgstr "Roll-off basso per il parlato"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefono"
 
@@ -7505,6 +7963,43 @@ msgstr "La frequenza di campionamento della traccia è troppo bassa per questo e
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Effetto non disponibile"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7579,12 +8074,24 @@ msgid "D&efault"
 msgstr "Pr&edefinito"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE con &thread"
 
 #: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
 msgstr "AV&X con thread"
+
+#: src/effects/Equalization.cpp
+msgid "&Bench"
+msgstr ""
 
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
@@ -7793,6 +8300,11 @@ msgid "Creates labels where clipping is detected"
 msgstr "Crea etichette dove è rilevato il clipping"
 
 #: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Clipping forte"
+
+#: src/effects/FindClipping.cpp
 msgid "&Start threshold (samples):"
 msgstr "Soglia di &inizio (campioni):"
 
@@ -7817,7 +8329,8 @@ msgid "Builtin Effects"
 msgstr "Effetti incorporati"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Fornisce ad Audacity gli effetti incorporati"
 
 #: src/effects/LoadEffects.cpp
@@ -7827,6 +8340,10 @@ msgstr "Nome sconosciuto dell'effetto incorporato"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "sonorità percepita"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7858,6 +8375,14 @@ msgstr "&Normalizza"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Sonorità LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7927,8 +8452,21 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (predefinito)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
 msgstr "Hamming, nessuno"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
+msgstr "Hamming, nessuno"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -8023,8 +8561,9 @@ msgid "Step 1"
 msgstr "Passo 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Selezionare pochi secondi del rumore in modo che Audacity riconosca quello va filtrato,\n"
@@ -8076,13 +8615,62 @@ msgstr "Tipi di &finestra:"
 msgid "Window si&ze:"
 msgstr "Dimen&sione finestra:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (predefinito)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Pa&ssi per finestra:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8198,12 +8786,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "&Normalizza canali stereo indipendentemente"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Allunga"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Usa Paulstretch solo per un estremo allungamento temporale o un effetto di \"stasi\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Fa&ttore di allungamento:"
@@ -8255,6 +8849,10 @@ msgstr ""
 "o a ridurre la risoluzione temporale a meno di %.1f secondi."
 
 #: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
 msgstr "Combina segnali sfasati con il segnale originale"
 
@@ -8269,6 +8867,10 @@ msgstr "Passaggi"
 #: src/effects/Phaser.cpp
 msgid "&Dry/Wet:"
 msgstr "&Dry/wet:"
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
@@ -8293,6 +8895,11 @@ msgstr "Profondit&à:"
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "Depth in percent"
 msgstr "Profondità in percentuale"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Feedbac&k (%):"
+msgstr "River&bero (%):"
 
 #: src/effects/Phaser.cpp
 msgid "Feedback in percent"
@@ -8473,6 +9080,11 @@ msgstr "Inverti l'audio selezionato"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Tempo SBSMS / stiramento intonazione"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8628,6 +9240,11 @@ msgstr "Usa predefiniti"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Ripristina predefiniti"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8787,6 +9404,10 @@ msgstr "Rileva silenzio"
 msgid "Tr&uncate to:"
 msgstr "Tr&onca a:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Com&primi a:"
@@ -8800,7 +9421,8 @@ msgid "VST Effects"
 msgstr "Effetti VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Aggiunge la capacità di utilizzare effetti VST in Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8812,7 +9434,8 @@ msgstr "Scansione shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registrazione %d di %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Non è stato possibile caricare la libreria"
 
@@ -8832,7 +9455,8 @@ msgstr "La dimensione del buffer controlla il numero di campioni inviati all'eff
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Dimensione &buffer (da 8 a 1048576 campioni):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Compensazione latenza"
 
@@ -8840,7 +9464,8 @@ msgstr "Compensazione latenza"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Come parte del loro processo, alcuni effetti VST ritardano l'audio restituito ad Audacity. Quando questo ritardo non è compensato verranno inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione per fornire questa compensazione; notare che tuttavia potrebbe non funzionare con tutti gli effetti VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Abilita &compensazione"
 
@@ -8874,7 +9499,8 @@ msgid "Standard VST program file"
 msgstr "File di programma VST standard"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "File di combinazioni VST di Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8901,7 +9527,8 @@ msgstr "Errore durante il caricamento delle combinazioni VST"
 msgid "Unable to load presets file."
 msgstr "Impossibile caricare il file delle combinazioni."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Impostazioni effetto"
 
@@ -8917,6 +9544,16 @@ msgstr "Non è stato possibile leggere il file delle combinazioni."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Questo file di parametri è stato salvato da %s. Procedere?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8948,7 +9585,8 @@ msgid "Audio Unit Effects"
 msgstr "Effetti unità audio"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Fornisce ad Audacity il supporto agli effetti unità audio"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8964,7 +9602,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Opzioni effetti unità audio"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Come parte del loro processo, alcuni effetti Audio Unit ritardano l'audio restituito ad Audacity. Quando questo ritardo non è compensato verranno inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione per fornire questa compensazione; notare che tuttavia potrebbe non funzionare con tutti gli effetti Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9108,6 +9747,7 @@ msgstr "Unità audio"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Effetti LADSPA"
@@ -9117,7 +9757,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Fornisce effetti LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity non usa più vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9125,12 +9766,30 @@ msgid "LADSPA Effect Options"
 msgstr "Opzioni effetti LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Come parte del loro processo, alcuni effetti LADSPA ritardano l'audio restituito ad Audacity. Quando questo ritardo non è compensato verranno inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione per fornire questa compensazione; notare che tuttavia potrebbe non funzionare con tutti gli effetti LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s tra:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Uscita effetto"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Effetti LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9142,7 +9801,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Dimensione &buffer (8 to %d) in campioni:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Come parte del loro processo, alcuni effetti LV2 ritardano l'audio restituito ad Audacity. Quando questo ritardo non è compensato verranno inseriti dei silenzi di breve durata nell'audio. Abilitare questa opzione per fornire questa compensazione; notare che tuttavia potrebbe non funzionare con tutti gli effetti LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9167,12 +9827,19 @@ msgstr "%s richiede l'opzione non supportata %s\n"
 msgid "Generator"
 msgstr "Generatore"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Effetti VL2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Fornisce ad Audacity il supporto agli effetti LV2"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9180,7 +9847,8 @@ msgid "Nyquist Effects"
 msgstr "Effetti Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Fornisce ad Audacity il supporto agli effetti Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9408,7 +10076,8 @@ msgstr "Seleziona un file"
 msgid "Save file as"
 msgstr "Salva file come"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "senza titolo"
 
@@ -9417,7 +10086,8 @@ msgid "Vamp Effects"
 msgstr "Effetti Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Fornisce ad Audacity il supporto agli effetti Vamp"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9439,6 +10109,12 @@ msgstr "Impostazioni estensione"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programma"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9597,6 +10273,10 @@ msgid "Command Output"
 msgstr "Output del comando"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "È stato specificato un nome di file senza alcuna. Si è certi?"
 
@@ -9735,7 +10415,8 @@ msgstr "Esportazione dell'audio come %s"
 msgid "Invalid sample rate"
 msgstr "Frequenza di campionamento non valida"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Ricampiona"
 
@@ -9765,6 +10446,14 @@ msgstr "È possibile ricampionare a una delle seguenti frequenze."
 msgid "Sample Rates"
 msgstr "Frequenze di campionamento"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Bit rate:"
@@ -9772,6 +10461,48 @@ msgstr "Bit rate:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualità (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f sec"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9782,12 +10513,42 @@ msgid "Constrained"
 msgstr "Vincolato"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Audio"
+msgstr "File audio"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Poco ritardo"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9874,8 +10635,17 @@ msgid "Replace preset '%s'?"
 msgstr "Sostituire la combinazione '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Do"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principale"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9945,6 +10715,12 @@ msgstr "Importa combinazioni"
 msgid "Export Presets"
 msgstr "Esporta combinazioni"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Codec attuale:"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
 msgstr "Non tutti i formati e codec sono compatibili. Non tutte le combinazioni di opzioni sono compatibili con tutti i codec."
@@ -9979,6 +10755,10 @@ msgstr "Lingua:"
 msgid "Bit Reservoir"
 msgstr "Deposito bit"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9989,6 +10769,10 @@ msgstr ""
 "Tag del codec (FOURCC)\n"
 "Opzionale\n"
 "vuoto - automatico"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10091,6 +10875,11 @@ msgstr ""
 "max - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Nome:"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "LPC coefficients precision\n"
 "Optional\n"
@@ -10103,6 +10892,11 @@ msgstr ""
 "0 - predefinito\n"
 "min - 1\n"
 "max - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Usa LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10283,6 +11077,16 @@ msgid "Failed to find the codec"
 msgstr "Non è stato possibile trovare il codec"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "DWVW a 16 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "DWVW a 24 bit"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (la più veloce)"
 
@@ -10351,6 +11155,41 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (qualità migliore)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Estremo, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "Medio, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "Medio, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (file più piccoli)"
 
@@ -10361,6 +11200,11 @@ msgstr "Senza senso, 320 kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "Extreme, 220-260 kbps"
+msgstr "Estremo, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Standard, 170-210 kbps"
 msgstr "Estremo, 220-260 kbps"
 
 #: src/export/ExportMP3.cpp
@@ -10375,6 +11219,11 @@ msgstr "Insano"
 #: src/export/ExportMP3.cpp
 msgid "Extreme"
 msgstr "Estremo"
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "Medium"
@@ -10391,6 +11240,16 @@ msgstr "Media"
 #: src/export/ExportMP3.cpp
 msgid "Constant"
 msgstr "Costante"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "Non collegare stereo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
 
 #: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
@@ -10415,8 +11274,8 @@ msgid "Locate LAME"
 msgstr "Individua LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity necessita del file %s per creare gli MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10444,10 +11303,10 @@ msgid "Where is %s?"
 msgstr "Dove si trova il file %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Ci si sta collegando a lame_enc.dll v%d.%d. Questa versione non è compatibile con Audacity %d.%d.%d.\n"
 "Scaricare l'ultima versione di 'LAME per Audacity'."
@@ -10752,6 +11611,14 @@ msgstr "Esportazione dell'audio selezionato come Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Esportazione dell'audio come Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Intestazione:"
@@ -10765,9 +11632,10 @@ msgid "Other uncompressed files"
 msgstr "Altri file non compressi"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Si è cercato di esportare un file WAV o AIFF che sarebbe più grande di 4GB.\n"
 "Questa operazione non è supportata da Aucacity: l'esportazione è stata interrotta."
@@ -10777,8 +11645,9 @@ msgid "Error Exporting"
 msgstr "Errore di esportazione"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Il file WAV esportato è stato troncato in quanto Aucacity non può esportare\n"
@@ -10818,11 +11687,11 @@ msgid "All supported files"
 msgstr "Tutti i file supportati"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10831,11 +11700,11 @@ msgstr ""
 "ma è possibile modificarlo facendo clic su File > Importa > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "non è un file audio. \n"
@@ -10846,18 +11715,18 @@ msgid "Select stream(s) to import"
 msgstr "Selezionare i flussi da importare"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Questa versione di Audacity non è stata compilata con il supporto per %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è una traccia di un CD audio. \n"
 "Audacity non può aprire direttamente i CD audio. \n"
@@ -10866,10 +11735,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" è una playlist. \n"
@@ -10878,10 +11747,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file Windows Media Audio. \n"
@@ -10890,10 +11759,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file Advanced Audio Coding. \n"
@@ -10902,12 +11771,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file audio criptato. \n"
@@ -10918,10 +11787,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file multimediale RealPlayer. \n"
@@ -10930,12 +11799,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" è un file basato sulle note, non un file audio. \n"
 "Audacity non può aprire questo tipo di file. \n"
@@ -10944,10 +11813,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10960,10 +11829,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file audio Wavpack. \n"
@@ -10972,10 +11841,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file audio Dolby Digital. \n"
@@ -10984,10 +11853,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file audio Ogg Speex. \n"
@@ -10996,10 +11865,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" è un file video. \n"
@@ -11013,9 +11882,9 @@ msgstr "Impossibile trovare il file \"%s\"."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11031,11 +11900,16 @@ msgstr ""
 "Provare ad installare FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11065,12 +11939,13 @@ msgid "Import Project"
 msgstr "Importa progetto"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Il progetto è stato salvato con Audacity versione 1.0 o precente.\n"
 "Il formato è cambiato e questa versione di Audacity non è in\n"
@@ -11123,7 +11998,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Non è stato possibile trovare la cartella coi dati del progetto: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Nel progetto sono state trovate tracce MIDI, tuttavia questa versione di Audacity non supporta i MIDI: le tracce verranno ignorate."
 
 #: src/import/ImportAUP.cpp
@@ -11228,40 +12104,6 @@ msgstr "Indice[%02x] Codec[%s], Lingua[%s], Bitrate[%s], Canali[%d], Durata[%d]"
 msgid "FLAC files"
 msgstr "File FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "File compatibili con GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Impossibile aggiungere il decodificatore alla pipeline"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importatore GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Impossibile impostare lo stato del flusso su pausa."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indice[%02d], Tipo[%s], Canali[%d], Frequenza[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Il file non contiene alcun flusso audio."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Impossibile importare il file, il cambiamento di stato non è riuscito."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Errore GStreamer: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Elenco di file in formato testo di base"
@@ -11363,18 +12205,98 @@ msgstr "Errore logico interno"
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, e altri tipi non compressi"
 
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/import/ImportPCM.cpp
 msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (codec audio FLAC senza perdita)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (contenitore in formato OGG)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (senza intestazione)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11405,6 +12327,39 @@ msgid "64 bit float"
 msgstr "64 bit virgola mobile"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "DWVW a 16 bit"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "DWVW a 16 bit"
 
@@ -11413,12 +12368,20 @@ msgid "24 bit DWVW"
 msgstr "DWVW a 24 bit"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "PCM a 16 bit "
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "PCM a 8 bit"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11467,6 +12430,19 @@ msgstr "Importa dati raw"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Nessun ordine dei byte"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Mediano"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -11541,6 +12517,7 @@ msgstr "%s destra"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11564,6 +12541,7 @@ msgstr "fine"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11590,7 +12568,8 @@ msgstr "Clip spostate temporalmente a destra"
 msgid "Time shifted clips to the left"
 msgstr "Clip spostate temporalmente a sinistra"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Spostamento temporale"
 
@@ -11728,7 +12707,8 @@ msgstr "Ritaglia le tracce audio selezionate da %.2f secondi a %.2f"
 msgid "Trim Audio"
 msgstr "Ritaglia audio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Dividi"
 
@@ -11849,28 +12829,8 @@ msgid "Delete Key&2"
 msgstr "Tasto Canc&2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Re&gola volume di riproduzione..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Incrementa volume di riproduzione"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Decrementa volume di riproduzione"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Reg&ola volume di registrazione..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "I&ncrementa volume di registrazione"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "D&ecrementa volume di registrazione"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12038,8 +12998,18 @@ msgid "Export MI&DI..."
 msgstr "Esporta MI&DI..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "&Esporta audio..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Labels..."
 msgstr "&Etichette..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Esporta MI&DI..."
 
 #: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
@@ -12130,8 +13100,9 @@ msgid "&Getting Started"
 msgstr "&Per iniziare"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manuale di Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manuale..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12157,11 +13128,8 @@ msgstr "Informazioni sui dispositivi &MIDI..."
 msgid "Show &Log..."
 msgstr "Mostra &registro..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Informazioni su &Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etichetta aggiunta"
 
@@ -12363,6 +13331,10 @@ msgid "Move Forward Through Active Windows"
 msgstr "Sposta in avanti tra le finestre attive"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Vai in&dietro da barre degli strumenti a tracce"
 
@@ -12405,6 +13377,11 @@ msgstr "Commuta traccia evi&denziata"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Non classificato"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Nuovo..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12843,6 +13820,7 @@ msgstr "Sposta&mento lungo del cursore a destra"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Cer&ca"
@@ -13054,18 +14032,21 @@ msgid "Created new label track"
 msgstr "Nuova traccia etichette creata"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Questa versione di Audacity permette solo una traccia temporale per ciascuna finestra di progetto."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Nuova traccia temporale creata"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nuova frequenza di campionamento (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Il valore inserito non è valido"
 
@@ -13143,6 +14124,10 @@ msgstr "Traccia &etichette"
 #: src/menus/TrackMenus.cpp
 msgid "&Time Track"
 msgstr "Traccia &temporale"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
@@ -13318,7 +14303,9 @@ msgstr "Riproduzione"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Registrazione"
 
@@ -13469,10 +14456,6 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "So&ftware playthrough (attiva/disattiva)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Regolazione a&utomatica livello di registrazione (attiva/disattiva)"
-
-#: src/menus/TransportMenus.cpp
 msgid "T&ransport"
 msgstr "Att&ività"
 
@@ -13480,6 +14463,11 @@ msgstr "Att&ività"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "R&iproduci"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -13557,6 +14545,13 @@ msgstr "Vai all'etichetta &successiva"
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Visualizza"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "Zoom vert:"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
@@ -13675,13 +14670,18 @@ msgstr "Preferenze per qualità"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Aggiorna Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
 msgid "&Check for Updates"
 msgstr "&Controlla aggiornamenti..."
+
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+#, fuzzy
+msgid "Batch"
+msgstr "Corrispondenza"
 
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
@@ -13718,7 +14718,8 @@ msgstr "&Sistema:"
 msgid "Using:"
 msgstr "Per mezzo di:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Riproduzione"
 
@@ -13738,7 +14739,8 @@ msgstr "Ca&nali:"
 msgid "Latency"
 msgstr "Latenza"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "millisecondi"
 
@@ -13767,7 +14769,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Cartelle"
 
@@ -13875,7 +14878,8 @@ msgid "Directory %s is not writable"
 msgstr "La cartella %s non è scrivibile"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "I cambiamenti della cartella temporanea non avranno effetto finché Audacity non viene riavviato"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13906,6 +14910,40 @@ msgstr "Raggruppati per editore"
 msgid "Grouped by Type"
 msgstr "Raggruppati per tipo"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Errore Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Abilita effetti"
@@ -13927,11 +14965,13 @@ msgid "Plugin Options"
 msgstr "Opzioni estensioni"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Controlla aggiornamenti estensioni all'avvio di Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Rianalizza le estensioni al prossimo avvio di Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14111,7 +15151,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Conserva e&tichette se la selezione si aggancia a un'etichetta"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "&Fondi tema di sistema e tema di Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14136,6 +15177,10 @@ msgstr "Mostra righello scorrimento"
 msgid "Language \"%s\" is unknown"
 msgstr "La lingua \"%s\" è sconosciuta"
 
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Importazione / esportazione"
@@ -14151,6 +15196,10 @@ msgstr "&Miscela a stereo o a mono"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Use Advanced Mixing Options"
 msgstr "&Usa opzioni avanzate di mixaggio"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "E&xtended (with frequency ranges)"
@@ -14281,7 +15330,8 @@ msgstr ""
 "   *   \"%s\"  (poiché la combinazione '%s' è usata da \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Selezionare un file XML contenente le combinazioni di tasti di Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14414,8 +15464,9 @@ msgid "Dow&nload"
 msgstr "Sca&rica"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity ha automaticamente individuato delle librerie FFmpeg valide.\n"
@@ -14474,8 +15525,9 @@ msgid "Preferences for Module"
 msgstr "Preferenze per modulo"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Questi sono moduli sperimentali. Abilitarli solo dopo aver letto il manuale di Audacity\n"
@@ -14483,12 +15535,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'Chiedi' indica che Audacity chiederà se caricare il modulo ad ogni avvio."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'Non riuscito' indica che Audacity ritiene che il modulo sia guasto e non lo esegue."
 
 #. i18n-hint preserve the leading spaces
@@ -14497,7 +15551,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Nuovo' indica che nessuna scelta è stata ancora fatta."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "I cambiamenti a queste impostazioni hanno effetto solo all'avvio di Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14515,6 +15570,14 @@ msgstr "Non è stato trovato alcun modulo"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modulo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
+msgid "Mouse"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp
 msgid "Preferences for Mouse"
@@ -14552,7 +15615,10 @@ msgstr "Sinistro-Trascina"
 msgid "Set Selection Range"
 msgstr "Imposta area di selezione"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Maiusc-Clic sinistro"
 
@@ -14640,6 +15706,15 @@ msgstr "-Sinistro-Trascina"
 msgid "Move clip up/down between tracks"
 msgstr "Sposta clip su/giù tra le tracce"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Sinistro-Trascina"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14668,6 +15743,11 @@ msgstr "Modifica più campioni"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Cambia UN solo campione"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Multi-strumento"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14759,7 +15839,8 @@ msgid "Always scrub un&pinned"
 msgstr "Scorrimento sempre s&bloccato"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferenze di Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14773,6 +15854,11 @@ msgstr "Preferenze:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferenze per qualità"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14815,6 +15901,14 @@ msgstr "Conver&titore della frequenza di campionamento:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Reti&natura:"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14884,41 +15978,32 @@ msgid "System T&ime"
 msgstr "Ora d&i sistema"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Regolazione automatica del livello di registrazione"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Abilita regolazione automatica del livello di registrazione."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Picco obiettivo:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Entro:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Tempo di analisi:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "millisecondi (tempo di un'analisi)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Numero di analisi consecutive:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 significa infinito"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Registrazione Punch e Roll"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Dissolvenza incrociata di clip"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15029,6 +16114,10 @@ msgid "&Range (dB):"
 msgstr "&Intervallo (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
 msgstr "Algoritmo"
 
@@ -15047,6 +16136,10 @@ msgstr "8 - la banda più larga"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - predefinita"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -15146,13 +16239,14 @@ msgid "Info"
 msgstr "Informazioni"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15333,7 +16427,8 @@ msgstr "Campioni"
 msgid "4 Pixels per Sample"
 msgstr "4 pixel per campione"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom massimo"
 
@@ -15455,16 +16550,24 @@ msgid "Stopped"
 msgstr "Arrestato"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Vai all'inizio"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Vai alla fine"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Seleziona fino all'inizio"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Seleziona fino alla fine"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15478,20 +16581,17 @@ msgstr "Registra nuova traccia"
 msgid "Append Record"
 msgstr "Accoda registrazione"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Seleziona fino alla fine"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Seleziona fino all'inizio"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s in pausa."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15571,11 +16671,17 @@ msgstr "Silenzia audio selezionato"
 msgid "Sync-Lock Tracks"
 msgstr "Blocca sincronizzazione tracce"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zoom avanti"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zoom indietro"
 
@@ -15642,43 +16748,6 @@ msgstr "Barra monitor &registrazione"
 msgid "&Playback Meter Toolbar"
 msgstr "Barra monitor ri&produzione"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volume registrazione"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volume riproduzione"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volume registrazione: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volume registrazione (non disponibile; usa mixer di sistema)."
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volume riproduzione: %.2f (simulato)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volume riproduzione: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volume riproduzione (non disponibile; usa mixer di sistema)."
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra mi&xer"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Ricerca"
@@ -15694,6 +16763,7 @@ msgstr "Scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Ferma scorrimento"
@@ -15701,6 +16771,7 @@ msgstr "Ferma scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Inizia scorrimento"
@@ -15708,6 +16779,7 @@ msgstr "Inizia scorrimento"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Ferma ricerca"
@@ -15715,6 +16787,7 @@ msgstr "Ferma ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Inizia ricerca"
@@ -15769,7 +16842,9 @@ msgstr "Ancoraggio"
 msgid "Length"
 msgstr "Lunghezza"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centra"
 
@@ -15833,8 +16908,8 @@ msgstr "Barra &temporale"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra degli strumenti %s di Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15861,7 +16936,8 @@ msgstr "Strumento spostamento temporale"
 msgid "Zoom Tool"
 msgstr "Strumento zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Strumento disegno"
 
@@ -15937,11 +17013,13 @@ msgstr "Trascina uno o più limiti etichette."
 msgid "Drag label boundary."
 msgstr "Trascina limite etichetta."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Etichetta modificata"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Modifica etichetta"
 
@@ -15996,31 +17074,42 @@ msgstr "Etichette modificate"
 msgid "New label"
 msgstr "Nuova etichetta"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Una &ottava su"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Una otta&va giù"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Fare clic per ingrandire verticalmente, Maiusc-clic per ridurre. Trascinare per specificare una regione d'ingrandimento."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clic destro per il menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zoom ripristinato"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Maiusc-Clic destro"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Clic sinistro/Trascina sinistra"
 
@@ -16062,7 +17151,8 @@ msgstr "Unisci"
 msgid "Expanded Cut Line"
 msgstr "Linea di taglio espansa"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Espandi"
 
@@ -16085,6 +17175,11 @@ msgstr "Campioni spostati"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Modifica campione"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16130,7 +17225,8 @@ msgstr "Elaborazione...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' modificato in %s"
@@ -16142,6 +17238,54 @@ msgstr "Cambiamento formato"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Fr&equenza"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16161,7 +17305,8 @@ msgstr "Cambiamento frequenza"
 msgid "Set Rate"
 msgstr "Imposta frequenza di campionamento"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Multi-vista"
 
@@ -16180,6 +17325,11 @@ msgstr "Div&idi traccia stereo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Dividi stereo in mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16230,6 +17380,16 @@ msgid "Split to Mono"
 msgstr "Dividi in mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Sinistro, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Sinistro, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Sinistro, %dHz"
@@ -16239,14 +17399,23 @@ msgstr "Sinistro, %dHz"
 msgid "Right, %dHz"
 msgstr "Destro, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% sinistra"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% destra"
@@ -16266,6 +17435,16 @@ msgstr "Riorganizza sotto-viste"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Close sub-view"
 msgstr "Chiudi sotto-vista"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Zoom avanti"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Zoom avanti"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
@@ -16356,9 +17535,8 @@ msgstr "&Interpolazione logaritmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Fare clic e trascinare per spostare una traccia nel tempo"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16409,6 +17587,7 @@ msgstr "Inviluppo regolato."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Scorri"
@@ -16420,6 +17599,7 @@ msgstr "Ricerca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Righello scorrimento"
@@ -16615,6 +17795,12 @@ msgstr "Sx"
 msgid "R"
 msgstr "Dx"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16648,13 +17834,28 @@ msgstr "Vuoto"
 msgid "Backwards"
 msgstr "Indietro"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Avanti"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Aiuto su internet"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Menu"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -16775,6 +17976,23 @@ msgstr "Selezionare un'azione"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 secondi"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "gg:hh:mm:ss"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 giorni 024 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in days, hours,
 #. * minutes and seconds
 #: src/widgets/NumericTextCtrl.cpp
@@ -16796,11 +18014,35 @@ msgstr "0100 giorni 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + centesimi"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 fotogrammi|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + millisecondi"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 fotogrammi|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16822,6 +18064,7 @@ msgstr "0100 h 060 m 060 s+># campioni"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "campioni"
@@ -16975,6 +18218,36 @@ msgstr "Fotogrammi CDDA (75 frame/sec)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 frame|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "01000,01000,01000 campioni|#"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
@@ -17039,6 +18312,11 @@ msgstr "(usare il menu contestuale per cambiare formato)"
 msgid "centiseconds"
 msgstr "centesimi di secondo"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Tempo trascorso:"
@@ -17080,6 +18358,11 @@ msgstr "Conferma chiusura"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Non è stato possibile le combinazioni da \"%s\""
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -17184,15 +18467,27 @@ msgstr "Impossibile analizzare XML"
 msgid "Spectral edit multi tool"
 msgstr "Multistrumento modifica spettrale"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtraggio in corso..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Rilasciato sotto i termini della GNU General Public License versione 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aSelezionare le frequenze."
@@ -17219,7 +18514,8 @@ msgstr ""
 "                      Provare ad aumentare il limite delle basse frequenze~%~\n"
 "                      o a ridurre la 'larghezza' del filtro."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Errore.~%"
@@ -17280,6 +18576,25 @@ msgstr "Studio dissolvenza in uscita"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Applicazione dissolvenza in corso..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Imposta prede&finito"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Rilasciato secondi i termini della licenza GNU General Public versione 2 o successiva."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17423,6 +18738,11 @@ msgstr "Ricerca battuta"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Ricerca battute in corso..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Registro di Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17747,13 +19067,38 @@ msgstr "Filtro passa-alto"
 msgid "Performing High-Pass Filter..."
 msgstr "Applicazione filtro passa-alto in corso..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequenza (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB per ottava)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17774,10 +19119,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Suoni etichette"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Rilasciato secondi i termini della licenza GNU General Public versione 2 o successiva."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17838,6 +19179,12 @@ msgstr "Silenzio finale massimo"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Suono ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -18017,6 +19364,12 @@ msgstr ""
 "Picco basato sui primi ~a secondi ~a dB~%\n"
 "Impostazione soglia suggerita ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Filtro notch"
@@ -18065,7 +19418,8 @@ msgstr "File Lisp"
 msgid "HTML file"
 msgstr "File HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "File di testo"
 
@@ -18142,6 +19496,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Valori MIDI per le note di do: 36, 48, 60 [do centrale], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Intonazione pizzicato MIDI"
 
@@ -18170,6 +19528,10 @@ msgid "Generating Rhythm..."
 msgstr "Generazione ritmo in corso..."
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 battute/minuto"
 
@@ -18184,6 +19546,10 @@ msgstr "1 - 20 battute/misura"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Quantità swing"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18254,6 +19620,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Intonazione MIDI di battuta forte"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Intonazione MIDI di battuta debole"
 
@@ -18272,6 +19642,10 @@ msgstr "Tamburo Risset"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Generazione tamburo Risset in corso..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18374,6 +19748,11 @@ msgstr "Mostra messaggi"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Solo errori"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18642,6 +20021,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Error.~%Frequenze di campionamento della traccia inferiori a 100 Hz non sono supportate."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Applicazione tremolo in corso..."
 
@@ -18668,6 +20051,10 @@ msgstr "Riduzione e isolamento vocale"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Applicazione azione in corso..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18810,8 +20197,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Questa estensione funziona solo con tracce stereo."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Elaborazione Vocoder in corso..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18853,6 +20248,229 @@ msgstr "Frequenza degli aghi radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Errore.~%Richiesta traccia stereo."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Aggiorna Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "Trala&scia"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Installa aggiornamento"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Registro modifiche"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Ulteriori informazioni su GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Errore durante la verifica di aggiornamenti"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Non è stato possibile collegarsi al server degli aggiornamenti di Audacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "I dati dell'aggiornamento sono danneggiati."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Errore durante lo scaricamento dell'aggiornamento."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Non è stato possibile aprire il collegamento al download di Audacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "È disponibile Audacity %s!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Registrazione"
+
+#~ msgid "Commit Id:"
+#~ msgstr "ID commit:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Libreria GUI multi-piattaforma"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importazione tramite GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Ottimizzazione ulteriore impossibile. Livello ancora troppo alto."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "La regolazione automatica del livello di registrazione ha ridotto il volume a %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Ottimizzazione ulteriore impossibile. Livello ancora troppo basso."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "La regolazione automatica del livello di registrazione ha aumentato il volume a %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Il numero totale di analisi è stato superato senza trovare un volume accettabile. Livello ancora troppo alto."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Il numero totale di analisi è stato superato senza trovare un volume accettabile. Livello ancora troppo basso."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "La regolazione automatica del livello di registrazione è stata interrotta. Sembra che %.2f sia un volume accettabile."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Ricevuto %d durante l'apertura dei dispositivi\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Non è stato possibile aprire Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Mixer disponibili:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Fonti di registrazione disponibili:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volumi di riproduzione disponibili:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Il volume di registrazione è simulato\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Il volume di registrazione è nativo\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Il volume di riproduzione è simulato\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Il volume di riproduzione è nativo\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Data e ora di fine"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "File compatibili con GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Impossibile aggiungere il decodificatore alla pipeline"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importatore GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Impossibile impostare lo stato del flusso su pausa."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indice[%02d], Tipo[%s], Canali[%d], Frequenza[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Il file non contiene alcun flusso audio."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Impossibile importare il file, il cambiamento di stato non è riuscito."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Errore GStreamer: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Re&gola volume di riproduzione..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Incrementa volume di riproduzione"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Decrementa volume di riproduzione"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Reg&ola volume di registrazione..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "I&ncrementa volume di registrazione"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "D&ecrementa volume di registrazione"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manuale di Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Informazioni su &Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Regolazione a&utomatica livello di registrazione (attiva/disattiva)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Regolazione automatica del livello di registrazione"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Abilita regolazione automatica del livello di registrazione."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Picco obiettivo:"
+
+#~ msgid "Within:"
+#~ msgstr "Entro:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Tempo di analisi:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "millisecondi (tempo di un'analisi)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Numero di analisi consecutive:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 significa infinito"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volume registrazione"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volume riproduzione"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volume registrazione: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume registrazione (non disponibile; usa mixer di sistema)."
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volume riproduzione: %.2f (simulato)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volume riproduzione: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume riproduzione (non disponibile; usa mixer di sistema)."
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra mi&xer"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Fare clic e trascinare per spostare una traccia nel tempo"
 
 #~ msgid "Program build date:"
 #~ msgstr "Data di compilazione programma:"

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/tenacity/tenacity/ja/>\n"
@@ -22,72 +22,6 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Audacity を更新"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "スキップ(&S)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "更新をインストール(&I)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "更新履歴"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "GitHub でもっと読む"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "更新確認エラー"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Audacity の更新サーバーに接続できません。"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "更新データが破損しました。"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "更新ダウンロードエラー。"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Audacity のダウンロードリンクを開けません。"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s 始めました！"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "録音"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "測定できません"
@@ -96,6 +30,29 @@ msgstr "測定できません"
 #, c-format
 msgid "%s bytes"
 msgstr "%s バイト"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
+#: libraries/lib-strings/Languages.cpp
+#, fuzzy
+msgid "Simplified"
+msgstr "単純"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "System"
@@ -218,7 +175,8 @@ msgid "Script"
 msgstr "スクリプト"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "出力"
 
@@ -234,7 +192,12 @@ msgstr "Nyquist スクリプト (*.ny)|*.ny|Lisp スクリプト (*.lsp)|*.lsp|�
 msgid "Script was not saved."
 msgstr "Nyquist スクリプトは保存されていません。"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "警告"
 
@@ -247,7 +210,24 @@ msgid "Find dialog"
 msgstr "ダイアログの検索"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "エフェクト作成 IDE を提供する外部 Audacity モジュールです。"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -270,7 +250,8 @@ msgstr "無題"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist エフェクトワークベンチ - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "新規"
 
@@ -312,7 +293,8 @@ msgstr "コピー"
 msgid "Copy to clipboard"
 msgstr "クリップボードへコピー"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "切り取り"
 
@@ -320,7 +302,8 @@ msgstr "切り取り"
 msgid "Cut to clipboard"
 msgstr "切り取った内容をクリップボードに退避"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "貼り付け"
 
@@ -346,7 +329,8 @@ msgstr "すべて選択"
 msgid "Select all text"
 msgstr "すべてのテキストを選択"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "元に戻す"
 
@@ -354,7 +338,8 @@ msgstr "元に戻す"
 msgid "Undo last change"
 msgstr "直前の変更を元に戻す"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "やり直し"
 
@@ -371,19 +356,54 @@ msgid "Find text"
 msgstr "テキスト検索"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Match"
+msgstr "自動実行"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Go to matching paren"
 msgstr "対応する paren へ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Top"
+msgstr "変更後回転数"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "書き出すプリセットがありません"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "上へ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to higher S-expr"
+msgstr "Higher S-expr(&H)\tF10"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "１つ前"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "一つ前の S-expr(&P)\tF11"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Next"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to next S-expr"
+msgstr "ヘルプ情報のご案内"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "開始"
 
@@ -391,7 +411,8 @@ msgstr "開始"
 msgid "Start script"
 msgstr "スクリプトの開始"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "停止"
 
@@ -406,16 +427,25 @@ msgstr "スクリプトの停止"
 msgid "About %s"
 msgstr "%s について"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "OK"
+msgstr "OK(&O)"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "ビルド情報"
 
 # ja: 「無効」と見分けやすくするためにあえて文字数を増やす
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "有効です"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "無効"
 
@@ -425,8 +455,9 @@ msgid "The Build"
 msgstr "ビルド"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "コミット ID:"
+#, fuzzy
+msgid "Version:"
+msgstr "バージョン"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -436,22 +467,28 @@ msgstr "ビルドの種類:"
 msgid "Compiler:"
 msgstr "コンパイラ:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "インストールプレフィックス:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "設定フォルダー:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "設定フォルダー:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "サポートするファイル形式"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "クロスプラットフォームの GUI ライブラリ"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -465,7 +502,6 @@ msgstr "サンプリング周波数変換"
 msgid "MP3 Importing"
 msgstr "MP3 の取り込み"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis の取り込みと書き出し"
@@ -474,7 +510,6 @@ msgstr "Ogg Vorbis の取り込みと書き出し"
 msgid "ID3 tag support"
 msgstr "ID3 タグのサポート"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC の取り込みと書き出し"
@@ -492,14 +527,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg による取り込み/書き出し"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "GStreamer 経由の取り込み"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "機能"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "プラグインのサポート"
 
@@ -514,6 +541,10 @@ msgstr "ピッチとテンポの変化のサポート"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "急激なピッチとテンポの変化のサポート"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "機能"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -632,6 +663,10 @@ msgstr "グラフィック: %s"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (%s、%s、%s、%s、%s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -641,6 +676,10 @@ msgstr "%s は、録音と音声編集のために開発された<br>無料 &amp
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "クレジット"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -691,6 +730,7 @@ msgstr "ウェブサイトとグラフィック"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "日本語訳:<br>Atsushi Yoshida (ayoshida.pub@gmail.com)<br>Phroneris (phroneris@gmail.com)"
@@ -708,6 +748,22 @@ msgstr "スペシャルサンクス:"
 #, c-format
 msgid "%s website: "
 msgstr "%s ウェブサイト: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "支援者の方々"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -730,6 +786,7 @@ msgstr "タイムライン"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "クリックまたはドラッグでシーク開始"
@@ -737,6 +794,7 @@ msgstr "クリックまたはドラッグでシーク開始"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "クリックまたはドラッグでスクラブ開始"
@@ -744,6 +802,7 @@ msgstr "クリックまたはドラッグでスクラブ開始"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "クリック＆移動でスクラブ、クリック＆ドラッグでシークします。"
@@ -751,6 +810,7 @@ msgstr "クリック＆移動でスクラブ、クリック＆ドラッグでシ
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "移動でシーク"
@@ -758,6 +818,7 @@ msgstr "移動でシーク"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "移動でスクラブ"
@@ -819,7 +880,17 @@ msgstr ""
 "プロジェクトの最後より先の領域を\n"
 "ロックすることはできません。"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "エラー"
 
@@ -844,7 +915,8 @@ msgstr ""
 "一度だけ表示される質問です。"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Audacity の環境設定をリセット"
 
 # ja: 文字列だけ見ると「（既に）削除されています」かと思っちゃうが、これは見つからなかったファイルについて「（今）削除しました」という意味。
@@ -860,7 +932,8 @@ msgstr ""
 "最近のファイル一覧から削除しました。"
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite ライブラリの初期化に失敗しました。  続行不能です。"
 
 #: src/AudacityApp.cpp
@@ -886,7 +959,7 @@ msgstr "開く(&O)..."
 msgid "Open &Recent..."
 msgstr "最近開いたファイル(&R)..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "Audacity について(&A)..."
@@ -900,9 +973,10 @@ msgid "&File"
 msgstr "ファイル(&F)"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity は一時ファイルを保存する安全な場所を見つけられませんでした。\n"
@@ -910,20 +984,23 @@ msgstr ""
 "環境設定ダイアログで適切なディレクトリ名を入力してください。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity は一時ファイルを保存する場所を見つけられませんでした。\n"
 "環境設定ダイアログで適切なディレクトリ名を入力してください。"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity を終了させます。新しい一時ディレクトリを利用するには、Audacity を再起動してください。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -932,15 +1009,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity は一時ファイルのあるフォルダーをロックできませんでした。\n"
 "このフォルダは別に起動している Audacity が使用中のようです。\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "それでも Audacity を開始しますか？"
 
 #: src/AudacityApp.cpp
@@ -948,19 +1027,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "一時フォルダーのロックに失敗"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "動作中の他の Audacity があることが、システムによって検知されました。\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "複数のプロジェクトを同時に開いて作業するには、今動作している Audacity で\n"
 "[新規] または [開く] コマンドを実行してください。\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity は既に起動しています"
 
 #: src/AudacityApp.cpp
@@ -976,7 +1058,8 @@ msgstr ""
 "コンピューターを再起動すると解決する場合があります。"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity 起動失敗"
 
 #: src/AudacityApp.cpp
@@ -1016,8 +1099,9 @@ msgstr ""
 "コンピューターを再起動すると解決する場合があります。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1049,7 +1133,8 @@ msgstr "自己診断の実行"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Audacity のバージョン表示"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1059,9 +1144,10 @@ msgid "audio or project file name"
 msgstr "音声またはプロジェクトファイル名"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1074,16 +1160,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity プロジェクトファイル"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "メッセージ"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Audacity 設定エラー"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1093,7 +1181,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "以下の設定ファイルにアクセスできません:\n"
 "\n"
@@ -1108,12 +1196,15 @@ msgstr ""
 "あるいは、[Audacity を終了] をクリックした場合、現在のプロジェクトは未保存状態に保たれ、\n"
 "次に開いた時に回復の対象となります。"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "ヘルプ"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Audacity を終了(&Q)"
 
 #: src/AudacityFileConfig.cpp
@@ -1121,7 +1212,8 @@ msgid "&Retry"
 msgstr "再試行(&R)"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity ログ"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1133,9 +1225,14 @@ msgstr "保存(&S)..."
 msgid "Cl&ear"
 msgstr "消去(&E)"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "閉じる(&C)"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1184,7 +1281,8 @@ msgid "Error Initializing Midi"
 msgstr "MIDI 初期化エラー"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity 音声"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1199,37 +1297,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "メモリ不足です！"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "録音レベル自動調整機能は停止しました。音量が大きすぎるため、調整できませんでした。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "録音レベル自動調整機能により、音量が %f まで下がりました。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "録音レベル自動調整機能は停止しました。音量が小さすぎるため、調整できませんでした。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "録音レベル自動調整機能により、音量が %.2f まで上がりました。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "録音レベル自動調整機能は停止しました。解析を繰り返しましたが、適切な音量を見つけることができませんでした。音量がまだ大きすぎます。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "録音レベル自動調整機能は停止しました。解析を繰り返しましたが、適切な音量を見つけることができませんでした。音量がまだ小さすぎます。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "録音レベル自動調整機能は停止しました。%.2f が適切な音量と推定されます。"
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1328,43 +1395,6 @@ msgstr "再生デバイス「%s」が見つかりませんでした。\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "両デバイスのどちらかが欠けているため、共通のサンプリング周波数を確認できません。\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "デバイスを開く際にエラー %d を受け取りました\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Portmixer を開けません\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "利用可能なミキサー:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "利用可能な録音ソース:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "利用可能な再生音量:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "録音音量はエミュレートされています\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "録音音量はネイティブです\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "再生音量はエミュレートされています\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "再生音量はネイティブです\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1407,8 +1437,9 @@ msgid "Automatic Crash Recovery"
 msgstr "クラッシュからの自動回復"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1421,12 +1452,14 @@ msgid "Recoverable &projects"
 msgstr "回復可能なプロジェクト(&P)"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "選択"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "名前"
 
@@ -1514,6 +1547,11 @@ msgstr "エフェクト"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "メニューコマンド (パラメーター有り)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1659,7 +1697,8 @@ msgstr "復旧(&S)"
 msgid "I&mport..."
 msgstr "取り込み(&M)..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "書き出し(&X)..."
 
@@ -1700,7 +1739,8 @@ msgstr "上へ(&U)"
 msgid "Move &Down"
 msgstr "下へ(&D)"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "保存(&S)"
 
@@ -1791,9 +1831,17 @@ msgstr "実行(&R)"
 
 # ja: 独自アクセスキー
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "閉じる(&X)"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "ベンチマーク"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1929,11 +1977,6 @@ msgid "No revision identifier was provided"
 msgstr "リビジョン識別子が提供されていません"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "終了日時"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "デバッグビルド (デバッグレベル %d)"
@@ -2018,6 +2061,11 @@ msgid ""
 msgstr ""
 "この操作を適用する音声を最初に選択してください。\n"
 "(音声以外のトラックには利用できません)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2181,6 +2229,11 @@ msgstr "行方不明 %s"
 msgid "&Copy Names to Clipboard"
 msgstr "名前をクリップボードへコピー(&C)"
 
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
 # ja: もう使われなくなった要らない子
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -2191,10 +2244,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "続行すると、プロジェクトはディスクに保存されません。続行しますか？"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2208,7 +2262,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "依存性のチェック"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "無し"
 
@@ -2216,7 +2273,7 @@ msgstr "無し"
 msgid "Rectangle"
 msgstr "矩形"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "三角形"
 
@@ -2278,9 +2335,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg サポートはコンパイルされていません"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2302,8 +2360,8 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg の場所を指定"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "FFmpeg を通じた音声の取り込みと書き出しには、ファイル「%s」が必要です。"
 
 # ja: 独自アクセスキー
@@ -2318,7 +2376,8 @@ msgid "To find '%s', click here -->"
 msgstr "「%s」を見つけるには、こちらをクリック -->"
 
 # ja: 独自アクセスキー
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "参照(&B)..."
 
@@ -2345,8 +2404,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg が見つかりません"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2376,24 +2436,24 @@ msgid "Only libavformat.so"
 msgstr "libavformat.so のみ"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "ファイル %s が書き込めません"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "ファイル %s が書き込めません"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "ファイルを %s に書き込むことはできましたが、%s にリネームすることはできませんでした。"
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2431,7 +2491,9 @@ msgstr "いかなる音声もコピーしない(&N)"
 msgid "As&k"
 msgstr "確認する(&K)"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "すべてのファイル"
 
@@ -2529,6 +2591,17 @@ msgstr "リニア周波数軸"
 msgid "Log frequency"
 msgstr "対数周波数軸"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "スクロール"
@@ -2536,6 +2609,15 @@ msgstr "スクロール"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "拡大"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2602,6 +2684,18 @@ msgid "s"
 msgstr "秒"
 
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f 秒 (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f 秒 (%d Hz) (%s) = %.3f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
@@ -2616,10 +2710,16 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f 秒 (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "スペクトラム"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "スペクトルデータの書き出し:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "ファイルに書き込めませんでした: %s"
@@ -2794,6 +2894,16 @@ msgstr "使用クリップボード領域(&B)"
 msgid "D&iscard"
 msgstr "破棄(&I)"
 
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Compact"
+msgstr "コマンド(&C)"
+
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2802,20 +2912,20 @@ msgstr "操作履歴(&H)..."
 
 # ja: 運営に報告してねとあるので、報告しやすくするために内部エラー部分は原文ママとする。
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internal error in %s at %s line %d.\n"
 "是非、Audacity チーム (https://forum.audacityteam.org/) にご報告ください。"
 
 # ja: 運営に報告してねとあるので、報告しやすくするために内部エラー部分は原文ママとする。
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internal error at %s line %d.\n"
 "是非、Audacity チーム (https://forum.audacityteam.org/) にご報告ください。"
@@ -2834,7 +2944,9 @@ msgid "Track"
 msgstr "トラック"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "ラベル"
 
@@ -2894,7 +3006,8 @@ msgstr "トラック名を入力"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "ラベルトラック"
 
@@ -2905,11 +3018,13 @@ msgstr "保存した 1 個以上のラベルが読み込めませんでした。
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity の初めての起動"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Audacity で使用する言語の選択:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2919,7 +3034,8 @@ msgstr "Audacity で使用する言語の選択:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "選択された言語 %s (%s) は、システム言語 %s (%s) と異なります。"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "確認"
 
@@ -2937,12 +3053,13 @@ msgstr ""
 "古いファイルは「%s」という名前で保存されました。"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity プロジェクトファイルを開く"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity カラオケ%s"
 
 #: src/LyricsWindow.cpp
@@ -2993,19 +3110,23 @@ msgid "Mixing and rendering tracks"
 msgstr "トラックのミックスとレンダリング"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity ミキサーボード %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "ゲイン"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "ベロシティ"
 
@@ -3014,17 +3135,23 @@ msgid "Musical Instrument"
 msgstr "楽器"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "パン"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "ミュート"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "ソロ"
 
@@ -3032,15 +3159,18 @@ msgstr "ソロ"
 msgid "Signal Level Meter"
 msgstr "信号レベルメーター"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "移動されたゲインススライダー"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "移動されたベロシティスライダー"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "移動されたパンスライダー"
 
@@ -3075,9 +3205,9 @@ msgstr ""
 "このモジュールのロードは行われません。"
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3111,16 +3241,19 @@ msgstr ""
 "\n"
 "信頼できるソースからのモジュールだけをお使いください"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "はい"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "いいえ"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacity モジュールローダー"
 
 #: src/ModuleManager.cpp
@@ -3143,6 +3276,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "ノートトラック"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3253,7 +3496,8 @@ msgstr "すべて選択(&S)"
 msgid "C&lear All"
 msgstr "すべてクリア(&L)"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "有効化(&E)"
 
@@ -3333,9 +3577,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "サンプリング周波数の不一致"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "このサンプリング周波数で録音するには、選択トラック数が少なすぎます。\n"
@@ -3364,10 +3609,11 @@ msgid "Dropouts"
 msgstr "ドロップアウト"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3411,11 +3657,11 @@ msgstr "プロジェクトファイルを精査しています"
 # ・"Treat missing audio as silence (this session only)"
 # ・"Replace missing audio with silence (permanent immediately)."
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3457,11 +3703,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "警告 - エイリアスファイルが見つかりません"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "フォルダー「%s」のプロジェクトチェックにおいて、\n"
@@ -3486,12 +3732,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "警告 - エイリアス要約ファイルが見つかりません"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3550,7 +3796,8 @@ msgstr "警告 - 無用なブロックファイル"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "進行"
 
@@ -3575,6 +3822,11 @@ msgstr "警告: 自動回復に問題が発生しています"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<無題>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[プロジェクト %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3644,12 +3896,14 @@ msgstr ""
 "(処理上必要な一時ファイルを作成できません)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "これは Audacity プロジェクトファイルではありません"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3781,9 +4035,9 @@ msgid "Error Writing to File"
 msgstr "ファイルへの書き込みエラー"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3791,11 +4045,23 @@ msgstr ""
 "書き込み可能でないか、あるいはディスク容量がない恐れがあります。\n"
 "容量解放のコツについて知るには、ヘルプボタンをクリックしてください。"
 
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Compacting project"
+msgstr "プロジェクトをコピー中"
+
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[プロジェクト %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "ベロシティ"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3804,10 +4070,10 @@ msgstr "(回復済)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "このファイルは Audacity %s を用いて保存されました。\n"
 "現在お使いの Audacity は %s です。このファイルを開くには、新しいバージョンにアップグレードしてください。"
@@ -3881,8 +4147,9 @@ msgid "Backing up project"
 msgstr "プロジェクトをバックアップ中"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3891,8 +4158,9 @@ msgstr ""
 "プロジェクトは直近のスナップショットまで復元されました。"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3971,8 +4239,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sプロジェクトを「%s」として保存..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "[保存] によって保存されるのは、音声ファイルではなく Audacity プロジェクトファイルです。\n"
@@ -4049,11 +4318,12 @@ msgid "Error Opening Project"
 msgstr "プロジェクトオープンエラー"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "自動作成されたバックアップファイルを開こうとしています。\n"
 "これは深刻なデータ喪失を起こす可能性があります。\n"
@@ -4122,6 +4392,32 @@ msgstr "取り込みエラー"
 msgid "Cannot import AUP3 format.  Use File > Open instead"
 msgstr "AUP3 フォーマットを取り込めません。  代わりに [ファイル] > [開く] をご利用ください。"
 
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact Project"
+msgstr "プロジェクトの取り込み"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compacted project file"
+msgstr "プロジェクトファイルを開けません"
+
+#: src/ProjectFileManager.cpp
+msgid "Compact"
+msgstr ""
+
 #: src/ProjectHistory.cpp
 msgid "Created new project"
 msgstr "新しいプロジェクトが作られました"
@@ -4131,8 +4427,8 @@ msgid "Automatic database backup failed."
 msgstr "データベースの自動バックアップに失敗しました。"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Audacity version %s へようこそ"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4210,6 +4506,21 @@ msgstr "水平スクロールバー"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "垂直スクロールバー"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -4330,7 +4641,8 @@ msgstr "全環境設定"
 msgid "SelectionBar"
 msgstr "選択バー"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "スペクトル選択"
 
@@ -4338,46 +4650,55 @@ msgstr "スペクトル選択"
 msgid "Timer"
 msgstr "タイマー"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "道具箱"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "録音/再生"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "ミキサー"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "メーター"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "再生メーター"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "録音メーター"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "編集"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "デバイス"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "変速再生"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "スクラブ"
 
@@ -4392,7 +4713,10 @@ msgstr "ルーラー"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "トラック"
 
@@ -4502,7 +4826,8 @@ msgid "Activation level (dB):"
 msgstr "録音起動レベル (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Audacity へようこそ！"
 
 # ja: 独自アクセスキー
@@ -4650,9 +4975,9 @@ msgstr ""
 "適切なドライブ選択について知るには、ヘルプボタンをクリックしてください。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr "ファイル %s が書き込めませんでした。"
 
@@ -4668,17 +4993,17 @@ msgid ""
 msgstr "テーマが %s に書き込まれました。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr "書き込むためのファイル %s を開けませんでした。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr "イメージをファイル %s に書き込めませんでした。"
 
@@ -4691,9 +5016,9 @@ msgid ""
 msgstr "テーマを C 言語コードとして %s に書き込みました。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4702,9 +5027,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4712,8 +5037,9 @@ msgstr ""
 "不正な png フォーマットではありませんか？"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "デフォルトのテーマを読み取ることができませんでした。\n"
@@ -4748,9 +5074,9 @@ msgstr ""
 "既に存在するファイルがあります。上書きしますか？"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "ファイルに保存できませんでした:\n"
@@ -4789,7 +5115,11 @@ msgstr "カスタム"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "継続時間"
 
@@ -4800,7 +5130,8 @@ msgid "Time Track"
 msgstr "タイムトラック"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity タイマー録音"
 
 #: src/TimerRecordDialog.cpp
@@ -4874,7 +5205,8 @@ msgstr "現在のプロジェクト"
 msgid "Recording start:"
 msgstr "録音開始:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "継続時間:"
 
@@ -4895,7 +5227,8 @@ msgid "Action after Timer Recording:"
 msgstr "タイマー録音後の動作:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity タイマー録音進捗"
 
 #: src/TimerRecordDialog.cpp
@@ -4991,6 +5324,7 @@ msgstr "099日024時間060分060秒"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "開始日時"
@@ -5035,7 +5369,8 @@ msgstr "自動書き出し(&E)"
 msgid "Export Project As:"
 msgstr "プロジェクト書き出し先:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "オプション"
 
@@ -5048,7 +5383,8 @@ msgid "Do nothing"
 msgstr "何もしない"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Audacity を終了"
 
 #: src/TimerRecordDialog.cpp
@@ -5072,7 +5408,8 @@ msgid "Scheduled to stop at:"
 msgstr "録音停止予定:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity タイマー録音 - 開始待機中"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5098,7 +5435,8 @@ msgid "Recording Exported:"
 msgstr "録音を書き出しました:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity タイマー録音 - 待機中"
 
 #: src/TrackInfo.cpp
@@ -5224,6 +5562,10 @@ msgstr "トラックを上へ移動"
 msgid "Move Track Down"
 msgstr "トラックを下へ移動"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -5290,6 +5632,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "「%s」を適用中..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "失敗"
@@ -5308,16 +5660,29 @@ msgstr "%s は、%s に指定できるパラメーターではありません"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "パラメーター「%s」の値が不正です。%s である必要があります"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "コマンド"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s を再適用"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
 
 #: src/commands/CommandManager.cpp
 msgid "Shortcuts have been removed"
@@ -5336,12 +5701,20 @@ msgid "Compares a range on two tracks."
 msgstr "2 本のトラックのレンジを比較します。"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "ディレイ時間 (秒):"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "減衰倍数:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -5420,7 +5793,8 @@ msgstr "クリップ"
 msgid "Envelopes"
 msgstr "エンベロープ"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "ラベル"
 
@@ -5429,11 +5803,26 @@ msgstr "ラベル"
 msgid "Boxes"
 msgstr "ボックス"
 
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "種類:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "フォーマット:"
 
@@ -5460,6 +5849,10 @@ msgstr "コメント"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "コマンド:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5497,12 +5890,17 @@ msgstr "ファイルに書き出します。"
 msgid "Builtin Commands"
 msgstr "内蔵コマンド"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity チーム"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Audacity に内蔵コマンドを提供"
 
 #: src/commands/LoadCommands.cpp
@@ -5565,7 +5963,10 @@ msgstr "ログの内容を消します。"
 msgid "Get Preference"
 msgstr "環境設定を取得"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "名前:"
 
@@ -5613,7 +6014,8 @@ msgstr "画面全体"
 msgid "Toolbars"
 msgstr "ツールバー"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "エフェクト"
 
@@ -5678,6 +6080,10 @@ msgstr "キャプチャ対象:"
 #: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "背景:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -5749,7 +6155,8 @@ msgstr "設定"
 msgid "Add"
 msgstr "追加"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "削除"
 
@@ -5834,7 +6241,8 @@ msgid "Edited Envelope"
 msgstr "エンベロープを編集しました"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "エンベロープ"
 
@@ -5877,6 +6285,14 @@ msgstr "サンプリング周波数:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "大きさ変更:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5926,7 +6342,10 @@ msgstr "パン:"
 msgid "Set Track Visuals"
 msgstr "トラック表示設定"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "リニア"
 
@@ -6043,7 +6462,9 @@ msgid "Duck &amount:"
 msgstr "ダッキング量(&A):"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "秒"
 
@@ -6067,7 +6488,8 @@ msgstr "内側のフェードダウンする長さ(&O):"
 msgid "Inner &fade up length:"
 msgstr "内側のフェードアップする長さ(&F):"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "閾値(&T):"
 
@@ -6209,11 +6631,13 @@ msgstr "変更後 (Hz)"
 msgid "t&o"
 msgstr "→ 変更後(&O)"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "変更率 (%) (&H):"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "変更率 (%)"
 
@@ -6224,6 +6648,22 @@ msgstr "高品質な伸縮を使用 (低速) (&U)"
 #: src/effects/ChangeSpeed.cpp
 msgid "33⅓"
 msgstr "33 + 1/3"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 # ja: 独自アクセスキー
 #: src/effects/ChangeSpeed.cpp
@@ -6251,6 +6691,7 @@ msgstr "標準レコード回転数:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "変更前回転数"
@@ -6263,6 +6704,7 @@ msgstr "変更前(&F)"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "変更後回転数"
@@ -6411,6 +6853,12 @@ msgstr "コンプレッサー(&C)"
 msgid "Compresses the dynamic range of audio"
 msgstr "音声のダイナミックレンジを圧縮します"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6420,6 +6868,20 @@ msgstr "%.2f 秒"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f 秒"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6536,7 +6998,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "2 件の選択音声同士の RMS 音量の差を計測する、コントラスト解析機能です。"
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "終了"
 
@@ -6602,6 +7065,12 @@ msgstr "ヘルプ(&H)"
 msgid "RMS = %s."
 msgstr "RMS = %s"
 
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "ゼロ"
@@ -6609,6 +7078,13 @@ msgstr "ゼロ"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "確定できません"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.1f dB 平均 rms"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6662,6 +7138,12 @@ msgstr "現在の差異"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "計測された前景音レベル"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f 倍"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6746,6 +7228,141 @@ msgstr "コントラスト解析 (WCAG2 準拠)"
 #: src/effects/Contrast.cpp
 msgid "Contrast..."
 msgstr "コントラスト(&C)..."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Clipping"
+msgstr "過激なクリッピング"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Soft Clipping"
+msgstr "控え目なクリッピング"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Soft Overdrive"
+msgstr "削除の確認"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Medium Overdrive"
+msgstr "削除の確認"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "上書き"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Expand and Compress"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Leveller"
+msgstr "レベラー..."
+
+# ja: 独自アクセスキー
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "ディストーション(&D)"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "過激なリミッティング"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -6894,7 +7511,9 @@ msgstr "DTMF シーケンス(&S):"
 msgid "&Amplitude (0-1):"
 msgstr "振幅 (0～1) (&A):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "継続時間(&D):"
 
@@ -6907,12 +7526,29 @@ msgid "Duty cycle:"
 msgstr "デューティ比:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f 秒"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "トーン持続時間:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "無音持続時間:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 # ja: 独自アクセスキー
 #: src/effects/Echo.cpp
@@ -6924,7 +7560,8 @@ msgstr "エコー(&E)"
 msgid "Repeats the selected audio again and again"
 msgstr "選択した音声を何度も繰り返します"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "指定された値はメモリの許容範囲外です。"
 
@@ -6949,7 +7586,8 @@ msgstr "プリセット"
 msgid "Export Effect Parameters"
 msgstr "エフェクトパラメーターの書き出し"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "ファイルが開けませんでした:「%s」"
@@ -6986,6 +7624,15 @@ msgstr "プレビューの準備中"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "プレビュー"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist エフェクト(&Y)"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7311,6 +7958,46 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "特定の周波数の音量を調節します"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Boost"
+msgstr "低域の強調..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "低域"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "高域"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Cut"
+msgstr "高域"
+
+#: src/effects/Equalization.cpp
 msgid ""
 "To use this filter curve in a macro, please choose a new name for it.\n"
 "Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
@@ -7335,12 +8022,41 @@ msgid "Effect Unavailable"
 msgstr "エフェクト利用不能"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "最大 dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "最小 dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7673,7 +8389,8 @@ msgid "Builtin Effects"
 msgstr "内蔵エフェクト"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Audacity に内蔵エフェクトを提供"
 
 #: src/effects/LoadEffects.cpp
@@ -7683,6 +8400,10 @@ msgstr "不明な内蔵エフェクト名"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "知覚的ラウドネス"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 # ja: 独自アクセスキー
 #: src/effects/Loudness.cpp
@@ -7715,6 +8436,14 @@ msgstr "ノーマライズ対象(&N)"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "ラウドネス LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7759,6 +8488,52 @@ msgstr "3 種類の異なるノイズを生成します"
 #: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "ノイズの種類(&N):"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Median"
+msgstr "中帯域"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Second greatest"
+msgstr "2 番目トラック"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hann, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, Hann (default)"
+msgstr "4 (デフォルト)"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "ブラックマン窓"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, none"
+msgstr "ハミング窓"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
+msgstr "ハミング窓"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 # ja: 独自アクセスキー
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
@@ -7856,8 +8631,9 @@ msgid "Step 1"
 msgstr "ステップ 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Audacity にフィルター対象を判断させるために、ノイズのみの区間 (数秒間) を選択し、\n"
@@ -7909,13 +8685,62 @@ msgstr "窓関数の種類(&W):"
 msgid "Window si&ze:"
 msgstr "窓関数のサイズ(&Z):"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (デフォルト)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "窓あたりのステップ数(&T):"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8045,6 +8870,7 @@ msgstr "Paul ストレッチは、極端な時間伸縮か「停滞」的エフ�
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "伸縮倍数(&S):"
@@ -8332,6 +9158,10 @@ msgstr "前後を反転(&V)"
 msgid "Reverses the selected audio"
 msgstr "選択した音声の反転"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
 #. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Butterworth"
@@ -8493,6 +9323,11 @@ msgstr "デフォルト"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "デフォルトに復旧"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 # ja: 独自アクセスキー
 #. i18n-hint: noun
@@ -8660,6 +9495,10 @@ msgstr "無音検出"
 msgid "Tr&uncate to:"
 msgstr "切り詰め(&U):"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "圧縮(&O):"
@@ -8673,7 +9512,8 @@ msgid "VST Effects"
 msgstr "VST エフェクト"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Audacity で VST エフェクトを使用可能にします。"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8685,7 +9525,8 @@ msgstr "シェル VST をスキャンしています"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "%2$d 個中 %1$d 個目を登録中: %3$-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "ライブラリが読み込めませんでした"
 
@@ -8710,7 +9551,8 @@ msgstr ""
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "バッファーサイズ (8～1048576 サンプル) (&B):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "レイテンシー補償"
 
@@ -8722,7 +9564,8 @@ msgstr ""
 "このオプションを有効化することで、そのような遅延に対する補償が行われるようになります。\n"
 "ただし、すべての VST エフェクトに有効とは限りません。"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "補償を有効化(&C)"
 
@@ -8759,7 +9602,8 @@ msgid "Standard VST program file"
 msgstr "標準 VST プログラムファイル"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity VST プリセットファイル"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8786,7 +9630,8 @@ msgstr "VST プリセット読み込みエラー"
 msgid "Unable to load presets file."
 msgstr "プリセットファイルをロードできません。"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "エフェクト設定"
 
@@ -8802,6 +9647,13 @@ msgstr "プリセットファイルを読み込めません。"
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "このパラメーターファイルは %s から保存されました。続けますか？"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+#, fuzzy
+msgid "VST"
+msgstr "VST(&S)"
 
 # ja: 独自アクセスキー
 #: src/effects/Wahwah.cpp
@@ -8839,7 +9691,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio Unit エフェクト"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Audacity を Audio Unit エフェクト対応にします"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8855,7 +9708,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio Unit エフェクトオプション"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr ""
 "Audio Unit エフェクトによっては、処理の過程で Audacity へ返す音声がどうしても遅延することがあります。\n"
 "この遅延を補償しないと、音声に微小な無音が挿入されたように聞こえてしまいます。\n"
@@ -8877,6 +9731,20 @@ msgstr ""
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "インターフェイスの選択(&I)"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "全帯域"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Generic"
+msgstr "ジェネレーター"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
@@ -8987,8 +9855,16 @@ msgstr "プリセットのためのプロパティリストの作成に失敗し
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "プリセット「%s」のためのクラス情報の設定に失敗しました"
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Audio Unit エフェクト"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA エフェクト"
@@ -8998,7 +9874,8 @@ msgid "Provides LADSPA Effects"
 msgstr "LADSPA エフェクトの提供"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity はもう VST ブリッジを必要としません"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9006,16 +9883,34 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA エフェクトオプション"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr ""
 "LADSPA エフェクトによっては、処理の過程で Audacity へ返す音声がどうしても遅延することがあります。\n"
 "この遅延を補償しないと、音声に微小な無音が挿入されたように聞こえてしまいます。\n"
 "このオプションを有効化することで、そのような遅延に対する補償が行われるようになります。\n"
 "ただし、すべての LADSPA エフェクトに有効とは限りません。"
 
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s。"
+
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "エフェクト出力"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA(&L)"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9027,7 +9922,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "バッファーサイズ (8～%d サンプル) (&B):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr ""
 "LV2 エフェクトによっては、処理の過程で Audacity へ返す音声がどうしても遅延することがあります。\n"
 "この遅延を補償しないと、音声に微小な無音が挿入されたように聞こえてしまいます。\n"
@@ -9059,12 +9955,20 @@ msgstr "%s は、サポートされていないオプション「%s」を要求�
 msgid "Generator"
 msgstr "ジェネレーター"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+#, fuzzy
+msgid "LV2"
+msgstr "LV2(&2)"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 エフェクト"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Audacity を LV2 エフェクト対応にします"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9072,7 +9976,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist エフェクト"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Audacity を Nyquist エフェクト対応にします"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9299,7 +10204,8 @@ msgstr "ファイルを選択"
 msgid "Save file as"
 msgstr "名前を付けて保存"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "無題"
 
@@ -9308,7 +10214,8 @@ msgid "Vamp Effects"
 msgstr "Vamp エフェクト"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Audacity を Vamp エフェクト対応にします"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9330,6 +10237,13 @@ msgstr "プラグインの設定"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "プログラム"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+#, fuzzy
+msgid "Vamp"
+msgstr "Vamp(&V)"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9409,6 +10323,18 @@ msgstr "フォーマットオプション"
 #, c-format
 msgid "Channel: %2d"
 msgstr "チャンネル: %2d"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -9619,7 +10545,8 @@ msgstr "音声を %s として書き出し"
 msgid "Invalid sample rate"
 msgstr "無効なサンプリング周波数です"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "再サンプリング"
 
@@ -9649,6 +10576,15 @@ msgstr "以下のいずれかのサンプリング周波数へ再サンプリン
 msgid "Sample Rates"
 msgstr "サンプリング周波数"
 
+#  i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "ビットレート:"
@@ -9656,6 +10592,48 @@ msgstr "ビットレート:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "品質 (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f 秒"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9666,12 +10644,40 @@ msgid "Constrained"
 msgstr "制限つき"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "音声"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "低遅延"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9757,9 +10763,21 @@ msgstr "プリセット「%s」は存在しません。"
 msgid "Replace preset '%s'?"
 msgstr "プリセット %s を置き換えますか？"
 
+#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#  i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "メイン"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9867,6 +10885,10 @@ msgstr "言語:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bit リザーバ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10000,6 +11022,14 @@ msgstr ""
 "0 - デフォルト\n"
 "最小 - 1\n"
 "最大 - 15"
+
+#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#  i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10180,6 +11210,16 @@ msgid "Failed to find the codec"
 msgstr "コーデックが見つかりませんでした"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16bit DWVW"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "24bit DWVW"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (最速)"
 
@@ -10309,7 +11349,8 @@ msgstr "変態"
 msgid "Extreme"
 msgstr "極端"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "標準"
 
@@ -10360,8 +11401,8 @@ msgid "Locate LAME"
 msgstr "LAME の場所を指定"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "MP3 の作成には、ファイル %s が必要です。"
 
 #: src/export/ExportMP3.cpp
@@ -10389,10 +11430,10 @@ msgid "Where is %s?"
 msgstr "%s はどこにありますか？"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "lame_enc.dll v%d.%d とリンクしようとしています。このバージョンは Audacity %d.%d.%d との互換性がありません。\n"
 "「LAME for Audacity」の最新版をダウンロードしてください。"
@@ -10697,6 +11738,15 @@ msgstr "選択した音声を Ogg Vorbis ファイルに書き出し"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "音声を Ogg Vorbis ファイルに書き出し"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft) 16bit PCM 符号あり"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "ヘッダー:"
@@ -10710,9 +11760,10 @@ msgid "Other uncompressed files"
 msgstr "その他の非圧縮ファイル"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "4GB を超える WAV ファイルまたは AIFF ファイルを書き出そうとしています。\n"
 "Audacity ではそのような処理はいたしかねます。書き出しを打ち切りました。"
@@ -10722,8 +11773,9 @@ msgid "Error Exporting"
 msgstr "書き出しエラー"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Audacity では 4GB を超える WAV ファイルを書き出すことができないため、\n"
@@ -10763,11 +11815,11 @@ msgid "All supported files"
 msgstr "すべてのサポートされるファイル"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "「%s」は MIDI ファイルであり、音声ファイルではありません。\n"
@@ -10775,11 +11827,11 @@ msgstr ""
 "[ファイル] > [取り込み] > [MIDI の取り込み] をクリックすることで編集はできます。"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "「%s」は音声ファイルではありません。\n"
 "Audacity はこの種のファイルを開くことはできません。"
@@ -10789,18 +11841,18 @@ msgid "Select stream(s) to import"
 msgstr "取り込むストリームを選択"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "このバージョンの Audacity は、%s サポート機能と一緒にコンパイルされていません。"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "「%s」は音声 CD トラックです。\n"
 "Audacity は音声 CD を直接開くことはできません。\n"
@@ -10809,10 +11861,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "「%s」はプレイリストファイルです。\n"
@@ -10821,10 +11873,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」は Windows Media Audio ファイルです。\n"
@@ -10833,10 +11885,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」は Advanced Audio Coding ファイルです。\n"
@@ -10845,12 +11897,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "「%s」は暗号化された音声ファイルです。\n"
@@ -10861,10 +11913,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」は RealPlayer メディアファイルです。\n"
@@ -10873,12 +11925,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "「%s」は音符に基づくファイルであり、音声ファイルでありません。\n"
 "Audacity はこの形式のファイルを開くことはできません。\n"
@@ -10887,10 +11939,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10904,10 +11956,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」は Wavpack 音声ファイルです。\n"
@@ -10916,10 +11968,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」は Dolby Digital 音声ファイルです。\n"
@@ -10928,10 +11980,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」は Ogg Speex 音声ファイルです。\n"
@@ -10940,10 +11992,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "「%s」は映像ファイルです。\n"
@@ -10957,9 +12009,9 @@ msgstr "ファイル「%s」が見つかりません。"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -10975,11 +12027,16 @@ msgstr ""
 "FFmpeg のインストールをお試しください。\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "テスター: %s"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11009,12 +12066,13 @@ msgid "Import Project"
 msgstr "プロジェクトの取り込み"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "このプロジェクトは Audacity バージョン 1.0 以下で保存されています。\n"
 "ファイル形式の違いにより、現在の Audacity ではプロジェクトを取り込めません。\n"
@@ -11065,7 +12123,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "プロジェクトデータフォルダーが見つかりませんでした:「%s」"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr ""
 "プロジェクトファイルに MIDI トラックが見つかりましたが、\n"
 "Audacity のこのビルドには MIDI サポートが含まれていません。\n"
@@ -11176,40 +12235,6 @@ msgstr "インデックス[%02x] コーデック[%s]、言語[%s]、ビットレ
 msgid "FLAC files"
 msgstr "FLAC ファイル"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer 互換ファイル"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "デコーダーをパイプラインに追加できません"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer 取り込み機能"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "ストリーム状態を pause に設定できません。"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "インデックス[%02d]、種類[%s]、チャンネル[%d]、サンプリング周波数[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "ファイルが音声ストリームを含んでいません。"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "ファイルを取り込めません。ステート変更に失敗しました。"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer エラー: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "基本的なテキストフォーマットによるファイルリスト"
@@ -11312,6 +12337,14 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV、AIFF、その他の非圧縮形式"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "CAF (Apple Core Audio File)"
 msgstr "CAF (Apple コア音声ファイル)"
 
@@ -11325,24 +12358,77 @@ msgid "HTK (HMM Tool Kit)"
 msgstr "HTK (HMM ツールキット)"
 
 #: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG コンテナフォーマット)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (ヘッダーなし)"
 
 #: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "SDS (Midi Sample Dump Standard)"
 msgstr "SDS (MIDI サンプルダンプスタンダード)"
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "WAV (NIST Sphere)"
 msgstr "WAV (NIST SPHERE)"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAVEX (Microsoft)"
+msgstr "WAV (Microsoft) 16bit PCM 符号あり"
+
+#: src/import/ImportPCM.cpp
 msgid "WVE (Psion Series 3)"
 msgstr "WVE (Psion シリーズ 3)"
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11377,6 +12463,31 @@ msgid "U-Law"
 msgstr "μ-Law"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "A-Law"
+msgstr "μ-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12bit DWVW"
 
@@ -11389,12 +12500,20 @@ msgid "24 bit DWVW"
 msgstr "24bit DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16bit DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8bit DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11529,6 +12648,7 @@ msgstr "%s 右"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11551,6 +12671,7 @@ msgstr "終わり"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11575,7 +12696,8 @@ msgstr "クリップを右に移動しました"
 msgid "Time shifted clips to the left"
 msgstr "クリップを左に移動しました"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "時間移動"
 
@@ -11715,7 +12837,8 @@ msgstr "選択音声トラックを %.2f 秒から %.2f 秒までトリミング
 msgid "Trim Audio"
 msgstr "音声のトリミング"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "分離"
 
@@ -11840,34 +12963,6 @@ msgid "Ext&ra"
 msgstr "拡張(&R)"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "ミキサー(&X)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "再生音量調整(&J)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "再生音量を上げる(&I)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "再生音量を下げる(&D)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "録音音量調整(&U)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "録音音量を上げる(&N)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "録音音量を下げる(&E)"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "デバイス(&V)"
 
@@ -11903,6 +12998,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "選択した音声を書き出し"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "ラベル文字"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -11964,6 +13065,12 @@ msgstr "MIDI ファイル"
 #: src/menus/FileMenus.cpp
 msgid "Allegro files"
 msgstr "Allegro ファイル"
+
+# ja: 独自アクセスキー
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Dangerous Reset..."
+msgstr "プリセットの保存(&S)..."
 
 #. i18n-hint: This is the name of the menu item on Mac OS X only
 #: src/menus/FileMenus.cpp
@@ -12124,8 +13231,9 @@ msgid "&Getting Started"
 msgstr "さあ始めよう(&G)"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity マニュアル(&M)"
+#, fuzzy
+msgid "&Manual"
+msgstr "マニュアル(&M)..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12151,11 +13259,8 @@ msgstr "MIDI デバイス情報(&M)..."
 msgid "Show &Log..."
 msgstr "ログの表示(&L)..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Audacity について(&A)..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "ラベルを追加しました"
 
@@ -12403,6 +13508,16 @@ msgstr "フォーカスするトラックを切り替え(&D)"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "未分類"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "新規..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Unknown"
+msgstr "不明なエラー (Unknown error)"
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -12841,6 +13956,7 @@ msgstr "カーソルを大きく右へ(&M)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "シーク(&K)"
@@ -13052,7 +14168,8 @@ msgid "Created new label track"
 msgstr "新規ラベルトラックを作りました"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr ""
 "このバージョンの Audacity では、時間トラックは\n"
 "プロジェクトウィンドウごとに 1 本しか許容されません。"
@@ -13061,11 +14178,13 @@ msgstr ""
 msgid "Created new time track"
 msgstr "新規タイムトラックを作りました"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "新しいサンプリング周波数 (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "入力された値は不適切です"
 
@@ -13322,7 +14441,9 @@ msgstr "再生中"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "録音"
 
@@ -13474,10 +14595,6 @@ msgstr "オーバーダブ (オン/オフ) (&O)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "ソフトウェアによる再生 (オン/オフ) (&F)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "録音レベル自動調整 (オン/オフ) (&U)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13693,7 +14810,7 @@ msgstr "品質の環境設定"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Audacity を更新"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13740,7 +14857,8 @@ msgstr "ホスト(&H):"
 msgid "Using:"
 msgstr "利用中:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "再生"
 
@@ -13760,7 +14878,8 @@ msgstr "チャンネル(&N):"
 msgid "Latency"
 msgstr "レイテンシー"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "ミリ秒"
 
@@ -13789,7 +14908,8 @@ msgid "2 (Stereo)"
 msgstr "2 (ステレオ)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "ディレクトリ"
 
@@ -13897,7 +15017,8 @@ msgid "Directory %s is not writable"
 msgstr "ディレクトリ %s は書き込みできません"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "一時ディレクトリの変更は Audacity を再起動するまで有効になりません"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13930,6 +15051,7 @@ msgstr "種類でグループ化"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "LADSPA(&L)"
@@ -13981,11 +15103,13 @@ msgid "Plugin Options"
 msgstr "プラグインオプション"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Audacity 起動時にプラグインの更新を確認"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Audacity 次回起動時にプラグインを再スキャンします"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14165,7 +15289,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "選択範囲の端でスナップしたラベルを消去時に残す(&T)"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "システムと Audacity のテーマをブレンドする(&L)"
 
 # ja: 独自アクセスキー
@@ -14193,6 +15318,10 @@ msgstr "スクラブルーラーを表示(&U)"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "「%s」は不明な言語です"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14247,6 +15376,10 @@ msgstr "ラベルの書き出し形式:"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "Allegro (.gro) ファイルの時間基準:"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14342,7 +15475,8 @@ msgstr ""
 "   ・ 【%s】 … ショートカット「%s」は【%s】に使われます\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Audacty のキーボードショートカットが定義されている XML ファイルを選択..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14471,8 +15605,9 @@ msgid "Dow&nload"
 msgstr "ダウンロード(&N)"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity は既に、有効な FFmpeg ライブラリを自動検出しています。\n"
@@ -14531,19 +15666,22 @@ msgid "Preferences for Module"
 msgstr "モジュールの環境設定"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr "これらは試用モジュールです。マニュアルを熟読し、よく理解した上で有効化してください。"
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  「確認」は、Audacity 起動時にモジュールをロードするか毎回尋ねるという意味です。"
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  「失敗」は、モジュールが壊れたと判断されており実行不能な状態です。"
 
 #. i18n-hint preserve the leading spaces
@@ -14552,7 +15690,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  「新規」は何も選択されていないことを示します。"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "設定の変更は Audacity の再起動時に有効になります。"
 
 #: src/prefs/ModulePrefs.cpp
@@ -14570,6 +15709,10 @@ msgstr "モジュールがありません"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "モジュール"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14611,7 +15754,10 @@ msgstr "左ドラッグ"
 msgid "Set Selection Range"
 msgstr "選択範囲を設定"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift+左クリック"
 
@@ -14698,6 +15844,15 @@ msgstr "+左ドラッグ"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "トラック間でクリップを上下に移動"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "+左ドラッグ"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14822,7 +15977,8 @@ msgid "Always scrub un&pinned"
 msgstr "スクラブ時にピン留めを無視(&P)"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity の環境設定"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14836,6 +15992,11 @@ msgstr "環境設定:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "品質の環境設定"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14941,6 +16102,11 @@ msgid "Custom name text"
 msgstr "カスタム名前テキスト"
 
 #: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Recorded_Audio"
+msgstr "録音された音声"
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Track Number"
 msgstr "トラック番号(&T)"
 
@@ -14953,39 +16119,6 @@ msgid "System T&ime"
 msgstr "システム時刻(&I)"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "録音レベル自動調整機能"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "録音レベル自動調整機能を有効化します。"
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "ピークのターゲット:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "以内:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "解析時間:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "ミリ秒 (解析一回あたり)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "解析連続回数:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 はエンドレスの意味です"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "パンチ＆ロール録音"
 
@@ -14996,6 +16129,21 @@ msgstr "プリロール(&L):"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "クロスフェード(&F):"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15130,6 +16278,10 @@ msgid "1024 - default"
 msgstr "1024 - デフォルト"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - 最も狭いバンド幅"
 
@@ -15227,13 +16379,14 @@ msgid "Info"
 msgstr "情報"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15418,7 +16571,8 @@ msgstr "サンプル"
 msgid "4 Pixels per Sample"
 msgstr "サンプルあたり 4 ピクセル"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "最大"
 
@@ -15543,16 +16697,24 @@ msgid "Stopped"
 msgstr "停止"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "一時停止"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "最初に移動"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "最後に移動"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "一時停止"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "最初まで選択"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "最後まで選択"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15565,14 +16727,6 @@ msgstr "新規トラックに録音"
 #: src/toolbars/ControlToolBar.cpp
 msgid "Append Record"
 msgstr "追加録音"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "最後まで選択"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "最初まで選択"
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
@@ -15664,11 +16818,17 @@ msgstr "選択部分を無音化"
 msgid "Sync-Lock Tracks"
 msgstr "トラックを同期ロック"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "拡大"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "縮小"
 
@@ -15735,43 +16895,6 @@ msgstr "録音メーターツールバー(&R)"
 msgid "&Playback Meter Toolbar"
 msgstr "再生メーターツールバー(&P)"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "録音音量"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "再生音量"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "録音音量: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "録音音量 (使用不能。システムミキサーをお使いください)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "再生音量: %.2f (エミュレート)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "再生音量: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "再生音量 (使用不能。システムミキサーをお使いください)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "ミキサーツールバー(&X)"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "シーク"
@@ -15787,6 +16910,7 @@ msgstr "スクラブ"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "スクラブ停止"
@@ -15794,6 +16918,7 @@ msgstr "スクラブ停止"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "スクラブ開始"
@@ -15801,6 +16926,7 @@ msgstr "スクラブ開始"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "シーク停止"
@@ -15808,6 +16934,7 @@ msgstr "シーク停止"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "シーク開始"
@@ -15862,7 +16989,9 @@ msgstr "スナップモード"
 msgid "Length"
 msgstr "長さ"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "中央"
 
@@ -15926,8 +17055,8 @@ msgstr "時間ツールバー(&T)"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %sツールバー"
 
 #: src/toolbars/ToolBar.cpp
@@ -15954,7 +17083,8 @@ msgstr "移動ツール"
 msgid "Zoom Tool"
 msgstr "拡大ツール"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "描画ツール"
 
@@ -16030,11 +17160,13 @@ msgstr "1 個以上のラベル境界をドラッグします。"
 msgid "Drag label boundary."
 msgstr "ラベル境界をドラッグします。"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "ラベルを変更しました"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "ラベルの編集"
 
@@ -16089,31 +17221,42 @@ msgstr "ラベルを編集しました"
 msgid "New label"
 msgstr "新規ラベル"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "オクターブを上げる(&O)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "オクターブを下げる(&V)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "クリックで垂直方向に拡大、Shift+クリックで縮小、ドラッグで拡大範囲を指定します。"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "右クリックでメニューを表示します。"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "拡大をリセット"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift+右クリック"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "左クリック/左ドラッグ"
 
@@ -16155,7 +17298,8 @@ msgstr "連結"
 msgid "Expanded Cut Line"
 msgstr "展開したカットライン"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "展開"
 
@@ -16178,6 +17322,11 @@ msgstr "移動したサンプル"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "サンプルの編集"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16223,7 +17372,8 @@ msgstr "処理中...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "「%s」を %s に変更しました"
@@ -16235,6 +17385,54 @@ msgstr "フォーマットの変更"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "サンプリング周波数(&E)"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16254,7 +17452,8 @@ msgstr "サンプリング周波数の変更"
 msgid "Set Rate"
 msgstr "サンプリング周波数設定"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "同時表示(&M)"
 
@@ -16346,14 +17545,23 @@ msgstr "左、%dHz"
 msgid "Right, %dHz"
 msgstr "右、%dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%%左"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%%右"
@@ -16471,9 +17679,8 @@ msgstr "対数補間(&I)"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "クリック＆ドラッグでトラックを時間移動"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16524,6 +17731,7 @@ msgstr "エンベロープを調整しました。"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "スクラブ(&S)"
@@ -16535,6 +17743,7 @@ msgstr "シーク"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "スクラブルーラー(&R)"
@@ -16718,6 +17927,18 @@ msgstr "押す"
 msgid "Button"
 msgstr "ボタン"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
 #. i18n-hint: "x" suggests a multiplicative factor
 #: src/widgets/ASlider.cpp
 #, c-format
@@ -16757,9 +17978,19 @@ msgstr "空"
 msgid "Backwards"
 msgstr "後方へ"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "前方へ"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16972,6 +18203,7 @@ msgstr "0100時間060分060秒+>#サンプル"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "サンプル"
@@ -17138,6 +18370,11 @@ msgstr "010000>0100Hz"
 msgid "centihertz"
 msgstr "センチヘルツ"
 
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -17214,6 +18451,11 @@ msgstr "(フォーマットを変更するにはコンテクストメニュー�
 msgid "centiseconds"
 msgstr "センチ秒"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "処理時間:"
@@ -17256,6 +18498,11 @@ msgstr "閉じる確認"
 msgid "Unable to write files to directory: %s."
 msgstr "「%s」からプリセットファイルを読み込めません"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17272,6 +18519,10 @@ msgstr "ディレクトリの環境設定"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "このメッセージを次回からは表示しない"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17356,15 +18607,27 @@ msgstr "XML を解釈できませんでした"
 msgid "Spectral edit multi tool"
 msgstr "スペクトル編集: マルチツール(&M)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "フィルター適用中..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "GNU General Public License version 2 の下に公開"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~a周波数を選択してください。"
@@ -17390,7 +18653,8 @@ msgstr ""
 "低域周波数を高くするか、フィルタリングする帯域幅を~%~\n"
 "狭くしてみてください。"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "エラー。~%"
@@ -17452,6 +18716,25 @@ msgstr "スタジオフェードアウト(&F)"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "フェードを適用中..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "デフォルトに設定(&F)"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "GNU General Public License version 2 (またはそれ以降) の下に公開"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17597,6 +18880,11 @@ msgstr "拍の検出(&B)"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "拍の検出中..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Audacity ログ"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17837,6 +19125,10 @@ msgstr "ラベルの間隔 (秒)"
 msgid "Length of label region (seconds)"
 msgstr "ラベル領域の長さ (秒)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
@@ -17929,13 +19221,39 @@ msgstr "ハイパスフィルター(&H)"
 msgid "Performing High-Pass Filter..."
 msgstr "ハイパスフィルターを実行中..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Dominic Mazzoni"
+msgstr "Dominic Mazzoni によるノイズの除去"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "周波数 (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "減衰傾度 (オクターブあたり)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17957,10 +19275,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "音声から自動ラベル付け(&L)"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "GNU General Public License version 2 (またはそれ以降) の下に公開"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18265,7 +19579,8 @@ msgstr "Lisp ファイル"
 msgid "HTML file"
 msgstr "HTML ファイル"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "テキストファイル"
 
@@ -18341,6 +19656,10 @@ msgstr "プラック音を生成中..."
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "ドの MIDI ノート番号: 36、48、60 [中央ド]、72、84、96。"
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
@@ -18487,6 +19806,10 @@ msgstr "Risset ドラム(&D)"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Risset ドラムを生成中..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18913,6 +20236,10 @@ msgid "Applying Action..."
 msgstr "アクションを適用中..."
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "ボーカル音を除去: モノラルへ"
 
@@ -19062,6 +20389,10 @@ msgid "Processing Vocoder..."
 msgstr "ボコーダー処理中..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "距離: (1～120、デフォルトは 20)"
 
@@ -19102,6 +20433,232 @@ msgstr "くし歯の周波数 (Hz)"
 msgid "Error.~%Stereo track required."
 msgstr "エラー。~%ステレオトラックが必要です。"
 
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Audacity を更新"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "スキップ(&S)"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "更新をインストール(&I)"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "更新履歴"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "GitHub でもっと読む"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "更新確認エラー"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Audacity の更新サーバーに接続できません。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "更新データが破損しました。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "更新ダウンロードエラー。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Audacity のダウンロードリンクを開けません。"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s 始めました！"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "録音"
+
+#~ msgid "Commit Id:"
+#~ msgstr "コミット ID:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "クロスプラットフォームの GUI ライブラリ"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "GStreamer 経由の取り込み"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "録音レベル自動調整機能は停止しました。音量が大きすぎるため、調整できませんでした。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "録音レベル自動調整機能により、音量が %f まで下がりました。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "録音レベル自動調整機能は停止しました。音量が小さすぎるため、調整できませんでした。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "録音レベル自動調整機能により、音量が %.2f まで上がりました。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "録音レベル自動調整機能は停止しました。解析を繰り返しましたが、適切な音量を見つけることができませんでした。音量がまだ大きすぎます。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "録音レベル自動調整機能は停止しました。解析を繰り返しましたが、適切な音量を見つけることができませんでした。音量がまだ小さすぎます。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "録音レベル自動調整機能は停止しました。%.2f が適切な音量と推定されます。"
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "デバイスを開く際にエラー %d を受け取りました\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Portmixer を開けません\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "利用可能なミキサー:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "利用可能な録音ソース:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "利用可能な再生音量:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "録音音量はエミュレートされています\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "録音音量はネイティブです\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "再生音量はエミュレートされています\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "再生音量はネイティブです\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "終了日時"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer 互換ファイル"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "デコーダーをパイプラインに追加できません"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer 取り込み機能"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "ストリーム状態を pause に設定できません。"
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "インデックス[%02d]、種類[%s]、チャンネル[%d]、サンプリング周波数[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "ファイルが音声ストリームを含んでいません。"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "ファイルを取り込めません。ステート変更に失敗しました。"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer エラー: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "ミキサー(&X)"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "再生音量調整(&J)..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "再生音量を上げる(&I)"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "再生音量を下げる(&D)"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "録音音量調整(&U)..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "録音音量を上げる(&N)"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "録音音量を下げる(&E)"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity マニュアル(&M)"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Audacity について(&A)..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "録音レベル自動調整 (オン/オフ) (&U)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "録音レベル自動調整機能"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "録音レベル自動調整機能を有効化します。"
+
+#~ msgid "Target Peak:"
+#~ msgstr "ピークのターゲット:"
+
+#~ msgid "Within:"
+#~ msgstr "以内:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "解析時間:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "ミリ秒 (解析一回あたり)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "解析連続回数:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 はエンドレスの意味です"
+
+#~ msgid "Recording Volume"
+#~ msgstr "録音音量"
+
+#~ msgid "Playback Volume"
+#~ msgstr "再生音量"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "録音音量: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "録音音量 (使用不能。システムミキサーをお使いください)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "再生音量: %.2f (エミュレート)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "再生音量: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "再生音量 (使用不能。システムミキサーをお使いください)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "ミキサーツールバー(&X)"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "クリック＆ドラッグでトラックを時間移動"
+
 #~ msgid "Program build date:"
 #~ msgstr "プログラムのビルド日:"
 
@@ -19133,9 +20690,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 
 #~ msgid "Unknown assertion"
 #~ msgstr "不明なアサーション (Unknown assertion)"
-
-#~ msgid "Unknown error"
-#~ msgstr "不明なエラー (Unknown error)"
 
 #~ msgid "Failed to send crash report"
 #~ msgstr "クラッシュ報告の送信に失敗しました"
@@ -19773,11 +21327,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 #~ "不正な Nyquist 'control' タイプ:「%s」(プラグインファイル「%s」）。\n"
 #~ "control は作成できませんでした。"
 
-#  i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#, fuzzy
-#~ msgid "%d kpbs"
-#~ msgstr "%d kbps"
-
 #~ msgid "dummyStringClipBoundaryMessage"
 #~ msgstr ""
 #~ "※読み上げ用。翻訳者への注記参照。\n"
@@ -19984,9 +21533,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 
 #~ msgid "AIFF (Apple) signed 16-bit PCM"
 #~ msgstr "AIFF (Apple) 16bit PCM 符号あり"
-
-#~ msgid "WAV (Microsoft) signed 16-bit PCM"
-#~ msgstr "WAV (Microsoft) 16bit PCM 符号あり"
 
 #~ msgid "WAV (Microsoft) signed 24-bit PCM"
 #~ msgstr "WAV (Microsoft) 24bit PCM 符号あり"
@@ -20444,13 +21990,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 #~ msgid "S-E"
 #~ msgstr "SSE"
 
-#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
-#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
-#  i18n-hint: One-letter abbreviation for Left, in VU Meter
-#, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
-
 #, fuzzy
 #~ msgid "Show start time and end time"
 #~ msgstr "開始日時"
@@ -20556,9 +22095,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 #~ msgid "Offset"
 #~ msgstr "オフセット"
 
-#~ msgid "Version"
-#~ msgstr "バージョン"
-
 #~ msgid "C&ategory:"
 #~ msgstr "カテゴリー(&A):"
 
@@ -20624,10 +22160,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "描画を行うには、「波形」をトラックのドロップダウンメニューで選んでください。"
-
-#, fuzzy
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "%.1f dB 平均 rms"
 
 #, fuzzy
 #~ msgid "Average RMS = %.2f dB."
@@ -21315,9 +22847,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 #~ msgid "Inverting"
 #~ msgstr "上下を反転"
 
-#~ msgid "Leveler..."
-#~ msgstr "レベラー..."
-
 #~ msgid "Noise Generator"
 #~ msgstr "ノイズジェネレータ"
 
@@ -21914,9 +23443,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 #~ msgid "Noise Threshold (Hiss/Hum/Ambient Noise)"
 #~ msgstr "ノイズの閾値 (ヒス/ハム/環境ノイズ)"
 
-#~ msgid "Noise Removal by Dominic Mazzoni"
-#~ msgstr "Dominic Mazzoni によるノイズの除去"
-
 #~ msgid "by Nasca Octavian Paul"
 #~ msgstr "Nasca Octavian Paul による"
 
@@ -22003,9 +23529,6 @@ msgstr "エラー。~%ステレオトラックが必要です。"
 
 #~ msgid "Boost dB"
 #~ msgstr "ブースト dB"
-
-#~ msgid "BassBoost..."
-#~ msgstr "低域の強調..."
 
 #~ msgid ""
 #~ "If you have more than one Audio Track, you can\n"

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -9,11 +9,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Georgian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/ka/>\n"
+"Language-Team: Georgian <https://hosted.weblate.org/projects/tenacity/tenacity/ka/>\n"
 "Language: ka\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,42 +20,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-Bookmarks: -1,1872,-1,-1,-1,-1,-1,-1,-1,-1\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Audacity-ის დახურვა"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "არხი"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "ფაილის გახსნის შეცდომა"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "ფაილის გახსნის შეცდომა"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s ხელსაწყოთა ზოლი"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "ჩაწერა"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -66,6 +29,24 @@ msgstr "შეუძლებელია დადგენა"
 #, c-format
 msgid "%s bytes"
 msgstr " ბაიტები"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -84,12 +65,68 @@ msgid "2nd Experimental Command"
 msgstr "ბრძანების არჩევა"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Nyquist ეფექტის გააქტიურება..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&ჩასმა"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&ჩასმა"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&ჩასმა"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&ჩასმა"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "მონიშვნა"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -112,15 +149,37 @@ msgid "Show &Output"
 msgstr "გამონატანის ჩვენება"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "&ხელსაწყოთა ზოლები"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "გაჩერება"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "ცვლადი"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "გამონატანის მთვლელი"
 
@@ -128,13 +187,38 @@ msgstr "გამონატანის მთვლელი"
 msgid "Load Nyquist script"
 msgstr "Nyquist Prompt..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "გაფრთხილება"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Nyquist Prompt..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -145,16 +229,39 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "Leland Lucius-ის მიერ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Nyquist ეფექტის გააქტიურება..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "No matches found"
+msgstr "გაერთიანებული სტერეო"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist ეფექტის გააქტიურება..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&ახალი"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "უკანასკნელის გახსნა"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -188,7 +295,8 @@ msgstr "კოპირება"
 msgid "Copy to clipboard"
 msgstr "გაცვლის ბუფერში დამატება"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "ამოჭრა"
 
@@ -196,7 +304,8 @@ msgstr "ამოჭრა"
 msgid "Cut to clipboard"
 msgstr "გაცვლის ბუფერში დამატება"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "ჩასმა"
 
@@ -221,13 +330,30 @@ msgstr "მონიშვნა"
 msgid "Select all text"
 msgstr "მონიშვნა"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "დაბრუნება"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Undo last change"
 msgstr "ფორმატის შეცვლა"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&გამეორება"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "ფორმატის შეცვლა"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "&შენიშვნების ძება"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -238,23 +364,46 @@ msgid "Match"
 msgstr "ჯგუფური"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "კენ:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "საექსპორტო იარლიყები არ მოიძებნა."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "ზემოთ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "წინა ხელსაწყო"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "ფოკუსის წინა ტრეკზე გადატანა"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "შემდეგი ხელსაწყო"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "დაწყება"
 
@@ -262,7 +411,8 @@ msgstr "დაწყება"
 msgid "Start script"
 msgstr "Nyquist Prompt..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "გაჩერება"
 
@@ -270,8 +420,15 @@ msgstr "გაჩერება"
 msgid "Stop script"
 msgstr "Nyquist Prompt..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "დიახ"
 
@@ -279,11 +436,13 @@ msgstr "დიახ"
 msgid "Build Information"
 msgstr "აგების ინფორმაცია"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "გააქტიურებულია"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "გამორთულია"
 
@@ -293,8 +452,9 @@ msgid "The Build"
 msgstr "ხარვეზების მოცილების აგება"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "ბრძანება:"
+#, fuzzy
+msgid "Version:"
+msgstr "რევერსია"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -304,13 +464,23 @@ msgstr "აგების ტიპი:"
 msgid "Compiler:"
 msgstr "კომპრესორი"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "ინსტალაციის პრეფიქსი:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "პარამეტრების საქაღალდე:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "პარამეტრების საქაღალდე:"
 
 #: src/AboutDialog.cpp
@@ -329,7 +499,6 @@ msgstr "სანიმუშე კოეფიციენტის კონ�
 msgid "MP3 Importing"
 msgstr "MP3 იმპორტირება"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis იმპორტი და ექსპორტი"
@@ -338,7 +507,6 @@ msgstr "Ogg Vorbis იმპორტი და ექსპორტი"
 msgid "ID3 tag support"
 msgstr "ID3 ჭდეების მხარდაჭერა"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC  იმპორტი და ექსპორტი"
@@ -356,14 +524,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg იმპორტი/ექსპორტის ბიბლიოთეკა"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "იმპორტი QuickTime-ით"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "ფუნქციები"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "მოდულის მხარდაჭერა"
 
@@ -378,6 +538,10 @@ msgstr "Pitch და Tempo შეცვლის მხარდაჭერა"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Pitch და Tempo შეცვლის მხარდაჭერა"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "ფუნქციები"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -404,6 +568,18 @@ msgstr "კონვერტი"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "კონვერტი"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "კონვერტი"
 
@@ -415,9 +591,51 @@ msgstr "კონვერტი"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "კონვერტი"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "კონვერტი"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "კონვერტი"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "გრაფიკული EQ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "კონვერტი"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "კონვერტი"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -438,8 +656,26 @@ msgid "%s, graphics"
 msgstr "გრაფიკული EQ"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "კრედიტები"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -457,6 +693,11 @@ msgstr "სხვა კონტრიბუტორები"
 msgid "Tenacity Special thanks:"
 msgstr "განსაკუთრებული მადლობა:"
 
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "ძირითადი ბიბლიოთეკები"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
@@ -470,14 +711,23 @@ msgid "%s Team Members"
 msgstr "ჯგუფის სხვა გამორჩეული წევრები"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "სხვა კონტრიბუტორები"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "მთარგმნელის_შესახებ"
@@ -496,6 +746,26 @@ msgstr "განსაკუთრებული მადლობა:"
 msgid "%s website: "
 msgstr "Audacity-ის პირველი გაშვება"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "სხვა კონტრიბუტორები"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "სტერეო ტრეკების რელატიური ზომის მოსარგებად დააწკაპუნეთ და გადაათრიეთ."
@@ -513,6 +783,7 @@ msgstr "დროის შემცვლელი"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "დააწკაპუნეთ და გადაათრიეთ  სემპლების რედაქტირებისთვის"
@@ -520,17 +791,66 @@ msgstr "დააწკაპუნეთ და გადაათრიეთ 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "ტრეკის ზომის შესაცვლელად დაუწკაპუნეთ და გადაათრიეთ."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "ფოკუსის შემდეგ ტრეკზე გადატანა"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "ტრეკის ჩამოტანა"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "ფოკუსირებული ტრეკის დახურვა"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr "(გაუქმებულია)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr "(გაუქმებულია)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "მოდულის პარამეტრები"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -548,7 +868,23 @@ msgstr "არეს და&კვრა"
 msgid "Pinned Play Head"
 msgstr "ჩაწერის დასასრული"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "შეცდომა"
 
@@ -558,8 +894,36 @@ msgid "Failed to remove %s"
 msgstr "შეუძლებელია '%s'-ის წაშლა"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Audacity  პარამეტრები"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -578,6 +942,11 @@ msgstr "&გახსნა..."
 
 #: src/AudacityApp.cpp
 #, fuzzy
+msgid "Open &Recent..."
+msgstr "უკანასკნელის გახსნა"
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
+#, fuzzy
 msgid "&About Tenacity..."
 msgstr "Audacity-ის &შესახებ..."
 
@@ -590,29 +959,33 @@ msgid "&File"
 msgstr "&ფაილი"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity ვერ პოულობს დროებითი ფაილების შესანახ ადგილს.\n"
 "გთხოვთ, შეიყვანოთ შესაბამისი დირექტორია პარამეტრების დიალოგურ სარკმელში."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity ვერ პოულობს დროებითი ფაილების შესანახ ადგილს.\n"
 "გთხოვთ, შეიყვანოთ შესაბამისი დირექტორია პარამეტრების დიალოგურ სარკმელში."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity  ახლა დაიხურება. გთხოვთ, გაუშვათ თავიდან ახალი დროებითი დირექტორიის გამოსაყენებლად."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -621,36 +994,91 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity-მა ვერ შეძლო დროებითი ფაილების დირექტორიის ჩაკეტვა.\n"
 "ეს საქაღალდე შეიძლება Audacity-ის სხვა ასლის მიერ გამოიყენება.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "კვლავ გსურთ  Audacity-ის დაწყება?"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "ფაილის გახსნის შეცდომა"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "სისტემამ დაადგინა, რომ გაშვებულია Audacity -ის ასლი.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "გამოიყენეთ ახალი ან გახსნა ბრძანებები მიმდინარე Audacity-ში\n"
 "პროცესში მრავალჯერადი პროექტების თანადროული გახსნისთვის.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity კვლავ გაშვებულია"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity პროექტის ფაილები"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -670,7 +1098,8 @@ msgstr "\t-ტესტი (დიაგნოსტიკის გაშვე
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-ვერსია (Audacity ვერსიის ჩვენება)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -680,9 +1109,10 @@ msgid "audio or project file name"
 msgstr "შეუძლებელია პროექტის ფაილის გახსნა"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -695,29 +1125,73 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity პროექტის ფაილები"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&რესემპლირება..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "აუდიოს ჩაწერა"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "დახმარება"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Audacity-ის დახურვა"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity %s ხელსაწყოთა ზოლი"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "&შენახვა..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&დახურვა"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "შენახულია"
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -746,7 +1220,26 @@ msgid "Error Initializing Audio"
 msgstr "აუდიოს დაწყების შეცდომა"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"ვერ შეძლებთ აუდიოს დაკვრას ან ჩაწერას.\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "აუდიოს დაწყების შეცდომა"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity %s ხელსაწყოთა ზოლი"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -757,24 +1250,26 @@ msgid ""
 msgstr "ხმის მოწყობილობის გახსნის შეცდომა"
 
 #: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+msgid "Out of memory!"
+msgstr ""
 
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "ჩაწერის დასასრული\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "ჩაწერის დასასრული\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -812,8 +1307,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "ჩაწერის დასასრული\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "ჩაწერის დასასრული\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "ჩაწერის დასასრული\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "ჩაწერის დასასრული\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -827,37 +1332,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "ჩაწერის დასასრული\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "ჩაწერის დასასრული\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "დაკვრის სიჩქარე\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "შეუძლებელია ჟანრის ფაილის შენახვა.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "დაკვრის სიჩქარე\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "ჩაწერა\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "სემპლის კ0ოეფიციენტები\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "დაკვრა\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "ჩაწერის დასასრული\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "ჩაწერის დასასრული\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "დაკვრა\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "დაკვრა\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -865,8 +1373,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "ჩაწერის დასასრული\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "ჩაწერის დასასრული\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "დაკვრის სიჩქარე\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "დაკვრის სიჩქარე\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -874,8 +1392,9 @@ msgid "Automatic Crash Recovery"
 msgstr "ავტომატური აღდგენა მარცხის მერე"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -887,12 +1406,14 @@ msgid "Recoverable &projects"
 msgstr "აღდგენადი პროექტები"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "მონიშვნა"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "სახელი"
 
@@ -903,6 +1424,10 @@ msgstr "მონიშვნა"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "მონიშვნა"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -938,8 +1463,16 @@ msgid "&Parameters"
 msgstr "&პარამეტრები"
 
 #: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "ბრძანების ა&მორჩევა"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -968,6 +1501,22 @@ msgstr "ეფ&ექტი"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&პარამეტრების რედაქტირება"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&პარამეტრების რედაქტირება"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1014,11 +1563,30 @@ msgstr "ტესტირების რეჟიმი"
 msgid "Apply %s"
 msgstr "%s-ის გააქტიურება"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "პარამეტრის წაშლა"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&იარლიყები..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "ჯაჭვის გააქტიურება"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1074,13 +1642,34 @@ msgstr "&გაუქმება"
 msgid "Remo&ve"
 msgstr "&წაშლა"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "&რესემპლირება..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Re&store"
 msgstr "არ&ეს აღდგენა"
 
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "&იმპორტი..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "&ექსპორტი..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "ჟანრების რედაქტირება"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1110,9 +1699,20 @@ msgstr "აწევა"
 msgid "Move &Down"
 msgstr "ჩამოწევა"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&შენახვა..."
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
+
+#. i18n-hint: This is the last item in a list.
+#: src/BatchProcessDialog.cpp
+msgid "- END -"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 #, c-format
@@ -1153,11 +1753,38 @@ msgid "Benchmark"
 msgstr "Benchmark-ის &გაშვება..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "გასამეორებელი ჯერების ოდენობა:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "დახურვა"
 
@@ -1172,8 +1799,30 @@ msgid "Export Benchmark Data as:"
 msgstr "სპექტრული მონაცემების ექსპორტი როგორც:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "ხედის მომზადება\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1182,17 +1831,104 @@ msgstr "გამეორების შესრულება\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "ჩასმა\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "აუდიოს ჩაწერა\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "დასასრული თარიღი და დრო"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "გამოცემის აგება"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1213,9 +1949,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "ჯერ უნდა აირჩიოთ აუდიო."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "ჯაჭვი არაა მონიშნული"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1241,6 +2001,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "მონიშვნა"
 
@@ -1258,10 +2023,24 @@ msgstr "მიმდინარე &პროექტის გააქტი
 msgid "Checkpointing %s"
 msgstr "%s იმპორტირება"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "შეუძლებელია ფაილზე ჩაწერა:\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"შეუძლებელია პროექტის გახსნა. შესაძლოა%s \n"
+"არ არის ჩაწერადი ან დისკია გადავსებული."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1279,6 +2058,10 @@ msgid ""
 "%s"
 msgstr "შეუძლებელია '%s'-ის წაშლა"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "დამოკიდებულთა წაშლა"
@@ -1286,6 +2069,25 @@ msgstr "დამოკიდებულთა წაშლა"
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "აუდიო მონაცემების პროექტის კოპირება..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "პროექტის შენახვისას, რომელიც დამოკიდებულია სხვა აუდიო ფაილებზე"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1300,8 +2102,27 @@ msgid "Disk Space"
 msgstr "დისკის ზომა"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "მონიშვნა"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "შენახვის გაუქმება"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "იარლიყი"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Do Not Copy"
+msgstr "არა აღადგინო"
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1313,9 +2134,32 @@ msgstr "როდესაც პროექტი დამოკიდებ�
 msgid "Ask me"
 msgstr "მკითხე"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "MIDI ფაილის ამორჩევა"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "გაცვლის ბუფერში დამატება"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1326,10 +2170,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "თუ გააგრძელებთ, თქვენი პროექტი არ შეინახება დისკზე. ასე გსურთ?"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "დამოკიდებულების შემოწმება"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "არცერთიი"
 
@@ -1337,7 +2193,7 @@ msgstr "არცერთიი"
 msgid "Rectangle"
 msgstr "მართკუთხედი"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "სამკუთხედი"
 
@@ -1351,8 +2207,64 @@ msgstr "მართკუთხედი"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "მოგესალმებით!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg library not found"
@@ -1363,11 +2275,22 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg მდებარეობის დადგენა"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity-ის სჭირდება ფაილი %s აუდიოს იმპორტისა და ექსპორტისთვის FFmpeg-ის საშუალებით."
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "%s'-ის მდებარეობა:"
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "To find '%s', click here -->"
+msgstr "%s'-ის მოსაძებნად აქ დაუწკაპუნეთ -->"
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "ამორჩევა..."
 
@@ -1375,28 +2298,74 @@ msgstr "ამორჩევა..."
 msgid "To get a free copy of FFmpeg, click here -->"
 msgstr "FFmpeg-ის უფასო ასლის მისაღებად აქ დააწკაპუნეთ -->"
 
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Download"
+msgstr "&ჩამოტვირთვა"
+
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "სად არის %s'?"
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg not found"
 msgstr "FFmpeg ვერ მოიძებნა"
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
-msgstr ""
-"Audacity ვერ შეძლო ფაილის ჩაწერა:\n"
-"  %s."
-
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
-msgstr ""
-"Audacity ვერ შეძლო ფაილის ჩაწერა:\n"
-"  %s."
-
-#: src/FileException.cpp
-#, c-format
+#: src/FFmpeg.cpp
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "მეტჯერ აღარ აჩვენო ეს გაფრთხილება"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity ვერ შეძლო ფაილის ჩაწერა:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+"Audacity ვერ შეძლო ფაილის ჩაწერა:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1425,7 +2394,17 @@ msgstr "არაკომპრესირებული ფაილებ�
 msgid "&Copy all audio into project (safest)"
 msgstr "აუდიო მონაცემების პროექტის კოპირება..."
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "ყველა ფაილი(*)|*"
 
@@ -1434,6 +2413,11 @@ msgstr "ყველა ფაილი(*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "პროექტის მონაცემთა ფაილების შენახვა "
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "ძირითადი ბიბლიოთეკები"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1447,12 +2431,24 @@ msgstr "ფაილების სახელების დარქმე�
 msgid "XML files"
 msgstr "MP3 ფაილები"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "MP3 ფაილები"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -1479,6 +2475,14 @@ msgstr "Cuberoot ავტოკორექცია"
 msgid "Enhanced Autocorrelation"
 msgstr "გაუმჯობესებული ავტოკორექცია"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "სპექტრი"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1495,9 +2499,34 @@ msgstr "ლინეარული სიხშირე"
 msgid "Log frequency"
 msgstr "ჩანაწერის სიხშირე"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "გადიდება"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1512,6 +2541,14 @@ msgstr "ჰორიზონტალური სტერეო"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "კურსორი მარცხნივ"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Algorithm:"
@@ -1550,17 +2587,59 @@ msgstr "ზედმეტი აუდიო იყო მონიშნულ
 msgid "Not enough data selected."
 msgstr "არ არის საკმარისი მონაცემები მონიშნული."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "სპექტრი"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "სპექტრული მონაცემების ექსპორტი როგორც:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "შეუძლებელია ფაილზე ჩაწერა:"
 
 #: src/FreqWindow.cpp
 msgid "Frequency (Hz)\tLevel (dB)"
+msgstr "სიხშირის  (Hz)\tდონე(dB)"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Lag (seconds)\tFrequency (Hz)\tLevel"
 msgstr "სიხშირის  (Hz)\tდონე(dB)"
 
 #: src/FreqWindow.cpp
@@ -1613,12 +2692,75 @@ msgstr "Audacity პროექტის შენახვა"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
 msgid "Burn to CD"
 msgstr "CD-ზე ჩაწერა"
 
 #: src/HelpText.cpp
 msgid "No Local Help"
 msgstr "ლოკალური დახმარების გარეშე"
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1637,6 +2779,10 @@ msgid "Used Space"
 msgstr "დისკის ზომა"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&უკუსვლის დონეები ხელმისაწვდომია"
 
@@ -1650,6 +2796,10 @@ msgid "&Discard"
 msgstr "&გაუქმება"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&გაუქმება"
 
@@ -1657,15 +2807,39 @@ msgstr "&გაუქმება"
 msgid "&Compact"
 msgstr "&ბრძანება"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&ისტორია..."
 
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
 #: src/InconsistencyException.h
 msgid "Internal Error"
 msgstr "(გარე პროგრამა)"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "რედაქტირებული იარლიყები"
 
 #. i18n-hint: (noun).  A track contains waves, audio etc.
 #: src/LabelDialog.cpp
@@ -1673,7 +2847,9 @@ msgid "Track"
 msgstr "ტრეკი"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "იარლიყი"
 
@@ -1730,19 +2906,47 @@ msgstr "ახალი იარლიყის ტრეკი"
 msgid "Enter track name"
 msgstr "ტრეკის სახელის შეყვანა"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "&იარლიყის ტრეკი"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity-ის პირველი გაშვება"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "ენის ამორჩევა Audacity-ისთვის:"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "დადასტურება"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "ფაილის შენახვის შეცდომა:"
 
 #: src/Legacy.cpp
 #, c-format
@@ -1754,8 +2958,19 @@ msgstr ""
 "ძველი ფაილი შეინახა როგორც '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity პროექტის გახსნა"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "განსაკუთრებული მადლობა:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "ამორჩევა..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1776,6 +2991,12 @@ msgid "&Redo"
 msgstr "&გამეორება"
 
 #: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
 msgid "Disallowed"
 msgstr "გაუქმებული."
 
@@ -1792,23 +3013,80 @@ msgstr "&არევა და რენდერი"
 msgid "Mixing and rendering tracks"
 msgstr "ტრეკების არევა და რენდერინგი"
 
+#: src/MixerBoard.cpp
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr "Audacity ტაიმერის ჩაწერა"
+
+#. i18n-hint: title of the Gain slider, used to adjust the volume
+#. i18n-hint: Title of the Gain slider, used to adjust the volume
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Gain"
+msgstr "Gain"
+
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Velocity"
+msgstr "შენიშვნის სიჩქარე"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "Musical Instrument"
+msgstr "ინსტრუმენტი"
+
+#. i18n-hint: Title of the Pan slider, used to move the sound left or right
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Pan"
+msgstr "ტრეკის ზოლი"
+
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "დადუმება"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "სოლო"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "გადაადგილებული gain ცოცია"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "გადაადგილებული gain ცოცია"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "გადაადგილებული pan ცოცია"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "&ტაიმერის ჩაწერა..."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1818,13 +3096,73 @@ msgid ""
 "Error: %s"
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "გააქტიურებულია"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy, c-format
+msgid "Module \"%s\" found."
+msgstr "FFmpeg ვერ მოიძებნა"
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "არცერთიი"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "მოდულატორი"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1834,18 +3172,126 @@ msgstr "გაითვალისწინეთ ტრეკი"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "არსებულ ფაილებზე გადაწერა"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -1867,14 +3313,34 @@ msgstr[1] "Vamp მოდულის გაშვებამ მარცხ�
 msgid "Enable new plug-ins"
 msgstr "Vamp მოდულის გაშვებამ მარცხი განიცადა."
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Nyquist ეფექტის გააქტიურება..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Vamp მოდულის გაშვებამ მარცხი განიცადა."
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "ყველა კოდეკის ჩვენება"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
 msgid "Show all"
 msgstr "ყველა კოდეკის ჩვენება"
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
+msgid "&All"
+msgstr ""
 
 #. i18n-hint: Radio button to show just the currently disabled effects
 #: src/PluginRegistrationDialog.cpp
@@ -1896,6 +3362,25 @@ msgstr "გააქტიურებულია"
 msgid "E&nabled"
 msgstr "გააქტიურებულია"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "გააქტიურებულია"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "მონიშვნა"
@@ -1904,7 +3389,8 @@ msgstr "მონიშვნა"
 msgid "C&lear All"
 msgstr "&გაწმენდა"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "გააქტიურებულია"
 
@@ -1943,6 +3429,14 @@ msgstr "ამობეჭდვის შეცდომა."
 msgid "Print"
 msgstr "ამობეჭდვა"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgid "Actual Rate: %d"
@@ -1958,6 +3452,21 @@ msgstr "ხმის მოწყობილობის გახსნის 
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "სპექტრის აგებისთვის ყველა მონიშნული ტრეკს უნდა ჰქონდეს სემპლის თანაბარი კოეფიციენტი."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "ჩაწერილი აუდიო"
@@ -1966,9 +3475,99 @@ msgstr "ჩაწერილი აუდიო"
 msgid "Record"
 msgstr "ჩაწერა"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "პროექტის მყისიერი დახურვა ცვლილებების გარეშე"
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "შეუძლებელია პროექტის ფაილის გახსნა"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Treat missing audio as silence (this session only)"
+msgstr "სიჩუმის ამოვსება  ნაკლული მონაცემებისთვის [მხოლოდ ეს სესია]"
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Fill in silence for missing display data (this session only)"
@@ -1978,11 +3577,88 @@ msgstr "სიჩუმის ამოვსება  ნაკლული �
 msgid "Close project immediately with no further changes"
 msgstr "პროექტის მყისიერი დახურვა შემდგომი ცვლილებების გარეშე"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "მიმდინარეობა"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "ქეშის დირექტორიების გაწმენდა"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning: Problems in Automatic Recovery"
+msgstr "ფაილის შენახვის შეცდომა:"
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "პროექტის მორგება"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2021,11 +3697,96 @@ msgid ""
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "შეუძლებელია '%s'-ის წაშლა"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Audacity პროექტის შენახვა"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2034,12 +3795,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "შეუძლებელია  MP3  ნაკადის დაწყება"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "შეუძლებელია '%s'-ის სახელის გადარქმევა  '%s'-ად"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "შეუძლებელია '%s'-ის წაშლა"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2050,9 +3837,9 @@ msgid "Error Writing to File"
 msgstr "ფაილის შენახვის შეცდომა:"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2063,8 +3850,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "ახალი შექმნილი პროექტი"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity %s ხელსაწყოთა ზოლი"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2072,9 +3868,21 @@ msgstr "Tenacity %s ხელსაწყოთა ზოლი"
 msgid "(Recovered)"
 msgstr "(აღდგენილია)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "შეუძლებელია პროექტის ფაილის გახსნა"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2089,14 +3897,62 @@ msgid "Unable to parse project information."
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&პროექტის შენახვა"
 
-#: src/ProjectFileManager.cpp
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Audacity  ტაიმერის ჩაწერის მიმდინარეობა"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "&პროექტის შენახვა"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
+msgstr ""
+"ზოგიერთი პროექტი არ შეინახა სწორად, როდესაც Audacity იყო გაშვებული ბოლოს.\n"
+"საბედნიეროდ, შემდეგი პროექტების ავტომატური აღდგენა შესაძლებელია:"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
 msgstr ""
 "ზოგიერთი პროექტი არ შეინახა სწორად, როდესაც Audacity იყო გაშვებული ბოლოს.\n"
 "საბედნიეროდ, შემდეგი პროექტების ავტომატური აღდგენა შესაძლებელია:"
@@ -2105,9 +3961,49 @@ msgstr ""
 msgid "Project Recovered"
 msgstr "პროექტი აღდგენილია"
 
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "დროებითი ფაილების დირექტორია"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+"\n"
+"შენახვის შემთხვევაში პროექტს არ ექნება ტრეკები.\n"
+"\n"
+"ადრე გახსნილი ტრეკის შესანახად::\n"
+"გაუქმეთ, რედაქტირება>მოქმედება დააბრუნეთ\n"
+"სანამ ყველა ტრეკი გახსნილია, შემდეგ ფაილი > პროექტის შენახვა."
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "Audacity პროექტის შენახვა"
+
 #: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "დისკის ზომა"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -2115,9 +4011,34 @@ msgid "Saved %s"
 msgstr "შენახულია %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "პროექტის შენახვა, &როგორც..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2125,9 +4046,21 @@ msgid "Overwrite Project Warning"
 msgstr "არსებულ ფაილებზე გადაწერა"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "პროექტის კომპრესირებული ასლის შენახვა..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -2150,6 +4083,23 @@ msgstr "ერთი ან მეტი აუდიო ფაილის მ�
 msgid "%s is already open in another window."
 msgstr "%s უკვე გახსნილია სხვა ფანჯარაში."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "ფაილის გახსნის შეცდომა"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "ფაილის გახსნის შეცდომა"
@@ -2166,6 +4116,17 @@ msgid ""
 msgstr ""
 "ფაილი შესაძლოა არასწორია ან დაზიანებული: \n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "ფაილის გახსნის შეცდომა"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -2193,12 +4154,33 @@ msgid "Error Importing"
 msgstr "იმპორტის შეცდომა"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&პროექტის შენახვა"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "შეუძლებელია პროექტის ფაილის გახსნა"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&ბრძანება"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2209,8 +4191,8 @@ msgid "Automatic database backup failed."
 msgstr "ავტომატური აღდგენა მარცხის მერე"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "მოგესალმებათ Audacity-ის ვერსია %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2245,6 +4227,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "ჩაწერისთვის დარჩენილი სივრცე %d წუთი."
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -2257,6 +4243,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2272,6 +4270,26 @@ msgstr "ჰორიზონტალური სტერეო"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "ვერტიკალური სტერეო"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(საუკეთესო ხარისხი)"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -2300,9 +4318,86 @@ msgstr "24-ბიტიანი PCM"
 msgid "32-bit float"
 msgstr "32-ბიტიანი მცოცავი"
 
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "ექსპორტირებული ფაილების შესანახი მდებარეობის არჩევა"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "შევინახო ცვლილებები?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "არჩევა..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "სახის ზომა"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "სახის ზომა"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "White Bkgnd"
+msgstr "თეთრი"
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr "ფანჯარა"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "ფანჯრის ტიპი"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "კურსორი ტრეკის &დასასრულთან"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "&ხელსაწყოთა ზოლები"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -2316,7 +4411,13 @@ msgstr "ყველა ფაილი(*)|*"
 msgid "All Preferences"
 msgstr "პარამეტრები..."
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "მონიშვნა"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "მონიშვნა"
 
@@ -2324,47 +4425,153 @@ msgstr "მონიშვნა"
 msgid "Timer"
 msgstr "დრო"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "ხელსაწყოები"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "&გადატანა"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "მიქსერი"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "მთვლელი"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "მთვლელის დაკვრა"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "რეკორდის გამზომავი"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&რედაქტირება"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "მოწყობილობა"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "დაკვრა სიჩქარით"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "&ხელსაწყოთა ზოლები"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
 msgstr "ტრეკის ზოლი"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "ტრეკები"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "ტრეკების &დახარისხება"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "ახალი ტრეკი"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "ერთი წამი დაკვრა"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "ტრეკების &დახარისხება"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "ყველა ტრეკის &ჩაჩუმება"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "ტრეკების &გასწორება"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "ექსპორტირებული ფაილების შესანახი მდებარეობის არჩევა"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-დახმარება (ეს შეტყობინება)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
@@ -2382,6 +4589,19 @@ msgstr "&პარამეტრები..."
 msgid "Debu&g"
 msgstr "&ხარვეზების აღმოფხვრა"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "გადაღების ჩართვა"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
 #: src/SoundActivatedRecord.cpp
 msgid "Sound Activated Record"
 msgstr "ხმაგააქტიურებული ჩაწერა"
@@ -2391,7 +4611,8 @@ msgid "Activation level (dB):"
 msgstr "აქტივაციის დონე (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "&მოგესალმებათ Audacity!"
 
 #: src/SplashDialog.cpp
@@ -2431,6 +4652,20 @@ msgid "Comments"
 msgstr "კომენტარები"
 
 #: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Tag"
+msgstr "ჭდე:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "დონე:"
+
+#: src/Tags.cpp
 msgid "&Add"
 msgstr "&დამატება"
 
@@ -2443,12 +4678,27 @@ msgid "Genres"
 msgstr "ჟანრები"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&რედაქტირება"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "პარამეტრების გარდაქმნა"
+
+#: src/Tags.cpp
 msgid "Template"
 msgstr "შაბლონი"
 
 #: src/Tags.cpp
 msgid "&Load..."
 msgstr "&ჩატვირთვა..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "ნაგულისხმევი"
 
 #: src/Tags.cpp
 msgid "Don't show this when exporting audio"
@@ -2475,26 +4725,67 @@ msgid "Unable to open genre file."
 msgstr "შეუძლებელია ჟანრის ფაილის შენახვა."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Load Metadata As:"
+msgstr "მეტამონაცემების შენახვა როგორც:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "მეტამონაცემების რედაქტირება"
+
+#: src/Tags.cpp
 msgid "Save Metadata As:"
 msgstr "მეტამონაცემების შენახვა როგორც:"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "ფაილის გახსნის შეცდომა"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "გააქტიურებულია"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "დროებითი ფაილების დირექტორია"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity ვერ შეძლო ფაილის ჩაწერა:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2503,18 +4794,26 @@ msgstr ""
 "ფაილის გახსნა ჩასაწერად."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity ვერ შეძლო გამოსახულებების ჩაწერა ფაილზე:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -2524,9 +4823,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -2535,8 +4834,9 @@ msgstr ""
 "იქნებ ცუდი png ფორმატია?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity ვერ წაიკითხა თავისი ნაგულისხმევი თემა.\n"
@@ -2574,18 +4874,40 @@ msgstr ""
 "უკვე არსებობს."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity-ის არ შეუძლია ფაილის შენახვა:\n"
 "  %s"
 
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "მსუბუქი"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "ტრეკის სახელი"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2594,12 +4916,24 @@ msgstr "მსუბუქი"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "ხანგრძლოვობა"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "&დროის ტრეკი"
+
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity ტაიმერის ჩაწერა"
 
 #: src/TimerRecordDialog.cpp
@@ -2607,12 +4941,59 @@ msgid "Save Timer Recording As"
 msgstr "ჩაწერა"
 
 #: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
 msgstr "Audacity  ტაიმერის ჩაწერის მიმდინარეობა"
 
 #: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "აუდიოს ჩაწერა"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "ავტომატური აღდგენა მარცხის მერე"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "ფაილის შენახვის შეცდომა:"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "ინდივიდუალური FFmpeg ექსპორტირება"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "ფაილის შენახვის შეცდომა:"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "&ტაიმერის ჩაწერა..."
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -2622,7 +5003,8 @@ msgstr "მიმდინარე &პროექტის გააქტი
 msgid "Recording start:"
 msgstr "ჩაწერის დაწყება"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "ხანგრძლივობა:"
 
@@ -2643,7 +5025,8 @@ msgid "Action after Timer Recording:"
 msgstr "Audacity ტაიმერის ჩაწერა"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity  ტაიმერის ჩაწერის მიმდინარეობა"
 
 #: src/TimerRecordDialog.cpp
@@ -2678,6 +5061,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "ჩაწერის დასასრული"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Audacity  ტაიმერის ჩაწერის მიმდინარეობა"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "ჩაწერა"
@@ -2697,6 +5104,7 @@ msgstr "0100 დღე 024 ს 060 წ 060 წ"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "საწყისი თარიღი და დრო"
@@ -2715,6 +5123,11 @@ msgstr "დასასრული თარიღი"
 
 #: src/TimerRecordDialog.cpp
 msgid "Automatic Save"
+msgstr "ავტომატური აღდგენა მარცხის მერე"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
 msgstr "ავტომატური აღდგენა მარცხის მერე"
 
 #: src/TimerRecordDialog.cpp
@@ -2737,7 +5150,8 @@ msgstr "შეუძლებელია ესპორტირება"
 msgid "Export Project As:"
 msgstr "პარამეტრების ექსპორტი"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "პარამეტრები..."
 
@@ -2746,8 +5160,21 @@ msgid "After Recording completes:"
 msgstr "რეკორდის გამზომავი"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Audacity-ის დახურვა"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -2762,7 +5189,8 @@ msgid "Scheduled to stop at:"
 msgstr "დასაწყისზე მონიშვნა"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity ტაიმერის ჩაწერა - დაწყების მოლოდინი"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -2770,6 +5198,14 @@ msgstr "Audacity ტაიმერის ჩაწერა - დაწყე�
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "ჩაწერის დასასრული"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -2780,8 +5216,19 @@ msgid "Recording Exported:"
 msgstr "ჩაწერის დასასრული"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity ტაიმერის ჩაწერა - დაწყების მოლოდინი"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "სტერეო,"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -2811,6 +5258,15 @@ msgstr "სოლო"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "მონიშვნა"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "მონიშვნა - სიჩუმე"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -2889,6 +5345,10 @@ msgstr "ტრეკის ატანა"
 msgid "Move Track Down"
 msgstr "ტრეკის ჩამოტანა"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -2934,21 +5394,80 @@ msgstr "მონიშვნის ჩასასმელად არ არ
 msgid "There is not enough room available to expand the cut line"
 msgstr "ამოჭრის ხაზის გასაფართოებლად არ არის საკმარისი სივრცე"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "გააქტიურება..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "ბრძანების არჩევა"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "&ბრძანება"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "გამეორება %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -2958,6 +5477,15 @@ msgstr "იარლიყების კოპირება"
 msgid "Threshold:"
 msgstr "ზღვარი:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "შეყოვნების დრო (წამები):"
@@ -2965,6 +5493,10 @@ msgstr "შეყოვნების დრო (წამები):"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "შეყოვნების ფაქტორი:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -2986,6 +5518,11 @@ msgstr "ტრეკი"
 msgid "Track 1"
 msgstr "ტრეკი"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "ფანჯრის ტიპი"
@@ -2997,6 +5534,22 @@ msgstr "დან:"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "დან:"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -3022,13 +5575,42 @@ msgstr "კლინინგი"
 msgid "Envelopes"
 msgstr "კონვერტი"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "იარლიყების მიხედვით"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "ფილტრი"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "ფორმატი:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -3038,6 +5620,10 @@ msgstr "ტრეკის ჩამოტანა"
 msgid "Types:"
 msgstr "ფილტრი"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "კომენტარები"
@@ -3045,6 +5631,18 @@ msgstr "კომენტარები"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "ბრძანება:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -3063,6 +5661,11 @@ msgid "Number of Channels:"
 msgstr "გასამეორებელი ჯერების ოდენობა:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "მრავალჯერადი ექსპორტი"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "მრავალჯერადი ექსპორტი"
 
@@ -3070,9 +5673,26 @@ msgstr "მრავალჯერადი ექსპორტი"
 msgid "Builtin Commands"
 msgstr "ბრძანების არჩევა"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity %s მხარდაჭერის გუნდი"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "დასასრული თარიღი და დრო"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -3114,17 +5734,45 @@ msgstr "&პროექტის შენახვა"
 msgid "Saves a copy of current project."
 msgstr "&პროექტის შენახვა"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "პარამეტრები..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "სახელი"
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "პარამეტრები..."
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "დონე:"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3143,8 +5791,18 @@ msgid "Window Plus"
 msgstr "ფანჯრის ტიპი"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "&ხელსაწყოთა ზოლები"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "ეფ&ექტი"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Scriptables"
@@ -3186,6 +5844,10 @@ msgstr "ტრეკების &გასწორება"
 msgid "All Tracks Plus"
 msgstr "ყველა ტრეკის &ჩაჩუმება"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -3193,13 +5855,30 @@ msgid "White"
 msgstr "თეთრი"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "ფონი:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "ფაილის შენახვის შეცდომა:"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&ეკრანის ანაბეჭდის ხელსაწყოები..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -3246,6 +5925,10 @@ msgid "High:"
 msgstr "მაღალი სიხშირის ფილტრი"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "ტრეკების &დახარისხება"
 
@@ -3257,6 +5940,12 @@ msgstr "მონიშვნა"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "&დამატება"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&წაშლა"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -3275,6 +5964,11 @@ msgid "Selects a time range."
 msgstr "MIDI ფაილის ამორჩევა"
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "MIDI ფაილის ამორჩევა"
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
@@ -3286,9 +5980,37 @@ msgstr "აუდ&იოს დაჩუმება"
 msgid "Set Clip"
 msgstr "შემდეგი ხელსაწყო"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "დაწყება"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -3307,9 +6029,14 @@ msgid "Edited Envelope"
 msgstr "კონვერტი"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "კონვერტი"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -3319,6 +6046,10 @@ msgstr "იარლიყების დაყოფა"
 msgid "Label Index"
 msgstr "იარლიყის რედაქტირება"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "მონიშვნა"
@@ -3326,6 +6057,10 @@ msgstr "მონიშვნა"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "რედაქტირებული იარლიყები"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -3339,9 +6074,26 @@ msgstr "კოეფიციენტის მომართვა"
 msgid "Resize:"
 msgstr "სახის ზომა"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "მსუბუქი"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&პროექტის შენახვა"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -3356,6 +6108,10 @@ msgid "Set Track Status"
 msgstr "ტრეკის დასაწყისამდე"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "შეჩერება"
 
@@ -3368,10 +6124,17 @@ msgid "Gain:"
 msgstr "Gain"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "ტრეკების &დახარისხება"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "ლინეარული"
 
@@ -3384,8 +6147,16 @@ msgid "Times 2"
 msgstr "დრო"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
 msgstr "ეკრანი"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -3407,16 +6178,36 @@ msgstr "სპექტრული დამმუშავებელი"
 msgid "Spectral Select"
 msgstr "მონიშვნა"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "ახალი ტრეკი"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "გაძლიერება"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "გაძლიერება (dB):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "გაძლიერება (dB):"
 
 #: src/effects/Amplify.cpp
@@ -3426,6 +6217,14 @@ msgstr "ამპლიტუდის ახალი პიკი (dB):"
 #: src/effects/Amplify.cpp
 msgid "Allo&w clipping"
 msgstr "სანიშნების დაშვება"
+
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
 
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
@@ -3441,12 +6240,18 @@ msgstr "მონიშნული გაქვთ ტრეკი, რომ�
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck სჭირდება საკონტროლო ტრეკი, რომელიც მოთავსებული უნდა იყოს მონიშნული ტრეკ(ებ)ის ქვემოთ."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Duck რაოდენობა:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "წამები"
 
@@ -3470,7 +6275,8 @@ msgstr "შიდა მინავლების სიგრძე:"
 msgid "Inner &fade up length:"
 msgstr "შიდა ხმის აწევის სიგრძე:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "ზღვარი:"
 
@@ -3479,8 +6285,17 @@ msgid "Preview not available"
 msgstr "დათვალიერება შეუძლებელია"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "კონტრასტის მარცხნივ მონიშნვა"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "ხარვეზის ზღვარი:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3491,12 +6306,31 @@ msgid "Ba&ss (dB):"
 msgstr "Boost (dB):"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "Bass Boost"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "დონე:"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "იარლიყის რედაქტირება"
+
+#: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
 msgstr "დონე:"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "დონე:"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -3507,8 +6341,18 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Pitch  შეცვლა Tempo-ს შეცვლის გარეშე"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Pitch და Tempo შეცვლის მხარდაჭერა"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Pitch  შეცვლა Tempo-ს შეცვლის გარეშე"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
@@ -3563,17 +6407,36 @@ msgstr "სიხშირე (Hz)"
 msgid "from (Hz)"
 msgstr "დან"
 
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "to (Hz)"
+msgstr "დან"
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "კენ"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "პროცენტის შეცვლა:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "პროცენტის შეცვლა"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -3585,7 +6448,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "მიუწვდომელია"
 
@@ -3613,6 +6478,7 @@ msgstr "სტანდარტული Vinyl RPM:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "RPM-დან"
@@ -3622,6 +6488,14 @@ msgstr "RPM-დან"
 msgctxt "change speed"
 msgid "&from"
 msgstr "დან"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "RPM-დან"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -3727,6 +6601,19 @@ msgid "Click Removal"
 msgstr "დაწკაპუნების წაშლა"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "სახელი არ უნდა იყოს ცარიელი"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "ზღვარის ამორჩევა (დაბალი უფრო მგრძნობიარეა):"
 
@@ -3738,9 +6625,23 @@ msgstr "ზღვარი"
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "სპაიკის მაქსიმალური სიგანე (მაღალი უფრო მგრძNობიარეა):"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 msgid "Compressor"
 msgstr "კომპრესორი"
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -3752,6 +6653,20 @@ msgstr "%.1f წამი"
 msgid "%.1f secs"
 msgstr "%.1f წამი"
 
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
+msgstr "%.1f წამი"
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
@@ -3761,6 +6676,16 @@ msgstr "პროპორცია %.0f to 1"
 #, c-format
 msgid "Ratio %.1f to 1"
 msgstr "პროპორცია %.1f to 1"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "ხარვეზის ტიპი"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "ხარვეზი..."
 
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
@@ -3798,10 +6723,26 @@ msgstr "გასული დრო:"
 msgid "Release Time"
 msgstr "გამოცემის აგება"
 
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "ზღვარი %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -3814,17 +6755,56 @@ msgid "Release Time %.1f secs"
 msgstr "დაწევის დრო %.1f წამი"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "დასასრული"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "დონე:"
+
+#: src/effects/Contrast.cpp
 msgid "&Foreground:"
 msgstr "წინა პლანი:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground start time"
+msgstr "წინა პლანი:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground end time"
+msgstr "სიგრძიდან წამებში"
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
@@ -3832,6 +6812,16 @@ msgstr "სიჩუმის მონიშვნა"
 
 #: src/effects/Contrast.cpp
 msgid "&Background:"
+msgstr "ფონი:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background start time"
+msgstr "ფონი:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
 msgstr "ფონი:"
 
 #: src/effects/Contrast.cpp
@@ -3858,12 +6848,67 @@ msgstr "განსხვავება:"
 msgid "&Help"
 msgstr "&დახმარება"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "შეუძლებელია დადგენა"
+
 #. i18n-hint: dB abbreviates decibels
 #. * RMS abbreviates root mean square, a certain averaging method
 #: src/effects/Contrast.cpp
 #, c-format
 msgid "%.2f dB RMS"
 msgstr "%.1f dB"
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -3875,11 +6920,110 @@ msgstr "WCAG2 გავლა"
 msgid "WCAG2 Fail"
 msgstr "WCAG2 მარცხი"
 
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr ""
+"შეუძლებელია დირექტორიის შექმნა:\n"
+"  %s"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
 #. i18n-hint: short form of 'decibels'
 #: src/effects/Contrast.cpp
 #, c-format
 msgid "%.2f dB"
 msgstr "%.1f dB"
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "კონტრასტის შედეგი:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr ": ფაილის სახელი ძალიან მოკლეა."
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground"
+msgstr "წინა პლანი:"
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "ფონი:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "შედეგი"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "შრიფტი..."
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -3898,6 +7042,19 @@ msgid "Medium Overdrive"
 msgstr "გადაწერის დადასტურება"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "გადაწერის დადასტურება"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "დინამიური დიაპაზონის კომპრესორი"
 
@@ -3908,6 +7065,96 @@ msgstr "გამასწორებელი"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "რღვევა"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "ლიმიტერი"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "გადაწერის დადასტურება"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "გადაწერის დადასტურება"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "გადაწერის დადასტურება"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -3930,8 +7177,16 @@ msgid "Distortion"
 msgstr "რღვევა"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "რღვევა"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -3946,8 +7201,21 @@ msgid "Clipping level"
 msgstr "კლინინგი"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "ჯაჭვის გააქტიურება"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "ზღვარი:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -3962,6 +7230,14 @@ msgid "Repeat processing"
 msgstr "CleanSpeech ჯგუფური დამუშავება"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "გასწორების ხარისხი"
 
@@ -3973,9 +7249,48 @@ msgstr "ლიმიტერი"
 msgid "Wet level"
 msgstr "2-დონე"
 
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2-დონე"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "DTMF ტონები..."
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -3985,7 +7300,9 @@ msgstr "DTMF მიმსევრობა:"
 msgid "&Amplitude (0-1):"
 msgstr "ამპლიტუდა (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "ხანგრძლივობა:"
 
@@ -4030,6 +7347,11 @@ msgstr "ექო"
 msgid "Repeats the selected audio again and again"
 msgstr "მონიშნული აუდიოს ექსპორტირება როგორც %s"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "შეყოვნების დრო (წამები):"
@@ -4039,6 +7361,10 @@ msgid "D&ecay factor:"
 msgstr "შეყოვნების ფაქტორი:"
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "წინასწარი მომართვა"
 
@@ -4046,7 +7372,8 @@ msgstr "წინასწარი მომართვა"
 msgid "Export Effect Parameters"
 msgstr "&პარამეტრების რედაქტირება"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "შეუძლებელია ფაილის გახსნა: \"%s\""
@@ -4070,6 +7397,12 @@ msgstr "&პარამეტრების რედაქტირება"
 msgid "%s: is not a valid presets file.\n"
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "ხედის მომზადება"
@@ -4077,6 +7410,15 @@ msgstr "ხედის მომზადება"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "დათვალიერება"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -4113,8 +7455,28 @@ msgid "Factory Defaults"
 msgstr "&ნაგულისხმევი პარამეტრები"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr "Vamp მოდულის დაწყებამ მარცხი განიცადა."
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -4137,6 +7499,23 @@ msgid "&Bypass"
 msgstr "სიბრტყოვანი ფილტრი"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "გახსწორებული"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "აწევა"
 
@@ -4153,6 +7532,24 @@ msgid "Move effect down in the rack"
 msgstr "სხვა ტრეკზე გადატანილი სანიშნი"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "სხვა ტრეკზე გადატანილი სანიშნი"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "ახალი ჯაჭვის სახელის შეტანა"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "ლატენცია"
@@ -4160,6 +7557,20 @@ msgstr "ლატენცია"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "ბრძანების არჩევა"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "მართვის ისტორია"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "დაკვრა"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -4220,14 +7631,33 @@ msgid "Options..."
 msgstr "პარამეტრები..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "ფილტრი"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "სახელი"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "რევერსია"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "შეცდომა: "
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "ტრანსკრიპცია"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -4263,6 +7693,16 @@ msgstr "დაკვრა"
 msgid "Play"
 msgstr "დაკვრა"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Cosine"
+
 #: src/effects/Equalization.cpp
 msgid "Cubic"
 msgstr "კუბური"
@@ -4280,12 +7720,56 @@ msgid "Graphic EQ"
 msgstr "გრაფიკული EQ"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Boost"
+msgstr "Bass Boost"
+
+#: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Bass Boost"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "იარლიყის რედაქტირება"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "იარლიყის რედაქტირება"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -4300,9 +7784,41 @@ msgid "Effect Unavailable"
 msgstr "დათვალიერება შეუძლებელია"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 #, c-format
 msgid "%d dB"
 msgstr "%3d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -4313,6 +7829,11 @@ msgid "Draw Curves"
 msgstr "ხვეულების დახაზვა"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "დახატვის ხელსაწყო"
+
+#: src/effects/Equalization.cpp
 msgid "&Graphic"
 msgstr "გრაფიკული EQ"
 
@@ -4321,8 +7842,54 @@ msgid "Interpolation type"
 msgstr "ინტერპოლაცია:"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "ლინეარული სიხშირე"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "ლინეარული სიხშირე"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "დათვალიერების რეჟიმის სიგრძე:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "დათვალიერების რეჟიმის სიგრძე:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "პარამეტრის წაშლა"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "პარამეტრის წაშლა"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "ინვერსია"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Processing: "
@@ -4333,12 +7900,106 @@ msgid "D&efault"
 msgstr "&ნაგულისხმევი პარამეტრები"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "Benchmark-ის &გაშვება..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "პარამეტრის ჩატვირთვა"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "ეკვალიზაციის შესრულება"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Curve not found"
 msgstr "FFmpeg ვერ მოიძებნა"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "მართვის ისტორია"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "ხვეულების დახაზვა"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "კურსორი მარცხნივ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "სახელი"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "წაშლა"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "არჩევა..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "ნაგულისხმევი"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4346,14 +8007,42 @@ msgid "Rename '%s' to..."
 msgstr "სახელშეცვლილია '%s' -დან  '%s'-ზე"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "&რესემპლირება..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "სახელშეცვლილია '%s' -დან  '%s'-ზე"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "სახის სახელი"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr "არსებულ ფაილებზე გადაწერა"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "ჩამოწევა"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "შეუძლებელია აუდიოს ექსპორტი %s-ზე"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4370,8 +8059,52 @@ msgid "Delete %d items?"
 msgstr "გამეორდა %d-ჯერ"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "შეუძლებელია ძველი ავტოშენახული ფაილის წაშლა"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "იარლიყების ექსპორტი..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "შეუძლებელია აუდიოს ექსპორტი %s-ზე"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "ჩაწერის დასასრული"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "FFmpeg ვერ მოიძებნა"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "საექსპორტო იარლიყები არ მოიძებნა."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -4385,9 +8118,18 @@ msgstr "გამკვეთრება"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "აუდიოს მოსანიშნად დააწკაპუნეთ და გადაათრიეთ"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "აუდიოს მოსანიშნად დააწკაპუნეთ და გადაათრიეთ"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "კლიპინგის მოძიება"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -4401,13 +8143,47 @@ msgstr "ზღვარის დაწყება (მაგალითებ
 msgid "St&op threshold (samples):"
 msgstr "ზღვარის გაჩერება (მაგალითები):"
 
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "მონიშვნის ჩასასმელად არ არის საკმარისი სივრცე"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "ინვერსია"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Nyquist ეფექტის გააქტიურება..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "მაქსიმალური ამპლიტუდის ნორმალიზაცია :"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -4426,6 +8202,31 @@ msgstr "Auto Duck დამუშავება..."
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "ნორმალიზაცია"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -4451,6 +8252,10 @@ msgid "Noise"
 msgstr "ხარვეზი..."
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "ხარვეზის ტიპი"
 
@@ -4463,16 +8268,73 @@ msgid "Second greatest"
 msgstr "წამები"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "ნაგულისხმევი მასშტაბირება"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "ნაგულისხმევი მასშტაბირება"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "ხარვეზის შემცირება (dB):"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "ყველა ტრეკს სემპლის თანაბარი კოეფიციენტი უნდა გააჩნდეს"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -4480,6 +8342,11 @@ msgstr "ხმის გასაღების გამოსაყენე�
 
 #: src/effects/NoiseReduction.cpp
 msgid "&Noise reduction (dB):"
+msgstr "ხარვეზის შემცირება (dB):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
 msgstr "ხარვეზის შემცირება (dB):"
 
 #: src/effects/NoiseReduction.cpp
@@ -4510,6 +8377,11 @@ msgstr "გამოცემის აგება"
 msgid "&Frequency smoothing (bands):"
 msgstr "სიხშირის დარბილება (Hz):"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "სიხშირის დარბილება (Hz):"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "მგრძNობელობა"
@@ -4523,8 +8395,9 @@ msgid "Step 1"
 msgstr "ნაბიჯი 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "მონიშნეთ ხარვეზის რამდენიმე წამი, რათა Audacity-მ იცოდეს რა უნდა გაფილტროს,\n"
@@ -4546,6 +8419,27 @@ msgstr ""
 "ამოირჩეით ყველა გასაფილტრი აუდიო, შემდეგ კი გასაფილტრი ხარვეზის ოდენობა\n"
 "შემდეგ კი დაუწკაპუნეთ \"დიახ\"-ს ხარვეზისგან გასაწმენდად.\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "ხარვეზი..."
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "ტრეკების წაშლ&ა"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "სახის ზომა"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "მიქსირების დამატებითი პარამეტრები"
@@ -4557,6 +8451,11 @@ msgstr "ფანჯრის ტიპი"
 #: src/effects/NoiseReduction.cpp
 msgid "Window si&ze:"
 msgstr "ფანჯრის ტიპი"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
 
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
@@ -4570,17 +8469,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - ნაგულისხმევი"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "ნაგულისხმევი მასშტაბირება"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "ხარვეზების გაწმენდა"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -4595,6 +8540,11 @@ msgid "Noise re&duction (dB):"
 msgstr "ხარვეზის შემცირება (dB):"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "მგრძNობელობა"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr "სიხშირის დარბილება (Hz):"
 
@@ -4602,13 +8552,66 @@ msgstr "სიხშირის დარბილება (Hz):"
 msgid "Attac&k/decay time (secs):"
 msgstr "შეტევის/დანებების დრო (წამები):"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "შეტევის/დანებების დრო (წამები):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&წაშლა"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "ნორმალიზაცია"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "ხარვეზის წაშლა\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "ხარვეზის წაშლა\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "ხარვეზის წაშლა\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Remove DC offset (center on 0.0 vertically)"
@@ -4622,9 +8625,23 @@ msgstr "მაქსიმალური ამპლიტუდის ნო�
 msgid "Peak amplitude dB"
 msgstr "ამპლიტუდის ახალი პიკი (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "შეყოვნების ფაქტორი:"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "შეყოვნების ფაქტორი:"
@@ -4633,9 +8650,43 @@ msgstr "შეყოვნების ფაქტორი:"
 msgid "&Time Resolution (seconds):"
 msgstr "შეყოვნების დრო (წამები):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "ფეიზერი"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -4698,6 +8749,10 @@ msgid "Repair"
 msgstr "აღდგნა"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -4726,6 +8781,10 @@ msgid "Repeat"
 msgstr "გამეორება"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "გასამეორებელი ჯერების ოდენობა:"
 
@@ -4747,13 +8806,64 @@ msgstr "ახალი მონიშვნის სიგრძე:"
 msgid "New selection length: %s"
 msgstr "ახალი მონიშვნის სიგრძე:"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "ტრეკის წაშლა"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "საშუალო"
 
 #: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "ექო"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "ზომა"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "შეტევის/დანებების დრო (წამები):"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -4762,6 +8872,34 @@ msgstr "გამოხმაურება (%):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "სიღრმე (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "სიღრმე (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "გამონატანი არხები: %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "გამონატანი არხები: %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "სტერეო"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -4776,6 +8914,25 @@ msgstr "რევერსია"
 msgid "Reverses the selected audio"
 msgstr "მონიშნული აუდიოს ექსპორტირება როგორც %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "დაბალი სიხშირის ფილტრი"
@@ -4785,12 +8942,35 @@ msgid "Highpass"
 msgstr "მაღალი სიხშირის ფილტრი"
 
 #: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "ფაილის &ატვირთვა.."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "სპექტრის აგებისთვის ყველა მონიშნული ტრეკს უნდა ჰქონდეს სემპლის თანაბარი კოეფიციენტი."
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
 msgstr "ფილტრი"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
@@ -4800,9 +8980,32 @@ msgstr "აგების ტიპი:"
 msgid "Cutoff (Hz)"
 msgstr "დან"
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "C&utoff:"
+msgstr "დან"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "MIDI სინქრონიზაცია აუდიოსთან"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "ხანგრძლივობა:"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "ხანგრძლივობა:"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -4811,6 +9014,14 @@ msgstr "ფანჯრის ტიპი"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "ფანჯრის ტიპი"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -4826,6 +9037,15 @@ msgstr "ზღვარი:"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "დროის მიხედვით დახარისხება"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "დროის მიხედვით დახარისხება"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -4864,11 +9084,20 @@ msgstr "&ნაგულისხმევი პარამეტრები"
 msgid "Restore Defaults"
 msgstr "&ნაგულისხმევი პარამეტრები"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "დაჩუმება"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -4893,6 +9122,42 @@ msgstr "სტეროდან მონოზე გააქტიურე�
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "შეყოვნების ფაქტორი:"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Tempo Change (%)"
+msgstr "Pitch და Tempo შეცვლის მხარდაჭერა"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Tempo Change (%)"
+msgstr "Pitch და Tempo შეცვლის მხარდაჭერა"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Pitch Shift"
+msgstr "ხმის სიმაღლის წამნაცვლებელი"
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Pitch Shift"
+msgstr "ხმის სიმაღლის წამნაცვლებელი"
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
 
 #: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
 msgid "Logarithmic"
@@ -4923,12 +9188,40 @@ msgid "Tone"
 msgstr "ტონი..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "ტალღოვანი:"
 
 #: src/effects/ToneGen.cpp
 msgid "&Frequency (Hz):"
 msgstr "სიხშირე (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "სიხშირე (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "სიხშირე (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "ამპლიტუდა (0-1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "ამპლიტუდა (0-1)"
 
 #: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
@@ -4939,8 +9232,20 @@ msgid "Truncate Detected Silence"
 msgstr "სიჩუმის ამოჭრა"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "სიჩუმის ამოჭრა"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -4950,11 +9255,38 @@ msgstr "სიჩუმეებთან მი&ერთება"
 msgid "Tr&uncate to:"
 msgstr "სიჩუმის ამოჭრა"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "კომპრესორი"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "ეფ&ექტი"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "შეუძლებელია MP3 კოდირების ბიბლიოთეკის გახსნა !"
 
@@ -4962,8 +9294,32 @@ msgstr "შეუძლებელია MP3 კოდირების ბი
 msgid "VST Effect Options"
 msgstr "ეფექტის პარამეტრები"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "სიგრძე"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
+msgstr "კლავიშთა კომბინაცია"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
 msgstr "კლავიშთა კომბინაცია"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -4971,12 +9327,45 @@ msgid "Graphical Mode"
 msgstr "გრაფიკული EQ"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "პარამეტრის შენახვა"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "პარამეტრების ექსპორტი"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "პარამეტრების ექსპორტი"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity პროექტის ფაილები"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "პარამეტრის ჩატვირთვა"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Load VST Preset:"
@@ -4994,13 +9383,38 @@ msgstr "პარამეტრის ჩატვირთვა"
 msgid "Unable to load presets file."
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "ეფექტის პარამეტრები"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -5022,6 +9436,17 @@ msgstr "Wah სიხშირის ოფსეტი (%):"
 msgid "Wah frequency offset in percent"
 msgstr "Wah სიხშირის ოფსეტი პროცენტულად"
 
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "ეფექტის პარამეტრები"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "ეფექტის პარამეტრები"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "შეუძლებელია ფაილის გახსნა"
@@ -5035,20 +9460,41 @@ msgid "Audio Unit Effect Options"
 msgstr "ეფექტის პარამეტრები"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "ინტერფეისი"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "შენატანი მოწყობილობა"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Multiband"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&გენერაცია"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "პარამეტრების იმპორტი"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -5124,6 +9570,11 @@ msgid "Failed to retrieve preset content"
 msgstr "შეუძლებელია '%s'-ის წაშლა"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "სანიმუშე კოეფიციენტის კონვერსია"
 
@@ -5132,15 +9583,60 @@ msgstr "სანიმუშე კოეფიციენტის კონ�
 msgid "Failed to write XML preset to \"%s\""
 msgstr "შეუძლებელია '%s'-ის წაშლა"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "შეუძლებელია '%s'-ის წაშლა"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "შეუძლებელია '%s'-ის წაშლა"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "აუდიო ფაილი"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "ეფ&ექტი"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "ეფ&ექტი"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "ეფექტის პარამეტრები"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -5148,6 +9644,7 @@ msgstr "ეფექტის პარამეტრები"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "ეფ&ექტი"
@@ -5157,16 +9654,57 @@ msgid "LV2 Effect Settings"
 msgstr "ეფექტის პარამეტრები"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Generator"
 msgstr "გენერატორი"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
 
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "ეფ&ექტი"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Nyquist ეფექტის გააქტიურება..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -5182,6 +9720,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Nyquist გამონატანი: "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "მონიშვნის დასასრულით გასწორებული"
 
@@ -5194,12 +9750,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "ვწუხვართ, შეუძლებელია ეფექტის გააქტიურება სტერეო ტრეკებზე, სადაც ტრეკები არ ემთხვევა."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Nyquist გამონატანი: "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Auto Duck დამუშავება..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -5242,6 +9816,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist არ დააბრუნა აუდიო.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Audacity ეს ვერსია არ იყო კომპილირებული %s მხარდაჭერით."
@@ -5250,10 +9828,37 @@ msgstr "Audacity ეს ვერსია არ იყო კომპილ�
 msgid "Could not open file"
 msgstr "შეუძლებელია ფაილის გახსნა"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "შეუძლებელია ფაილის გახსნა:"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -5274,6 +9879,21 @@ msgid "Lisp scripts"
 msgstr "Nyquist Prompt..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "შეუძლებელია ფაილის გახსნა"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -5292,9 +9912,18 @@ msgstr "MIDI ფაილის ამორჩევა"
 msgid "Save file as"
 msgstr "ფაილების შენახვა"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "ეფ&ექტი"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -5316,6 +9945,17 @@ msgstr "მოდულის პარამეტრები"
 msgid "Program"
 msgstr "პროგრამა"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "ეფექტის პარამეტრები"
+
 #: src/export/Export.cpp
 msgid "Export Audio"
 msgstr "ფაილის ექსპორტი"
@@ -5330,6 +9970,11 @@ msgstr "ექსპორტი"
 
 #: src/export/Export.cpp
 msgid "All selected audio is muted."
+msgstr "მონიშნული აუდიოს ექსპორტი როგორც %s"
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "All audio is muted."
 msgstr "მონიშნული აუდიოს ექსპორტი როგორც %s"
 
 #: src/export/Export.cpp
@@ -5418,10 +10063,25 @@ msgstr "შეუძლებელია ესპორტირება"
 msgid "Show output"
 msgstr "გამონატანის ჩვენება"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "ცვლადი"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "ბრძანების არჩევა"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -5459,13 +10119,118 @@ msgstr ""
 "გავაგრძელო?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "FFmpeg ვერ მოიძებნა"
 
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "FFmpeg ბიბლიოთეკა:"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -5481,7 +10246,8 @@ msgstr "მონიშნული აუდიოს ექსპორტი 
 msgid "Invalid sample rate"
 msgstr "სემპლის არასწორი კოეფიციენტი"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "რესემპლირება"
 
@@ -5513,7 +10279,8 @@ msgstr "სემპლის კ0ოეფიციენტები"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "კბწ"
@@ -5525,6 +10292,51 @@ msgstr "ბიტური კოეფიციენტი:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "ხარისხი"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "კბწ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -5539,6 +10351,10 @@ msgid "Constrained"
 msgstr "კონსტანტა"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&აუდიო..."
 
@@ -5547,8 +10363,44 @@ msgid "Low Delay"
 msgstr "შეყოვნება"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "საშუალო"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -5569,6 +10421,11 @@ msgstr "რეჟიმები"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "ჯაჭვის გააქტიურება"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Cutoff:"
+msgstr "დან"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Open custom FFmpeg format options"
@@ -5596,9 +10453,38 @@ msgid "Confirm Overwrite"
 msgstr "გადაწერის დადასტურება"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "%s დირექტორია არ არსებობს. შევქმნა?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "წავშალო '%s' პარამეტრი?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "მარცხ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "ძირითადი არევა"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -5607,6 +10493,11 @@ msgstr "M4A (AAC) ფაილები (FFmpeg)"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "AC3 Files (FFmpeg)"
 msgstr "AC3 Fფაილები (FFmpeg)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr "WMA (ვერსია 2) ფაილები (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Opus (OggOpus) Files (FFmpeg)"
@@ -5670,12 +10561,21 @@ msgid "Codec:"
 msgstr "კოდეკი:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Formats"
 msgstr "ყველა ფორმატის ჩვენება"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Codecs"
 msgstr "ყველა კოდეკის ჩვენება"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "მოდულის პარამეტრები"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -5690,6 +10590,14 @@ msgstr ""
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "ენა:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -5771,6 +10679,11 @@ msgid "Profile:"
 msgstr "პროფილი:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "FLAC პარამეტრების განსაზღვრა"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Compression level\n"
 "Required for FLAC\n"
@@ -5783,6 +10696,11 @@ msgstr ""
 "-1 - ავტომატური \n"
 "წუთი - 0 (სწრაფი კოდირება, დიდი გამონატანი ფაილი)\n"
 "მაქს - 10 (ნელი კოდირება, პატარა გამონატანი ფაილი)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "კომპრესორი"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -5799,6 +10717,11 @@ msgstr ""
 "მაქს - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "სახელი"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "LPC coefficients precision\n"
 "Optional\n"
@@ -5813,6 +10736,10 @@ msgstr ""
 "მაქს - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -5823,6 +10750,10 @@ msgstr ""
 "დაახლოებითი - ყველაზე სწრაფი, დაბალი კომპრესია\n"
 "ჩანაწერის ძიება - ყველაზე დაბალი, საუკეთესო კომპრესიაn\n"
 "სრული ძიება - ნაგულისხმევი"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -5838,6 +10769,10 @@ msgstr ""
 "მაქს -  32 (LPC-ით) ან 4 (LPC-ის გარეშე)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal prediction order\n"
 "Optional\n"
@@ -5849,6 +10784,10 @@ msgstr ""
 "0 - ნაგულისხმევი\n"
 "მინ - 1\n"
 "მაქს -  32 (LPC-ით) ან 4 (LPC-ის გარეშე)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -5864,6 +10803,10 @@ msgstr ""
 "მაქს - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal partition order\n"
 "Optional\n"
@@ -5876,6 +10819,21 @@ msgstr ""
 "-1 - ნაგულისხმევი\n"
 "მინ - 0\n"
 "მაქს - 8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "დასარულზე მონიშვნა"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -5913,6 +10871,11 @@ msgid "Packet Size:"
 msgstr "პაკეტის ზომა:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "You can't delete a preset without name"
+msgstr "შეუძლებელია პროექტის შენახვა სახელის გარეშე"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Delete preset '%s'?"
 msgstr "წავშალო '%s' პარამეტრი?"
@@ -5932,6 +10895,28 @@ msgstr "საექსპორტო იარლიყები არ მო
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Select xml file to export presets into"
 msgstr "xml  ფაილის შენახვა პარამეტრებით ექსპორტირებისთვის"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -5960,6 +10945,18 @@ msgstr "ბიტური სიღრმე:"
 #: src/export/ExportFLAC.cpp
 msgid "FLAC Files"
 msgstr "FLAC ფაილები"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "შეუძლებელია ფაილის გახსნა: \"%s\""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr "Vamp მოდულის დაწყებამ მარცხი განიცადა."
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
@@ -5996,8 +10993,57 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(საუკეთესო ხარისხი)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(პატარა ფაილები)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -6008,7 +11054,8 @@ msgstr "არანორმალური"
 msgid "Extreme"
 msgstr "ექსტრემალური"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "სტანდარტული"
 
@@ -6049,14 +11096,19 @@ msgstr "ხარისხი"
 msgid "Channel Mode:"
 msgstr "არხის რეჯიმი"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "წაშლილი ამოჭრის ხაზი"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Lame მდებარეობის განსაზღვრა"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity საჭიროებს %s  ფაილს MP3 შესაქმნელად."
 
 #: src/export/ExportMP3.cpp
@@ -6082,6 +11134,34 @@ msgstr "Lame უფასო ასლის მისაღებად და�
 #, c-format
 msgid "Where is %s?"
 msgstr "სად არის %s'?"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "პროექტის მონაცემთა ფაილების შენახვა "
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -6128,6 +11208,11 @@ msgid "Exporting the audio with VBR quality %s"
 msgstr "მონიშნული აუდიოს VBR  %s ხარისხით ექსპორტი"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "მონიშნული აუდიოს ექსპორტი %ld კბწ-ით"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Exporting selected audio at %d Kbps"
@@ -6155,6 +11240,15 @@ msgstr ""
 "პროექტის სემპლის (%d) და ბიტის (%d kbps)  კოეფიციენტის კომბინაცია არ არის მხარდაჭერილი არცერთი MP3\n"
 "ფაილის ფორმატით"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 export library not found"
+msgstr "FFmpeg ბიბლიოთეკა ვერ მოიძებნა"
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
 msgstr "მრავალჯერადი ექსპორტი"
@@ -6164,8 +11258,18 @@ msgid "Cannot Export Multiple"
 msgstr "მრავალჯერადი ექსპორტი"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "მდებარეობის ექსპორტირება:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -6200,6 +11304,16 @@ msgid "Using Label/Track Name"
 msgstr "იარლიყის/ტრეკის სახელის გამოყენება"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "იარლიყის/ტრეკის სახელის გამოყენება"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "ფაილის სახელის პრექფიქსი"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
 msgstr "ფაილის სახელის პრექფიქსი"
 
@@ -6222,6 +11336,31 @@ msgstr "ექსპორტირებული ფაილების შ�
 
 #: src/export/ExportMultiple.cpp
 #, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
 msgid ""
 "\"%s\" doesn't exist.\n"
 "\n"
@@ -6235,6 +11374,27 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "შენახვა, როგორც..."
@@ -6242,6 +11402,31 @@ msgstr "შენახვა, როგორც..."
 #: src/export/ExportOGG.cpp
 msgid "Ogg Vorbis Files"
 msgstr "Ogg Vorbis ფაილები"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -6254,6 +11439,10 @@ msgstr "მონიშნული Ogg Vorbis აუდიოს ექსპ�
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "მონიშნული Ogg Vorbis აუდიოს ექსპორტირება"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -6272,8 +11461,28 @@ msgid "Other uncompressed files"
 msgstr "სხვა არაკომპრესირებული ფაილები"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "იმპორტის შეცდომა"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -6284,16 +11493,26 @@ msgstr "შეუძლებელია აუდიოს ამ ფორმ
 msgid "Exporting the selected audio as %s"
 msgstr "მონიშნული აუდიოს ექსპორტირება როგორც %s"
 
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "სემპლის კ0ოეფიციენტები"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -6302,11 +11521,11 @@ msgstr ""
 "მისი რედაქტირება შეგიძლია შემდეგნაირად ფაილი > იმპორტი > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "MIDI ფაილია. \n"
@@ -6318,18 +11537,18 @@ msgid "Select stream(s) to import"
 msgstr "ნაკადების მონიშვნა იმპორტირებისთვის"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Audacity ეს ვერსია არ იყო კომპილირებული %s მხარდაჭერით."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" აუდიო CD ტრეკია. \n"
 "Audacity-ის არ შეუძლია აუდიო CD პირდაპირ გახსნა \n"
@@ -6338,10 +11557,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" რეპერტუარის ფაილია \n"
@@ -6350,10 +11569,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"   Windows Media Audio ფაილია. \n"
@@ -6362,10 +11581,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is an Advanced Audio Coding file. \n"
@@ -6374,12 +11593,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" დაშიფრული აუდიო ფაილია. \n"
@@ -6390,10 +11609,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" RealPlayer მედია ფაილი. \n"
@@ -6402,17 +11621,79 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" შენიშვნებზე დაფუძნებული ფაილია, არა აუდიო. \n"
 "Audacity-ს არ შეუძლია ამ ტიპის ფაილის გახსნაe. \n"
 "მოახდინეთ კონვერტაცია - WAV ან AIFF ფორმატში \n"
 "შემდეგ მოახდინეთ იმპორტი ან ჩაწერეთ Audacity-ში."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+"\"%s\"   Windows Media Audio ფაილია. \n"
+"Audacity-ის არ შეუძლია მისი გახსნა სალიცენზიო აკრძალვების გამო. \n"
+"გადაიყვანეთ მხარდაჭერილ ფორმატში, როგორიცაა WAV ან AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" RealPlayer მედია ფაილი. \n"
+"Audacity-ის არ შეუძლია ამ ფორმატის გახსნა. \n"
+"გადაიყვანეთ მხარდაჭერილ აუდიო ფორმატშიt, მაგ. WAV or AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\"   Windows Media Audio ფაილია. \n"
+"Audacity-ის არ შეუძლია მისი გახსნა სალიცენზიო აკრძალვების გამო. \n"
+"გადაიყვანეთ მხარდაჭერილ ფორმატში, როგორიცაა WAV ან AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\"   Windows Media Audio ფაილია. \n"
+"Audacity-ის არ შეუძლია მისი გახსნა სალიცენზიო აკრძალვების გამო. \n"
+"გადაიყვანეთ მხარდაჭერილ ფორმატში, როგორიცაა WAV ან AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+"\"%s\"   Windows Media Audio ფაილია. \n"
+"Audacity-ის არ შეუძლია მისი გახსნა სალიცენზიო აკრძალვების გამო. \n"
+"გადაიყვანეთ მხარდაჭერილ ფორმატში, როგორიცაა WAV ან AIFF."
 
 #: src/import/Import.cpp
 #, c-format
@@ -6421,14 +11702,40 @@ msgstr "FFmpeg ვერ მოიძებნა"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity ვერ ამოიცნო ფაილი '%s'-ის ტიპი.\n"
 "ის არაკომპრესირებულია, შეეცადეთ მის იმპორტირებას  \"დაუმუშავებელის იმპორტი\"-ის საშალებით."
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "პროექტის მონაცემთა ფაილების შენახვა "
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -6445,21 +11752,132 @@ msgid "Import Project"
 msgstr "პარამეტრების იმპორტი"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "შეუძლებელია პროექტის მონაცემთა საქაღალდის პოვნა: \"%s\""
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "პროექტის კოეფიციენტი (Hz):"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "სემპლის არასწორი კოეფიციენტი"
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "სემპლის არასწორი კოეფიციენტი"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -6480,25 +11898,15 @@ msgstr "შეუძლებელია ტესტის ფაილის 
 msgid "FFmpeg-compatible files"
 msgstr "FFmpeg-თავსებადი ფაილები"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC ფაილები"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "FFmpeg-თავსებადი ფაილები"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "შეუძლებელია '%s'-ის სახელის გადარქმევა  '%s'-ად"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -6558,9 +11966,22 @@ msgstr "შეუძლებელია ფაილის გახსნა"
 msgid "MP3 files"
 msgstr "MP3 ფაილები"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis ფაილები"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -6587,8 +12008,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, და სხვა არაკომპრესირებული ტიპები"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) ხელმოწერილი 6 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-ბიტიანი PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -6599,12 +12114,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-ბიტიანი PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-ბიტიანი PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-ბიტიანი PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-ბიტიანი მცოცავი"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-ბიტიანი მცოცავი"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) ხელმოწერილი 6 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 ბიტი"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -6615,12 +12174,20 @@ msgid "24 bit DWVW"
 msgstr "24 ბიტი"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-ბიტიანი PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-ბიტიანი PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -6630,6 +12197,33 @@ msgstr "%s იმპორტირება"
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "QuickTime ფაილები"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "შეუძლებელია ჟანრის ფაილის შენახვა."
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "შეუძლებელია '%s'-ის წაშლა"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "შეუძლებელია ჟანრის ფაილის შენახვა."
 
 #. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
 #: src/import/ImportRaw.cpp
@@ -6707,6 +12301,10 @@ msgstr "სემპლის კოეფიციენტი"
 msgid "&Import"
 msgstr "&იმპორტი"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -6727,6 +12325,7 @@ msgstr "მარჯვენა"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -6750,6 +12349,7 @@ msgstr "დასასრული"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -6769,12 +12369,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "დრო შენაცვლებული ტრეკები/კლიპები  %s %.02f  წამი"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "დრო შენაცვლებული ტრეკები/კლიპები  %s %.02f  წამი"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "დრო-ცვლა"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "მონიშვნის დასაწყისამდე"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -6791,6 +12414,26 @@ msgstr "შემდეგი ხელსაწყო"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "შემდეგი ხელსაწყო"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "წინა ხელსაწყო"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "კურსორი ტრეკის &დასასრულთან"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "შემდეგი ხელსაწყო"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "მონიშვნის დასაწყისამდე"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -6878,7 +12521,8 @@ msgstr "დაჩუმებული მონუშნული ტრეკ�
 msgid "Trim Audio"
 msgstr "აუდიოს ჩაწერა"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "დაყოფა"
 
@@ -6898,6 +12542,15 @@ msgstr "შეერთება %.2f წამები t=%.2f"
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "შეერთება"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "წაშლილია %.2f წამი t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
@@ -6930,6 +12583,11 @@ msgstr "&ჩასმა"
 #: src/menus/EditMenus.cpp
 msgid "Duplic&ate"
 msgstr "დუბ&ლირება"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "ტრეკების წაშლ&ა"
 
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
@@ -6986,32 +12644,8 @@ msgid "Delete Key&2"
 msgstr "გასაღების წაშლა2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "მიქსერის ხელსაწყოთა ზოლი"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "დაკვრა"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "დაკვრა"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "დაკვრა"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "ჩაწერის დასასრული"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "ჩაწერის დასასრული"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "ჩაწერის დასასრული"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -7038,8 +12672,21 @@ msgid "&Full Screen (on/off)"
 msgstr "აუდიოს გადაწერა (ჩართვა/გამორთვა)"
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "მონიშნული აუდიოს ექსპორტი როგორც %s"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "იარლიყის რედაქტირება"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -7089,6 +12736,11 @@ msgstr "იარლიყების იმპორტი"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "MIDI ფაილის ამორჩევა"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "ყველა ფაილი(*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -7169,6 +12821,11 @@ msgid "&Labels..."
 msgstr "&იარლიყები..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "MIDI ექსპორტი..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&დაუმუშავებელი მონაცემები..."
 
@@ -7185,6 +12842,10 @@ msgstr "&ამობეჭდვა..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&გამოსვლა"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -7217,6 +12878,10 @@ msgid "Nothing to do"
 msgstr "დასაბრუნებელი მოქმედება არ არსებობს"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "ფოკუსირებული ტრეკის დახურვა"
 
@@ -7229,6 +12894,18 @@ msgid "Recording stops and starts"
 msgstr "ჩაწერის დაწყება"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "&დახმარება"
 
@@ -7237,7 +12914,8 @@ msgid "&Getting Started"
 msgstr "მონიშვნის დაწყება"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "Audacity %s ხელსაწყოთა ზოლი"
 
 #: src/menus/HelpMenus.cpp
@@ -7245,20 +12923,34 @@ msgid "&Quick Help..."
 msgstr "&დახმარება"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
 msgstr "\t-ტესტი (დიაგნოსტიკის გაშვება)"
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
 msgid "Show &Log..."
 msgstr "&ჩანაწერის ჩვენება ..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Audacity-ის &შესახებ..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "დამატებული იარლიყი"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "ფოკუსის შემდეგ ტრეკზე გადატანა"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -7374,6 +13066,15 @@ msgid "Add Label at &Playback Position"
 msgstr "იარლიყის დამატება &დაკვრის პოზიციისას"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "ფოკუსის შემდეგ ტრეკზე გადატანა"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "და&ხარისხებული არეები"
 
@@ -7408,6 +13109,11 @@ msgid "Label Split Delete"
 msgstr "დაყოფა წაშლა"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "აუდ&იოს დაჩუმება"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "დაჩუმება"
 
@@ -7432,6 +13138,23 @@ msgstr "იარლიყის რედაქტირება"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "იარლიყის რედაქტირება"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "ფოკუსის შემდეგ ტრეკზე გადატანა"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -7470,8 +13193,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "ფოკუსირებული ტრეკის ჩართვა"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "ახალი..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -7488,6 +13219,10 @@ msgid "&Generate"
 msgstr "&გენერაცია"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
 msgstr "ტონის გენერატორი"
 
@@ -7496,8 +13231,18 @@ msgid "Effe&ct"
 msgstr "ეფ&ექტი"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "ტონის გენერატორი"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&ანალიზი"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "ტონის გენერატორი"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -7561,6 +13306,16 @@ msgid "Set Track Status..."
 msgstr "ტრეკის დასაწყისამდე"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "აუდ&იოს დაჩუმება"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "ტრეკების &დახარისხება"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "პარამეტრები..."
 
@@ -7584,9 +13339,20 @@ msgstr "&იარლიყების რედაქტირება"
 msgid "Set Project..."
 msgstr "პროექტის შენახვა, &როგორც..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "ცვლადი"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "ტრეკების &დახარისხება"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "ინფო"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -7617,6 +13383,21 @@ msgstr "კომპრესორი"
 msgid "Screenshot (short format)..."
 msgstr "&ეკრანის ანაბეჭდის ხელსაწყოები..."
 
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "მონიშვნის წერტილის დაყენება"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "აუდიოს პოზიცია"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "მონიშვნის წერტილის დაყენება"
+
 #. i18n-hint: (verb) It's an item on a menu.
 #: src/menus/SelectMenus.cpp
 msgid "&Select"
@@ -7633,6 +13414,15 @@ msgstr "მონიშვნა"
 #: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
 msgid "&Tracks"
 msgstr "&ტრეკები"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "ტრეკების &გასწორება"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Sync-Locked"
@@ -7707,8 +13497,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "ლინეარული სიხშირე"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "დასაწყისზე მონიშვნა"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "აუდიოს პოზიცია"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -7845,6 +13644,30 @@ msgstr "კურსორის გრძელი გადასვლა მ
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "კურსორის გრძელი გადასვლა მარჯვნივ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "&Toolbars"
@@ -8009,6 +13832,11 @@ msgid "Synchronize MIDI with Audio"
 msgstr "MIDI-ის სინქრონიზაცია აუდიოსთან"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr "MIDI-ის სინქრონიზაცია აუდიოსთან"
+
+#: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
 msgstr " მორგებული gain"
 
@@ -8033,14 +13861,20 @@ msgid "Created new label track"
 msgstr "შექმნილია ახალი იარლიყის ტრეკი"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "შექმნილი ახალი დროის ტრეკი"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "სემპლის ახალი კოეფიციენტი (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "შეყვანილი მნიშვნელობა არასწორია"
 
@@ -8062,8 +13896,22 @@ msgid "Please select at least one audio track and one MIDI track."
 msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Sync MIDI with Audio"
 msgstr "MIDI სინქრონიზაცია აუდიოსთან"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -8106,6 +13954,11 @@ msgid "&Time Track"
 msgstr "&დროის ტრეკი"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "მიქსერის ხელსაწყოთა ზოლი"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "სტეროდან მონოზე გააქტიურება"
 
@@ -8144,6 +13997,10 @@ msgstr "ყველა ტრეკის &ჩაჩუმება"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "ყველა ტრეკის &ხმის აწევა"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -8200,6 +14057,11 @@ msgstr "&საწყისი დროით"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "&სახელით"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "სხვა ტრეკზე გადატანილი სანიშნი"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -8271,7 +14133,9 @@ msgstr "დაკვრა"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "ჩაწერა"
 
@@ -8284,8 +14148,27 @@ msgid "no label track at or below focused track"
 msgstr "ფოკუსირებულ ტრეკზე მარცხნივ მოტრიალება"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "შექმნილია ახალი იარლიყის ტრეკი"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -8314,9 +14197,19 @@ msgstr "&გადატანა"
 msgid "Pl&aying"
 msgstr "დაკვრა"
 
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
 #: src/menus/TransportMenus.cpp
 msgid "Play/Stop and &Set Cursor"
 msgstr "დაკვრა/გაჩერებისა და მომართვის კურსორი"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "დაკვრა სიჩქარით"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Pause"
@@ -8344,6 +14237,11 @@ msgid "&Timer Record..."
 msgstr "&ტაიმერის ჩაწერა..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "ხმის გააქტიურებული ჩაწერა"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "არეს და&კვრა"
 
@@ -8354,6 +14252,11 @@ msgstr "&ჩაკეტვა"
 #: src/menus/TransportMenus.cpp
 msgid "&Unlock"
 msgstr "&მოხსნა"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "ჩაწერის დასასრული"
 
 #: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
@@ -8368,6 +14271,11 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "ჩაწერის დასასრული"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "აუდიოს გადაწერა (ჩართვა/გამორთვა)"
 
@@ -8376,12 +14284,19 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "პროგრამული დაკვრა (ჩათვლა/გამორთვა)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
-
-#: src/menus/TransportMenus.cpp
 msgid "T&ransport"
 msgstr "&გადატანა"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&ay"
+msgstr "დაკვრა"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -8499,6 +14414,11 @@ msgid "&Fit to Width"
 msgstr "ფანჯარაზე მორგება"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "ფანჯარაზე მორგება"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "ყველა ტრეკის &მოშლა"
 
@@ -8534,9 +14454,26 @@ msgstr "აუდიოს გადაწერა (ჩართვა/გა�
 msgid "&Show Clipping (on/off)"
 msgstr "მიმაგრების &ჩვენება"
 
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "ეფ&ექტი"
+
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr "ფანჯარა"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
 
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
@@ -8563,7 +14500,7 @@ msgstr "პარამეტრები..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Audacity-ის დახურვა"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -8588,6 +14525,11 @@ msgid "&Don't apply effects in batch mode"
 msgstr "არ გააქტიურო ეფექტები ჯგუფურ რეჟიმში"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "მოწყობილობა"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
 msgstr "პარამეტრები..."
 
@@ -8597,11 +14539,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "ინტერფეისი"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "გამოყენებით:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "დაკვრა"
 
@@ -8621,7 +14569,8 @@ msgstr "არხები:"
 msgid "Latency"
 msgstr "ლატენცია"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "მილიწამები"
 
@@ -8634,6 +14583,15 @@ msgid "&Latency compensation:"
 msgstr "კლავიშთა კომბინაცია"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "წაშლილი აუდიო ტრეკ(ბ)ი"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "1 (მონო)"
 
@@ -8642,17 +14600,37 @@ msgid "2 (Stereo)"
 msgstr "2 (სტერეო)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "დირექტორიები"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "პროექტების აღდგენა"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "დირექტორიები"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "ამორჩევა..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -8683,6 +14661,11 @@ msgid "Temporary files directory"
 msgstr "დროებითი ფაილების დირექტორია"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "მოქმედება"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory cannot be on a FAT drive."
 msgstr "დროებითი ფაილების დირექტორია"
 
@@ -8699,8 +14682,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "დროებითი დირექტორიის მოსათავსებელი მდებარეობის შერჩევა"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "ბრძანების ა&მორჩევა"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -8717,8 +14709,14 @@ msgid "Directory %s is not writable"
 msgstr "%s დირექტორია არაჩაწერადია"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "დროებით დირექტორიაში შეტანილიც ცვლილებები არ გააქტიურდება Audacity-ის გადატვირთვამდე"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "ახალი დროებითი დირექტორია"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -8728,11 +14726,36 @@ msgstr "პარამეტრები..."
 msgid "Sorted by Effect Name"
 msgstr "სახელის მიხედვით დახარისხება"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "სახელის მიხედვით დახარისხება"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "სახელის მიხედვით დახარისხება"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "ეფ&ექტი"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -8742,21 +14765,140 @@ msgstr "ეფ&ექტი"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "ეფ&ექტი"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "ეფექტის პარამეტრები"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "მოდულის პარამეტრები"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
 msgstr "ინსტრუმენტი"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "იმპორტი"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "პარამეტრები..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "ფილტრი"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "პარამეტრების იმპორტი"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "აწევა"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "ჩამოწევა"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "აწევა"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "ჩამოწევა"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "წაშლილი იარლიყდადებული არეები"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "მდებარეობის ექსპორტირება:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "მონიშვნა"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "დარწმუნებული ხართ, რომ გსურთ %s-ის წაშლა?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "აუდიოს ჩაწერა"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -8805,6 +14947,11 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (PCM დიაპაზონი 24 ბიტიანი სემპლებისთვის)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "მოქმედება"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
 msgstr "ინტერნეტიდან"
 
@@ -8813,12 +14960,85 @@ msgid "Display"
 msgstr "ეკრანი"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "ენა:"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "%s'-ის მდებარეობა:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "ტალღოვანი (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "\t-დახმარება (ეს შეტყობინება)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "დიდი ხანგრძლივობის მოქმედებების დასრულებისას სიგნალი"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "მოდულის პარამეტრები"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "მთვლელის გააქტიურება"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "იმპორტი / ექსპორტი"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "პარამეტრები..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -8831,6 +15051,10 @@ msgstr "მიქსირების დამატებითი პარ�
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "სტანდარტული"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -8848,9 +15072,22 @@ msgstr "ტრეკების ექსპორტისას აუდი�
 msgid "S&how Metadata Tags editor before export"
 msgstr "მეტამონაცემების რედაქტორის ჩვენება ექსპორტამდე"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "იარლიყის ექსპორტი, როგორც:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -8862,6 +15099,18 @@ msgid "Preferences for KeyConfig"
 msgstr "პარამეტრები..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "კლავიატურის ბმები"
 
@@ -8870,12 +15119,49 @@ msgid "View by:"
 msgstr "&ნახვა"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "სახელი"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&ნახვა"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&ნახვა"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&ნახვა"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
 msgstr "კლავიატურის ბმები"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&პარამეტრები..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -8890,7 +15176,15 @@ msgid "&Defaults"
 msgstr "&ნაგულისხმევი პარამეტრები"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "მონიშნეთ XML ფაილი, რომელიც შეიცავს Audacity კლავიშების მალსახმობებს..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -8899,8 +15193,21 @@ msgstr "კლავიშების მალსახმობების �
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "ჩატვირთულია %d კლავიატურის მალსახმობი\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -8913,6 +15220,38 @@ msgstr "კლავიშების მალსახმობების �
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "კლავიშების მალსახმობების ექსპორტი როგორც:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -8935,6 +15274,15 @@ msgid "FFmpeg Import/Export Library"
 msgstr "FFmpeg იმპორტი/ექსპორტის ბიბლიოთეკა"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "No compatible FFmpeg library was found"
+msgstr "FFmpeg ბიბლიოთეკა ვერ მოიძებნა"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "FFmpeg Library Version:"
 msgstr "FFmpeg  ბიბლიოთეკის ვერსია:"
 
@@ -8942,19 +15290,67 @@ msgstr "FFmpeg  ბიბლიოთეკის ვერსია:"
 msgid "FFmpeg Library:"
 msgstr "FFmpeg ბიბლიოთეკა:"
 
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "&შენახვა..."
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Dow&nload"
+msgstr "&ჩამოტვირთვა"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
 msgstr "MP3 ბიბლიოთეკა:"
 
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "MP3 ფაილები"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "პარამეტრები..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "ინტერფეისი"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
 msgctxt "MIDI"
 msgid "Interface"
 msgstr "ინტერფეისი"
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "მინიმალური სიხშირე ინტეგრალი უნდა იყოს"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
 
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
@@ -8966,16 +15362,50 @@ msgid "Preferences for Module"
 msgstr "პარამეტრები..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "დროებით დირექტორიაში შეტანილიც ცვლილებები არ გააქტიურდება Audacity-ის გადატვირთვამდე"
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "მკითხე"
 
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "მოდულატორი"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -9017,7 +15447,10 @@ msgstr "მარცხენა გადათრევა"
 msgid "Set Selection Range"
 msgstr "მონიშვნის დიაპაზონის მომართვა"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-მარცხენა-წკაპი"
 
@@ -9104,6 +15537,15 @@ msgstr "მარცხენა გადათრევა"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "სანიშნის  ტრეკებს შორის ატანა/ჩამოტანა "
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "მარცხენა გადათრევა"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -9207,9 +15649,34 @@ msgstr "ამოჭრის მერე დათვალიერება:
 msgid "Seek Time when playing"
 msgstr "დროის ძიება დაკვრისას"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity  პარამეტრები"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -9218,6 +15685,11 @@ msgstr "პარამეტრები..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "პარამეტრები..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -9236,12 +15708,32 @@ msgid "Default Sample &Format:"
 msgstr "სემპლის ნაგულისხმევი ფორმატი:"
 
 #: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "სანიმუშე კოეფიციენტის კონვერსია"
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Con&verter:"
 msgstr "სემპლის კოეფიციენტის კონვერტორი"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "მაღალი ხარისხის Sinc ინტერპოლაცია"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "სემპლის კოეფიციენტის კონვერტორი"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -9260,12 +15752,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "ოვერდუბლიკაცია: სხვა ტრეკების &დაკვრა ახლის ჩაწერის პარალელურად"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "პროგრამული დაკვრა (ჩათვლა/გამორთვა)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "ახალი ტრეკი"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "ნაკადების მონიშვნა იმპორტირებისთვის"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -9279,6 +15781,11 @@ msgstr "დონე:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Name newly recorded tracks"
 msgstr "ტრეკების არევა და რენდერინგი"
+
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
@@ -9301,22 +15808,62 @@ msgid "System &Date"
 msgstr "საწყისი დრო"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+#, fuzzy
+msgid "System T&ime"
+msgstr "საწყისი დრო"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "ხმის გააქტიურებული ჩაწერა"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "გაითვალისწინეთ ტრეკი"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
 
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "ნაგულისხმევი მასშტაბირება"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "ნაგულისხმევი მასშტაბირება"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "ლინეარული"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -9328,9 +15875,43 @@ msgstr "ლინეარული"
 msgid "Frequencies"
 msgstr "სიხშირე (Hz)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
+#. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Pitch (EAC)"
+msgstr "Pitch (EAC)"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "მინიმალური სიხშირე 0 Hz მაინც უნდა იყოს"
+
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "მინიმალური სიხშირე 0 Hz მაინც უნდა იყოს"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "მინიმალური სიხშირე 0 Hz მაინც უნდა იყოს"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "მინიმალური სიხშირე 0 Hz მაინც უნდა იყოს"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -9349,6 +15930,10 @@ msgstr "პარამეტრები..."
 msgid "&Use Preferences"
 msgstr "პარამეტრები..."
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "მინიმალური სიხშირე (Hz):"
@@ -9356,6 +15941,24 @@ msgstr "მინიმალური სიხშირე (Hz):"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "მაქსიმალური სიხშირე (Hz):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "გამონატანი არხები: %2d"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Boost (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -9370,8 +15973,17 @@ msgid "Window &size:"
 msgstr "ფანჯრის ტიპი"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "8 - most wideband"
+msgstr "32768 - ყველაზე ვიწრო"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "256 - ნაგულისხმევი"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -9382,8 +15994,23 @@ msgid "Window &type:"
 msgstr "ფანჯრის ტიპი"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "შეყოვნების ფაქტორი:"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "მონიშვნა"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "FFT Find Notes"
+msgstr "&შენიშვნების ძება"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Minimum Amplitude (dB):"
@@ -9418,8 +16045,33 @@ msgid "The minimum frequency must be an integer"
 msgstr "მინიმალური სიხშირე ინტეგრალი უნდა იყოს"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "მაქსიმალური სიხშირე ინტეგრალი უნდა იყოს"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "მაქსიმალური სიხშირე ინტეგრალი უნდა იყოს"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "მაქსიმალური სიხშირე ინტეგრალი უნდა იყოს"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "The minimum amplitude (dB) must be an integer"
 msgstr "მინიმალური ამპლიტუდა  (dB) უნდა იყოს ინტეგრალი"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "მაქსიმალური სიხშირე ინტეგრალი უნდა იყოს"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "მაქსიმალური სიხშირე ინტეგრალი უნდა იყოს"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
@@ -9438,13 +16090,14 @@ msgid "Info"
 msgstr "ინფო"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -9462,6 +16115,12 @@ msgstr ""
 "[Only the control toolbar and the colors on the \n"
 "wavetrack are currently affected, even though the\n"
 "image file shows other icons too.]"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
 #. * so keep it as is
@@ -9520,8 +16179,24 @@ msgid "Enable &dragging selection edges"
 msgstr "მარცხენა და მარჯვენა მონიშვნის კიდეების გადათრევის გააქტიურება"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "\"ტრეკის ფოკუსის ციკლების გადაადგილება\" განმეორებითად ტრეკებზე"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
@@ -9543,6 +16218,14 @@ msgstr "ტალღოვანი"
 msgid "Spectrogram"
 msgstr "სპექტოგრამები"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "ფანჯარაზე მორგება"
@@ -9554,6 +16237,10 @@ msgstr "მონიშვნამდე &გადიდება"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "ნაგულისხმევი მასშტაბირება"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -9576,6 +16263,16 @@ msgid "50ths of Seconds"
 msgstr "წამები"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "წამები"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "წამები"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "მილიწამები"
 
@@ -9583,7 +16280,12 @@ msgstr "მილიწამები"
 msgid "Samples"
 msgstr "სემპლები"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "გადიდება"
 
@@ -9592,12 +16294,42 @@ msgid "Preferences for Tracks"
 msgstr "პარამეტრები..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "ჩაწერის დასასრული"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "ნაგულისხმები დათვალიერების რეჟიმი"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "სემპლის ნაგულისხმევი ფორმატი:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "სემპლები"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -9620,9 +16352,46 @@ msgstr "პარამეტრები:"
 msgid "Preset 2:"
 msgstr "პარამეტრები:"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "გაფრთხილება"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "პარამეტრები..."
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&პროექტის შენახვა"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&პროექტის შენახვა"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "სტეროდან მონოზე გააქტიურება"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "სტეროდან მონოზე გააქტიურება"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -9645,16 +16414,24 @@ msgid "Stopped"
 msgstr "გაჩერება"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "შეჩერება"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "საწყისზე გადასვლა"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "ბოლოში გადასვლა"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "შეჩერება"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "დასაწყისზე მონიშვნა"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "დასარულზე მონიშვნა"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -9668,20 +16445,24 @@ msgstr "ახალი ტრეკი"
 msgid "Append Record"
 msgstr "ჩაწერის დამატება"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "დასარულზე მონიშვნა"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "დასაწყისზე მონიშვნა"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "შეჩერება"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "ტრანსკრი&პციის ხელსაწყოთა ზოლი"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -9692,6 +16473,11 @@ msgstr "დაკვრის სიჩქარე"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "ჩაწერის დასასრული"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "აუდიოს პოზიცია"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -9714,8 +16500,18 @@ msgid "Select Playback Device"
 msgstr "დაკვრის სიჩქარე"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "აუდ&იოს დაჩუმება"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "ჩაწერის დასასრული"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "დათვალიერება შეუძლებელია\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -9739,11 +16535,22 @@ msgstr "ამოჭრა მონიშვნის გარეთ"
 msgid "Silence audio selection"
 msgstr "სიჩუმის მონიშვნა"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "ტრეკების &დახარისხება"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "შემცირება"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "გადიდება"
 
@@ -9754,6 +16561,11 @@ msgstr "მონიშვნის ფანჯარაში მორგე�
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "პროექტის ფანჯარაში მორგება"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "ეფ&ექტი"
 
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
@@ -9806,38 +16618,24 @@ msgstr "რეკორდის გამზომავი"
 msgid "&Playback Meter Toolbar"
 msgstr "მთვლელის დაკვრა"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "ჩაწერის დასასრული"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "დაკვრა"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "მთვლელის გააქტიურება"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "ჩაწერის დასასრული"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "დაკვრა"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "დაკვრა"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "მიქსერის ხელსაწყოთა ზოლი"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Nyquist Prompt..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Nyquist Prompt..."
@@ -9845,6 +16643,7 @@ msgstr "Nyquist Prompt..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Nyquist Prompt..."
@@ -9852,9 +16651,24 @@ msgstr "Nyquist Prompt..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "მონიტორინგის დაწყება"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "მონიტორინგის დაწყება"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "მთვლელის გაუქმება"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -9902,9 +16716,24 @@ msgstr "გადაღება"
 msgid "Length"
 msgstr "სიგრძე"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "ცენტრში"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -9931,6 +16760,10 @@ msgstr "ბასების სიხშირეების გაძლი�
 msgid "Center Frequency"
 msgstr "ლინეარული სიხშირე"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -9949,8 +16782,8 @@ msgstr "&მოწყობილობათა ზოლი"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %s ხელსაწყოთა ზოლი"
 
 #: src/toolbars/ToolBar.cpp
@@ -9977,7 +16810,8 @@ msgstr "დროის ცვლის ხელსაწყო"
 msgid "Zoom Tool"
 msgstr "გადიდების ხელსაწყო"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "დახატვის ხელსაწყო"
 
@@ -10053,11 +16887,13 @@ msgstr "ერთი ან მეტი იარლიყის საზღ�
 msgid "Drag label boundary."
 msgstr "იარლიყის საზღვრის გადათრევა"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "შეცვლილი იარლიყი"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "იარლიყის რედაქტირება"
 
@@ -10112,31 +16948,42 @@ msgstr "რედაქტირებული იარლიყები"
 msgid "New label"
 msgstr "დამატებული იარლიყი"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "ოქტავით მაღლა"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "ოქტავით დაბლა"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "ვერტიკალური შემცირებისთვის დაუწკაპუნეთ, Shift-დაწკაპუნება გადიდებისთვის, გადათრევა კი ქმნის მასშტაბირების კონკრეტული არეს."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "მარჯვენა წკაპი"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "გადიდება"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-მარცხენა-წკაპი"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-მარცხენა-წკაპი"
 
@@ -10159,6 +17006,14 @@ msgid "Stretch"
 msgstr "შეყოვნების ფაქტორი:"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "შერწყმული სანიშნები"
 
@@ -10170,7 +17025,8 @@ msgstr "შერწყმა"
 msgid "Expanded Cut Line"
 msgstr "გაფართოებული ამოჭრის ხაზი"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "გაფართოება"
 
@@ -10194,6 +17050,11 @@ msgstr "გადაადგილებული სემპლი"
 msgid "Sample Edit"
 msgstr "სემპლის რედაქტირება"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "წერტილზე მასშტაბირება"
@@ -10201,6 +17062,16 @@ msgstr "წერტილზე მასშტაბირება"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "სპექტოგრამები"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -10226,7 +17097,8 @@ msgstr "Auto Duck დამუშავება..."
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "შეცვლილი '%s'-დან %s-ზე"
@@ -10240,7 +17112,60 @@ msgid "Rat&e"
 msgstr "კოეფიციენტის მომართვა"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 ს 060 წ 060>01000 წ"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -10261,7 +17186,8 @@ msgstr "კოეფიციენტის შეცვლა"
 msgid "Set Rate"
 msgstr "კოეფიციენტის მომართვა"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "მრავალი"
 
@@ -10354,10 +17280,25 @@ msgid "Right, %dHz"
 msgstr "მარჯვენა,"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "მარჯვენა"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -10367,6 +17308,15 @@ msgstr "სტერეო ტრეკების რელატიური 
 msgid "Click and drag to rearrange sub-views"
 msgstr "დაუწკაპუნეთ და გადაათრიეთ ტრეკის დროში გადასაადგილებლად"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "დაუწკაპუნეთ და გადაათრიეთ ტრეკის დროში გადასაადგილებლად"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "შემცირება"
@@ -10374,6 +17324,10 @@ msgstr "შემცირება"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "გადიდება"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -10419,12 +17373,28 @@ msgid "Set Range"
 msgstr "დიაპაზონის მორგება"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "ეკრანი"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "ინტერპოლაცია:"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
@@ -10444,9 +17414,8 @@ msgstr "სწრაფი Sinc ინტერპოლაცია"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "დაუწკაპუნეთ და გადაათრიეთ ტრეკის დროში გადასაადგილებლად"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -10497,6 +17466,21 @@ msgstr "მორგებული კონვერტი."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "&ხელსაწყოთა ზოლები"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "მონიტორინგის დაწყება"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "მთვლელის გააქტიურება"
@@ -10512,6 +17496,11 @@ msgstr "ფოკუსირებული ტრეკის დახურ�
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "ტრეკის ჩამოტანა"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Nyquist Prompt..."
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -10568,6 +17557,11 @@ msgstr "აუდიოს მოსანიშნად დააწკაპ�
 msgid "Click and drag to select audio"
 msgstr "აუდიოს მოსანიშნად დააწკაპუნეთ და გადაათრიეთ"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "დაუწკაპუნეთ და გადაათრიეთ ტრეკის დროში გადასაადგილებლად"
@@ -10589,6 +17583,10 @@ msgstr "დაჩუმებული მონუშნული ტრეკ�
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "დაჩუმებული მონუშნული ტრეკები %.2f-ისთვის.2f წამი %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -10615,6 +17613,12 @@ msgstr "&ბრძანება"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl-მარცხენა წკაპი"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -10680,6 +17684,14 @@ msgid "%.2fx"
 msgstr "%.1f dB"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" არ არსებობს\n"
+"\n"
+"გსურთ შექმნა?"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
 msgstr "გთხოვთ, ამოირჩიოთ მოქმედება"
 
@@ -10691,6 +17703,14 @@ msgstr "ფილტრი"
 msgid "&Clear"
 msgstr "&გაწმენდა"
 
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
 #: src/widgets/Grid.cpp
 msgid "Empty"
 msgstr "ცარიელი"
@@ -10699,13 +17719,28 @@ msgstr "ცარიელი"
 msgid "Backwards"
 msgstr "უაკნ"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "წინ"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "დახმარება ინტერნეტით"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "ყველა ფაილი(*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -10744,6 +17779,13 @@ msgid "Refresh Rate"
 msgstr "კოეფიციენტის მომართვა"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "განახლების კოეფიციენტის თვლა ყოველ წამზე  [1-100]: "
 
@@ -10756,12 +17798,21 @@ msgid "Meter Style"
 msgstr "მთვლელი"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "ფილტრი"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "ხანგრძლოვობა"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "ავტომატური აღდგენა მარცხის მერე"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -10776,9 +17827,26 @@ msgid " Monitoring "
 msgstr "მონიტორინგის შეჩერება"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Please select an action"
@@ -10822,6 +17890,25 @@ msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 დღე 024 ს 060 წ 060 წ"
 
 #. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "სს:წწ:წწ + სემპლები"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 ს 060 წ 060>01000 წ"
+
+#. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
@@ -10858,6 +17945,7 @@ msgstr "0100 ს 060 წ 060 წ+># სემპლები"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "სემპლები"
@@ -11019,6 +18107,15 @@ msgstr "01000,01000 კადრი|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 ს 060 წ 060>01000 წ"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -11026,6 +18123,10 @@ msgstr "0100 ს 060 წ 060>01000 წ"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 ს 060 წ 060>01000 წ"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -11041,11 +18142,36 @@ msgstr "ოქტავით დაბლა"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 კადრები|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in semitones and cents
 #: src/widgets/NumericTextCtrl.cpp
 msgid "semitones + cents"
 msgstr "ნახევარტონები ნახევარნაბიჯებში"
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
 
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
@@ -11053,9 +18179,24 @@ msgstr "ნახევარტონები ნახევარნაბ�
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 კადრები|24"
 
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "ფორმატის შესაცვლელად გამოიყენეთ მარჯვენა კლავიში ან კონტექსტური გასაღები"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "წამები"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -11099,6 +18240,11 @@ msgstr "დადასტურება"
 msgid "Unable to write files to directory: %s."
 msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -11117,6 +18263,10 @@ msgid "Don't show this warning again"
 msgstr "მეტჯერ აღარ აჩვენო ეს გაფრთხილება"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-უსასრულობა"
 
@@ -11125,13 +18275,31 @@ msgid "-Infinity"
 msgstr "-უსასრულობა"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "ცარიელი"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "ჩაწერის დამატება"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "დიაპაზონზე მასშტაბირება"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "LOF შეცდომა"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -11149,11 +18317,20 @@ msgid "Value must not be greater than %s"
 msgstr "დასაწყისი და დასასრული უნდა იყოს 0-ზე მეტი"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "ახალი შექმნილი პროექტი"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "დირექტორიები"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "დირექტორიები"
 
 #: src/xml/XMLFileReader.cpp
@@ -11174,16 +18351,49 @@ msgstr "შეუძლებელია ფაილის გახსნა"
 msgid "Spectral edit multi tool"
 msgstr "მონიშვნა"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "ფილტრი"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "სიხშირე (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "შეცდომა"
@@ -11211,6 +18421,22 @@ msgstr "სიხშირეზე წამებში"
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "მინიმალური სიხშირე 0 Hz მაინც უნდა იყოს"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "მონიშვნა"
@@ -11222,6 +18448,28 @@ msgstr "გამკვეთრება"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "გააქტიურება..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -11248,8 +18496,16 @@ msgid "S-Curve Down"
 msgstr "ჩამოწევა"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "დაწყება"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -11258,6 +18514,14 @@ msgstr "Gain"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "დაწყება"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -11270,6 +18534,14 @@ msgstr "ლინეარული"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "ლინეარული"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -11308,6 +18580,24 @@ msgstr "ჩამოწევა"
 msgid "Error~%~%"
 msgstr "შეცდომა"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "გამეორება"
@@ -11315,6 +18605,10 @@ msgstr "გამეორება"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "კლიპინგის მოძიება..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity %s ხელსაწყოთა ზოლი"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -11328,6 +18622,23 @@ msgstr "კლინინგი"
 msgid "Reconstructing clips..."
 msgstr "წკაპუნისა და ხტუნვის წაშლა..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "ზღვარი %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "გაითვალისწინეთ ტრეკი"
@@ -11335,6 +18646,21 @@ msgstr "გაითვალისწინეთ ტრეკი"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "გაითვალისწინეთ ტრეკი"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -11368,6 +18694,19 @@ msgstr "ტრეკის სახელი"
 msgid "Fade direction"
 msgstr "მონიშვნა"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "შეყოვნება"
@@ -11383,6 +18722,19 @@ msgstr "გასაღების ტიპი"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "მართკუთხედი"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "ხარვეზის შემცირება (dB):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -11408,6 +18760,14 @@ msgstr "ეს&კიზი"
 msgid "Number of echoes"
 msgstr "გასამეორებელი ჯერების ოდენობა:"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "პარამეტრის წაშლა"
@@ -11419,6 +18779,10 @@ msgstr "ეკვალიზაცია"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3 ფაილები"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -11433,10 +18797,24 @@ msgstr "გადაწერის დადასტურება"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "შეუძლებელია ჟანრის ფაილის შენახვა."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "შეცდომა (ფაილი შეიძლება არ ჩაწერილა): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "შეცდომა (ფაილი შეიძლება არ ჩაწერილა): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -11467,18 +18845,67 @@ msgstr "სიგრძე (წამებო)"
 msgid "Length of label region (seconds)"
 msgstr "სიგრძე (წამებო)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "იარლიყის რედაქტირება"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "კლავიშთა კომბინაცია"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "გაფრთხილება"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -11488,6 +18915,12 @@ msgstr "იარლიყების შეერთება"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "იარლიყების შეერთება"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -11506,13 +18939,46 @@ msgstr "ეკვალიზაციის შესრულება"
 msgid "Dominic Mazzoni"
 msgstr "Dominic Mazzoni-ის მიერ"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "სიხშირე (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "მინიმალური სიხშირე 0 Hz მაინც უნდა იყოს"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -11560,6 +19026,11 @@ msgid "Point after sound"
 msgstr "გაერთიანებული სტერეო"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "შენიშვნის სიგრძე (წამები)"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "შენიშვნის სიგრძე (წამები)"
 
@@ -11567,11 +19038,41 @@ msgstr "შენიშვნის სიგრძე (წამები)"
 msgid "Maximum leading silence"
 msgstr "სიჩუმის ამოჭრა..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "სიჩუმის ამოჭრა..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "სახელი არ უნდა იყოს ცარიელი"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -11603,8 +19104,25 @@ msgid "Hard Clip"
 msgstr "კლიპინგის მოძიება"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "მარჯვენა არხი"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "დონე:"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -11629,6 +19147,10 @@ msgstr "მონიშვნა"
 #: plug-ins/noisegate.ny
 msgid "Gate"
 msgstr "გეითი"
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Stereo Linking"
@@ -11662,6 +19184,44 @@ msgstr "შეტევის/დანებების დრო (წამ�
 msgid "Decay (ms)"
 msgstr "შეტევის/დანებების დრო (წამები):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "სახელი არ უნდა იყოს ცარიელი"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "ხმის სიმაღლის წამნაცვლებელი"
@@ -11669,6 +19229,22 @@ msgstr "ხმის სიმაღლის წამნაცვლებე�
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "გამასწორებლის გააქტიურება"
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -11691,7 +19267,8 @@ msgstr "MP3 ფაილები"
 msgid "HTML file"
 msgstr "MP3 ფაილები"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "ფაილების სახელების დარქმევა:"
 
@@ -11708,9 +19285,24 @@ msgid "Disallow"
 msgstr "გაუქმებული."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "გაუქმებული."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "შეუძლებელია '%s'-ის წაშლა"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -11721,16 +19313,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "MIDI ფაილის ამორჩევა"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "მდებარეობის ექსპორტირება:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "MIDI ფაილის ამორჩევა"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "ტონის გენერაცია"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "ფილტრი"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -11743,6 +19377,10 @@ msgstr "ტრეკის წაშლა"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Chirp გენერაცია"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -11761,8 +19399,20 @@ msgid "Swing amount"
 msgstr "რღვევა"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "გასამეორებელი ჯერების ოდენობა:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -11785,12 +19435,54 @@ msgid "Beat sound"
 msgstr "გამეორება"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "ხარვეზის წაშლა"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "ხარვეზი..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -11801,12 +19493,25 @@ msgid "Generating Risset Drum..."
 msgstr "ხარვეზის გენერაცია"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "შეყოვნების დრო (წამები):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "ლინეარული სიხშირე"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "სიხშირე (Hz)"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -11819,6 +19524,10 @@ msgstr "შეუძლებელია ესპორტირება"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "გააქტიურება..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -11837,6 +19546,10 @@ msgid "HTML files"
 msgstr "MP3 ფაილები"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "სემპლის რედაქტირება"
 
@@ -11849,8 +19562,29 @@ msgid "Include header information"
 msgstr "აგების ინფორმაცია"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "&All"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -11865,6 +19599,11 @@ msgstr "\t-დახმარება (ეს შეტყობინება
 msgid "Errors Only"
 msgstr "შეცდომა: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -11877,6 +19616,46 @@ msgstr "მარჯვენა არხი"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "სემპლები"
 
@@ -11884,6 +19663,43 @@ msgstr "სემპლები"
 #, lisp-format
 msgid "~a seconds."
 msgstr "წამები"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -11902,6 +19718,10 @@ msgid "Value (dB)"
 msgstr "დონე:"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "ლინეარული"
 
@@ -11918,6 +19738,14 @@ msgid "Right (dB)"
 msgstr "მარჯვენა,"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "ლინეარული"
 
@@ -11928,6 +19756,40 @@ msgstr "2 არხი (სტერეო)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 არხი (მონო)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "შეცდომა (ფაილი შეიძლება არ ჩაწერილა): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -11942,8 +19804,40 @@ msgid "Select file"
 msgstr "MIDI ფაილის ამორჩევა"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "შეცდომა"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -11953,6 +19847,15 @@ msgstr "შეუძლებელია ჟანრის ფაილის 
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "მონიშვნა"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -11975,8 +19878,16 @@ msgid "Wet level (percent)"
 msgstr "2-დონე"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "გააქტიურება..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -12018,9 +19929,96 @@ msgstr "&ანალიზი"
 msgid "Strength"
 msgstr "ფილტრი"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Auto Duck დამუშავება..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -12054,6 +20052,139 @@ msgstr "სიხშირე (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "სიხშირე (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Audacity-ის დახურვა"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "არხი"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "ფაილის გახსნის შეცდომა"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s ხელსაწყოთა ზოლი"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "ჩაწერა"
+
+#~ msgid "Commit Id:"
+#~ msgstr "ბრძანება:"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "იმპორტი QuickTime-ით"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "შეუძლებელია ჟანრის ფაილის შენახვა.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "ჩაწერა\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "დაკვრა\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "ჩაწერის დასასრული\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "ჩაწერის დასასრული\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "დაკვრა\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "დაკვრა\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "FFmpeg-თავსებადი ფაილები"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "შეუძლებელია '%s'-ის სახელის გადარქმევა  '%s'-ად"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "დაკვრა"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "დაკვრა"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "დაკვრა"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "ჩაწერის დასასრული"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "ჩაწერის დასასრული"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "ჩაწერის დასასრული"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Audacity-ის &შესახებ..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "ხმა-გააქტიურებული ჩაწერა (ჩართვა/გამორთვა)"
+
+#~ msgid "Recording Volume"
+#~ msgstr "ჩაწერის დასასრული"
+
+#~ msgid "Playback Volume"
+#~ msgstr "დაკვრა"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "ჩაწერის დასასრული"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "დაკვრა"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "დაკვრა"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "მიქსერის ხელსაწყოთა ზოლი"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "დაუწკაპუნეთ და გადაათრიეთ ტრეკის დროში გადასაადგილებლად"
+
 #~ msgid "Program build date:"
 #~ msgstr "პროგრამის აგების თარიღი:"
 
@@ -12066,15 +20197,8 @@ msgstr "სიხშირე (Hz)"
 #~ msgstr "ბრ"
 
 #, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "შეუძლებელია ტესტის ფაილის გახსნა/შექმნა"
-
-#, fuzzy
 #~ msgid "available"
 #~ msgstr "ცვლადი"
-
-#~ msgid "Core Libraries"
-#~ msgstr "ძირითადი ბიბლიოთეკები"
 
 #, fuzzy
 #~ msgid "Audacity Support Data"
@@ -12096,9 +20220,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgid "LAME MP3 Library:"
 #~ msgstr "LAME MP3 ბიბლიოთეკა:"
 
-#~ msgid "&Download"
-#~ msgstr "&ჩამოტვირთვა"
-
 #, fuzzy
 #~ msgid "Error.n"
 #~ msgstr "შეცდომა"
@@ -12110,10 +20231,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "Select any uncompressed audio file"
 #~ msgstr "ნებისმიერი არაკომპრესირებული ფაილის არჩევა"
-
-#, fuzzy
-#~ msgid "decode an autosave file"
-#~ msgstr "შეუძლებელია ძველი ავტოშენახული ფაილის წაშლა"
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -12187,9 +20304,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "დროებითი ფაილების გაწმენდა"
-
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "ქეშის დირექტორიების გაწმენდა"
 
 #~ msgid "Renamed file: %s\n"
 #~ msgstr "სახელშეცვლილი ფაილი: %s\n"
@@ -12270,9 +20384,6 @@ msgstr "სიხშირე (Hz)"
 
 #~ msgid "When importing audio files"
 #~ msgstr "აუდიოს ფაილების იმპორტისას "
-
-#~ msgid "When saving a project that depends on other audio files"
-#~ msgstr "პროექტის შენახვისას, რომელიც დამოკიდებულია სხვა აუდიო ფაილებზე"
 
 #, fuzzy
 #~ msgid "Silence Finder"
@@ -12375,10 +20486,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgstr "არეს და&კვრა"
 
 #, fuzzy
-#~ msgid "Disable Scrub Ruler"
-#~ msgstr "მთვლელის გაუქმება"
-
-#, fuzzy
 #~ msgid "Enable Scrub Ruler"
 #~ msgstr "მთვლელის გააქტიურება"
 
@@ -12470,10 +20577,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgstr "აგების გამოსაყენებლად ამოირჩიეთ  'ტალღოვანი' ტრეკის ჩამოსაშლელი სიიდან."
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "ტრეკის წაშლა"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "წკაპუნისა და ხტუნვის წაშლა..."
 
@@ -12511,18 +20614,6 @@ msgstr "სიხშირე (Hz)"
 
 #~ msgid "false"
 #~ msgstr "ყალბი"
-
-#, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "აუდიო ფაილი"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Nyquist ეფექტის გააქტიურება..."
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "შეუძლებელია ჟანრის ფაილის შენახვა."
 
 #, fuzzy
 #~ msgid "Unable to save MIDI device info"
@@ -12580,10 +20671,6 @@ msgstr "სიხშირე (Hz)"
 
 #~ msgid "Edit C&hains..."
 #~ msgstr "ჯაჭ&ვების რედაქტირება..."
-
-#, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "ტრანსკრი&პციის ხელსაწყოთა ზოლი"
 
 #, fuzzy
 #~ msgid "&Tools"
@@ -12651,10 +20738,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "ტრანსკრიპცია"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "&ხელსაწყოთა ზოლები"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -12725,9 +20808,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgid "Exporting the entire project as %s"
 #~ msgstr "მთლიანი პროექტის ექსპორტირება როგორც %s"
 
-#~ msgid ": Filename too short."
-#~ msgstr ": ფაილის სახელი ძალიან მოკლეა."
-
 #, fuzzy
 #~ msgid " (emulated)"
 #~ msgstr "შაბლონი"
@@ -12739,10 +20819,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "Length-Center"
 #~ msgstr "სიგრძე"
-
-#, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "დასარულზე მონიშვნა"
 
 #, fuzzy
 #~ msgid "Start - Length - End"
@@ -12759,10 +20835,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "Show start time and length"
 #~ msgstr "საწყისი თარიღი და დრო"
-
-#, fuzzy
-#~ msgid "Show length and end time"
-#~ msgstr "სიგრძიდან წამებში"
 
 #, fuzzy
 #~ msgid "Click to verticaly zoom in, Shift-click to zoom out, Drag to create a particular zoom region."
@@ -12827,16 +20899,8 @@ msgstr "სიხშირე (Hz)"
 #~ msgstr "მუშაობის ციკლი:"
 
 #, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "ამპლიტუდა (0-1)"
-
-#, fuzzy
 #~ msgid "Decay"
 #~ msgstr "დაწევის დრო"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "სახელი"
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -12894,10 +20958,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgstr "გამოხმაურება (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "ზომა"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "გამოხმაურება (%):"
 
@@ -12912,10 +20972,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Gain"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "სტერეო"
 
 #, fuzzy
 #~ msgid "FilterType"
@@ -12956,10 +21012,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "სიჩუმის ამოჭრა"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "რევერსია"
 
 #~ msgid ""
 #~ "The keyboard shortcut '%s' is already assigned to:\n"
@@ -13033,10 +21085,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgstr "&ინდივიდუალური მიქსინგის გამოყენება (მაგ.  5.1 მულტიარხოვანი ფაილის ექსპორტირებისთვის)"
 
 #, fuzzy
-#~ msgid "&Length of preview:"
-#~ msgstr "დათვალიერების რეჟიმის სიგრძე:"
-
-#, fuzzy
 #~ msgid "(uncheck when recording computer playback)"
 #~ msgstr "(ამორთვა ჩაწერისას  \"სტერეო შერევა\")"
 
@@ -13099,9 +21147,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgid "Welcome to Audacity "
 #~ msgstr "მოგესალმებათ Audacity "
 
-#~ msgid "Edit Metadata"
-#~ msgstr "მეტამონაცემების რედაქტირება"
-
 #~ msgid "Disk space remains for recording %d hours and %d minutes."
 #~ msgstr "ჩაწერისთვის დარჩენილი სივრცე %d საათი და %d წუთი."
 
@@ -13120,10 +21165,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "R&ight Channel"
 #~ msgstr "მარჯვენა არხი"
-
-#, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "Boost (dB):"
 
 #, fuzzy
 #~ msgid "&Enable level control"
@@ -13188,12 +21229,6 @@ msgstr "სიხშირე (Hz)"
 #~ "  %s"
 
 #, fuzzy
-#~ msgid "Current directory:"
-#~ msgstr ""
-#~ "შეუძლებელია დირექტორიის შექმნა:\n"
-#~ "  %s"
-
-#, fuzzy
 #~ msgid "Directory doesn't exist."
 #~ msgstr "%s დირექტორია არ არსებობს. შევქმნა?"
 
@@ -13204,10 +21239,6 @@ msgstr "სიხშირე (Hz)"
 #, fuzzy
 #~ msgid "Spectral Selection lo&g(f)"
 #~ msgstr "მონიშვნა"
-
-#, fuzzy
-#~ msgid "Pitc&h (EAC)"
-#~ msgstr "Pitch (EAC)"
 
 #, fuzzy
 #~ msgid "Set Sample &Format"
@@ -13260,9 +21291,6 @@ msgstr "სიხშირე (Hz)"
 
 #~ msgid "Specify Other Options"
 #~ msgstr "სხვა პარამეტრების განსაზღვრა"
-
-#~ msgid "Specify FLAC Options"
-#~ msgstr "FLAC პარამეტრების განსაზღვრა"
 
 #~ msgid "FLAC Export Setup"
 #~ msgstr "FLAC ექსპორტის მომართვა"
@@ -13338,9 +21366,6 @@ msgstr "სიხშირე (Hz)"
 
 #~ msgid "Unsorted"
 #~ msgstr "დაუხარისხებელი"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "მაღალი ხარისხის Sinc ინტერპოლაცია"
 
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "სწრაფი Sinc ინტერპოლაცია"
@@ -13471,9 +21496,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgid "Equalization..."
 #~ msgstr "ეკვალიზაცია..."
 
-#~ msgid "Performing Equalization"
-#~ msgstr "ეკვალიზაციის შესრულება"
-
 #~ msgid "Fading In"
 #~ msgstr "მინავლება"
 
@@ -13558,10 +21580,6 @@ msgstr "სიხშირე (Hz)"
 #~ msgid "Applying Reverb"
 #~ msgstr "გამასწორებლის გააქტიურება"
 
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "ფაილის &ატვირთვა.."
-
 #~ msgid "Silence..."
 #~ msgstr "სიჩუმე..."
 
@@ -13598,9 +21616,6 @@ msgstr "სიხშირე (Hz)"
 
 #~ msgid "Sorry, Plug-in Effects cannot be performed on stereo tracks where the individual channels of the track do not match."
 #~ msgstr "ვწუხვართ, მოდულის ეფექტის შესულება შეუძლებელია სტერეო ტრეკებზე, სადაც ტრეკის ინდივიდუალური არხები არ ემთხვევა."
-
-#~ msgid "Note velocity"
-#~ msgstr "შენიშვნის სიჩქარე"
 
 #~ msgid "Note key"
 #~ msgstr "შენიშვნის გასაღები"
@@ -13649,9 +21664,6 @@ msgstr "სიხშირე (Hz)"
 
 #~ msgid "Recovering a project will not change any files on disk before you save it."
 #~ msgstr "პროექტის აღდენა არ შეცვლის ფაილებს დისკებს სანამ შეინახავთ."
-
-#~ msgid "Do Not Recover"
-#~ msgstr "არა აღადგინო"
 
 #~ msgid "Confirm?"
 #~ msgstr "დავადასტურო?"

--- a/locale/km.po
+++ b/locale/km.po
@@ -7,53 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Khmer (Central) <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/km/>\n"
+"Language-Team: Khmer (Central) <https://hosted.weblate.org/projects/tenacity/tenacity/km/>\n"
 "Language: km\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "បិទ Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "ឆានែល"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "របារ​ឧបករណ៍​របស់ Audacity %s"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "ថត"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -64,9 +27,31 @@ msgstr "មិន​អាច​​កំណត់"
 msgid "%s bytes"
 msgstr "បៃ"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "ពង្រីក"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -77,12 +62,68 @@ msgid "2nd Experimental Command"
 msgstr "ជ្រើស​​ពាក្យ​បញ្ជា"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "អនុវត្ត​បែបផែន Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "បិទភ្ជាប់"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "បិទភ្ជាប់"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "បិទភ្ជាប់"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "បិទភ្ជាប់"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "ជ្រើស"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -105,15 +146,37 @@ msgid "Show &Output"
 msgstr "បង្ហាញ​លទ្ធផល"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "ឧបករណ៍"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "បញ្ឈប់ S"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "អថេរ"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "ចេញ"
 
@@ -121,13 +184,38 @@ msgstr "ចេញ"
 msgid "Load Nyquist script"
 msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "ការ​ព្រមាន"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -138,16 +226,39 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "ដោយ Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "អនុវត្ត​បែបផែន Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "No matches found"
+msgstr "ភ្ជាប់​ស្តេរ៉េអូ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "អនុវត្ត​បែបផែន Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "ថ្មី"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "បើក​​ថ្មីៗ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -181,7 +292,8 @@ msgstr "ចម្លង"
 msgid "Copy to clipboard"
 msgstr "កាត់​​ទៅ​ក្ដារ​​តម្បៀត​​ខ្ទាស់"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "កាត់"
 
@@ -189,7 +301,8 @@ msgstr "កាត់"
 msgid "Cut to clipboard"
 msgstr "កាត់​​ទៅ​ក្ដារ​​តម្បៀត​​ខ្ទាស់"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "បិទ​ភ្ជាប់"
 
@@ -214,7 +327,8 @@ msgstr "ជ្រើស"
 msgid "Select all text"
 msgstr "ជ្រើស"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "មិន​ធ្វើ​វិញ"
 
@@ -222,20 +336,70 @@ msgstr "មិន​ធ្វើ​វិញ"
 msgid "Undo last change"
 msgstr "ផ្លាស់ប្ដូរ​ទ្រង់ទ្រាយ"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "ធ្វើ​វិញ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "ផ្លាស់ប្ដូរ​ទ្រង់ទ្រាយ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Match"
 msgstr "បាច់"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "គ្មាន​​ស្លាក​​ត្រូវ​នាំចេញ ។"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "ឧបករណ៍​​មុន A"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "ផ្លាស់ទី​​ការ​​ផ្ដោត​​ទៅ​បទ​​មុន ឡើង​​លើ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "ឧបករណ៍​​​បន្ទាប់ D"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "ចាប់ផ្ដើម"
 
@@ -243,7 +407,8 @@ msgstr "ចាប់ផ្ដើម"
 msgid "Start script"
 msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "បញ្ឈប់ S"
 
@@ -251,26 +416,77 @@ msgstr "បញ្ឈប់ S"
 msgid "Stop script"
 msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "យល់ព្រម"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "បាន​អនុញ្ញាត"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "មិន​បាន​អនុញ្ញាត"
 
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "ពាក្យបញ្ជា ៖"
+msgid "The Build"
+msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Version:"
+msgstr "កំពុង​​ដាក់​បញ្ច្រាស"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr "ប្រភេទ​ការរំខាន"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "ការ​កំណត់​ថត ៖ "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "ការ​កំណត់​ថត ៖ "
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -278,8 +494,59 @@ msgid "Sample rate conversion"
 msgstr "កម្មវិធី​បម្លែង​អត្រា​គំរូ"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "កំហុស​ក្នុង​ការ​នាំ​ចូល"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Ogg Vorbis Import and Export"
+msgstr "រៀបចំ​​នាំ​ចេញ Ogg Vorbis"
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FLAC import and export"
+msgstr "រៀបចំការ​​​នាំចេញ FLAC"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "រៀបចំ​នាំចេញ MP2"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Import via QuickTime"
 msgstr "នាំចូល​ទិន្នន័យ​មិនទាន់​ដើម"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export"
+msgstr "កំហុស LOF"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "កម្មវិធី​ជំនួយពី %i ដល់ %i"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -306,6 +573,18 @@ msgstr "ស្រោម​សំបុត្រ"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "ស្រោម​សំបុត្រ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "ស្រោម​សំបុត្រ"
 
@@ -317,9 +596,51 @@ msgstr "ស្រោម​សំបុត្រ"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "ស្រោម​សំបុត្រ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "ស្រោម​សំបុត្រ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "ស្រោម​សំបុត្រ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "ក្រាហ្វិក EQ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "ស្រោម​សំបុត្រ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "ស្រោម​សំបុត្រ"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -340,8 +661,26 @@ msgid "%s, graphics"
 msgstr "ក្រាហ្វិក EQ"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "អ្នក​ចូលរួម"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -359,6 +698,11 @@ msgstr "អ្នក​ចូលរួម​​ផ្សេងៗ​ទៀត"
 msgid "Tenacity Special thanks:"
 msgstr "អរគុណ​ជា​ពិសេស​ ៖"
 
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "ថត"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
@@ -372,14 +716,23 @@ msgid "%s Team Members"
 msgstr "សមាជិក​​​ក្រុម​​ដែល​​ចូល​​និវត្តន៍​​ផ្សេង​ទៀត"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "អ្នក​ចូលរួម​​ផ្សេងៗ​ទៀត"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "ខឹម សុខែម, អេង វណ្ណៈ, អោក ពិសិដ្ឋ"
@@ -398,6 +751,26 @@ msgstr "អរគុណ​ជា​ពិសេស​ ៖"
 msgid "%s website: "
 msgstr "ដំបូង​រត់ Audacity"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "អ្នក​ចូលរួម​​ផ្សេងៗ​ទៀត"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "ចុច និង​អូស​ដើម្បី​លៃ​តម្រូវ​ទំហំ​បទ​ស្តេរ៉េអូ​នីមួយៗ ។"
@@ -408,9 +781,15 @@ msgstr "ចុច និង​អូស​ដើម្បី​លៃ​តម�
 msgid "Record/Play head"
 msgstr "ថត"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "ការ​កំណត់​កម្មវិធី​ជំនួយ"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "ចុច និង​អូស​ដើម្បី​កែសម្រួល​គំរូ"
@@ -418,17 +797,66 @@ msgstr "ចុច និង​អូស​ដើម្បី​កែសម្�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "ចុច និង​អូស​ដើម្បី​ប្ដូរ​ទំហំ​បទ ។"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "ផ្លាស់ទី​​ការ​​ផ្ដោត​​ទៅ​​បទ​​បន្ទាប់"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "ផ្លាស់ទី​បទ​ចុះ​ក្រោម"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "បិទ​បទ​​ដែលបាន​​ផ្ដោត ប្ដូរ(Shift)+C"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr " (បិទ)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr " (បិទ)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "ការ​កំណត់​កម្មវិធី​ជំនួយ"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -439,10 +867,30 @@ msgid "Update display while playing"
 msgstr "ធ្វើ​ឲ្យ​ការ​បង្ហាញ​ទាន់សម័យ​ ខណៈពេល​ចាក់"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "ថត"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "កំហុស"
 
@@ -452,8 +900,36 @@ msgid "Failed to remove %s"
 msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "ចំណូល​ចិត្ត Audacity"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -472,6 +948,11 @@ msgstr "បើក..."
 
 #: src/AudacityApp.cpp
 #, fuzzy
+msgid "Open &Recent..."
+msgstr "បើក​​ថ្មីៗ"
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
+#, fuzzy
 msgid "&About Tenacity..."
 msgstr "អំពី Audacity..."
 
@@ -484,29 +965,33 @@ msgid "&File"
 msgstr "ឯកសារ"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity មិនអាច​រក​កន្លែង​ដើម្បីទុក​ឯកសា​របណ្ដោះអាសន្ន​បានទេ ។\n"
 "សូម​បញ្ចូល​ថត​ដែលសមរម្យ​នៅ​ក្នុង​ប្រអប់​ចំណូលចិត្ត ។"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity មិនអាច​រក​កន្លែង​ដើម្បីទុក​ឯកសា​របណ្ដោះអាសន្ន​បានទេ ។\n"
 "សូម​បញ្ចូល​ថត​ដែលសមរម្យ​នៅ​ក្នុង​ប្រអប់​ចំណូលចិត្ត ។"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity នឹង​បិទ​ឥឡូវ ។ សូម​ចាប់ផ្ដើម Audacity ម្ដង​ទៀត ដើម្បី​ប្រើ​ថត​បណ្ដោះ​អាសន្ន​ថ្មី ។"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -515,36 +1000,91 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity មិនអាច​ចាក់សោ​ថត​ឯកសារ​បណ្ដោះអាសន្ន​បាន​ទេ ។\n"
 "ថត​នេះ​អាច​កំពុង​ប្រើ​ដោ​យ​ច្បាប់​ចម្លង​របស់​ Audacity ផ្សេង ។\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "តើ​អ្នក​នៅ​តែ​ចង់​ចាប់ផ្ដើម Audacity មែន​ទេ ?"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "ប្រព័ន្ធ​បាន​​ដឹង​ថា មាន​ច្បាប់ចម្លង​របស់ Audacity ផ្សេង​កំពុង​រត់ ។\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "ប្រើ​ពាក្យ​បញ្ជា​ថ្មី ឬ​ពាក្យ​បញ្ជា​ដែល​បើក​​នៅ​ក្នុង​ Audacity ដែលកំពុង​រត់​បច្ចុប្បន្ន\n"
 "ដំណើរការ​ដើម្បី​បើក​គម្រោង​ច្រើន​ដំណាល​គ្នា ។\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity កំពុង​រត់​​រួច​​ហើយ"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "ឯកសារ​​គម្រោង​​របស់ Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -564,7 +1104,8 @@ msgstr "\t-test (រត់​​ការ​វិនិច្ឆ័យ​ដោ
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (បង្ហាញ​​កំណែ​​របស់ Audacity)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -574,9 +1115,10 @@ msgid "audio or project file name"
 msgstr "មិន​អាច​បើក​ឯកសារ​គម្រោង"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -589,29 +1131,73 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "ឯកសារ​​គម្រោង​​របស់ Audacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "សាកល្បង​​ឡើងវិញ"
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "កំពុង​​ថត​​អូឌីយ៉ូ"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "ជំនួយ"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "បិទ Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "របារ​ឧបករណ៍​របស់ Audacity %s"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "រក្សា​ទុក..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "បិទ"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "បាន​រក្សាទុក "
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -640,7 +1226,26 @@ msgid "Error Initializing Audio"
 msgstr "កំហុស​ក្នុង​កា​រចាប់ផ្ដើម​អូឌីយ៉ូ"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"អ្នក​នឹង​មិនអាច​ចាក់ ឬ​ថត​អូឌីយ៉ូ​បាន​ទេ ។\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "កំហុស​ក្នុង​កា​រចាប់ផ្ដើម​អូឌីយ៉ូ"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "របារ​ឧបករណ៍​របស់ Audacity %s"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -650,10 +1255,27 @@ msgid ""
 "Error code: %s"
 msgstr "កំហុស​ខណៈពេល​​បើក​ឧបករណ៍​សំឡេង ។ "
 
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
+
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "ឧបករណ៍​បញ្ចូល\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "ឧបករណ៍​បញ្ចូល\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -691,8 +1313,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "ថត\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "ថត\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "ថត\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "ថត\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -706,37 +1338,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "ឧបករណ៍​បញ្ចូល\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "ឧបករណ៍​បញ្ចូល\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "ល្បឿន​ចាក់​ឡើងវិញ\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "មិន​អាច​បើក​ឯកសារ​ចង្វាក់ ។\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "ល្បឿន​ចាក់​ឡើងវិញ\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "ថត\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "អត្រា​គំរូ\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "ចាក់ឡើងវិញ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "ថត\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "ថត\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "ចាក់ឡើងវិញ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "ចាក់ឡើងវិញ\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -744,8 +1379,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "ឧបករណ៍​បញ្ចូល\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "ឧបករណ៍​បញ្ចូល\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "ល្បឿន​ចាក់​ឡើងវិញ\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "ល្បឿន​ចាក់​ឡើងវិញ\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -753,8 +1398,9 @@ msgid "Automatic Crash Recovery"
 msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ័យ​ប្រវត្តិ"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -766,12 +1412,14 @@ msgid "Recoverable &projects"
 msgstr "គម្រោង​​ដែល​​អាច​​សង្គ្រោះ​បាន"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "ជ្រើស"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "ឈ្មោះ"
 
@@ -784,8 +1432,19 @@ msgid "&Recover Selected"
 msgstr "ជ្រើស"
 
 #: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "គ្មាន​ស្រវាក់​បានជ្រើស"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -808,8 +1467,16 @@ msgid "&Parameters"
 msgstr "ប៉ារ៉ាម៉ែត្រ"
 
 #: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "ជ្រើស​ពាក្យ​បញ្ជា"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -838,6 +1505,22 @@ msgstr "បែបផែន"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "កែសម្រួល​ប៉ារ៉ាម៉ែត្រ"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "កែសម្រួល​ប៉ារ៉ាម៉ែត្រ"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -884,11 +1567,30 @@ msgstr "របៀប​​សាកល្បង"
 msgid "Apply %s"
 msgstr "អនុវត្ត %s"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "ការ​​កំណត់ជា​​ស្រេច"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "ស្លាក..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "អនុវត្ត​ច្រវាក់"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -944,13 +1646,43 @@ msgstr "បោះបង់"
 msgid "Remo&ve"
 msgstr "យកចេញ"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "សាកល្បង​​ឡើងវិញ"
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "នាំចូល..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "នាំចេញ..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "កែសម្រួល​ចង្វាក់"
 
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "ពាក្យ​បញ្ជា"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#, fuzzy
+msgid "Parameters"
+msgstr "ប៉ារ៉ាម៉ែត្រ"
 
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp
 msgid "&Insert"
@@ -972,9 +1704,15 @@ msgstr "ផ្លាស់ទី​ឡើងលើ"
 msgid "Move &Down"
 msgstr "ផ្លាស់ទី​ចុះក្រោម"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "រក្សា​ទុក..."
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1020,11 +1758,38 @@ msgid "Benchmark"
 msgstr "រត់ Benchmark..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "ចំនួន​ដង​ដើម្បី​ធ្វើ​ម្តង​ទៀត ៖"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "បិទ"
 
@@ -1039,8 +1804,30 @@ msgid "Export Benchmark Data as:"
 msgstr "នាំចេញ​ទិន្នន័យ​វិសាល​គម​​ជា ៖"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "រៀបចំការ​​មើល​ជា​មុន\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1049,17 +1836,109 @@ msgstr "អនុវត្ត​ការ​​ធ្វើ​ម្តង​ទ
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "បិទ​ភ្ជាប់\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "កំពុង​​ថត​​អូឌីយ៉ូ\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "កាល​បរិច្ឆេទ និង​ពេល​វេលា​បញ្ចប់"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
 
 #: src/BuildInfo.h
 #, fuzzy
@@ -1075,9 +1954,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "អ្នក​ត្រូវ​តែ​ជ្រើស​អូឌីយ៉ូ​ខ្លះ​សម្រាប់​ប្រើ​នេះ ។"
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "គ្មាន​ស្រវាក់​បានជ្រើស"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1103,6 +2006,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "ជម្រើស"
 
@@ -1116,9 +2024,28 @@ msgid "Checkpointing project"
 msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប្បន្ន"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប្បន្ន"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "មិន​អាច​សរសេរ​ទៅ​កាន់​ឯកសារ ៖ \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity មិន​អាច​សរសេរ​ឯកសារ ៖\n"
+"  %s ។"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1136,6 +2063,10 @@ msgid ""
 "%s"
 msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "យក​​ភាព​អាស្រ័យ​​ចេញ"
@@ -1143,6 +2074,25 @@ msgstr "យក​​ភាព​អាស្រ័យ​​ចេញ"
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "កំពុង​​ចម្លង​​ទិន្នន័យ​​អូឌីយ៉ូ​​ទៅ​​គម្រោង..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "នៅ​ពេល​រក្សាទុក​គម្រោង ដែល​អាស្រ័យ​លើ​ឯកសារ​អូឌីយ៉ូ​ផ្សេងៗ​ទៀត"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1157,8 +2107,26 @@ msgid "Disk Space"
 msgstr "ទំហំ​ថាស"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "ជម្រើស"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "បោះបង់​​ការ​រក្សាទុក"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "ស្លាក"
+
+#: src/Dependencies.cpp
+msgid "Do Not Copy"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1170,9 +2138,32 @@ msgstr "នៅ​​ពេល​ណា​​​ដែល​​គម្រោង
 msgid "Ask me"
 msgstr "សួរ​ខ្ញុំ"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "កាត់​​ទៅ​ក្ដារ​​តម្បៀត​​ខ្ទាស់"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1183,10 +2174,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "បើសិនជា​អ្នក​បន្ត គម្រោង​របស់​អ្នក​នឹង​មិន​ត្រូវ​បាន​រក្សាទុក​ក្នុង​ថាស​ទេ ។ តើនេះ​ជា​អ្វី​ដែលអ្នក​ចង់​បាន​មែនទេ ?"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "ការ​ពិនិត្យ​​ភាព​អាស្រ័យ"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "គ្មាន"
 
@@ -1194,7 +2197,7 @@ msgstr "គ្មាន"
 msgid "Rectangle"
 msgstr "ចតុកោណកែង"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "ត្រីកោណ"
 
@@ -1206,28 +2209,167 @@ msgstr "រាង"
 msgid "Rectangular"
 msgstr "ចតុកោណកែង"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "ទី​តាំង​របស់ %s ៖"
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "To find '%s', click here -->"
+msgstr "ដើម្បី​​ស្វែង​រក %s​ ចុច​ទី​នេះ -->"
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "រក​មើល..."
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
-msgstr ""
-"Audacity មិន​អាច​សរសេរ​ឯកសារ ៖\n"
-"  %s ។"
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr "ដើម្បី​យក​ច្បាប់​ថត​ចម្លង Lame ដោយ​ឥត​គិត​ថ្លៃ​ ចុចត្រង់នេះ -->"
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
 msgstr ""
-"Audacity មិន​អាច​សរសេរ​ឯកសារ ៖\n"
-"  %s ។"
 
-#: src/FileException.cpp
-#, c-format
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "តើឯកសារ %s នៅទីណា ?"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "កុំ​បង្ហាញ​ការ​ព្រមាន​នេះ​ម្តងទៀត"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity មិន​អាច​សរសេរ​ឯកសារ ៖\n"
+"  %s ។"
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+"Audacity មិន​អាច​សរសេរ​ឯកសារ ៖\n"
+"  %s ។"
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1245,10 +2387,29 @@ msgid "Error (file may not have been written): %s"
 msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %hs"
 
 #: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr "កំពុង​​ចម្លង​​ទិន្នន័យ​​អូឌីយ៉ូ​​ទៅ​​គម្រោង..."
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
 msgstr "កំពុង​​ចម្លង​​ទិន្នន័យ​​អូឌីយ៉ូ​​ទៅ​​គម្រោង..."
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "ឯកសារ​​ទាំងអស់ (*)|*"
 
@@ -1259,6 +2420,14 @@ msgid "AUP3 project files"
 msgstr "រក្សាទុក​​ឯកសារ​​ទិន្នន័យ​​គម្រោង"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "ឈ្មោះ​ឯកសារ ៖"
 
@@ -1266,12 +2435,24 @@ msgstr "ឈ្មោះ​ឯកសារ ៖"
 msgid "XML files"
 msgstr "ឯកសារ MP3"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "ឯកសារ MP3"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -1298,6 +2479,14 @@ msgstr "ទំនាក់ទំនង​​ដោយ​ស្វ័យ​​ប
 msgid "Enhanced Autocorrelation"
 msgstr "ទំនាក់ទំនង​​ដោយ​​ស្វ័យ​ប្រវត្តិ​​ដែល​​បាន​​បង្កើន"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "វិសាលគម"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1314,9 +2503,34 @@ msgstr "ប្រេកង់​​លីនេអ៊ែរ"
 msgid "Log frequency"
 msgstr "ប្រេកង់​​កំណត់​ហេតុ"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "ពង្រីក"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1331,6 +2545,14 @@ msgstr "ស្តេរ៉េអូ​ផ្ដេក"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "ទស្សន៍​​ទ្រនិច​ឆ្វេង ឆ្វេង"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Algorithm:"
@@ -1349,6 +2571,10 @@ msgid "&Function:"
 msgstr "សកម្មភាព"
 
 #: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Replot..."
 msgstr "ធ្វើ​​ម្ដង​ទៀត..."
 
@@ -1365,11 +2591,49 @@ msgstr "មាន​​អូឌីយ៉ូ​​ច្រើន​​ពេក
 msgid "Not enough data selected."
 msgstr "មិន​បាន​​ជ្រើស​​ទិន្នន័យ​​គ្រប់គ្រាន់ ។"
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "s"
+msgstr "មីល្លីវិនាទី"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "វិសាលគម"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "នាំចេញ​ទិន្នន័យ​វិសាល​គម​​ជា ៖"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "មិន​អាច​សរសេរ​ទៅ​កាន់​ឯកសារ ៖ "
@@ -1385,6 +2649,10 @@ msgstr "រយៈពេល​​ខុស​គ្នា (វិនាទី)\t�
 #: src/FreqWindow.cpp
 msgid "Plot Spectrum..."
 msgstr "វិសាលគម​​គ្រោង..."
+
+#: src/HelpText.cpp
+msgid "Welcome!"
+msgstr ""
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
@@ -1411,9 +2679,94 @@ msgstr "ថត"
 msgid "Recording - Setting the Recording Level"
 msgstr "ថត"
 
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "នាំ​ឯកសារ​ចេញ"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "បើក​​គម្រោង Audacity"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
 #: src/HelpText.cpp
 msgid "No Local Help"
 msgstr "គ្មាន​ជំនួយ​​មូលដ្ឋាន"
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1432,6 +2785,10 @@ msgid "Used Space"
 msgstr "ទំហំ​ថាស"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "មិន​ធ្វើ​កម្រិត​​ដែល​​មាន​វិញ"
 
@@ -1445,6 +2802,10 @@ msgid "&Discard"
 msgstr "បោះបង់"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "បោះបង់"
 
@@ -1452,15 +2813,39 @@ msgstr "បោះបង់"
 msgid "&Compact"
 msgstr "ពាក្យ​បញ្ជា"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "ប្រវត្តិ..."
 
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
 #: src/InconsistencyException.h
 msgid "Internal Error"
 msgstr "(កម្មវិធី​ខាងក្រៅ)"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "បាន​កែ​សម្រួល​​ស្លាក"
 
 #. i18n-hint: (noun).  A track contains waves, audio etc.
 #: src/LabelDialog.cpp
@@ -1468,7 +2853,9 @@ msgid "Track"
 msgstr "បទ"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "ស្លាក"
 
@@ -1525,19 +2912,47 @@ msgstr "បទ​ស្លាក​​ថ្មី"
 msgid "Enter track name"
 msgstr "បញ្ចូល​ឈ្មោះ​​បទ"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "បទ​​ស្លាក"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "ដំបូង​រត់ Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "ជ្រើស​​ភាសា​​សម្រាប់ Audacity ដើម្បី​​ប្រើ ៖"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "អះអាង"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "កំហុស​ក្នុង​ការ​ព្យាយាម​រក្សា​ទុក​ឯកសារ ៖ "
 
 #: src/Legacy.cpp
 #, c-format
@@ -1549,8 +2964,19 @@ msgstr ""
 "ឯកសារ​​ចាស់​​ត្រូវ​បាន​​រក្សាទុក​​ជា '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "បើក​​គម្រោង Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "អរគុណ​ជា​ពិសេស​ ៖"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "រក​មើល..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1570,6 +2996,17 @@ msgstr "ធ្វើ​វិញ %s"
 msgid "&Redo"
 msgstr "ធ្វើ​វិញ"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "មិន​បាន​អនុញ្ញាត"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
@@ -1583,34 +3020,76 @@ msgstr "លាយ និង​​បង្ហាញ"
 msgid "Mixing and rendering tracks"
 msgstr "លាយ និង​បង្ហាញ​បទ"
 
+#: src/MixerBoard.cpp
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr "ឧបករណ៍​កំណត់​ពេល​ថត​របស់ Audacity"
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "កំណើន"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "បន្ទះ"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "ស្ងាត់"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "សូឡូ"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "​គ្រាប់​រំកិល​កំណើន​ដែល​បាន​ផ្លាស់ទី"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "​គ្រាប់​រំកិល​កំណើន​ដែល​បាន​ផ្លាស់ទី"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "​គ្រាប់រុញ​រំកិល​ដែល​បាន​ផ្លាស់ទី​"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "របារ​​ឧបករណ៍​​ឧបករណ៍​​លាយ​​សំឡេង​"
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1620,13 +3099,73 @@ msgid ""
 "Error: %s"
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "បាន​អនុញ្ញាត"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "គ្មាន"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "របារ​ឧបករណ៍​របស់ Audacity %s"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1636,18 +3175,126 @@ msgstr "កំណត់​ចំណាំ​បទ"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "ជីកាបៃ"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "សរសេរ​ជាន់​លើ​ឯកសារ​ដែល​មាន​ស្រាប់"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -1668,9 +3315,29 @@ msgstr[0] "សូម​អភ័យ​ទោស បាន​បរាជ័យ�
 msgid "Enable new plug-ins"
 msgstr "សូម​អភ័យ​ទោស បាន​បរាជ័យ​ក្នុងការ​ផ្ទុក​កម្មវិធី​ជំនួយ Vamp ។"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "អនុវត្ត​បែបផែន Nyquist..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "សូម​អភ័យ​ទោស បាន​បរាជ័យ​ក្នុងការ​ផ្ទុក​កម្មវិធី​ជំនួយ Vamp ។"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "បាន​អនុញ្ញាត"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -1697,6 +3364,25 @@ msgstr "បាន​អនុញ្ញាត"
 msgid "E&nabled"
 msgstr "បាន​អនុញ្ញាត"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "បាន​អនុញ្ញាត"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "ជ្រើស"
@@ -1705,7 +3391,8 @@ msgstr "ជ្រើស"
 msgid "C&lear All"
 msgstr "ជម្រះ"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "បាន​អនុញ្ញាត"
 
@@ -1744,6 +3431,14 @@ msgstr "មាន​បញ្ហា​ក្នុង​ការ​បោះព
 msgid "Print"
 msgstr "បោះពុម្ព"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgid "Actual Rate: %d"
@@ -1759,6 +3454,21 @@ msgstr "កំហុស​​ពេល​​កំពុង​​បើក​​
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "ដើម្បី​​គ្រោង​​វិសាលគម បទ​​ដែល​​ជ្រើស​​ទាំងអស់​ត្រូវ​តែ​មាន​អត្រា​​គំរូ​​ដូច​គ្នា ។"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "ថត​អូឌីយ៉ូ"
@@ -1767,9 +3477,99 @@ msgstr "ថត​អូឌីយ៉ូ"
 msgid "Record"
 msgstr "ថត R"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "បិទ​​គម្រោង​​ភ្លាមៗ​​ដោយ​​គ្មាន​ការ​ផ្លាស់ប្ដួរ"
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "មិន​អាច​បើក​ឯកសារ​គម្រោង"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Treat missing audio as silence (this session only)"
+msgstr "បំពេញ​​ដោយ​​ស្ងាត់​​សម្រាប់​​ទិន្នន័យ​​បង្ហាញ​​ដែល​​បាត់ [តែ​សម័យ​​នេះ​ប៉ុណ្ណោះ]"
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Fill in silence for missing display data (this session only)"
@@ -1779,11 +3579,88 @@ msgstr "បំពេញ​​ដោយ​​ស្ងាត់​​សម្រ
 msgid "Close project immediately with no further changes"
 msgstr "បិទ​​គម្រោង​​ភ្លាមៗ​​ដោយ​​គ្មាន​​កា​រផ្លាស់ប្ដូរ​​ផ្សេង​​ទៀត"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "វឌ្ឍនភាព"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "ជម្រះ​​ថត​​ឃ្លាំង​សម្ងាត់"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning: Problems in Automatic Recovery"
+msgstr "កំហុស​ក្នុង​ការ​ព្យាយាម​រក្សា​ទុក​ឯកសារ ៖ "
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "ធ្វើ​ឲ្យ​សម​នឹង​​​​គម្រោង"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1822,11 +3699,96 @@ msgid ""
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1835,12 +3797,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "មិនអាចចាប់ផ្តើមស្ទ្រីម MP3​ បាន​ទេ"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "មិន​អាច​​ប្ដូរ​ឈ្មោះ '%s' ទៅ​​ជា '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1851,9 +3839,9 @@ msgid "Error Writing to File"
 msgstr "កំហុស​ក្នុង​ការ​ព្យាយាម​រក្សា​ទុក​ឯកសារ ៖ "
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1864,8 +3852,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "គម្រោង​ថ្មី​ដែល​បាន​បង្កើត"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "របារ​ឧបករណ៍​របស់ Tenacity %s"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -1873,9 +3870,21 @@ msgstr "របារ​ឧបករណ៍​របស់ Tenacity %s"
 msgid "(Recovered)"
 msgstr "(ការ​សង្គ្រោះ​ឯកសារ)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "មិន​អាច​បើក​ឯកសារ​គម្រោង"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -1890,14 +3899,62 @@ msgid "Unable to parse project information."
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "រក្សាទុក​គម្រោង"
 
-#: src/ProjectFileManager.cpp
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "អនុវត្ត​បែបផែន ៖ %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "រក្សាទុក​គម្រោង"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
+msgstr ""
+"គម្រោង​មួយ​ចំនួន​មិន​ត្រូវ​បាន​រក្សាទុកត្រឹមត្រូវ​ទេ នៅ​ពេលចុង​ក្រោយដែល Audacity ត្រូវ​បាន​រត់ ។\n"
+"ជា​កុសល គម្រោង​ដូច​ខាង​ក្រោម​អាច​ត្រូវ​បាន​សង្គ្រោះ​ដោយ​ស្វ័យ​ប្រវត្តិ ៖"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
 msgstr ""
 "គម្រោង​មួយ​ចំនួន​មិន​ត្រូវ​បាន​រក្សាទុកត្រឹមត្រូវ​ទេ នៅ​ពេលចុង​ក្រោយដែល Audacity ត្រូវ​បាន​រត់ ។\n"
 "ជា​កុសល គម្រោង​ដូច​ខាង​ក្រោម​អាច​ត្រូវ​បាន​សង្គ្រោះ​ដោយ​ស្វ័យ​ប្រវត្តិ ៖"
@@ -1906,9 +3963,42 @@ msgstr ""
 msgid "Project Recovered"
 msgstr "គម្រោង​​ត្រូវ​បាន​សង្គ្រោះ"
 
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "ថត​ឯកសារ​បណ្ដោះ​អាសន្ន"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "រក្សាទុក​គម្រោង"
+
 #: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "ទំហំ​ថាស"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -1916,9 +4006,34 @@ msgid "Saved %s"
 msgstr "បាន​រក្សា​ទុក %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "រក្សាទុក​គម្រោង​ជា..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -1926,9 +4041,21 @@ msgid "Overwrite Project Warning"
 msgstr "សរសេរ​ជាន់​លើ​ឯកសារ​ដែល​មាន​ស្រាប់"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "រក្សាទុក​គម្រោង​ជា..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -1951,6 +4078,23 @@ msgstr "ជ្រើស​ឯកសារ​អូឌីយ៉ូ​មួយ �
 msgid "%s is already open in another window."
 msgstr "%s បើក​រួច​ហើយ​នៅ​ក្នុង​បង្អួច​ផ្សេង ។"
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
@@ -1967,6 +4111,17 @@ msgid ""
 msgstr ""
 "ឯកសារ​ប្រហែល​ជា​មិន​ត្រឹមត្រូវ ឬ​ខូច ៖ \n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -1994,12 +4149,33 @@ msgid "Error Importing"
 msgstr "កំហុស​ក្នុង​ការ​នាំ​ចូល"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "រក្សាទុក​គម្រោង"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "មិន​អាច​បើក​ឯកសារ​គម្រោង"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "ពាក្យ​បញ្ជា"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2010,8 +4186,8 @@ msgid "Automatic database backup failed."
 msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ័យ​ប្រវត្តិ"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "សូម​ស្វាគមន៍​មក​កាន់ Audacity កំណែ %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2025,9 +4201,47 @@ msgid "Save project before closing?"
 msgstr "រក្សា​ទុក​ការ​ផ្លាស់ប្ដូរ មុន​ពេល​បិទ ?"
 
 #: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "Disk space remaining for recording: %s"
 msgstr "មាន​ទំហំ​ថាស​សម្រាប់​ថត %d នាទី ។"
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2044,6 +4258,26 @@ msgstr "ស្តេរ៉េអូ​ផ្ដេក"
 msgid "Vertical Scrollbar"
 msgstr "ស្តេរ៉េអូ​បញ្ឈរ"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "គុណភាព ៖"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "គុណភាព"
@@ -2051,6 +4285,10 @@ msgstr "គុណភាព"
 #: src/Resample.cpp
 msgid "High Quality"
 msgstr "គុណភាព"
+
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
 
 #. i18n-hint: Audio data bit depth (precision): 16-bit integers
 #: src/SampleFormat.cpp
@@ -2067,9 +4305,86 @@ msgstr "២៤ ប៊ីត PCM"
 msgid "32-bit float"
 msgstr "៣២ ប៊ីត float"
 
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "ជ្រើស​ទីតាំង​ដើម្បី​រក្សា​ទុក​ឯកសារ​ដែល​​ដែលបាននាំចេញ"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "រក្សា​ទុក​ការ​ផ្លាស់ប្ដូរ ?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "ជ្រើស..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "ទំហំ​មុខ"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "ទំហំ​មុខ"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "White Bkgnd"
+msgstr "ពណ៌ស"
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr " បង្អួច"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "ប្រភេទ​បង្អួច ៖"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប្បន្ន"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "ឧបករណ៍"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -2083,7 +4398,13 @@ msgstr "ឯកសារ​​ទាំងអស់ (*)|*"
 msgid "All Preferences"
 msgstr "​ចំណូលចិត្ត..."
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "ជម្រើស"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "ជម្រើស"
 
@@ -2091,47 +4412,153 @@ msgstr "ជម្រើស"
 msgid "Timer"
 msgstr "ពេលវេលា​​បញ្ចប់"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "ឧបករណ៍"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "ការ​ចម្លង"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "ឧបករណ៍​លាយ"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "ម៉ែត្រ"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "ឧបករណ៍​វាស់​ពេលចាក់"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "កែសម្រួល"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "ឧបករណ៍"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "ចាក់​នៅ​ល្បឿន"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "របារ​ឧបករណ៍​​កែសម្រួល"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
 msgstr "បន្ទះ​បទ"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "បទ"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "បទ"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "បទ​​ថ្មី"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "ចាក់​​មួយ​​វិនាទី"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "បទ"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "បទ"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "បទ"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "ជ្រើស​ទីតាំង​ដើម្បី​រក្សា​ទុក​ឯកសារ​ដែល​​ដែលបាននាំចេញ"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (សារ​នេះ)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
@@ -2149,8 +4576,32 @@ msgstr "ជម្រើស..."
 msgid "Debu&g"
 msgstr "បំបាត់​កំហុស"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "បើក​ការ​ខ្ទាស់"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Sound Activated Record"
+msgstr "ឧបករណ៍​កំណត់​ពេល​ថត​របស់ Audacity"
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "ការ​ពង្រីក (dB) ៖"
+
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "សូម​ស្វាគមន៍​មក​កាន់ Audacity !"
 
 #: src/SplashDialog.cpp
@@ -2190,6 +4641,19 @@ msgid "Comments"
 msgstr "មតិយោបល់"
 
 #: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "កម្រិត ៖"
+
+#: src/Tags.cpp
 msgid "&Add"
 msgstr "បន្ថែម"
 
@@ -2202,12 +4666,27 @@ msgid "Genres"
 msgstr "ចង្វាក់"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "កែសម្រួល"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "កំណត់​ឡើង​វិញ"
+
+#: src/Tags.cpp
 msgid "Template"
 msgstr "ពុម្ព"
 
 #: src/Tags.cpp
 msgid "&Load..."
 msgstr "ផ្ទុក..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "លំនាំដើម"
 
 #: src/Tags.cpp
 msgid "Don't show this when exporting audio"
@@ -2234,26 +4713,67 @@ msgid "Unable to open genre file."
 msgstr "មិន​អាច​បើក​ឯកសារ​ចង្វាក់ ។"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Load Metadata As:"
+msgstr "រក្សាទុក​ទិន្នន័យ​មេតា​ជា ៖"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "កែ​សម្រួល​​ទិន្នន័យ​​មេតា"
+
+#: src/Tags.cpp
 msgid "Save Metadata As:"
 msgstr "រក្សាទុក​ទិន្នន័យ​មេតា​ជា ៖"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "បាន​អនុញ្ញាត"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "ថត​ឯកសារ​បណ្ដោះ​អាសន្ន"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity មិន​អាច​សរសេរ​ឯកសារ ៖\n"
 "  %s ។"
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2262,18 +4782,26 @@ msgstr ""
 "សម្រាប់​សរសេរ ។"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity មិន​អាច​សរសេរ​រូបភាព​ទៅ​ឯកសារ ៖\n"
 "  %s ។"
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -2283,9 +4811,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -2294,8 +4822,9 @@ msgstr ""
 "ប្រហែល​ជា​ទ្រង់ទ្រាយ png មិន​ល្អ ?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity មិន​អាច​អាន​ស្បែក​លំនាំ​ដើម​របស់​វា ។\n"
@@ -2333,18 +4862,40 @@ msgstr ""
 "បាន​បង្ហាញ​រួច​ហើយ ។"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity មិន​អាច​រក្សាទុក​ឯកសារ ៖\n"
 "  %s"
 
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "ស្រាល"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "ឈ្មោះ​បទ"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2353,12 +4904,24 @@ msgstr "ស្រាល"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "ថិរវេលា"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "បទ​​ពេលវេលា"
+
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "ឧបករណ៍​កំណត់​ពេល​ថត​របស់ Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -2366,8 +4929,60 @@ msgid "Save Timer Recording As"
 msgstr "ថត"
 
 #: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "អនុវត្ត​បែបផែន ៖ %s"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "កំពុង​​ថត​​អូឌីយ៉ូ"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ័យ​ប្រវត្តិ"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "កំហុស​ក្នុង​ការ​ព្យាយាម​រក្សា​ទុក​ឯកសារ ៖ "
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ័យ​ប្រវត្តិ"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "កំហុស​ក្នុង​ការ​ព្យាយាម​រក្សា​ទុក​ឯកសារ ៖ "
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "ថត"
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -2376,6 +4991,12 @@ msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប
 #: src/TimerRecordDialog.cpp
 msgid "Recording start:"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "ថិរវេលា"
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
@@ -2391,6 +5012,11 @@ msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ
 
 #: src/TimerRecordDialog.cpp
 msgid "Action after Timer Recording:"
+msgstr "ឧបករណ៍​កំណត់​ពេល​ថត​របស់ Audacity"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "ឧបករណ៍​កំណត់​ពេល​ថត​របស់ Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -2410,12 +5036,44 @@ msgid ""
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "ថត"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
 "\n"
 "Recording exported: %s"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "ថត"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
@@ -2436,16 +5094,32 @@ msgstr "0100 ថ្ងៃ 024 ម៉ោង 060 នាទី 060 វិនាទ�
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "កាលបរិច្ឆេទ និង​ពេល​វេលា​ចាប់ផ្ដើម"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "ពេលវេលា​​ចាប់ផ្ដើម"
 
 #: src/TimerRecordDialog.cpp
 msgid "End Date and Time"
 msgstr "កាល​បរិច្ឆេទ និង​ពេល​វេលា​បញ្ចប់"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date"
+msgstr "កាល​បរិច្ឆេទ និង​ពេល​វេលា​បញ្ចប់"
+
+#: src/TimerRecordDialog.cpp
 msgid "Automatic Save"
+msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ័យ​ប្រវត្តិ"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
 msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ័យ​ប្រវត្តិ"
 
 #: src/TimerRecordDialog.cpp
@@ -2468,7 +5142,8 @@ msgstr "មិន​អាច​នាំ​ចេញ"
 msgid "Export Project As:"
 msgstr "នាំចេញ​​ស្លាក​ជា ៖"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "ជម្រើស..."
 
@@ -2477,8 +5152,25 @@ msgid "After Recording completes:"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "បិទ Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -2488,11 +5180,24 @@ msgstr "កំពុង​​ថត​​អូឌីយ៉ូ"
 msgid "Scheduled to stop at:"
 msgstr "ជជ្រើស​ដើម្បី​ចាប់ផ្ដើម ប្ដូរ(Shift)+ដើម(Home)"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr "ឧបករណ៍​កំណត់​ពេល​ថត​របស់ Audacity"
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -2503,8 +5208,19 @@ msgid "Recording Exported:"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "ឧបករណ៍​កំណត់​ពេល​ថត​របស់ Audacity"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "ស្តេរ៉េអូ "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -2534,6 +5250,15 @@ msgstr "សូឡូ"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "ជ្រើស"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "ជ្រើស​សំឡេង"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -2612,6 +5337,10 @@ msgstr "ផ្លាស់ទី​បទ​ឡើង​លើ"
 msgid "Move Track Down"
 msgstr "ផ្លាស់ទី​បទ​ចុះ​ក្រោម"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -2657,21 +5386,80 @@ msgstr "មិន​មាន​បន្ទប់​គ្រប់គ្រា
 msgid "There is not enough room available to expand the cut line"
 msgstr "មិន​មាន​បន្ទប់​គ្រប់គ្រាន់​ដើម្បី​ពង្រីក​បន្ទាត់​កាត់"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "កំពុង​​អនុវត្ត..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "ជ្រើស​​ពាក្យ​បញ្ជា"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "ពាក្យ​បញ្ជា"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "ធ្វើ %s ម្ដង​ទៀត បញ្ជា(Ctrl)+R"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -2681,6 +5469,15 @@ msgstr "ចម្លង​ស្លាក"
 msgid "Threshold:"
 msgstr "កម្រិត​ពន្លឺ ៖"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "ពេលវេលា​ពន្យារ (វិនាទី) ៖"
@@ -2688,6 +5485,10 @@ msgstr "ពេលវេលា​ពន្យារ (វិនាទី) ៖"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "កត្តា​បន្ថយ ៖"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -2709,9 +5510,38 @@ msgstr "បទ"
 msgid "Track 1"
 msgstr "បទ"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "ប្រភេទ​បង្អួច ៖"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -2737,17 +5567,55 @@ msgstr "ខ្ទាស់"
 msgid "Envelopes"
 msgstr "ស្រោម​សំបុត្រ"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "ស្លាក"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "ម៉ែត្រ"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "ទ្រង់ទ្រាយ ៖"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "ផ្លាស់ទី​បទ​ចុះ​ក្រោម"
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "ម៉ែត្រ"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
 
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
@@ -2756,6 +5624,18 @@ msgstr "មតិយោបល់"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "ពាក្យបញ្ជា ៖"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -2774,6 +5654,11 @@ msgid "Number of Channels:"
 msgstr "ចំនួន​ដង​ដើម្បី​ធ្វើ​ម្តង​ទៀត ៖"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "នាំចេញ​ច្រើន"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "នាំចេញ​ច្រើន"
 
@@ -2781,9 +5666,26 @@ msgstr "នាំចេញ​ច្រើន"
 msgid "Builtin Commands"
 msgstr "ជ្រើស​​ពាក្យ​បញ្ជា"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "ក្រុម​​​គាំទ្រ​​របស់ Audacity %s"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "កាល​បរិច្ឆេទ និង​ពេល​វេលា​បញ្ចប់"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -2825,17 +5727,45 @@ msgstr "រក្សាទុក​គម្រោង"
 msgid "Saves a copy of current project."
 msgstr "រក្សាទុក​គម្រោង"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "​ចំណូលចិត្ត..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "ឈ្មោះ"
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "​ចំណូលចិត្ត..."
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "កម្រិត ៖"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -2854,8 +5784,18 @@ msgid "Window Plus"
 msgstr "ប្រភេទ​បង្អួច ៖"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "ឧបករណ៍"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "បែបផែន"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Scriptables"
@@ -2897,6 +5837,10 @@ msgstr "បទ"
 msgid "All Tracks Plus"
 msgstr "បន្ទះ​បទ"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -2904,9 +5848,30 @@ msgid "White"
 msgstr "ពណ៌ស"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "កំហុស​ក្នុង​ការ​ព្យាយាម​រក្សា​ទុក​ឯកសារ ៖ "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "ឧបករណ៍​​រូបថត​​អេក្រង់..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -2949,6 +5914,14 @@ msgid "Select Frequencies"
 msgstr "ប្រេកង់ (Hz)"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "បទ"
 
@@ -2960,6 +5933,12 @@ msgstr "ជ្រើស"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "បន្ថែម"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "យកចេញ"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -2978,6 +5957,11 @@ msgid "Selects a time range."
 msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
 
@@ -2989,9 +5973,37 @@ msgstr "ថិរវេលាស្ងាត់ ៖"
 msgid "Set Clip"
 msgstr "ឧបករណ៍​​​បន្ទាប់ D"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "ចាប់ផ្ដើម"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -3010,9 +6022,14 @@ msgid "Edited Envelope"
 msgstr "ស្រោម​សំបុត្រ"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "ស្រោម​សំបុត្រ"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -3022,6 +6039,10 @@ msgstr "ពុះ​​ស្លាក"
 msgid "Label Index"
 msgstr "កែសម្រួល​ស្លាក"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "ជ្រើស"
@@ -3029,6 +6050,10 @@ msgstr "ជ្រើស"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "បាន​កែ​សម្រួល​​ស្លាក"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -3042,9 +6067,26 @@ msgstr "កំណត់​អត្រា"
 msgid "Resize:"
 msgstr "ទំហំ​មុខ"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "ស្រាល"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "រក្សាទុក​គម្រោង"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -3059,6 +6101,10 @@ msgid "Set Track Status"
 msgstr "ឈ្មោះ​បទ"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "ផ្អាក P"
 
@@ -3071,10 +6117,17 @@ msgid "Gain:"
 msgstr "កំណើន"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "បទ"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "លីនេអ៊ែរ"
 
@@ -3083,8 +6136,21 @@ msgid "Reset"
 msgstr "កំណត់​ឡើង​វិញ"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "ពេលវេលា​​បញ្ចប់"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
 msgstr "បង្ហាញ"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -3106,16 +6172,36 @@ msgstr "ការ​កំណត់​បែបផែន"
 msgid "Spectral Select"
 msgstr "ជម្រើស"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "បទ​​ថ្មី"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "ពង្រីក"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "ការ​ពង្រីក (dB) ៖"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "ការ​ពង្រីក (dB) ៖"
 
 #: src/effects/Amplify.cpp
@@ -3125,6 +6211,14 @@ msgstr "អាំភ្លី​កំពូល​ថ្មី (dB) ៖"
 #: src/effects/Amplify.cpp
 msgid "Allo&w clipping"
 msgstr "អនុញ្ញាត​ឲ្យ​ច្រឹប"
+
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
 
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
@@ -3140,12 +6234,18 @@ msgstr "អ្នក​ជ្រើស​បទ ដែល​មិន​មា�
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck ត្រូវតែ​ត្រួតពិនិត្យ​បទ​​ ដែល​ត្រូវ​បាន​ដាក់​ពី​ក្រោម​បទ​ដែល​ជ្រើស ។"
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "ចំនួន​ Duck សរុប ៖"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "វិនាទី"
 
@@ -3169,7 +6269,8 @@ msgstr "ប្រវែង​ផតចុះ​ខាង​ក្នុង ៖"
 msgid "Inner &fade up length:"
 msgstr "ប្រវែង​ផុសចេញ​ខាង​ក្នុង ៖"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "កម្រិត​ពន្លឺ ៖"
 
@@ -3178,8 +6279,17 @@ msgid "Preview not available"
 msgstr "មិន​មាន​ការ​មើល​ជាមុន"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "បង្រួញ​​ជម្រើស​ទៅ​ឆ្វេង បញ្ជា(Ctrl)+ប្ដូរ(Shift)+ស្ដាំ"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "កម្រិត​​ពន្លឺ​​សម្រាប់​​ការ​រំខាន ៖"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3190,12 +6300,31 @@ msgid "Ba&ss (dB):"
 msgstr "ដំឡើង (dB) ៖"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "ដំឡើង​បាស"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "កម្រិត ៖"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "កែសម្រួល​ស្លាក"
+
+#: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
 msgstr "កម្រិត ៖"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "កម្រិត ៖"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -3206,13 +6335,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "ផ្លាស់ប្តូរ​កម្ពស់​សំឡេង​ដោយ​មិន​ផ្លាស់ប្តូរ​ចង្វាក់​ភ្លេង"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "គុណភាព"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "ផ្លាស់ប្តូរ​កម្ពស់​សំឡេង​ដោយ​មិន​ផ្លាស់ប្តូរ​ចង្វាក់​ភ្លេង"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "កម្ពស់​សំឡេង (EAC)"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -3246,13 +6397,40 @@ msgstr "សំឡេង​ពាក់​កណ្តាល (ជំហាន​�
 msgid "Frequency"
 msgstr "ប្រេកង់ (Hz)"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "ទៅ"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "ភាគរយ​ផ្លាស់ប្តូរ ៖"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "ភាគរយ​ផ្លាស់ប្តូរ ៖"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -3264,7 +6442,9 @@ msgstr "៧"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "មិនមាន"
 
@@ -3283,6 +6463,32 @@ msgstr "ផ្លាស់ប្តូរ​ល្បឿន​ប៉ះពាល
 #: src/effects/ChangeSpeed.cpp
 msgid "&Speed Multiplier:"
 msgstr "នាំចេញ​ច្រើន"
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -3304,6 +6510,12 @@ msgstr ""
 msgid "Current length of selection."
 msgstr "កាត់​​តម្រឹម​​ឯកសារ​​ទៅ​​ការ​​ជ្រើស"
 
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
+
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
 msgstr "ប្រវែង"
@@ -3323,8 +6535,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "ផ្លាស់ប្តូរ​ចង្វាក់​ភ្លេង​ដោយ​មិន​ផ្លាស់ប្តូរ​កម្ពស់​សំឡេង"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "គុណភាព"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "ផ្លាស់ប្តូរ​ចង្វាក់​ភ្លេង​ដោយ​មិន​ផ្លាស់ប្តូរ​កម្ពស់​សំឡេង"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -3335,6 +6572,12 @@ msgstr "ទៅ"
 #: src/effects/ChangeTempo.cpp
 msgid "Length (seconds)"
 msgstr "ប្រវែង (វិនាទី)"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "from"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -3352,15 +6595,101 @@ msgid "Click Removal"
 msgstr "យក​ក្លីកចេញ"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "ឈ្មោះ​មិន​អាច​ទទេ​បាន​ទេ"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "ជ្រើស​កម្រិត​​ពន្លឺ (កាន់​តែ​ទាប​ កាន់​តែ​​ប្រសើរ) ៖"
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "កម្រិត​ពន្លឺ ៖"
 
 #: src/effects/ClickRemoval.cpp
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "ទទឹង​ spike អតិបរមា (កាន់​តែ​ខ្ពស់​ កាន់​តែ​ប្រសើរ) ៖"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "ឧបករណ៍​បង្ហាប់..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "ពេល​វេលា​វាយ ៖ %.1f វិនាទី"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "ប្រភេទ​ការរំខាន"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "ការ​រំខាន..."
+
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "ថិរវេលា"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "ថិរវេលា"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -3371,16 +6700,48 @@ msgid "&Attack Time:"
 msgstr "​ពេល​វេលា​វាយ ៖"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "​ពេល​វេលា​វាយ ៖"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "ពេល​វេលា​វាយ ៖ %.1f វិនាទី"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "ពេល​វេលា​វាយ ៖ %.1f វិនាទី"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "កម្រិត​ពន្លឺ ៖ %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -3393,29 +6754,272 @@ msgid "Release Time %.1f secs"
 msgstr "ពេល​វេលា​វាយ ៖ %.1f វិនាទី"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "ចុង"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "កម្រិត ៖"
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "ជម្រើស​ស្ងាត់"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "កាល​បរិច្ឆេទ និង​ពេល​វេលា​បញ្ចប់"
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "ជម្រើស​ស្ងាត់"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "R&eset"
 msgstr "កំណត់​ឡើង​វិញ"
 
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "​ចំណូលចិត្ត..."
+
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "ជំនួយ"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "មិន​អាច​​កំណត់"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr ""
+"មិន​អាច​បង្កើត​ថត ៖\n"
+"  %s"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "នាំចេញ​​ស្លាក​ជា ៖"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "បាន​ប្ដូរ​ឈ្មោះ '%s' ទៅ '%s'"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "ធ្វើ​​ម្ដង​​ទៀត"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "លំនាំដើម"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "ពុម្ពអក្សរ..."
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -3426,8 +7030,125 @@ msgid "Soft Clipping"
 msgstr "បង្ហាញ​​កា​រច្រឹប"
 
 #: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "ឧបករណ៍​បង្ហាប់​ជួរ​ថាមវន្ត"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Leveller"
+msgstr "Leveller..."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "ថិរវេលា"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "រក​កា​ខ្ទាស់"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -3450,8 +7171,16 @@ msgid "Distortion"
 msgstr "ថិរវេលា"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​រហ័ស"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -3466,8 +7195,26 @@ msgid "Clipping level"
 msgstr "ខ្ទាស់"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "អនុវត្ត​ច្រវាក់"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "កម្រិត​ពន្លឺ ៖"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "ថិរវេលា"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -3478,12 +7225,69 @@ msgid "Repeat processing"
 msgstr "កំពុង​ដំណើរ​ការ Auto Duck..."
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "កម្រិត​នៃ Leveling"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "រក​កា​ខ្ទាស់"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "ល្បឿន​ចាក់​ឡើងវិញ"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "ល្បឿន​ចាក់​ឡើងវិញ"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "សំឡេង DTMF..."
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -3493,7 +7297,9 @@ msgstr "លំដាប់ DTMF ៖"
 msgid "&Amplitude (0-1):"
 msgstr "អាំភ្លី (០-១)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "ថិរវេលា"
 
@@ -3506,12 +7312,29 @@ msgid "Duty cycle:"
 msgstr "ខួបមុខងារ ៖"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "ថិរវេលា​​សំឡេង ៖"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "ថិរវេលាស្ងាត់ ៖"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -3520,6 +7343,11 @@ msgstr "អេកូ"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "​នាំចេញ​អូឌីយ៉ូ​ទៅជា %s"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -3530,6 +7358,10 @@ msgid "D&ecay factor:"
 msgstr "កត្តា​បន្ថយ ៖"
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "ការ​​កំណត់ជា​​ស្រេច"
 
@@ -3537,7 +7369,8 @@ msgstr "ការ​​កំណត់ជា​​ស្រេច"
 msgid "Export Effect Parameters"
 msgstr "កែសម្រួល​ប៉ារ៉ាម៉ែត្រ"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "មិន​អាច​បើក​ឯកសារ ៖ \"%s\""
@@ -3561,6 +7394,12 @@ msgstr "កែសម្រួល​ប៉ារ៉ាម៉ែត្រ"
 msgid "%s: is not a valid presets file.\n"
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "រៀបចំការ​​មើល​ជា​មុន"
@@ -3568,6 +7407,15 @@ msgstr "រៀបចំការ​​មើល​ជា​មុន"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "ការ​មើលជា​មុន"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -3591,6 +7439,11 @@ msgstr "ការ​​កំណត់ជា​​ស្រេច"
 msgid "User Presets"
 msgstr "ការ​កំណត់​បែបផែន"
 
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "លំនាំដើម"
+
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
 msgstr "ការ​កំណត់​បែបផែន"
@@ -3600,8 +7453,28 @@ msgid "Factory Defaults"
 msgstr "លំនាំដើម"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr "សូម​អភ័យ​ទោស កម្មវិធី​ជំនួយ Vamp បាន​បរាជ័យ​ក្នុងកា​រចាប់ផ្ដើម ។"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -3620,6 +7493,27 @@ msgid "Latency: 0"
 msgstr "គម្លាត​ពេល"
 
 #: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "បាន​តម្រឹម"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "ផ្លាស់ទី​ឡើងលើ"
 
@@ -3636,6 +7530,24 @@ msgid "Move effect down in the rack"
 msgstr "ផ្លាស់ទី​ឈុត​ទៅ​បទ​មួយផ្សេង​ទៀត"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "ផ្លាស់ទី​ឈុត​ទៅ​បទ​មួយផ្សេង​ទៀត"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "បញ្ចូល​ឈ្មោះ​របស់​ច្រវាក់​ថ្មី"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "គម្លាត​ពេល"
@@ -3643,6 +7555,20 @@ msgstr "គម្លាត​ពេល"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "ជ្រើស​​ពាក្យ​បញ្ជា"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "គ្រប់គ្រង​​ប្រវត្តិ"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "ចាក់ឡើងវិញ"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3659,6 +7585,16 @@ msgid "&Preview effect"
 msgstr "មើល​ជា​មុន​ មុននឹង​​កាត់​តំបន់ ៖"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "រំលង​ដើម្បី​ចាប់ផ្ដើម ដើម"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "រំលង​ដើម្បី​ចាប់ផ្ដើម ដើម"
+
+#: src/effects/EffectUI.cpp
 msgid "Skip forward"
 msgstr "រំលង​ដើម្បី​ចាប់ផ្ដើម ដើម"
 
@@ -3673,6 +7609,11 @@ msgstr "បាន​អនុញ្ញាត"
 #: src/effects/EffectUI.cpp
 msgid "Save Preset..."
 msgstr "រក្សាទុក​ជា..."
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "ការ​​កំណត់ជា​​ស្រេច"
 
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
@@ -3691,9 +7632,24 @@ msgid "Options..."
 msgstr "ជម្រើស..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "ម៉ែត្រ"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "ឈ្មោះ"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "កំពុង​​ដាក់​បញ្ច្រាស"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "កំហុស ៖ "
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -3701,9 +7657,18 @@ msgid "Description: %s"
 msgstr "ការ​ចម្លង"
 
 #: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "តើ​​អ្នក​​ប្រាកដ​​ជា​​ចង់​​លុប %s ឬ ?"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "រក្សាទុក​ជា..."
 
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
@@ -3730,6 +7695,11 @@ msgstr "ចាក់ឡើងវិញ"
 msgid "Play"
 msgstr "ចាក់"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "កូស៊ីនុស"
@@ -3751,6 +7721,18 @@ msgid "Graphic EQ"
 msgstr "ក្រាហ្វិក EQ"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "ដំឡើង​បាស"
 
@@ -3759,8 +7741,35 @@ msgid "Bass Cut"
 msgstr "ដំឡើង​បាស"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "កែសម្រួល​ស្លាក"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "កែសម្រួល​ស្លាក"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -3775,16 +7784,55 @@ msgid "Effect Unavailable"
 msgstr "មិន​មាន​ការ​មើល​ជាមុន"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "dB អតិបរមា"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "dB អប្បបរមា"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "ម៉ែត្រ"
+
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "គូរ​ខ្សែ​កោង"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "ឧបករណ៍​គូរ F3"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -3795,8 +7843,54 @@ msgid "Interpolation type"
 msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​រហ័ស"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "ប្រេកង់​​លីនេអ៊ែរ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "ប្រេកង់​​លីនេអ៊ែរ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "ប្រវែង​នៃ​ការ​​មើល​ជាមុន"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "ប្រវែង​នៃ​ការ​​មើល​ជាមុន"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "ការ​​កំណត់ជា​​ស្រេច"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "ការ​​កំណត់ជា​​ស្រេច"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "ដាក់​បញ្ច្រាស"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Processing: "
@@ -3807,8 +7901,106 @@ msgid "D&efault"
 msgstr "លំនាំដើម"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "រត់ Benchmark..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "អនុវត្ត​បែបផែន ៖ %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "អនុវត្ត​អេហ្គុយ"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "គ្រប់គ្រង​​ប្រវត្តិ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "គូរ​ខ្សែ​កោង"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "ទស្សន៍​​ទ្រនិច​ឆ្វេង ឆ្វេង"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "ឈ្មោះ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "លុប"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "ជ្រើស..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "លំនាំដើម"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3816,14 +8008,42 @@ msgid "Rename '%s' to..."
 msgstr "បាន​ប្ដូរ​ឈ្មោះ '%s' ទៅ '%s'"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "សាកល្បង​​ឡើងវិញ"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "បាន​ប្ដូរ​ឈ្មោះ '%s' ទៅ '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "ឈ្មោះ​មុខ"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr "សរសេរ​ជាន់​លើ​ឯកសារ​ដែល​មាន​ស្រាប់"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "ផ្លាស់ទី​ចុះក្រោម"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "មិនអាច​នាំចេញ​អូឌីយ៉ូ​ទៅ %s​ បាន​ទេ"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3840,8 +8060,51 @@ msgid "Delete %d items?"
 msgstr "លុប​ស្លាក"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "មិន​អាច​យក​ចេញ​ឯកសារ​រក្សា​ទុក​ស្វ័យ​ប្រវត្តិ​ចាស់"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "នាំចេញ​ស្លាក..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "មិនអាច​នាំចេញ​អូឌីយ៉ូ​ទៅ %s​ បាន​ទេ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "ឧបករណ៍​ចាក់​ពេលថត"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "គ្មាន​​ស្លាក​​ត្រូវ​នាំចេញ ។"
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -3855,9 +8118,18 @@ msgstr "ផតចុះ"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "ចុច និង​អូស​ដើម្បី​ជ្រើស​អូឌីយ៉ូ"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "ចុច និង​អូស​ដើម្បី​ជ្រើស​អូឌីយ៉ូ"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "រក​កា​ខ្ទាស់"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -3871,13 +8143,47 @@ msgstr "កម្រិត​ពន្លឺ​ចាប់ផ្ដើម (គ�
 msgid "St&op threshold (samples):"
 msgstr "កម្រិត​ពន្លឺ​បញ្ចប់ (គំរូ) ៖"
 
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "មិន​មាន​បន្ទប់​គ្រប់គ្រាន់​ដើម្បី​បិទ​ភ្ជាប់​​ជម្រើស​ទេ"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "ដាក់​បញ្ច្រាស"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "អនុវត្ត​បែបផែន Nyquist..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "ធ្វើ​ឲ្យ​អាំភ្លី​អតិបរមា​ធម្មតា​ទៅ"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -3896,6 +8202,31 @@ msgstr "កំពុង​ដំណើរ​ការ Auto Duck..."
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "ធ្វើ​​ឲ្យ​ធម្មតា"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -3921,6 +8252,10 @@ msgid "Noise"
 msgstr "ការ​រំខាន..."
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "ប្រភេទ​ការរំខាន"
 
@@ -3933,16 +8268,73 @@ msgid "Second greatest"
 msgstr "វិនាទី"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "ពង្រីក​លំនាំដើម"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "ពង្រីក​លំនាំដើម"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "បន្ថយ​ការ​រំខាន (dB) ៖"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "បទ​ទាំងអស់​ត្រូវ​តែ​មាន​អត្រា​គំរូ​ដូចគ្នា"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -3950,6 +8342,11 @@ msgstr "ជម្រើស​តូច​ពេក​មិន​អាច​ប
 
 #: src/effects/NoiseReduction.cpp
 msgid "&Noise reduction (dB):"
+msgstr "បន្ថយ​ការ​រំខាន (dB) ៖"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
 msgstr "បន្ថយ​ការ​រំខាន (dB) ៖"
 
 #: src/effects/NoiseReduction.cpp
@@ -3980,6 +8377,11 @@ msgstr "បាន​ធ្វើ​ឡើងវិញ %d ដង"
 msgid "&Frequency smoothing (bands):"
 msgstr "ធ្វើ​ឲ្យ​ប្រេកង់​រលូន (Hz) ៖"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "ធ្វើ​ឲ្យ​ប្រេកង់​រលូន (Hz) ៖"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "ភាព​យល់ដឹង"
@@ -3993,8 +8395,9 @@ msgid "Step 1"
 msgstr "ជំហាន​ ១"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr "ជ្រើស​​វិនាទី​ខ្លះ​​របស់​​ការ​រំខាន ដូច្នេះ Audacity អាច​ដឹង​ថា​អ្វី​ដែល​ត្រូវ​ត្រង​ចេញ បន្ទាប់​មក​ចុច​យក​ទម្រង់​ការ​រំខាន ៖"
 
@@ -4012,6 +8415,27 @@ msgid ""
 "filtered out, and then click 'OK' to reduce noise.\n"
 msgstr "ជ្រើស​អូឌីយ៉ូ​ទាំងអស់​ដែល​អ្នក​ចង់​ត្រង​​ ជ្រើស​​ចំនួន​​ការ​រំខាន​ដែល​អ្នក​ចង់​ត្រង​ចេញ បន្ទាប់​មក​ចុច​ 'យល់ព្រម' ដើម្បី​យក​​ការ​​រំខាន​ចេញ ។\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "ការ​រំខាន..."
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "យក​បទ​​ចេញ"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "ទំហំ​មុខ"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "ជម្រើស​លាយ​កម្រិត​ខ្ពស់"
@@ -4023,6 +8447,11 @@ msgstr "ប្រភេទ​បង្អួច ៖"
 #: src/effects/NoiseReduction.cpp
 msgid "Window si&ze:"
 msgstr "ប្រភេទ​បង្អួច ៖"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "៧"
 
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
@@ -4036,11 +8465,44 @@ msgstr "២"
 msgid "64"
 msgstr "៤"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "២៥៦ - លំនាំដើម"
 
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
 msgid "2"
 msgstr "២"
 
@@ -4048,9 +8510,17 @@ msgstr "២"
 msgid "4 (default)"
 msgstr "ពង្រីក​លំនាំដើម"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "ការ​​យក​ការ​​រំខាន​​ចេញ"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -4063,6 +8533,11 @@ msgid "Noise re&duction (dB):"
 msgstr "បន្ថយ​ការ​រំខាន (dB) ៖"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "ភាព​យល់ដឹង"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr "ធ្វើ​ឲ្យ​ប្រេកង់​រលូន (Hz) ៖"
 
@@ -4070,13 +8545,70 @@ msgstr "ធ្វើ​ឲ្យ​ប្រេកង់​រលូន (Hz) �
 msgid "Attac&k/decay time (secs):"
 msgstr "ពេល​វេលា​វាយ/បន្ថយ (វិនាទី) ៖"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "ពេល​វេលា​វាយ/បន្ថយ (វិនាទី) ៖"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "យកចេញ"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "ធ្វើ​​ឲ្យ​ធម្មតា"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "​យក​ការ​រំខាន​ចេញ\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "​យក​ការ​រំខាន​ចេញ\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "​យក​ការ​រំខាន​ចេញ\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -4086,9 +8618,23 @@ msgstr "ធ្វើ​ឲ្យ​អាំភ្លី​អតិបរមា
 msgid "Peak amplitude dB"
 msgstr "អាំភ្លី​កំពូល​ថ្មី (dB) ៖"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "កត្តា​បន្ថយ ៖"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "កត្តា​បន្ថយ ៖"
@@ -4097,29 +8643,94 @@ msgstr "កត្តា​បន្ថយ ៖"
 msgid "&Time Resolution (seconds):"
 msgstr "ពេលវេលា​ពន្យារ (វិនាទី) ៖"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "ឧបករណ៍​កំណត់​ដំណាក់កាល"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "ដំណាក់កាល ៖"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "ដំណាក់កាល ៖"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "ប្រេកង់ LFO (Hz) ៖"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "ប្រេកង់ LFO (Hz) ៖"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "ដំណាក់​ចាប់ផ្តើម LFO (deg.) ៖"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "ដំណាក់​ចាប់ផ្តើម LFO (deg.) ៖"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "ជម្រៅ ៖"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "មតិ​អ្នកប្រើ (%) ៖"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "&Output gain (dB):"
@@ -4134,6 +8745,10 @@ msgid "Repair"
 msgstr "ជួសជុល"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -4143,9 +8758,22 @@ msgstr ""
 "\n"
 "ពង្រីក និង​ជ្រើស​ប្រភាគ​តូច​នៃ​ទីពីរ​ដើម្បី​ជួសជុល ។"
 
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "ធ្វើ​​ម្ដង​​ទៀត"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -4169,6 +8797,67 @@ msgstr "ប្រវែងជម្រើស​ថ្មី ៖"
 msgid "New selection length: %s"
 msgstr "ប្រវែងជម្រើស​ថ្មី ៖"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "យក​បទ​ចេញ"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "endian ធំ"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "ដាក់​បញ្ច្រាស"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "ទំហំ"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "ពេល​វេលា​វាយ/បន្ថយ (វិនាទី) ៖"
+
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
 msgstr "មតិ​អ្នកប្រើ (%) ៖"
@@ -4176,6 +8865,34 @@ msgstr "មតិ​អ្នកប្រើ (%) ៖"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "ជម្រៅ (%) ៖"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "ជម្រៅ (%) ៖"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "ឆានែល​លទ្ធផល ៖ %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "ឆានែល​លទ្ធផល ៖ %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "ស្តេរ៉េអូ"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -4190,13 +8907,98 @@ msgstr "ដាក់​បញ្ច្រាស"
 msgid "Reverses the selected audio"
 msgstr "​នាំចេញ​អូឌីយ៉ូ​ទៅជា %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "ផ្ទុក​ឯកសារ​ឡើង..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "ដើម្បី​​គ្រោង​​វិសាលគម បទ​​ដែល​​ជ្រើស​​ទាំងអស់​ត្រូវ​តែ​មាន​អត្រា​​គំរូ​​ដូច​គ្នា ។"
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "ម៉ែត្រ"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "តម្រឹម​​ចុង​​ដោយ​​ចុង​​ជម្រើស"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "ថិរវេលា"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "ថិរវេលា"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -4205,6 +9007,14 @@ msgstr "ប្រភេទ​បង្អួច ៖"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "ប្រភេទ​បង្អួច ៖"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -4220,6 +9030,15 @@ msgstr "កម្រិត​ពន្លឺ ៖"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "តម្រៀប​​តាម​​ពេល​វេលា"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "តម្រៀប​​តាម​​ពេល​វេលា"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -4258,15 +9077,28 @@ msgstr "លំនាំដើម"
 msgid "Restore Defaults"
 msgstr "លំនាំដើម"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "ស្ងាត់"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "ស្តេរីអូ​ទៅ​ជា​ម៉ូណូ"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -4283,6 +9115,43 @@ msgstr "អនុវត្ត​ស្តេរ៉េអូ​ទៅជា​​
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "កត្តា​បន្ថយ ៖"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​រហ័ស"
 
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
@@ -4309,12 +9178,40 @@ msgid "Tone"
 msgstr "សំឡេង..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "ទ្រង់ទ្រាយ​រលក ៖"
 
 #: src/effects/ToneGen.cpp
 msgid "&Frequency (Hz):"
 msgstr "ប្រេកង់ (Hz) ៖"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "ប្រេកង់ (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "ប្រេកង់ (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "អាំភ្លី (០-១)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "អាំភ្លី (០-១)"
 
 #: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
@@ -4325,8 +9222,20 @@ msgid "Truncate Detected Silence"
 msgstr "កាត់​ស្ងាត់​ឲ្យ​ខ្លី"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "កាត់​ស្ងាត់​ឲ្យ​ខ្លី"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -4336,11 +9245,38 @@ msgstr "ជ្រើស​ស្ងាត់"
 msgid "Tr&uncate to:"
 msgstr "កាត់​ស្ងាត់​ឲ្យ​ខ្លី"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "ឧបករណ៍​បង្ហាប់..."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "បែបផែន"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "មិនអាច​បើក​បណ្ណាល័យ​អ៊ិនកូឌីង MP3 បាន​ទេ !"
 
@@ -4348,8 +9284,32 @@ msgstr "មិនអាច​បើក​បណ្ណាល័យ​អ៊ិន
 msgid "VST Effect Options"
 msgstr "ការ​កំណត់​បែបផែន"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "ប្រវែង"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
+msgstr "បន្សំ​គ្រាប់ចុច"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
 msgstr "បន្សំ​គ្រាប់ចុច"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -4357,28 +9317,96 @@ msgid "Graphical Mode"
 msgstr "ក្រាហ្វិក EQ"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "រក្សា​ទុក​ការ​និយាយ​ជា ៖"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "នាំ​ឯកសារ​ចេញ"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "នាំ​ឯកសារ​ចេញ"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "ឯកសារ​​គម្រោង​​របស់ Audacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "អនុវត្ត​បែបផែន ៖ %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "ផ្ទុក​ឯកសារ"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "អនុវត្ត​បែបផែន ៖ %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "ការ​កំណត់​បែបផែន"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -4389,8 +9417,29 @@ msgid "Reso&nance:"
 msgstr "សំឡេង​ខ្ទរ ៖"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "សំឡេង​ខ្ទរ ៖"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "អុហ្វសិតប្រេកង់ Wah (%) ៖"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "អុហ្វសិតប្រេកង់ Wah (%) ៖"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "ការ​កំណត់​បែបផែន"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "ការ​កំណត់​បែបផែន"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -4405,16 +9454,42 @@ msgid "Audio Unit Effect Options"
 msgstr "ការ​កំណត់​បែបផែន"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "ចំណុច​ប្រទាក់"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "បង្រួញ​​ជម្រើស​ទៅ​ឆ្វេង បញ្ជា(Ctrl)+ប្ដូរ(Shift)+ស្ដាំ"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr " បង្អួច"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "បង្កើត"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "នាំ​ឯកសារ​ចេញ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -4490,19 +9565,74 @@ msgid "Failed to retrieve preset content"
 msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "កម្មវិធី​បម្លែង​អត្រា​គំរូ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "ឯកសារ​​អូឌីយ៉ូ"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "បែបផែន"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "បែបផែន"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "ការ​កំណត់​បែបផែន"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -4510,6 +9640,7 @@ msgstr "ការ​កំណត់​បែបផែន"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "បែបផែន"
@@ -4518,13 +9649,59 @@ msgstr "បែបផែន"
 msgid "LV2 Effect Settings"
 msgstr "ការ​កំណត់​បែបផែន"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "បង្កើត"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "បែបផែន"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "អនុវត្ត​បែបផែន Nyquist..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -4540,6 +9717,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "លទ្ធផល Nyquist ៖ "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "តម្រឹម​​ដោយ​​ចុង​​ជម្រើស"
 
@@ -4552,12 +9747,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "សូម​អភ័យទោស មិនអាច​អនុវត្ត​បែបផែន​លើ​បទ​ស្តេរ៉េអូ​បានទេ ដែល​បទ​មិនផ្គូផ្គង​គ្នា ។"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "លទ្ធផល Nyquist ៖ "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "កំពុង​ដំណើរ​ការ Auto Duck..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -4600,6 +9813,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist មិន​បាន​ត្រឡប់​អូឌីយ៉ូ ។\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Audacity កំណែ​នេះ​មិនទាន់​បាន​ចង​ក្រង​ជាមួយ %s គាំទ្រ ។"
@@ -4608,10 +9825,37 @@ msgstr "Audacity កំណែ​នេះ​មិនទាន់​បាន​
 msgid "Could not open file"
 msgstr "មិន​​អាច​​បើក​​ឯកសារ ៖ "
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "មិន​​អាច​​បើក​​ឯកសារ ៖ "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -4632,6 +9876,21 @@ msgid "Lisp scripts"
 msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "មិន​​អាច​​បើក​​ឯកសារ ៖ "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -4650,9 +9909,18 @@ msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
 msgid "Save file as"
 msgstr "រក្សាទុក​ឯកសារ"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "បែបផែន"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -4674,6 +9942,17 @@ msgstr "ការ​កំណត់​កម្មវិធី​ជំនួយ
 msgid "Program"
 msgstr "កម្មវិធី"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "ការ​កំណត់​បែបផែន"
+
 #: src/export/Export.cpp
 msgid "Export Audio"
 msgstr "នាំ​ឯកសារ​ចេញ"
@@ -4685,6 +9964,14 @@ msgstr "កែ​សម្រួល​​ស្លាក​​ទិន្នន
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "នាំចេញ"
+
+#: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -4758,6 +10045,11 @@ msgid "Output Channels: %2d"
 msgstr "ឆានែល​លទ្ធផល ៖ %2d"
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "បន្ទះ​បទ"
+
+#: src/export/Export.cpp
 #, c-format
 msgid ""
 "Unable to export.\n"
@@ -4768,10 +10060,25 @@ msgstr "មិន​អាច​នាំ​ចេញ"
 msgid "Show output"
 msgstr "បង្ហាញ​លទ្ធផល"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "អថេរ"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "ជ្រើស​​ពាក្យ​បញ្ជា"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -4802,9 +10109,128 @@ msgstr "លទ្ធផល​ពាក្យបញ្ជា"
 msgid "&OK"
 msgstr "យល់ព្រម"
 
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "កំហុស LOF"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "​នាំចេញ​អូឌីយ៉ូ​ទៅជា %s"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -4815,7 +10241,8 @@ msgstr "​នាំចេញ​អូឌីយ៉ូ​ទៅជា %s"
 msgid "Invalid sample rate"
 msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "ធ្វើ​គំរូ​ឡើង​វិញ"
 
@@ -4843,7 +10270,8 @@ msgstr "អត្រា​គំរូ"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -4855,6 +10283,17 @@ msgstr "អត្រា​ប៊ីត ៖"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "គុណភាព ៖"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "១"
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
 msgid "1"
@@ -4881,6 +10320,10 @@ msgid "7"
 msgstr "៧"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
 msgstr "១"
 
@@ -4893,6 +10336,10 @@ msgid "Constrained"
 msgstr "ថេរ"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "អូឌីយ៉ូ..."
 
@@ -4901,8 +10348,44 @@ msgid "Low Delay"
 msgstr "ប្រភេទ​គ្រាប់ចុច"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "endian ធំ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -4925,6 +10408,14 @@ msgid "Application:"
 msgstr "អនុវត្ត​ច្រវាក់"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប្បន្ន"
 
@@ -4933,21 +10424,433 @@ msgid "Current Codec:"
 msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប្បន្ន"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "អនុវត្ត​បែបផែន ៖ %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "សរសេរ​ជាន់​លើ​ឯកសារ​ដែល​មាន​ស្រាប់"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "អះអាង"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "មិន​ទាន់​មាន​ថត %s ទេ ។ បង្កើត​វា​ឬទេ ?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "បាន​ប្ដូរ​ឈ្មោះ '%s' ទៅ '%s'"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "ឆ្វេង"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "លាយ​មេ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "កំហុស LOF"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "កម្រិត ៖"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "កម្រិត ៖"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "កម្រិត ៖"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "ការ​​កំណត់ជា​​ស្រេច"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "ផ្ទុក​ឯកសារ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "នាំចេញ​​ស្លាក​ជា ៖"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "នាំចេញ​​ស្លាក​ជា ៖"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប្បន្ន"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "ការ​កំណត់​កម្មវិធី​ជំនួយ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "ភាសា ៖"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "គុណភាព ៖"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "អត្រា​គំរូ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "ឯកសារ​​ទាំងអស់ (*)|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "បញ្ជាក់​ជម្រើស FLAC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "ឧបករណ៍​បង្ហាប់..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "ឈ្មោះ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "ជម្រើស​ទៅ​ចុង ប្ដូរ(Shift)+ចុង(End)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "កំណត់​អត្រា"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "ចំណង​ជើង​បទ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "បាន​ប្ដូរ​ឈ្មោះ '%s' ទៅ '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "គ្មាន​​ស្លាក​​ត្រូវ​នាំចេញ ។"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "ជ្រើស​ឯកសារ​សម្រាប់​ដំណើរការ​បាច់..."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -4976,6 +10879,18 @@ msgstr "ជម្រៅ​ប៊ីត ៖"
 #: src/export/ExportFLAC.cpp
 msgid "FLAC Files"
 msgstr "ឯកសារ FLAC"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "មិន​អាច​បើក​ឯកសារ ៖ \"%s\""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr "សូម​អភ័យ​ទោស កម្មវិធី​ជំនួយ Vamp បាន​បរាជ័យ​ក្នុងកា​រចាប់ផ្ដើម ។"
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
@@ -5007,7 +10922,74 @@ msgstr "នាំចេញ​អូឌីយ៉ូ​ដែលបាន​ជ្
 msgid "Exporting the audio at %ld kbps"
 msgstr "នាំចេញ​អូឌីយ៉ូ​ដែលបាន​ជ្រើស​នៅល្បឿន %ld kbps"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "ស្តង់ដារ"
 
@@ -5048,14 +11030,19 @@ msgstr "គុណភាព"
 msgid "Channel Mode:"
 msgstr "របៀប​ឆានែល ៖"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "​បន្ទាត់​កាត់​ដែល​បាន​យកចេញ"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "រក​ទី​តាំង Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity ត្រូវ​ការ​ឯកសារ %s ដើម្បី​បង្កើត MP3 ។"
 
 #: src/export/ExportMP3.cpp
@@ -5081,6 +11068,38 @@ msgstr "ដើម្បី​យក​ច្បាប់​ថត​ចម្ល
 #, c-format
 msgid "Where is %s?"
 msgstr "តើឯកសារ %s នៅទីណា ?"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "រក្សាទុក​​ឯកសារ​​ទិន្នន័យ​​គម្រោង"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "MP3 Files"
@@ -5151,6 +11170,14 @@ msgid ""
 "supported by the MP3 file format. "
 msgstr "បន្សំ​រវាង​អត្រាគំរូ​គម្រោង (%d) និង​អត្រាប៊ីត (%d kbps)មិន​គាំទ្រ​ដោយ​ទ្រង់ទ្រាយ​ឯកសារ MP3 ទេ ។  "
 
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
 msgstr "នាំចេញ​ច្រើន"
@@ -5160,8 +11187,18 @@ msgid "Cannot Export Multiple"
 msgstr "នាំចេញ​ច្រើន"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "ទីតាំង​នាំចេញ ៖"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -5184,6 +11221,11 @@ msgid "First file name:"
 msgstr "ឈ្មោះ​ឯកសារ​ដំបូង ៖"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "ឈ្មោះ​ឯកសារ​ដំបូង ៖"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "ឈ្មោះ​ឯកសារ ៖"
 
@@ -5192,7 +11234,22 @@ msgid "Using Label/Track Name"
 msgstr "ប្រើប្រាស់​ស្លាក/ឈ្មោះ​បទ"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "ប្រើប្រាស់​ស្លាក/ឈ្មោះ​បទ"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "បុព្វបទ​ឈ្មោះ​ឯកសារ ៖"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "បុព្វបទ​ឈ្មោះ​ឯកសារ ៖"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "បុព្វបទ​ឈ្មោះ​ឯកសារ ៖"
 
 #: src/export/ExportMultiple.cpp
@@ -5210,6 +11267,31 @@ msgstr "ជ្រើស​ទីតាំង​ដើម្បី​រក្ស
 
 #: src/export/ExportMultiple.cpp
 #, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
 msgid ""
 "\"%s\" doesn't exist.\n"
 "\n"
@@ -5223,6 +11305,27 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "រក្សាទុក​ជា..."
@@ -5230,6 +11333,31 @@ msgstr "រក្សាទុក​ជា..."
 #: src/export/ExportOGG.cpp
 msgid "Ogg Vorbis Files"
 msgstr "ឯកសារ Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -5243,6 +11371,14 @@ msgstr "នាំ​ចេញ​អូឌីយ៉ូ​ទៅ​ជា Ogg Vorb
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "នាំ​ចេញ​អូឌីយ៉ូ​ទៅ​ជា Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "បឋមកថា ៖"
@@ -5252,8 +11388,33 @@ msgid "Encoding:"
 msgstr "អ៊ិនកូឌីង ៖"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "ជ្រើស​​ឯកសារ​​អូឌីយ៉ូ​​ដែល​​មិន​​បាន​​បង្ហាប់..."
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "កំហុស​ក្នុង​ការ​នាំ​ចូល"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -5264,14 +11425,200 @@ msgstr "មិន​អាច​នាំចេញ​អូឌីយ៉ូ​ក
 msgid "Exporting the selected audio as %s"
 msgstr "​នាំចេញ​អូឌីយ៉ូ​ទៅជា %s"
 
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "អត្រា​គំរូ"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "សូម​អភ័យ​ទោស កម្មវិធី​ជំនួយ Vamp បាន​បរាជ័យ​ក្នុងកា​រចាប់ផ្ដើម ។"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Audacity កំណែ​នេះ​មិនទាន់​បាន​ចង​ក្រង​ជាមួយ %s គាំទ្រ ។"
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "រក្សាទុក​​ឯកសារ​​ទិន្នន័យ​​គម្រោង"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5288,21 +11635,132 @@ msgid "Import Project"
 msgstr "នាំចេញ​​ស្លាក​ជា ៖"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "មិន​អាច​រក​ឃើញ​ថត​ទិន្នន័យ​គម្រោង ៖ \"%s\""
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "អត្រា​គម្រោង (Hz) ៖"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "អត្រា​គំរូ​មិន​ត្រឹមត្រូវ"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5319,21 +11777,19 @@ msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯក�
 msgid "Unable to read %lld samples from %s"
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "ឯកសារ FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "មិន​អាច​​ប្ដូរ​ឈ្មោះ '%s' ទៅ​​ជា '%s'"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -5393,9 +11849,22 @@ msgstr "មិន​អាច​បើក​ឯកសារ ៖ \"%s\""
 msgid "MP3 files"
 msgstr "ឯកសារ MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "ឯកសារ Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -5422,12 +11891,120 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF និង​ប្រភេទ​ឯកសារ​មិន​បង្ហាប់​ផ្សេង​ទៀត"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "១៦ ប៊ីត PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "១៦ ប៊ីត PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "២៤ ប៊ីត PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "២៤ ប៊ីត PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "១៦ ប៊ីត PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -5438,12 +12015,49 @@ msgid "64 bit float"
 msgstr "៣២ ប៊ីត float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "១៦​​ ប៊ីត"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "១៦​​ ប៊ីត"
 
 #: src/import/ImportPCM.cpp
 msgid "24 bit DWVW"
 msgstr "២៤ ប៊ីត"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
@@ -5453,9 +12067,51 @@ msgstr "១៦ ប៊ីត PCM"
 msgid "8 bit DPCM"
 msgstr "១៦ ប៊ីត PCM"
 
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "បាន​នាំ​ចូល '%s'"
+
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "ឯកសារ QuickTime"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "មិនអាច​រក្សាទុក​ឯកសារ​ចង្វាក់"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "មិនអាច​រក្សាទុក​ឯកសារ​ចង្វាក់"
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "នាំចូល​ទិន្នន័យ​មិនទាន់​ដើម"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -5498,6 +12154,15 @@ msgstr "ឆានែល ២​ (ស្តេរ៉េអូ)"
 msgid "%d Channels"
 msgstr "ឆានែល %d"
 
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "ឆានែល"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
@@ -5520,6 +12185,10 @@ msgstr "អត្រាគំរូ ៖"
 msgid "&Import"
 msgstr "នាំចូល"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -5532,6 +12201,21 @@ msgstr "ឆ្វេង"
 msgid "%s right"
 msgstr "ស្ដាំ"
 
+#. i18n-hint:
+#. First %s is replaced with the noun "start" or "end"
+#. identifying one end of a clip,
+#. first number gives the position of that clip in a sequence
+#. of clips,
+#. last number counts all clips,
+#. and the last string is the name of the track containing the
+#. clips.
+#.
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s %d of %d clip %s"
+msgid_plural "%s %d of %d clips %s"
+msgstr[0] ""
+
 #: src/menus/ClipMenus.cpp
 msgid "start"
 msgstr "ចាប់ផ្ដើម"
@@ -5540,13 +12224,61 @@ msgstr "ចាប់ផ្ដើម"
 msgid "end"
 msgstr "ចុង"
 
+#. i18n-hint:
+#. First two %s are each replaced with the noun "start"
+#. or with "end", identifying and end of a clip,
+#. first and second numbers give the position of those clips in
+#. a sequence of clips,
+#. last number counts all clips,
+#. and the last string is the name of the track containing the
+#. clips.
+#.
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s %d and %s %d of %d clip %s"
+msgid_plural "%s %d and %s %d of %d clips %s"
+msgstr[0] ""
+
+#. i18n-hint:
+#. first number identifies one of a sequence of clips,
+#. last number counts the clips,
+#. string names a track
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%d of %d clip %s"
+msgid_plural "%d of %d clips %s"
+msgstr[0] ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "ពេលវេលា​ប្តូរ​បទ/ឈុត %s %.02f វិនាទី"
+
 #: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "ពេលវេលា​ប្តូរ​បទ/ឈុត %s %.02f វិនាទី"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "អង្កិល​ពេល​វេលា"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "ទៅ​ដើម​​​ជម្រើស"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -5563,6 +12295,26 @@ msgstr "ឧបករណ៍​​​បន្ទាប់ D"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "ឧបករណ៍​​​បន្ទាប់ D"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "ឧបករណ៍​​មុន A"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "អនុវត្ត​ទៅ​គម្រោង​បច្ចុប្បន្ន"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "ឧបករណ៍​​​បន្ទាប់ D"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "ទៅ​ដើម​​​ជម្រើស"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -5596,6 +12348,11 @@ msgstr "កាត់​​ទៅ​ក្ដារ​​តម្បៀត​​
 #, c-format
 msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "%.2f seconds at t=%.2f ដែល​បាន​លុប"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasting one type of track into another is not allowed."
+msgstr "ចម្លង​​អូឌីយ៉ូ​​ស្តេរ៉េអូ​​ទៅ​​ក្នុង​​បទ​​ម៉ូណូ​​មិន​​ត្រូវ​​បាន​​អនុញ្ញាត​​ទេ ។"
 
 #: src/menus/EditMenus.cpp
 msgid "Copying stereo audio into a mono track is not allowed."
@@ -5646,7 +12403,8 @@ msgstr "ធ្វើ​​ឲ្យ​​ស្ងាត់​​បទ​​ដ
 msgid "Trim Audio"
 msgstr "កំពុង​​ថត​​អូឌីយ៉ូ"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "ពុះ"
 
@@ -5666,6 +12424,15 @@ msgstr "ភ្ជាប់ %.2f វិនាទី នៅ t=%.2f"
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "ភ្ជាប់"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "%.2f seconds at t=%.2f ដែល​បាន​លុប"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
@@ -5699,6 +12466,11 @@ msgstr "បិទភ្ជាប់"
 msgid "Duplic&ate"
 msgstr "ស្ទួន"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "យក​បទ​​ចេញ"
+
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
 msgid "Spl&it Cut"
@@ -5708,6 +12480,12 @@ msgstr "បំបែក​ការកាត់"
 #: src/menus/EditMenus.cpp
 msgid "Split D&elete"
 msgstr "បំបែក​ការ​លុប"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "តំបន់​​ដែល​មាន​​ស្លាក​​ដែល​​ស្ងាត់"
 
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
@@ -5728,9 +12506,19 @@ msgstr "បំបែក​ថ្មី"
 msgid "&Join"
 msgstr "ភ្ជាប់"
 
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "ជ្រើស​ស្ងាត់"
+
 #: src/menus/EditMenus.cpp
 msgid "&Metadata..."
 msgstr "កែ​សម្រួល​​ទិន្នន័យ​​មេតា"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "ចំណូល​ចិត្ត..."
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -5741,32 +12529,8 @@ msgid "Delete Key&2"
 msgstr "គ្រាប់​ចុច​លុប ២ លុប (Delete)"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "របារ​​ឧបករណ៍​​ឧបករណ៍​​លាយ​​សំឡេង​"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "ចាក់ឡើងវិញ"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "ចាក់ឡើងវិញ"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "ចាក់ឡើងវិញ"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "ថត"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "ថត"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "ថត"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -5788,9 +12552,26 @@ msgstr "​​ដាក់​​អូឌីយ៉ូ​​ក្នុង​​
 msgid "Change Recording Cha&nnels..."
 msgstr "ផ្លាស់ប្តូរ​កម្ពស់​សំឡេង"
 
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "នាំចេញ​ជម្រើស..."
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "កែសម្រួល​ស្លាក"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -5805,12 +12586,28 @@ msgid "Please select a Note Track."
 msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "នាំចេញ..."
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "ឯកសារ​​ទាំងអស់ (*)|*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "នាំចេញ..."
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -5824,6 +12621,11 @@ msgstr "នាំ​ចូល​​ស្លាក"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "ឯកសារ​​ទាំងអស់ (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -5841,6 +12643,12 @@ msgstr "រក្សាទុក​ជា..."
 #: src/menus/FileMenus.cpp
 msgid "Open Recent"
 msgstr "បើក​​ថ្មីៗ"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "រក្សាទុក​ឯកសារ"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -5921,6 +12729,10 @@ msgid "E&xit"
 msgstr "ចេញ"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "នាំចេញ​​ស្លាក​ជា ៖"
 
@@ -5951,6 +12763,10 @@ msgid "Nothing to do"
 msgstr "គ្មាន​​អ្វី​​ត្រូវ​​មិន​​ធ្វើ​វិញ​​ទេ"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "បិទ​បទ​​ដែលបាន​​ផ្ដោត ប្ដូរ(Shift)+C"
 
@@ -5963,6 +12779,18 @@ msgid "Recording stops and starts"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "ជំនួយ"
 
@@ -5971,7 +12799,8 @@ msgid "&Getting Started"
 msgstr "ដើម​ចម្រើស ៖"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "របារ​ឧបករណ៍​របស់ Audacity %s"
 
 #: src/menus/HelpMenus.cpp
@@ -5979,16 +12808,34 @@ msgid "&Quick Help..."
 msgstr "ជំនួយ"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
 msgstr "\t-test (រត់​​ការ​វិនិច្ឆ័យ​ដោយ​​ខ្លួន​ឯង)"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "អំពី Audacity..."
+msgid "Au&dio Device Info..."
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "បាន​បន្ថែម​​ស្លាក"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "ផ្លាស់ទី​​ការ​​ផ្ដោត​​ទៅ​​បទ​​បន្ទាប់"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -6104,6 +12951,15 @@ msgid "Add Label at &Playback Position"
 msgstr "បន្ថែម​​ស្លាក​​​នៅ​ទីតាំង​ចាក់​​ឡើង​វិញ"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "ផ្លាស់ទី​​ការ​​ផ្ដោត​​ទៅ​​បទ​​បន្ទាប់"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "ថត​អូឌីយ៉ូ"
 
@@ -6138,6 +12994,11 @@ msgid "Label Split Delete"
 msgstr "លុប​​ការ​ពុះ"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "តំបន់​​ដែល​មាន​​ស្លាក​​ដែល​​ស្ងាត់"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "ស្ងាត់"
 
@@ -6162,6 +13023,23 @@ msgstr "កែសម្រួល​ស្លាក"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "កែសម្រួល​ស្លាក"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "ផ្លាស់ទី​​ការ​​ផ្ដោត​​ទៅ​​បទ​​បន្ទាប់"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -6200,8 +13078,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "បិទ​​បើក​បទ​​ដែល​​ផ្ដោត"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "ថ្មី..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -6218,6 +13104,10 @@ msgid "&Generate"
 msgstr "បង្កើត"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
 msgstr "ឧបករណ៍​បង្កើត​សំឡេង"
 
@@ -6226,8 +13116,18 @@ msgid "Effe&ct"
 msgstr "បែបផែន"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "ឧបករណ៍​បង្កើត​សំឡេង"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "ធ្វើ​​វិភាគ"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "ឧបករណ៍​បង្កើត​សំឡេង"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -6265,6 +13165,10 @@ msgstr "រត់ Benchmark..."
 msgid "Simulate Recording Errors"
 msgstr "ថត"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -6285,6 +13189,16 @@ msgstr "ជ្រើស"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "ឈ្មោះ​បទ"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "ថិរវេលាស្ងាត់ ៖"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "បទ"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -6310,9 +13224,20 @@ msgstr "កែសម្រួល​​ស្លាក"
 msgid "Set Project..."
 msgstr "រក្សាទុក​គម្រោង​ជា..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "អថេរ"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "បទ"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "ព័ត៌មាន"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -6344,6 +13269,27 @@ msgid "Screenshot (short format)..."
 msgstr "ឧបករណ៍​​រូបថត​​អេក្រង់..."
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "កំណត់​ចំណុច​ជម្រើស"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "ទីតាំងអូឌីយ៉ូ ៖"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "កំណត់​ចំណុច​ជម្រើស"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "ជ្រើស"
+
+#: src/menus/SelectMenus.cpp
 msgid "&None"
 msgstr "គ្មាន"
 
@@ -6356,8 +13302,21 @@ msgid "&Tracks"
 msgstr "បទ"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "បទ"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Sync-Locked"
 msgstr "ជ្រើស​សំឡេង"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
@@ -6376,8 +13335,18 @@ msgid "Set Selection Right at Play Position"
 msgstr "កំណត់​ចំណុចជ្រើស​ និង​ចាក់"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "ជជ្រើស​ដើម្បី​ចាប់ផ្ដើម ប្ដូរ(Shift)+ដើម(Home)"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "ជជ្រើស​ដើម្បី​ចាប់ផ្ដើម ប្ដូរ(Shift)+ដើម(Home)"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "ឈ្មោះ​បទ"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -6416,8 +13385,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "ប្រេកង់​​លីនេអ៊ែរ"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "ជជ្រើស​ដើម្បី​ចាប់ផ្ដើម ប្ដូរ(Shift)+ដើម(Home)"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "ទីតាំងអូឌីយ៉ូ ៖"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -6554,6 +13532,40 @@ msgstr "ទស្សន៍​ទ្រនិច​វែង​​លោត​​
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "ទស្សន៍​ទ្រនិច​​វែង​​លោត​​ទៅ​ស្ដាំ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "ឧបករណ៍"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
@@ -6705,6 +13717,15 @@ msgid "Align Together"
 msgstr "តម្រឹម​បទ​​ជាមួយ​គ្នា"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "តម្រឹម​​ចុង​​ដោយ​​ចុង​​ជម្រើស"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
 msgstr "កំណើន​ដែល​បាន​លៃតម្រូវ"
 
@@ -6729,10 +13750,21 @@ msgid "Created new label track"
 msgstr "បាន​បង្កើត​បទ​ស្លាក​ថ្មី"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "បាន​បង្កើត​​បទ​​ពេល​វេលា​​​ថ្មី"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "អត្រាគំរូ ៖"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "តម្លៃ​ដែល​បញ្ចូល​មិន​ត្រឹមត្រូវ"
 
@@ -6752,6 +13784,25 @@ msgstr "ធ្វើ​គំរូ​បទ​ឡើង​វិញ"
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "តម្រឹម​​ចុង​​ដោយ​​ចុង​​ជម្រើស"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -6774,6 +13825,11 @@ msgid "Can't delete track with active audio"
 msgstr "មិន​អាច​លុប​បទ​ដែល​មាន​អូឌីយ៉ូ​សកម្ម"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "ថ្មី"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "ផ្លាស់ទី​បទ"
 
@@ -6790,8 +13846,18 @@ msgid "&Time Track"
 msgstr "បទ​​ពេលវេលា"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "របារ​​ឧបករណ៍​​ឧបករណ៍​​លាយ​​សំឡេង​"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "អនុវត្ត​ស្តេរ៉េអូ​ទៅជា​​ម៉ូណូ"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x and Render"
+msgstr "លាយ និង​​បង្ហាញ"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix and Render to Ne&w Track"
@@ -6810,6 +13876,11 @@ msgid "M&ute/Unmute"
 msgstr "ស្ងាត់/លឺ​បទ​ដែល​​ផ្ដោត ប្ដូរ(Shift)+U"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "ពង្រីក​​បទ​​ទាំង​អស់"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
 msgstr "ពង្រីក​​បទ​​ទាំង​អស់"
 
@@ -6820,6 +13891,10 @@ msgstr "បទ"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "ពង្រីក​​បទ​​ទាំង​អស់"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -6844,6 +13919,11 @@ msgstr "កណ្តាល"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Center"
 msgstr "កណ្តាល"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "បទ"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
@@ -6872,6 +13952,11 @@ msgstr "ពេលវេលា​​ចាប់ផ្ដើម"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "ឈ្មោះ"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "ផ្លាស់ទី​ឈុត​ទៅ​បទ​មួយផ្សេង​ទៀត"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -6943,7 +14028,9 @@ msgstr "ចាក់"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "ថត"
 
@@ -6956,8 +14043,27 @@ msgid "no label track at or below focused track"
 msgstr "បន្ទះ​​ឆ្វេង​​លើ​​បទ​​ដែល​​ផ្ដោត ជំនួស(Alt)+ប្ដូរ(Shift)+ឆ្វេង"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "បាន​បង្កើត​បទ​ស្លាក​ថ្មី"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -6986,9 +14092,34 @@ msgstr "ការ​ចម្លង"
 msgid "Pl&aying"
 msgstr "ចាក់"
 
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "ចាក់​នៅ​ល្បឿន"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "ផ្អាក P"
+
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "ថត"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "ថត R"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -6999,8 +14130,71 @@ msgid "Record &New Track"
 msgstr "យក​បទ​​ចេញ"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "ថត"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "ឧបករណ៍​ចាក់​ពេលថត"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "ការ​ចម្លង"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "ថត"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "ការ​ចម្លង"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&ay"
+msgstr "ចាក់"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -7118,6 +14312,11 @@ msgid "&Fit to Width"
 msgstr "សម​នឹង​បង្អួច"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "សម​នឹង​បង្អួច"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "វេញ​​បទ​ទាំងអស់"
 
@@ -7142,12 +14341,57 @@ msgid "Skip to Selection End"
 msgstr "ទៅ​ចុង​​ជម្រើស"
 
 #: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
 msgstr "បង្ហាញ​​កា​រច្រឹប"
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "បែបផែន"
 
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr " បង្អួច"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "ឧបករណ៍​ចាក់​ពេលថត"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -7155,7 +14399,7 @@ msgstr "​ចំណូលចិត្ត..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "បិទ Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -7180,6 +14424,11 @@ msgid "&Don't apply effects in batch mode"
 msgstr "កុំ​អនុវត្ត​បែបផែន​ក្នុង​របៀប​បាច់"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "ឧបករណ៍"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
 msgstr "​ចំណូលចិត្ត..."
 
@@ -7189,11 +14438,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "ចំណុច​ប្រទាក់"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "ការ​ប្រើ ៖"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "ចាក់ឡើងវិញ"
 
@@ -7213,7 +14468,8 @@ msgstr "ឆានែល"
 msgid "Latency"
 msgstr "គម្លាត​ពេល"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "មីល្លីវិនាទី"
 
@@ -7226,6 +14482,15 @@ msgid "&Latency compensation:"
 msgstr "បន្សំ​គ្រាប់ចុច"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "បាន​យក​បទ​អូឌីយ៉ូ​ចេញ"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "១​ (ម៉ូណូ)"
 
@@ -7234,17 +14499,37 @@ msgid "2 (Stereo)"
 msgstr "២ (ស្តេរ៉េអូ)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "ថត"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "សង្គ្រោះ​​គម្រោង"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "ថត"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "រក​មើល..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -7275,6 +14560,11 @@ msgid "Temporary files directory"
 msgstr "ថត​ឯកសារ​បណ្ដោះ​អាសន្ន"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "សកម្មភាព"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory cannot be on a FAT drive."
 msgstr "ថត​ឯកសារ​បណ្ដោះ​អាសន្ន"
 
@@ -7291,8 +14581,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "ជ្រើស​ទីតាំង​ត្រូវ​ដាក់​ថត​បណ្ដោះអាសន្ន"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "ជ្រើស​ពាក្យ​បញ្ជា"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -7309,8 +14608,14 @@ msgid "Directory %s is not writable"
 msgstr "ថត %s មិនអាច​សរសេរ​បាន"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "ផ្លាស់ប្ដូរ​ទៅ​ថត​បណ្ដោះអាសន្ន នឹង​គ្មាន​ប្រសិទ្ធភាព​ទេ រហូត​ដល់ Audacity ត្រូវ​បាន​ចាប់ផ្ដើម​ឡើង​វិញ"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "ថត​បណ្ដោះ​អាសន្ន​ថ្មី"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -7320,11 +14625,36 @@ msgstr "​ចំណូលចិត្ត..."
 msgid "Sorted by Effect Name"
 msgstr "តម្រៀប​​តាម​​ឈ្មោះ"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "តម្រៀប​​តាម​​ឈ្មោះ"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "តម្រៀប​​តាម​​ឈ្មោះ"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "បែបផែន"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -7334,17 +14664,141 @@ msgstr "បែបផែន"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "បែបផែន"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "ការ​កំណត់​បែបផែន"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "ការ​កំណត់​កម្មវិធី​ជំនួយ"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​រហ័ស"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "នាំ​ចូល"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "​ចំណូលចិត្ត..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "ប្រភេទ​ការរំខាន"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "នាំចេញ​​ស្លាក​ជា ៖"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "ផ្លាស់ទី​ឡើងលើ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "ផ្លាស់ទី​ចុះក្រោម"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "ផ្លាស់ទី​ឡើងលើ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "ផ្លាស់ទី​ចុះក្រោម"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "លុប​តំបន់​​ដែល​មាន​ស្លាក"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "ទីតាំង​នាំចេញ ៖"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "ជ្រើស"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "តើ​​អ្នក​​ប្រាកដ​​ជា​​ចង់​​លុប %s ឬ ?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "កំពុង​​ថត​​អូឌីយ៉ូ"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -7369,6 +14823,11 @@ msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-៤៨ dB (ជួរ PCM នៃគំរូ ៨ ប៊ីត)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-៩៦ dB (ជួរ PCM នៃ គំរូ ១៦ ប៊ីត)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
 msgstr "-៩៦ dB (ជួរ PCM នៃ គំរូ ១៦ ប៊ីត)"
 
@@ -7388,13 +14847,101 @@ msgstr "-១២០ dB (ព្រំដែន​ប្រហែល​នៃ​ក
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (ជួរ PCM នៃ គំរូ ២៤ ប៊ីត)"
 
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "សកម្មភាព"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "From Internet"
+msgstr "ជំនួយ​នៅ​លើ​អ៊ីនធឺណិត"
+
 #: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
 msgid "Display"
 msgstr "បង្ហាញ"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "ភាសា ៖"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "ទី​តាំង​របស់ %s ៖"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "ទ្រង់ទ្រាយ​រលក (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "\t-help (សារ​នេះ)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "បន្លឺ​សំឡេង​ប៊ីត​នៅ​ពេល​​បញ្ចប់​សកម្មភាព​វែងៗ"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "ការ​កំណត់​កម្មវិធី​ជំនួយ"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "អនុញ្ញាត​ម៉ែត្រ"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "នាំចេញ​​ស្លាក​ជា ៖"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "​ចំណូលចិត្ត..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -7409,6 +14956,10 @@ msgid "S&tandard"
 msgstr "ស្តង់ដារ"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
 msgstr "វិនាទី"
 
@@ -7417,12 +14968,29 @@ msgid "&Beats"
 msgstr "ធ្វើ​​ម្ដង​​ទៀត"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "S&how Metadata Tags editor before export"
 msgstr "កែ​សម្រួល​​ស្លាក​​ទិន្នន័យ​មេតា"
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "នាំចេញ​​ស្លាក​ជា ៖"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -7434,6 +15002,18 @@ msgid "Preferences for KeyConfig"
 msgstr "​ចំណូលចិត្ត..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "ចងគ្រាប់ចុច"
 
@@ -7442,12 +15022,49 @@ msgid "View by:"
 msgstr "មើល"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "ឈ្មោះ"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "មើល"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "មើល"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "មើល"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
 msgstr "ចងគ្រាប់ចុច"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "ជម្រើស..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -7462,7 +15079,15 @@ msgid "&Defaults"
 msgstr "លំនាំដើម"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "ជ្រើស​ឯកសារ XML ដែល​មាន​ផ្លូវកាត់​ក្តារចុច Audacity"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -7471,8 +15096,21 @@ msgstr "នាំចេញ​ផ្លូវកាត់​ក្តារចុ
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "បាន​ផ្ទុក​ផ្លូវកាត់​ក្ដារចុច %d\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -7486,6 +15124,38 @@ msgstr "នាំចេញ​ផ្លូវកាត់​ក្តារចុ
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "នាំចេញ​ផ្លូវកាត់​ក្តារចុច​ជា ៖"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "បន្សំ​គ្រាប់ចុច"
@@ -7495,12 +15165,72 @@ msgid "Preferences for Library"
 msgstr "​ចំណូលចិត្ត..."
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "កំណែ​បណ្ណាល័យ MP3 ៖"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "កំណែ​បណ្ណាល័យ MP3 ៖"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "កំហុស LOF"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "រក្សា​ទុក..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "ឯកសារ MP3"
 
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "​ចំណូលចិត្ត..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "ចំណុច​ប្រទាក់"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -7508,17 +15238,77 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "ចំណុច​ប្រទាក់"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​ជា​លេខគត់"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "​ចំណូលចិត្ត..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "ផ្លាស់ប្ដូរ​ទៅ​ថត​បណ្ដោះអាសន្ន នឹង​គ្មាន​ប្រសិទ្ធភាព​ទេ រហូត​ដល់ Audacity ត្រូវ​បាន​ចាប់ផ្ដើម​ឡើង​វិញ"
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "សួរ​ខ្ញុំ"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -7560,7 +15350,10 @@ msgstr "អូស​ឆ្វេង"
 msgid "Set Selection Range"
 msgstr "កំណត់ជួរ​ជម្រើស"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "ប្តូរ(Shift)​ខាង​ឆ្វេង-ចុចស្តាំ"
 
@@ -7647,6 +15440,15 @@ msgstr "អូស​ឆ្វេង"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "ផ្លាស់ទី​ឈុត​ឡើងលើ/ចុះក្រោម​រវាង​បទ"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "អូស​ឆ្វេង"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -7750,9 +15552,34 @@ msgstr "មើល​ជា​មុន​ បន្ទាប់​ពី​ក�
 msgid "Seek Time when playing"
 msgstr "ស្វែងរក​ពេលវេលា​ពេល​កំពុង​ចាក់"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "ចំណូល​ចិត្ត Audacity"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -7761,6 +15588,11 @@ msgstr "​ចំណូលចិត្ត..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "​ចំណូលចិត្ត..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -7779,12 +15611,32 @@ msgid "Default Sample &Format:"
 msgstr "ទ្រង់ទ្រាយ​គំរូ​លំនាំដើម ៖"
 
 #: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "កម្មវិធី​បម្លែង​អត្រា​គំរូ"
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Con&verter:"
 msgstr "កម្មវិធី​បម្លែង​អត្រា​គំរូ"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​គុណភាព​ខ្ពស់"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "កម្មវិធី​បម្លែង​អត្រា​គំរូ"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -7799,8 +15651,30 @@ msgid "Preferences for Recording"
 msgstr "​ចំណូលចិត្ត..."
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "បទ​​ថ្មី"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "ថត"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -7811,9 +15685,19 @@ msgstr "កម្រិត ៖"
 msgid "Name newly recorded tracks"
 msgstr "លាយ និង​បង្ហាញ​បទ"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "ឈ្មោះ​បទ"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "កែសម្រួល​ស្លាក"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -7823,11 +15707,67 @@ msgstr "ថត​អូឌីយ៉ូ"
 msgid "&Track Number"
 msgstr "លេខ​បទ"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "System &Date"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "​ចំណូលចិត្ត..."
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "កំណត់​ចំណាំ​បទ"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "ពង្រីក​លំនាំដើម"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "ពង្រីក​លំនាំដើម"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "លីនេអ៊ែរ"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -7839,14 +15779,42 @@ msgstr "លីនេអ៊ែរ"
 msgid "Frequencies"
 msgstr "ប្រេកង់ (Hz)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "កម្ពស់​សំឡេង (EAC)"
 
 #: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​មាន​តម្លៃ​តូចបំផុត ០ Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​មាន​តម្លៃ​តូចបំផុត ០ Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​មាន​តម្លៃ​តូចបំផុត ០ Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​មាន​តម្លៃ​តូចបំផុត ០ Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -7865,6 +15833,10 @@ msgstr "​ចំណូលចិត្ត..."
 msgid "&Use Preferences"
 msgstr "​ចំណូលចិត្ត..."
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "ប្រេកង់​អប្បបរមា (Hz) ៖"
@@ -7872,6 +15844,24 @@ msgstr "ប្រេកង់​អប្បបរមា (Hz) ៖"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "ប្រេកង់​អតិបរមា (Hz) ៖"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "ឆានែល​លទ្ធផល ៖ %2d"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "ដំឡើង (dB) ៖"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -7894,12 +15884,52 @@ msgid "1024 - default"
 msgstr "២៥៦ - លំនាំដើម"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "32768 - most narrowband"
+msgstr "៨ - ក្រុម​ទូលាយ​បំផុត"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "ប្រភេទ​បង្អួច ៖"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "កត្តា​បន្ថយ ៖"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "ជម្រើស"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "អាំភ្លី​កំពូល​ថ្មី (dB) ៖"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -7916,6 +15946,36 @@ msgstr "ប្រេកង់​អតិបរមា​ត្រូវតែ​
 #: src/prefs/SpectrumPrefs.cpp
 msgid "The minimum frequency must be an integer"
 msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​ជា​លេខគត់"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "ប្រេកង់​អតិបរមា​ត្រូវតែ​ជា​លេខ​គត់"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "ប្រេកង់​អតិបរមា​ត្រូវតែ​ជា​លេខ​គត់"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "ប្រេកង់​អតិបរមា​ត្រូវតែ​ជា​លេខ​គត់"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​ជា​លេខគត់"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "ប្រេកង់​អតិបរមា​ត្រូវតែ​ជា​លេខ​គត់"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "ប្រេកង់​អតិបរមា​ត្រូវតែ​ជា​លេខ​គត់"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
@@ -7934,13 +15994,14 @@ msgid "Info"
 msgstr "ព័ត៌មាន"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -7958,6 +16019,12 @@ msgstr ""
 "[មាន​តែ​របារ​ឧបករណ៍​​ត្រួតពិនិត្យ និង​ពណ៌​នៅ​លើ \n"
 "ដាន​រលក​ត្រូវ​បាន​ប៉ះពាល់​បច្ចុប្បន្ន​នេះ ទោះ​បីជា\n"
 "ឯកសារ​រូបភាព​បង្ហាញ​រូបតំណាង​ផ្សេង​ក៏​ដោយ ។]"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
 #. * so keep it as is
@@ -7995,6 +16062,11 @@ msgid "Preferences for TracksBehaviors"
 msgstr "ឥរិយាបថ"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "គំរូ"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
 msgstr "ច្រើន"
 
@@ -8012,8 +16084,33 @@ msgid "Enable &dragging selection edges"
 msgstr "បន្ថែម​ស្លាក​នៅ​ជម្រើស"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "ជម្រើស​លាយ​កម្រិត​ខ្ពស់"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "ប៊ូតុង"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -8027,6 +16124,14 @@ msgstr "ទ្រង់ទ្រាយ​រលក"
 msgid "Spectrogram"
 msgstr "ក្រាហ្វិក​វិសាលគម"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "សម​នឹង​បង្អួច"
@@ -8038,6 +16143,10 @@ msgstr "ពង្រីក​សម​នឹង​ជម្រើស"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "ពង្រីក​លំនាំដើម"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -8060,6 +16169,16 @@ msgid "50ths of Seconds"
 msgstr "វិនាទី"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "វិនាទី"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "វិនាទី"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "មីល្លីវិនាទី"
 
@@ -8067,7 +16186,12 @@ msgstr "មីល្លីវិនាទី"
 msgid "Samples"
 msgstr "គំរូ"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "ពង្រីក"
 
@@ -8076,12 +16200,42 @@ msgid "Preferences for Tracks"
 msgstr "​ចំណូលចិត្ត..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "ថត"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "អត្រា​គំរូ​លំនាំដើម ៖"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "ទ្រង់ទ្រាយ​គំរូ​លំនាំដើម ៖"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "គំរូ"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -8104,9 +16258,46 @@ msgstr "ការ​​កំណត់ជា​​ស្រេច"
 msgid "Preset 2:"
 msgstr "ការ​​កំណត់ជា​​ស្រេច"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "ការ​ព្រមាន"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "​ចំណូលចិត្ត..."
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "រក្សាទុក​គម្រោង"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "រក្សាទុក​គម្រោង"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "អនុវត្ត​ស្តេរ៉េអូ​ទៅជា​​ម៉ូណូ"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "អនុវត្ត​ស្តេរ៉េអូ​ទៅជា​​ម៉ូណូ"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -8129,16 +16320,24 @@ msgid "Stopped"
 msgstr "បញ្ឈប់ S"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "ផ្អាក P"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "រំលង​ដើម្បី​ចាប់ផ្ដើម ដើម"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "រំលង​​ដើម្បី​បញ្ចប់ ចុង"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "ផ្អាក P"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "ជជ្រើស​ដើម្បី​ចាប់ផ្ដើម ប្ដូរ(Shift)+ដើម(Home)"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "ជម្រើស​ទៅ​ចុង ប្ដូរ(Shift)+ចុង(End)"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -8152,20 +16351,24 @@ msgstr "បទ​​ថ្មី"
 msgid "Append Record"
 msgstr "ថត R"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "ជម្រើស​ទៅ​ចុង ប្ដូរ(Shift)+ចុង(End)"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "ជជ្រើស​ដើម្បី​ចាប់ផ្ដើម ប្ដូរ(Shift)+ដើម(Home)"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "ផ្អាក P"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "របារ​​ឧបករណ៍​​​កា​រចម្លង​"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -8176,6 +16379,11 @@ msgstr "ល្បឿន​ចាក់​ឡើងវិញ"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "ឧបករណ៍​ចាក់​ពេលថត"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "ទីតាំងអូឌីយ៉ូ ៖"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -8198,8 +16406,18 @@ msgid "Select Playback Device"
 msgstr "ល្បឿន​ចាក់​ឡើងវិញ"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "ថិរវេលាស្ងាត់ ៖"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "ឆានែល​ស្ដាំ"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "មិន​មាន​ការ​មើល​ជាមុន\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -8223,11 +16441,22 @@ msgstr "កាត់​តម្រឹម​ខាង​ក្រៅ​ជម្
 msgid "Silence audio selection"
 msgstr "ជម្រើស​ស្ងាត់"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "បទ"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "ពង្រីក"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "បង្រួម"
 
@@ -8238,6 +16467,11 @@ msgstr "ធ្វើ​ឲ្យ​ជម្រើស​សម​នឹង​ប
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "ធ្វើ​ឲ្យ​គម្រោង​សម​​នៅ​ក្នុង​បង្អួច"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "បែបផែន"
 
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
@@ -8290,38 +16524,24 @@ msgstr "របារ​ឧបករណ៍​​ម៉ែត្រ"
 msgid "&Playback Meter Toolbar"
 msgstr "ឧបករណ៍​វាស់​ពេលចាក់"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "ថត"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "ចាក់ឡើងវិញ"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "អនុញ្ញាត​ម៉ែត្រ"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "ថត"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "ចាក់ឡើងវិញ"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "ចាក់ឡើងវិញ"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "របារ​​ឧបករណ៍​​ឧបករណ៍​​លាយ​​សំឡេង​"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
@@ -8329,6 +16549,7 @@ msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
@@ -8336,9 +16557,24 @@ msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "ចាប់ផ្តើម​ត្រួតពិនិត្យ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "ចាប់ផ្តើម​ត្រួតពិនិត្យ"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "មិន​អនុញ្ញាត​ម៉ែត្រ"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -8374,6 +16610,10 @@ msgstr "កំណត់ (ឬ​ពង្រីក) ជម្រើស​​ឆ�
 msgid "Length and Center of Selection"
 msgstr "កាត់​​តម្រឹម​​ឯកសារ​​ទៅ​​ការ​​ជ្រើស"
 
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Snap To"
 msgstr "ខ្ទាស់ទៅ"
@@ -8382,9 +16622,24 @@ msgstr "ខ្ទាស់ទៅ"
 msgid "Length"
 msgstr "ប្រវែង"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "កណ្តាល"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -8411,6 +16666,10 @@ msgstr "ប្រេកង់​ដំឡើង​បាស"
 msgid "Center Frequency"
 msgstr "ប្រេកង់​​លីនេអ៊ែរ"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -8429,13 +16688,18 @@ msgstr "របារ​​ឧបករណ៍​​ឧបករណ៍"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "របារ​ឧបករណ៍​របស់ Audacity %s"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "ចុច និង​អូស​ដើម្បី​ប្ដូរ​ទំហំ​បទ ។"
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "ឧបករណ៍"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -8453,7 +16717,8 @@ msgstr "ឧបករណ៍​ប្ដូរ​ពេល​វេលា F5"
 msgid "Zoom Tool"
 msgstr "ឧបករណ៍​ពង្រីក F4"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "ឧបករណ៍​គូរ F3"
 
@@ -8529,11 +16794,13 @@ msgstr "អូស​ស៊ុម​ស្លាក​មួយ ឬ​ច្រ�
 msgid "Drag label boundary."
 msgstr "អូស​ស៊ុម​ស្លាក"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "ស្លាក​ដែល​បានកែប្រែ"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "កែសម្រួល​ស្លាក"
 
@@ -8588,31 +16855,42 @@ msgstr "បាន​កែ​សម្រួល​​ស្លាក"
 msgid "New label"
 msgstr "បាន​បន្ថែម​​ស្លាក"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Octave ឡើង"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Octave ចុះ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "ចុច​ដើម្បី​​ពង្រីក​បញ្ឈរ ប្ដូរ​(Shift) - ចុច ដើម្បី​បង្រួម អូស​ដើម្បី​បង្កើត​តំបន់​ពង្រីក​ជាក់លាក់ ។"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "ចុចស្តាំ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "បង្រួម"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "ប្តូរ(Shift)​ខាង​ឆ្វេង-ចុចស្តាំ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "ប្តូរ(Shift)​ខាង​ឆ្វេង-ចុចស្តាំ"
 
@@ -8635,6 +16913,14 @@ msgid "Stretch"
 msgstr "កត្តា​បន្ថយ ៖"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "បញ្ចូល​ឈុត​ចូល​គ្នា"
 
@@ -8646,7 +16932,8 @@ msgstr "បញ្ចូល​ចូល​គ្នា"
 msgid "Expanded Cut Line"
 msgstr "ពង្រីក​បន្ទាត់​កាត់"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "ពង្រីក"
 
@@ -8659,12 +16946,21 @@ msgid "Click and drag to edit the samples"
 msgstr "ចុច និង​អូស​ដើម្បី​កែសម្រួល​គំរូ"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "គំរូ​ដែលបានផ្លាស់ទី"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "កែសម្រួល​គំរូ"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -8673,6 +16969,16 @@ msgstr "ពង្រីក​លើ​ចំណុច"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "ក្រាហ្វិក​វិសាលគម"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -8698,7 +17004,8 @@ msgstr "កំពុង​ដំណើរ​ការ Auto Duck..."
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "ផ្លាស់ប្ដូរ '%s' ទៅ %s"
@@ -8712,7 +17019,60 @@ msgid "Rat&e"
 msgstr "កំណត់​អត្រា"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -8733,7 +17093,8 @@ msgstr "ផ្លាស់ប្ដូរ​អត្រា"
 msgid "Set Rate"
 msgstr "កំណត់​អត្រា"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "ច្រើន"
 
@@ -8825,6 +17186,27 @@ msgstr "ឆ្វេង "
 msgid "Right, %dHz"
 msgstr "ស្ដាំ "
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "ស្ដាំ"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "ចុច និង​អូស​ដើម្បី​លៃ​តម្រូវ​ទំហំ​បទ​ស្តេរ៉េអូ​នីមួយៗ ។"
@@ -8832,6 +17214,15 @@ msgstr "ចុច និង​អូស​ដើម្បី​លៃ​តម�
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "ចុច និង​អូស​ដើម្បី​ផ្លាស់ទី​បទ​នៅ​ក្នុង​ពេលវេលា"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "ចុច និង​អូស​ដើម្បី​ផ្លាស់ទី​បទ​នៅ​ក្នុង​ពេលវេលា"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -8841,6 +17232,10 @@ msgstr "ពង្រីក"
 msgid "Zoom x2"
 msgstr "ពង្រីក"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "ទ្រង់ទ្រាយ​រលក"
@@ -8848,6 +17243,11 @@ msgstr "ទ្រង់ទ្រាយ​រលក"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "ទ្រង់ទ្រាយ​រលក"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -8880,16 +17280,37 @@ msgid "Set Range"
 msgstr "កំណត់​ជួរ"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "បង្ហាញ"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​រហ័ស"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "លីនេអ៊ែរ"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​រហ័ស"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -8901,9 +17322,8 @@ msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "ចុច និង​អូស​ដើម្បី​ផ្លាស់ទី​បទ​នៅ​ក្នុង​ពេលវេលា"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -8954,6 +17374,21 @@ msgstr "​ស្រោម​សំបុត្រ​ដែល​បាន​ល
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "របារ​ឧបករណ៍​​កែសម្រួល"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "ចាប់ផ្តើម​ត្រួតពិនិត្យ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "អនុញ្ញាត​ម៉ែត្រ"
@@ -8969,6 +17404,16 @@ msgstr "បិទ​បទ​​ដែលបាន​​ផ្ដោត ប្�
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "ផ្លាស់ទី​បទ​ចុះ​ក្រោម"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "ប្រអប់​​បញ្ចូល Nyquist..."
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "រំលង​ដើម្បី​ចាប់ផ្ដើម ដើម"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -9021,6 +17466,11 @@ msgstr "ចុច និង​អូស​ដើម្បី​ជ្រើស�
 msgid "Click and drag to select audio"
 msgstr "ចុច និង​អូស​ដើម្បី​ជ្រើស​អូឌីយ៉ូ"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "ចុច និង​អូស​ដើម្បី​ផ្លាស់ទី​បទ​នៅ​ក្នុង​ពេលវេលា"
@@ -9042,6 +17492,10 @@ msgstr "ធ្វើ​​ឲ្យ​​ស្ងាត់​​បទ​​ដ
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "ធ្វើ​​ឲ្យ​​ស្ងាត់​​បទ​​ដែល​​ជ្រើស %.2f វិនាទី នៅ %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -9068,6 +17522,12 @@ msgstr "ពាក្យ​បញ្ជា"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "បញ្ជា(Ctrl) ចុចឆ្វេង"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -9126,6 +17586,20 @@ msgstr "ឆ្វេង"
 msgid "R"
 msgstr "ស្តាំ"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" មិន​ទាន់​មាន\n"
+"\n"
+"តើ​អ្នក​ចង់​បង្កើត​វា​ទេ?"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
 msgstr "សូមជ្រើស​អំពើ"
@@ -9151,8 +17625,32 @@ msgid "Empty"
 msgstr "ទទេ"
 
 #: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "រំលង​ដើម្បី​ចាប់ផ្ដើម ដើម"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "ជំនួយ​នៅ​លើ​អ៊ីនធឺណិត"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "ឯកសារ​​ទាំងអស់ (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -9191,6 +17689,13 @@ msgid "Refresh Rate"
 msgstr "កំណត់​អត្រា"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "អត្រា​ធ្វើ​ឲ្យ​ម៉ែត្រ​ស្រស់ក្នុង​មួយ​វិនាទី​ [១-១០០] ៖ "
 
@@ -9203,12 +17708,21 @@ msgid "Meter Style"
 msgstr "ម៉ែត្រ"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "ម៉ែត្រ"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "ថិរវេលា"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "សង្គ្រោះ​ការគាំង​ដោយ​ស្វ័យ​ប្រវត្តិ"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -9222,12 +17736,46 @@ msgstr "បន្ទាត់​បញ្ឈរ"
 msgid " Monitoring "
 msgstr "ឈប់​ត្រួតពិនិត្យ"
 
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "បង្កើត​​បទ​​អូឌីយ៉ូ​​ថ្មី"
+
 #. i18n-hint: Format string for displaying time in seconds. Change the comma
 #. * in the middle to the 1000s separator for your locale, and the 'seconds'
 #. * on the end to the word for seconds. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000,01000 seconds"
 msgstr "01000,01000 វិនាទី"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + គំរូ"
 
 #. i18n-hint: Format string for displaying time in hours, minutes and
 #. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
@@ -9238,6 +17786,12 @@ msgstr "01000,01000 វិនាទី"
 msgid "0100 h 060 m 060 s"
 msgstr "0100 ម៉ោង 060 នាទី 060 វិនាទី"
 
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -9246,6 +17800,25 @@ msgstr "0100 ម៉ោង 060 នាទី 060 វិនាទី"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 ថ្ងៃ 024 ម៉ោង 060 នាទី 060 វិនាទី"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "hh:mm:ss + គំរូ"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
@@ -9284,6 +17857,7 @@ msgstr "0100 ម៉ោង 060 នាទី 060 វិនាទី+># គំរ�
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "គំរូ"
@@ -9445,6 +18019,15 @@ msgstr "01000,01000 ស៊ុម|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -9452,6 +18035,10 @@ msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 ម៉ោង 060 នាទី 060>01000 វិនាទី"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -9467,15 +18054,76 @@ msgstr "Octave ចុះ"
 msgid "100>01000 octaves|1.442695041"
 msgstr "០១០០០,០១០០០ ស៊ុម|២៤"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "០១០០០,០១០០០ ស៊ុម|២៤"
 
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "ប្រើ​ប៊ូតុង​កណ្តុរ​​ស្តាំ​​ ឬ​គ្រាប់​ចុច​បរិបទ​ដើម្បី​ផ្លាស់ប្តូរ​ទ្រង់ទ្រាយ"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "វិនាទី"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "ពេល​វេលា​វាយ ៖ %.1f វិនាទី"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "ពេលវេលា​​បញ្ចប់"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Cancel"
+msgstr "បោះបង់"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to cancel?"
@@ -9507,6 +18155,11 @@ msgstr "អះអាង"
 msgid "Unable to write files to directory: %s."
 msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -9524,14 +18177,44 @@ msgstr "សង្គ្រោះ​​គម្រោង"
 msgid "Don't show this warning again"
 msgstr "កុំ​បង្ហាញ​ការ​ព្រមាន​នេះ​ម្តងទៀត"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
 #: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "ទទេ"
 
 #: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "ថត R"
+
+#: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "ពង្រីក​លើ​ជួរ"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "កំហុស LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -9549,12 +18232,26 @@ msgid "Value must not be greater than %s"
 msgstr "ឈ្មោះ​មិន​អាច​ទទេ​បាន​ទេ"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "គម្រោង​ថ្មី​ដែល​បាន​បង្កើត"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
 msgstr "ថត"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "ថត"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "កំហុស ៖ "
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
@@ -9569,16 +18266,49 @@ msgstr "មិន​​អាច​​បើក​​ឯកសារ ៖ "
 msgid "Spectral edit multi tool"
 msgstr "ជម្រើស"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "ប្រវែង"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "ប្រេកង់ (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "កំហុស"
@@ -9593,8 +18323,34 @@ msgstr "ឆានែល​លទ្ធផល ៖ %2d"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​មាន​តម្លៃ​តូចបំផុត ០ Hz"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -9607,6 +18363,28 @@ msgstr "ផតចុះ"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "កំពុង​​អនុវត្ត..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -9633,8 +18411,16 @@ msgid "S-Curve Down"
 msgstr "ផ្លាស់ទី​ចុះក្រោម"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "ចាប់ផ្ដើម"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -9643,6 +18429,14 @@ msgstr "កំណើន"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "ចាប់ផ្ដើម"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -9655,6 +18449,14 @@ msgstr "លីនេអ៊ែរ"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "លីនេអ៊ែរ"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -9693,6 +18495,24 @@ msgstr "ផ្លាស់ទី​ចុះក្រោម"
 msgid "Error~%~%"
 msgstr "កំហុស"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "ធ្វើ​​ម្ដង​​ទៀត"
@@ -9700,6 +18520,10 @@ msgstr "ធ្វើ​​ម្ដង​​ទៀត"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "រក​ការ​ខ្ទាស់..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "របារ​ឧបករណ៍​របស់ Tenacity %s"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -9713,6 +18537,23 @@ msgstr "ខ្ទាស់"
 msgid "Reconstructing clips..."
 msgstr "កំពុង​យក​ក្លីក និង​ផប់​ចេញ..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "កម្រិត​ពន្លឺ ៖ %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "កំណត់​ចំណាំ​បទ"
@@ -9720,6 +18561,21 @@ msgstr "កំណត់​ចំណាំ​បទ"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "កំណត់​ចំណាំ​បទ"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -9753,6 +18609,19 @@ msgstr "ឈ្មោះ​បទ"
 msgid "Fade direction"
 msgstr "ជម្រើស"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "ប្រភេទ​គ្រាប់ចុច"
@@ -9770,6 +18639,19 @@ msgid "Regular"
 msgstr "ចតុកោណកែង"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "បន្ថយ​ការ​រំខាន (dB) ៖"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "ពេលវេលា​ពន្យារ (វិនាទី) ៖"
 
@@ -9782,12 +18664,24 @@ msgid "Pitch/Tempo"
 msgstr "កម្ពស់​សំឡេង (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
 msgstr "មើល​ជាមុន"
 
 #: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "ចំនួន​ដង​ដើម្បី​ធ្វើ​ម្តង​ទៀត ៖"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -9802,18 +18696,40 @@ msgid "XML file"
 msgstr "ឯកសារ MP3"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "ថត R"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "មិន​អាច​បើក​ឯកសារ​ចង្វាក់ ។"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %hs"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %hs"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -9844,18 +18760,67 @@ msgstr "ប្រវែង (វិនាទី)"
 msgid "Length of label region (seconds)"
 msgstr "ប្រវែង (វិនាទី)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "កែសម្រួល​ស្លាក"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "បន្សំ​គ្រាប់ចុច"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "ការ​ព្រមាន"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -9865,6 +18830,17 @@ msgstr "តស្លាក"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "តស្លាក"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -9878,13 +18854,46 @@ msgstr "អនុវត្ត​អេហ្គុយ"
 msgid "Dominic Mazzoni"
 msgstr "ការ​យក​​​ការ​រំខាន​​ចេញ​​ដោយ Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "ប្រេកង់ (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "ប្រេកង់​អប្បបរមា​ត្រូវតែ​មាន​តម្លៃ​តូចបំផុត ០ Hz"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -9908,6 +18917,11 @@ msgid "Average level"
 msgstr "មធ្យម"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "ល្បឿន​ចាក់​ឡើងវិញ"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "ថិរវេលា​ស្ងាត់​អតិ. ៖"
 
@@ -9928,14 +18942,57 @@ msgid "Point after sound"
 msgstr "ភ្ជាប់​ស្តេរ៉េអូ"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "ភ្ជាប់​ស្តេរ៉េអូ"
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "កំពុង​កាត់​ស្ងាត់​ឲ្យ​ខ្លី..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "កំពុង​កាត់​ស្ងាត់​ឲ្យ​ខ្លី..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "ឈ្មោះ​មិន​អាច​ទទេ​បាន​ទេ"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -9963,8 +19020,25 @@ msgid "Hard Clip"
 msgstr "រក​កា​ខ្ទាស់"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "ឆានែល​ស្ដាំ"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "កម្រិត ៖"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -9985,6 +19059,14 @@ msgstr "ប្រភេទ​ការរំខាន"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "ជម្រើស"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Stereo Linking"
@@ -10018,6 +19100,44 @@ msgstr "ពេល​វេលា​វាយ/បន្ថយ (វិនាទី
 msgid "Decay (ms)"
 msgstr "ពេល​វេលា​វាយ/បន្ថយ (វិនាទី) ៖"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "ឈ្មោះ​មិន​អាច​ទទេ​បាន​ទេ"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "កំពុង​​អនុវត្ត​ Leveller..."
@@ -10025,6 +19145,22 @@ msgstr "កំពុង​​អនុវត្ត​ Leveller..."
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "កំពុង​​អនុវត្ត​ Leveller..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -10047,7 +19183,8 @@ msgstr "ឯកសារ MP3"
 msgid "HTML file"
 msgstr "ឯកសារ MP3"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "ឈ្មោះ​ឯកសារ ៖"
 
@@ -10064,9 +19201,24 @@ msgid "Disallow"
 msgstr "មិន​បាន​អនុញ្ញាត"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "មិន​បាន​អនុញ្ញាត"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -10077,16 +19229,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "ទីតាំង​នាំចេញ ៖"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "កំពុង​បង្កើត​សំឡេង"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "ប្រភេទ​ការរំខាន"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -10101,8 +19295,40 @@ msgid "Generating Rhythm..."
 msgstr "កំពុង​បង្កើត Chirp"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "ចំនួន​ដង​ដើម្បី​ធ្វើ​ម្តង​ទៀត ៖"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -10125,12 +19351,54 @@ msgid "Beat sound"
 msgstr "ធ្វើ​​ម្ដង​​ទៀត"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "​យក​ការ​រំខាន​ចេញ"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "ការ​រំខាន..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -10141,12 +19409,25 @@ msgid "Generating Risset Drum..."
 msgstr "បង្កើត​ការ​រំខាន"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "ពេលវេលា​ពន្យារ (វិនាទី) ៖"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "ប្រេកង់​​លីនេអ៊ែរ"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "ប្រេកង់ (Hz)"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -10159,6 +19440,10 @@ msgstr "មិន​អាច​នាំ​ចេញ"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "កំពុង​​អនុវត្ត..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -10177,6 +19462,10 @@ msgid "HTML files"
 msgstr "ឯកសារ MP3"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "កែសម្រួល​គំរូ"
 
@@ -10185,8 +19474,34 @@ msgid "Time Indexed"
 msgstr "កែសម្រួល​ស្លាក"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "ទាំងអស់"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -10201,6 +19516,11 @@ msgstr "\t-help (សារ​នេះ)"
 msgid "Errors Only"
 msgstr "កំហុស ៖ "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -10213,6 +19533,46 @@ msgstr "ឆានែល​ស្ដាំ"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "គំរូ"
 
@@ -10220,6 +19580,43 @@ msgstr "គំរូ"
 #, lisp-format
 msgid "~a seconds."
 msgstr "វិនាទី"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -10238,6 +19635,10 @@ msgid "Value (dB)"
 msgstr "កម្រិត ៖"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "លីនេអ៊ែរ"
 
@@ -10254,6 +19655,14 @@ msgid "Right (dB)"
 msgstr "ស្ដាំ "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "លីនេអ៊ែរ"
 
@@ -10264,6 +19673,40 @@ msgstr "ឆានែល ២​ (ស្តេរ៉េអូ)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "ឆានែល ១ (ម៉ូណូ)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "កំហុស (ឯកសារ​អាច​មិន​ទាន់​ត្រូវ​បាន​សរសេរ) ៖ %hs"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -10278,8 +19721,40 @@ msgid "Select file"
 msgstr "ជ្រើស​​ឯកសារ​​មីឌី..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "កំហុស"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -10289,6 +19764,15 @@ msgstr "មិន​អាច​បើក​ឯកសារ​ចង្វាក
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "ជម្រើស"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -10306,9 +19790,21 @@ msgstr "ធ្មេញ​រណារ"
 msgid "Starting phase (degrees)"
 msgstr "ដំណាក់​ចាប់ផ្តើម LFO (deg.) ៖"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "កំពុង​​អនុវត្ត..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -10350,9 +19846,96 @@ msgstr "ធ្វើ​​វិភាគ"
 msgid "Strength"
 msgstr "ប្រវែង"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "កំពុង​ដំណើរ​ការ Auto Duck..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -10386,6 +19969,109 @@ msgstr "ប្រេកង់ (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "ប្រេកង់ (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "បិទ Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "ឆានែល"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "កំហុស​ក្នុង​ការ​បើក​ឯកសារ"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "របារ​ឧបករណ៍​របស់ Audacity %s"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "ថត"
+
+#~ msgid "Commit Id:"
+#~ msgstr "ពាក្យបញ្ជា ៖"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "មិន​អាច​បើក​ឯកសារ​ចង្វាក់ ។\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "ថត\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "ចាក់ឡើងវិញ\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "ថត\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "ថត\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "ចាក់ឡើងវិញ\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "ចាក់ឡើងវិញ\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "មិន​អាច​​ប្ដូរ​ឈ្មោះ '%s' ទៅ​​ជា '%s'"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "ចាក់ឡើងវិញ"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "ចាក់ឡើងវិញ"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "ចាក់ឡើងវិញ"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "ថត"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "ថត"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "ថត"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "អំពី Audacity..."
+
+#~ msgid "Recording Volume"
+#~ msgstr "ថត"
+
+#~ msgid "Playback Volume"
+#~ msgstr "ចាក់ឡើងវិញ"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "ថត"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "ចាក់ឡើងវិញ"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "ចាក់ឡើងវិញ"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "ចុច និង​អូស​ដើម្បី​ផ្លាស់ទី​បទ​នៅ​ក្នុង​ពេលវេលា"
+
 #~ msgid "Program build date:"
 #~ msgstr "កាល​បរិច្ឆេទ​ស្ថាបនា​កម្មវិធី ៖"
 
@@ -10396,10 +20082,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "មិ"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "មិន​​អាច​​បើក/បង្កើត​​ឯកសារ​​សាកល្បង"
 
 #, fuzzy
 #~ msgid "available"
@@ -10429,14 +20111,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "Failed to copy tags"
 #~ msgstr "មិន​អាច​យក '%s' ចេញ​បាន​ទេ"
-
-#, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "ជ្រើស​​ឯកសារ​​អូឌីយ៉ូ​​ដែល​​មិន​​បាន​​បង្ហាប់..."
-
-#, fuzzy
-#~ msgid "decode an autosave file"
-#~ msgstr "មិន​អាច​យក​ចេញ​ឯកសារ​រក្សា​ទុក​ស្វ័យ​ប្រវត្តិ​ចាស់"
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -10488,10 +20162,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ "/%s/%s.%s"
 #~ msgstr "ថត"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "ថត"
-
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
 #~ msgstr "ការ​គាំទ្រ Ogg Vorbis មិន​ត្រូវ​បាន​រួម​បញ្ចូល​នៅ​ក្នុង​ការ​ស្ថាបនា​របស់ Audacity ទេ"
 
@@ -10511,9 +20181,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "ជម្រះ​​ឯកសារ​​បណ្ដោះ​​អាសន្ន"
-
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "ជម្រះ​​ថត​​ឃ្លាំង​សម្ងាត់"
 
 #~ msgid "Renamed file: %s\n"
 #~ msgstr "បាន​​ប្ដូ​រឈ្មោះ​​ឯកសារ ៖ %s\n"
@@ -10547,10 +20214,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "មិន​អាច​យក​ចេញ​ឯកសារ​រក្សា​ទុក​ស្វ័យ​ប្រវត្តិ​ចាស់"
 
 #, fuzzy
-#~ msgid "Compress"
-#~ msgstr "ឧបករណ៍​បង្ហាប់..."
-
-#, fuzzy
 #~ msgid ""
 #~ "MP3 Decoding Failed:\n"
 #~ "\n"
@@ -10574,9 +20237,6 @@ msgstr "ប្រេកង់ (Hz)"
 
 #~ msgid "Audio cache"
 #~ msgstr "ឃ្លាំង​សម្ងាត់​អូឌីយ៉ូ"
-
-#~ msgid "When saving a project that depends on other audio files"
-#~ msgstr "នៅ​ពេល​រក្សាទុក​គម្រោង ដែល​អាស្រ័យ​លើ​ឯកសារ​អូឌីយ៉ូ​ផ្សេងៗ​ទៀត"
 
 #, fuzzy
 #~ msgid "Silence Finder"
@@ -10684,10 +20344,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "ធ្វើ​ឲ្យ​ការ​បង្ហាញ​ទាន់សម័យ​ ខណៈពេល​ចាក់"
 
 #, fuzzy
-#~ msgid "Disable Scrub Ruler"
-#~ msgstr "មិន​អនុញ្ញាត​ម៉ែត្រ"
-
-#, fuzzy
 #~ msgid "Enable Scrub Ruler"
 #~ msgstr "អនុញ្ញាត​ម៉ែត្រ"
 
@@ -10710,9 +20366,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "Selected:"
 #~ msgstr "ជ្រើស"
-
-#~ msgid "ms"
-#~ msgstr "មីល្លីវិនាទី"
 
 #, fuzzy
 #~ msgid "XML files (*.xml)|*.xml|All files|*"
@@ -10757,10 +20410,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "មិន​អាច​បង្កើត​ឯកសារ​រក្សា​ទុក​ស្វ័យ​ប្រវត្តិ ៖ "
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "យក​បទ​ចេញ"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "កំពុង​យក​ក្លីក និង​ផប់​ចេញ..."
 
@@ -10798,18 +20447,6 @@ msgstr "ប្រេកង់ (Hz)"
 
 #~ msgid "false"
 #~ msgstr "មិនពិត"
-
-#, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "ឯកសារ​​អូឌីយ៉ូ"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "អនុវត្ត​បែបផែន Nyquist..."
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "មិនអាច​រក្សាទុក​ឯកសារ​ចង្វាក់"
 
 #, fuzzy
 #~ msgid "Unable to save MIDI device info"
@@ -10869,10 +20506,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "កែសម្រួល​ច្រវាក់..."
 
 #, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "របារ​​ឧបករណ៍​​​កា​រចម្លង​"
-
-#, fuzzy
 #~ msgid "&Tools"
 #~ msgstr "ឧបករណ៍"
 
@@ -10894,10 +20527,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ "Error opening sound device.\n"
 #~ "Try changing the audio host, recording device and the project sample rate."
 #~ msgstr "កំហុស​​ពេល​​កំពុង​​បើក​​ឧបករណ៍​សំឡេង។ សូម​ត្រួតពិនិត្យ​មើល​ការ​កំណត់​ឧបករណ៍​លទ្ធផល និង​​អត្រា​​គំរូ​​គម្រោង"
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "ថត"
 
 #, fuzzy
 #~ msgid "Slider Playback"
@@ -10931,10 +20560,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "ការ​ចម្លង"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "របារ​ឧបករណ៍​​កែសម្រួល"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -11011,10 +20636,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "ប្រវែង"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "ជម្រើស​ទៅ​ចុង ប្ដូរ(Shift)+ចុង(End)"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "ទៅ​ចុង​​ជម្រើស"
 
@@ -11073,10 +20694,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "ភាគរយ​ផ្លាស់ប្តូរ ៖"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "​ពេល​វេលា​វាយ ៖"
-
-#, fuzzy
 #~ msgid "Repeats"
 #~ msgstr "ធ្វើ​​ម្ដង​​ទៀត"
 
@@ -11087,14 +20704,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "Duty Cycle"
 #~ msgstr "ខួបមុខងារ ៖"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "អាំភ្លី (០-១)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "ឈ្មោះ"
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -11146,10 +20755,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "មតិ​អ្នកប្រើ (%) ៖"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "ទំហំ"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "មតិ​អ្នកប្រើ (%) ៖"
 
@@ -11164,14 +20769,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "កំណើន"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "ស្តេរ៉េអូ"
-
-#, fuzzy
-#~ msgid "FilterType"
-#~ msgstr "ម៉ែត្រ"
 
 #, fuzzy
 #~ msgid "RatePercentChangeStart"
@@ -11200,10 +20797,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "កាត់​ស្ងាត់​ឲ្យ​ខ្លី"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "កំពុង​​ដាក់​បញ្ច្រាស"
 
 #~ msgid ""
 #~ "The keyboard shortcut '%s' is already assigned to:\n"
@@ -11264,10 +20857,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "ប្រើការ​​លាយ​​ផ្លាល់ខ្លួ​ន (ឧទាហរណ៍ នាំចេញ​ឯកសារ​ពហុ​ឆានែល ៥.១)"
 
 #, fuzzy
-#~ msgid "&Length of preview:"
-#~ msgstr "ប្រវែង​នៃ​ការ​​មើល​ជាមុន"
-
-#, fuzzy
 #~ msgid "Add &Track Number"
 #~ msgstr "លេខ​បទ"
 
@@ -11306,9 +20895,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgid "Welcome to Audacity "
 #~ msgstr "សូម​ស្វាគមន៍​មក​កាន់ Audacity !"
 
-#~ msgid "Edit Metadata"
-#~ msgstr "កែ​សម្រួល​​ទិន្នន័យ​​មេតា"
-
 #~ msgid "Disk space remains for recording %d hours and %d minutes."
 #~ msgstr "នៅ​តែ​មាន​ទំហំ​ថាស​សម្រាប់​ថត %d ម៉ោង និង %d នាទី ។"
 
@@ -11327,10 +20913,6 @@ msgstr "ប្រេកង់ (Hz)"
 #, fuzzy
 #~ msgid "R&ight Channel"
 #~ msgstr "ឆានែល​ស្ដាំ"
-
-#, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "ដំឡើង (dB) ៖"
 
 #, fuzzy
 #~ msgid "&Enable level control"
@@ -11385,12 +20967,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ "  %s"
 
 #, fuzzy
-#~ msgid "Current directory:"
-#~ msgstr ""
-#~ "មិន​អាច​បង្កើត​ថត ៖\n"
-#~ "  %s"
-
-#, fuzzy
 #~ msgid "Directory doesn't exist."
 #~ msgstr "មិន​ទាន់​មាន​ថត %s ទេ ។ បង្កើត​វា​ឬទេ ?"
 
@@ -11431,17 +21007,8 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgid "Command Line Export Setup"
 #~ msgstr "រៀបចំ​ការ​នាំចេញ​បន្ទាត់​ពាក្យ​បញ្ជា"
 
-#~ msgid "Specify FLAC Options"
-#~ msgstr "បញ្ជាក់​ជម្រើស FLAC"
-
-#~ msgid "FLAC Export Setup"
-#~ msgstr "រៀបចំការ​​​នាំចេញ FLAC"
-
 #~ msgid "Specify MP2 Options"
 #~ msgstr "បញ្ជាក់​ជម្រើស MP2"
-
-#~ msgid "MP2 Export Setup"
-#~ msgstr "រៀបចំ​នាំចេញ MP2"
 
 #~ msgid "Specify MP3 Options"
 #~ msgstr "បញ្ជាក់​ជម្រើស MP3"
@@ -11454,9 +21021,6 @@ msgstr "ប្រេកង់ (Hz)"
 
 #~ msgid "Specify Ogg Vorbis Options"
 #~ msgstr "បញ្ជាក់​ជម្រើស​ Ogg Vorbis"
-
-#~ msgid "Ogg Vorbis Export Setup"
-#~ msgstr "រៀបចំ​​នាំ​ចេញ Ogg Vorbis"
 
 #~ msgid "Uncompressed Export Setup"
 #~ msgstr "រៀបចំ​នាំចេញ​​ដែល​មិន​បង្ហាប់"
@@ -11503,9 +21067,6 @@ msgstr "ប្រេកង់ (Hz)"
 
 #~ msgid "&Audio Track"
 #~ msgstr "បទ​អូឌីយ៉ូ"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​គុណភាព​ខ្ពស់"
 
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "ការ​កែខៃ​ធ្វើ​សមកាលកម្ម​រហ័ស"
@@ -11585,9 +21146,6 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgid "Equalization..."
 #~ msgstr "អេហ្គុយ..."
 
-#~ msgid "Performing Equalization"
-#~ msgstr "អនុវត្ត​អេហ្គុយ"
-
 #~ msgid "Fading In"
 #~ msgstr "កំពុងផុសចេញ"
 
@@ -11602,10 +21160,6 @@ msgstr "ប្រេកង់ (Hz)"
 
 #~ msgid "Inverting"
 #~ msgstr "ការ​ដាក់​បញ្ច្រាស"
-
-#, fuzzy
-#~ msgid "Leveler..."
-#~ msgstr "Leveller..."
 
 #~ msgid "Noise Generator"
 #~ msgstr "ឧបករណ៍​​បង្កើត​​ការ​រំខាន"
@@ -11649,24 +21203,12 @@ msgstr "ប្រេកង់ (Hz)"
 #~ msgstr "ប្ដូរ​ឈ្មោះ"
 
 #, fuzzy
-#~ msgid "Load preset:"
-#~ msgstr "ផ្ទុក​ឯកសារ"
-
-#, fuzzy
 #~ msgid "Change name to:"
 #~ msgstr "ផ្លាស់ប្ដូរ​ឈ្មោះ​បទ​ទៅ ៖"
 
 #, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "ដាក់​បញ្ច្រាស"
-
-#, fuzzy
 #~ msgid "Applying Reverb"
 #~ msgstr "កំពុង​​អនុវត្ត​ Leveller..."
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "ផ្ទុក​ឯកសារ​ឡើង..."
 
 #~ msgid "Silence..."
 #~ msgstr "ស្ងាត់..."

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/tenacity/tenacity/ko/>\n"
@@ -22,72 +22,6 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "오데시티 업데이트"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "건너뛰기(&S)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "업데이트 설치 (&I)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "변경 로그"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "GitHub의 상세정보를 참조하세요. "
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "업데이트를 위한 오류 점검"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "오데시티 업데이트 서버에 접속할 수 없습니다. "
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "업데이트 데이터가 손실되었습니다."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "업그레이드를 다운로드하는데 오류"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "오데시티 다운로드 링크를 열 수 없습니다."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "오데시티 %s 를 사용할 수 있습니다."
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "녹음"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "결정할 수 없음"
@@ -96,6 +30,18 @@ msgstr "결정할 수 없음"
 #, c-format
 msgid "%s bytes"
 msgstr "%s 바이트"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
 
 #. i18n-hint: Abbreviation for Giga bytes
 #: libraries/lib-strings/Internat.cpp
@@ -228,7 +174,8 @@ msgid "Script"
 msgstr "스크립트"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "출력"
 
@@ -244,7 +191,12 @@ msgstr "나이키스트 스크립트 (*.ny)|*.ny|Lisp 스크립트 (*.lsp)|*.lsp
 msgid "Script was not saved."
 msgstr "스크립트가 저장되지 않음."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "경고"
 
@@ -273,7 +225,8 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 리랜드 루시우스"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "효과 작성용 간단한 IDE를 제공하는 외부 오데시티 모듈."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -296,7 +249,8 @@ msgstr "무제"
 msgid "Nyquist Effect Workbench - "
 msgstr "나이키스트 효과 작업벤치 - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "새로 만들기"
 
@@ -336,7 +290,8 @@ msgstr "복사"
 msgid "Copy to clipboard"
 msgstr "클립보드에 복사"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "잘라내기"
 
@@ -344,7 +299,8 @@ msgstr "잘라내기"
 msgid "Cut to clipboard"
 msgstr "클립보드로 잘라내기"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "붙여넣기"
 
@@ -369,7 +325,8 @@ msgstr "전체 선택"
 msgid "Select all text"
 msgstr "전체 텍스트 선택"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "실행 취소"
 
@@ -377,7 +334,8 @@ msgstr "실행 취소"
 msgid "Undo last change"
 msgstr "마지막 변경사항 실행 취소"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "재실행"
 
@@ -434,7 +392,8 @@ msgid "Go to next S-expr"
 msgstr "다음 S-표현식으로 이동"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "시작"
 
@@ -442,7 +401,8 @@ msgstr "시작"
 msgid "Start script"
 msgstr "스크립트 시작"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "정지"
 
@@ -457,7 +417,8 @@ msgid "About %s"
 msgstr "정보 %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "확인"
 
@@ -465,11 +426,13 @@ msgstr "확인"
 msgid "Build Information"
 msgstr "빌드 정보"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "활성화"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "비활성화"
 
@@ -479,8 +442,9 @@ msgid "The Build"
 msgstr "빌드"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "제출 ID:"
+#, fuzzy
+msgid "Version:"
+msgstr "버전: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -490,22 +454,28 @@ msgstr "빌드 형식:"
 msgid "Compiler:"
 msgstr "컴파일러:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "설치 접두사:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "설정 폴더:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "설정 폴더:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "지원 파일 형식"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "크로스 플랫폼 GUI 라이브러리"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -519,7 +489,6 @@ msgstr "샘플링 주파수 변환"
 msgid "MP3 Importing"
 msgstr "MP3 가져오기"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis 가져오기/내보내기"
@@ -528,7 +497,6 @@ msgstr "Ogg Vorbis 가져오기/내보내기"
 msgid "ID3 tag support"
 msgstr "ID3 태그 지원"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC 가져오기/내보내기"
@@ -546,14 +514,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg 가져오기/내보내기"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "GStreamer를 통해 가져오기"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "특징"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "플러그인 지원"
 
@@ -568,6 +528,10 @@ msgstr "피치 및 템포 변경 지원"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "극한의 피치와 템포 변경 지원"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "특징"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -686,6 +650,10 @@ msgstr "%s, 그래픽"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (%s, %s, %s, %s, 그리고 %s를 통합중)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -695,6 +663,10 @@ msgstr "%s 는 소리 녹화와 편집을 위한 무료, 오픈소스, 크로스
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "만든 사람들"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -745,6 +717,7 @@ msgstr "웹사이트와 그래픽스"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Seong-ho Cho<darkcircle.0426@gmail.com>, sheppaul<at gmail dot com>"
@@ -762,6 +735,22 @@ msgstr "특별히 감사할 분들:"
 #, c-format
 msgid "%s website: "
 msgstr "%s 웹사이트: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "공헌한 분들"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -784,6 +773,7 @@ msgstr "시간표시줄"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "탐색 시작은 누르거나 드래그하세요"
@@ -791,6 +781,7 @@ msgstr "탐색 시작은 누르거나 드래그하세요"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "스크러빙 시작은 누르거나 드래그하세요"
@@ -798,6 +789,7 @@ msgstr "스크러빙 시작은 누르거나 드래그하세요"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "스크러빙은 클릭 후 이동, 탐색은 클릭 후 드래그하세요"
@@ -805,6 +797,7 @@ msgstr "스크러빙은 클릭 후 이동, 탐색은 클릭 후 드래그하세�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "탐색하려면 이동하세요"
@@ -812,6 +805,7 @@ msgstr "탐색하려면 이동하세요"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "스크러빙하려면 이동하세요"
@@ -868,7 +862,17 @@ msgstr ""
 "프로젝트 끝 너머의 영역은\n"
 "잠글 수 없습니다."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "오류"
 
@@ -892,7 +896,8 @@ msgstr ""
 "이 질문은 환경 설정을 초기화하도록 하는 '설치' 과정 이후 한 번만 묻습니다."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "오데시티 환경 설정 초기화"
 
 #: src/AudacityApp.cpp
@@ -907,7 +912,8 @@ msgstr ""
 "최근 파일 목록에서 제거되었습니다."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite 라이브러리 초기화 실패. 오데시티는 계속 실행할 수 없습니다."
 
 #: src/AudacityApp.cpp
@@ -933,7 +939,7 @@ msgstr "열기(&O)..."
 msgid "Open &Recent..."
 msgstr "최근 열기(&R)..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "오데시티 정보(&A)..."
@@ -947,9 +953,10 @@ msgid "&File"
 msgstr "파일(&F)"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "오데시티는 임시 파일을 저장할 안전한 장소를 찾지 못했습니다.\n"
@@ -957,20 +964,23 @@ msgstr ""
 "환경 설정 대화상자에서 적절한 폴더를 입력해 주세요."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "오데시티는 임시 파일을 저장할 장소를 찾을 수 없습니다.\n"
 "환경 설정 대화상자에서 적당한 폴더를 입력하세요."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "오데시티를 지금 종료할 것입니다. 새 임시 폴더를 사용하도록 오데시티를 다시 실행하세요."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -978,15 +988,17 @@ msgstr ""
 "시스템 크래쉬가 발생할 수도 있습니다.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "오데시티는 임시 파일 폴더를 잠글 수 없습니다.\n"
 "오데시티의 다른 사본에서 이 폴더를 사용 중인 것 같습니다.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "그래도 오데시티를 시작할까요?"
 
 #: src/AudacityApp.cpp
@@ -994,19 +1006,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "임시 폴더를 잠그는 중 오류"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "이 시스템은 오데시티의 다른 사본이 실행 중인 것을 감지했습니다.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "현재 실행중인 오데시티 프로세스에서 여러 프로젝트를 동시에\n"
 "열려면 '새로 만들기'나 '열기' 명령을 사용하세요.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "오데시티가 이미 실행 중입니다"
 
 #: src/AudacityApp.cpp
@@ -1022,7 +1037,8 @@ msgstr ""
 "리부트를 하면 해결될 수 있습니다."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "오데시티 시동 실패"
 
 #: src/AudacityApp.cpp
@@ -1062,8 +1078,9 @@ msgstr ""
 "리부트를 하면 해결될 수 있습니다."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1095,7 +1112,8 @@ msgstr "자체 진단 실행"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "오데시티 버전 표시"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1105,9 +1123,10 @@ msgid "audio or project file name"
 msgstr "오디오나 프로젝트 파일 이름"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1120,16 +1139,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "오데시티 프로젝트 파일"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "메시지"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "오데시티 설정 오류"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1139,7 +1160,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "다음 설정 파일에 접근할 수 없습니다:\n"
 "\n"
@@ -1151,12 +1172,15 @@ msgstr ""
 "\n"
 "만일 \"오데시티 종료\" 버튼을 선택하면, 현재의 프로젝트는 저장되지 않은 상태로 남고, 다시 열때 복구를 시도할 것입니다. "
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "도움말"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "오데시티 끝내기 (&Q)"
 
 #: src/AudacityFileConfig.cpp
@@ -1164,7 +1188,8 @@ msgid "&Retry"
 msgstr "재시도(&R)"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "오데시티 로그"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1176,9 +1201,14 @@ msgstr "저장(&S)..."
 msgid "Cl&ear"
 msgstr "지우기(&E)"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "닫기(&C)"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1227,7 +1257,8 @@ msgid "Error Initializing Midi"
 msgstr "미디 초기화 중 오류"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "오데시티 오디오"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1242,37 +1273,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "메모리가 부족합니다!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "자동 녹음 레벨 조정 중단. 더 이상 최적화가 불가능합니다. 여전히 너무 높습니다."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "자동 녹음 레벨 조정: 볼륨을 %.2f로 줄였습니다."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "자동 녹음 레벨 조정 중단. 더 이상 최적화가 불가능합니다. 여전히 너무 낮습니다."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "자동 녹음 레벨 조정: 볼륨을 %.2f로 올렸습니다."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "자동 녹음 레벨 조정 중단됨. 알맞은 볼륨을 찾기위한 최대 분석횟수를 초과했습니다. 여전히 너무 높습니다."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "자동 녹음 레벨 조정 중단됨. 알맞은 볼륨을 찾기위한 최대 분석횟수를 초과했습니다. 여전히 너무 낮습니다."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "자동 녹음 레벨 조정 중단: %.2f은 무난한 볼륨인 듯 싶습니다."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1371,43 +1371,6 @@ msgstr "'%s'를 위한 재생 장치를 찾을 수 없습니다.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "두 장치 없이 상호 샘플링 속도를 확인할 수 없습니다.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "장치를 여는 동안 %d를 받았습니다.\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Portmixer를 열 수 없습니다.\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "사용가능한 믹서:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "사용가능한 녹음 자원:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "사용가능한 재생 볼륨:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "녹음 볼륨이 복사되었습니다\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "녹음 볼륨을 기본으로\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "재생 볼륨이 복사되었습니다\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "재생 볼륨을 기본으로\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1450,8 +1413,9 @@ msgid "Automatic Crash Recovery"
 msgstr "자동 충돌 복구"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1463,12 +1427,14 @@ msgid "Recoverable &projects"
 msgstr "복구 가능한 프로젝트 (&P)"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "선택"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "이름"
 
@@ -1554,6 +1520,11 @@ msgstr "효과"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "메뉴 명령 (매개 변수 있음)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1699,7 +1670,8 @@ msgstr "복구 및 저장"
 msgid "I&mport..."
 msgstr "가져오기(&M)..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "내보내기(&X)..."
 
@@ -1740,7 +1712,8 @@ msgstr "위로 이동(&U)"
 msgid "Move &Down"
 msgstr "아래로 이동(&D)"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "저장(&S)"
 
@@ -1823,9 +1796,17 @@ msgid "Run"
 msgstr "실행"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "닫기"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "벤치마크"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1963,11 +1944,6 @@ msgid "No revision identifier was provided"
 msgstr "수정본 ID가 없습니다."
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "끝 날짜 및 시간"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "디버그 빌드 (디버그 레벨 %d) "
@@ -2051,6 +2027,11 @@ msgid ""
 msgstr ""
 "이 동작을 수행하려면 일부 오디오를 우선 선택해야 합니다.\n"
 "(다른 종류의 트랙을 선택하면 동작하지 않을 것입니다.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2213,6 +2194,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "클립보드에 이름 복사"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "누락된"
 
@@ -2221,10 +2207,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "계속 진행하면, 프로젝트를 디스크에 저장하지 않을 것입니다. 계속 진행할까요?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2238,7 +2225,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "의존성 확인"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "없음"
 
@@ -2246,7 +2236,7 @@ msgstr "없음"
 msgid "Rectangle"
 msgstr "Rectangle (직사각형)"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triangle (삼각형)"
 
@@ -2308,9 +2298,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg 지원은 컴파일되지 않았습니다"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2332,8 +2323,8 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg 찾기"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "오데시티에서 FFmpeg을 통해 오디오를 가져오고 내보내는데 '%s' 파일이 필요합니다."
 
 #: src/FFmpeg.cpp
@@ -2346,7 +2337,8 @@ msgstr "'%s' 위치:"
 msgid "To find '%s', click here -->"
 msgstr "'%s'을 찾으려면, 여기를 누르세요 -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "찾아보기..."
 
@@ -2372,8 +2364,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg을 찾지 못했습니다"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2403,24 +2396,24 @@ msgid "Only libavformat.so"
 msgstr "오직 libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "오데시티에서 1%s의 파일을 열지 못했습니다."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "오데시티는 1%s의 파일에서 읽지 못했습니다."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "오데시티에서 %s에 파일을 잘 썼지만 이름을 %s로 바꾸는데 실패했습니다."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2457,7 +2450,9 @@ msgstr "어떤 오디오도 복사하지 않기(&N)"
 msgid "As&k"
 msgstr "묻기(&K)"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "모든 파일"
 
@@ -2482,6 +2477,10 @@ msgstr "텍스트 파일"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML 파일ㄷ"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2546,6 +2545,17 @@ msgstr "선형 주파수"
 msgid "Log frequency"
 msgstr "로그 주파수"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "스크롤"
@@ -2553,6 +2563,15 @@ msgstr "스크롤"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "확대/축소"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2613,6 +2632,23 @@ msgstr "너무 많은 오디오를 선택했습니다. 오디오의 처음 %.1f�
 msgid "Not enough data selected."
 msgstr "충분한 데이터를 선택하지 않았습니다."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f 초 (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f 초 (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2628,10 +2664,16 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f 초 (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "스펙트럼"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "다른 이름으로 스펙트럼 데이터 내보내기:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "파일에 쓸 수 없습니다: %s"
@@ -2821,19 +2863,19 @@ msgid "&History..."
 msgstr "작업내역(&H)..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "내부 오류: %s에서, %s의 %d번째 줄.\n"
 "오데시티 팀에게 https://forum.audacityteam.org/로 알려주세요."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "내부 오류: %s의 %d번째 줄.\n"
 "오데시티 팀에게 https://forum.audacityteam.org/로 알려주세요."
@@ -2852,7 +2894,9 @@ msgid "Track"
 msgstr "트랙"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "레이블"
 
@@ -2912,7 +2956,8 @@ msgstr "트랙 이름을 입력하세요"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "레이블 트랙"
 
@@ -2923,11 +2968,13 @@ msgstr "하나 이상의 저장된 레이블을 읽을 수 없습니다."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "오데시티 처음 실행"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "오데시티에서 사용할 언어 선택:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2937,7 +2984,8 @@ msgstr "오데시티에서 사용할 언어 선택:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "선택한 언어 %s (%s)가 시스템 언어 %s (%s)와 같지 않습니다."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "확인"
 
@@ -2955,12 +3003,13 @@ msgstr ""
 "이전 파일은 '%s' 이름으로 저장했습니다"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "오데시티 프로젝트 열기"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "오데시티 가라오케%s"
 
 #: src/LyricsWindow.cpp
@@ -3011,19 +3060,23 @@ msgid "Mixing and rendering tracks"
 msgstr "트랙 믹싱/렌더링"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "오데시티 믹서 보드%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "게인"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "속도"
 
@@ -3032,17 +3085,23 @@ msgid "Musical Instrument"
 msgstr "악기"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "팬"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "음소거"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "독주"
 
@@ -3050,15 +3109,18 @@ msgstr "독주"
 msgid "Signal Level Meter"
 msgstr "신호 레벨 미터"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "게인 슬라이더를 이동했습니다"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "속도 슬라이더를 이동했습니다"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "팬 슬라이더를 이동했습니다"
 
@@ -3093,9 +3155,9 @@ msgstr ""
 "이 모듈은 불러오지 않을 것입니다."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3129,16 +3191,19 @@ msgstr ""
 "\n"
 "신뢰하는 소스의 모듈만 사용합니다"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "예"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "아니요"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "오데시티 모듈 로더"
 
 #: src/ModuleManager.cpp
@@ -3161,6 +3226,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "노트 트랙"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3269,7 +3444,8 @@ msgstr "전체 선택(&S)"
 msgid "C&lear All"
 msgstr "모두 지우기(&L)"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "활성화(&E)"
 
@@ -3346,9 +3522,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "샘플링 주파수가 맞지 않음"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "이 샘플링 주파수에서 녹음을 위한 트랙이 너무 적게 선택되었습니다. \n"
@@ -3377,10 +3554,11 @@ msgid "Dropouts"
 msgstr "드롭아웃"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3420,11 +3598,11 @@ msgid "Inspecting project file data"
 msgstr "프로젝트 파일 데이터 검사 중"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3467,11 +3645,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "경고 - 별명 파일이 없습니다"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "\"%s\" 폴더의 프로젝트 검사에서\n"
@@ -3496,12 +3674,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "경고 - 별명 요약 파일이 없습니다"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3558,7 +3736,8 @@ msgstr "경고 - 부모 없는 블럭 파일입니다"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "진행"
 
@@ -3583,6 +3762,11 @@ msgstr "경고: 자동 복구에 문제가 있습니다"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<제목 없음>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[프로젝트 %02i] 오데시티 \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3652,12 +3836,14 @@ msgstr ""
 "(필요한 임시 파일을 생성할 수 없음)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "이 파일은 오데시티 프로젝트 파일이 아닙니다"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3789,9 +3975,9 @@ msgid "Error Writing to File"
 msgstr "파일을 쓰는 중 오류"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3804,12 +3990,15 @@ msgstr "프로젝트 압축"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[프로젝트 %02i] 오데시티 \"%s\""
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "오데시티"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -3819,10 +4008,10 @@ msgstr "(복구함)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "이 파일은 오데시티 %s 버전에서 저장했습니다.\n"
 "현재 오데시티 %s 버전을 사용 중입니다. 이 파일을 열려면 새로운 버전으로 업그레이드하세요."
@@ -3894,8 +4083,9 @@ msgid "Backing up project"
 msgstr "프로젝트 백업 중"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3904,8 +4094,9 @@ msgstr ""
 "이전 스냅샷으로 복구되었습니다."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3984,8 +4175,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%s프로젝트 \"%s\"를 다른 이름으로 저장..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'프로젝트 저장'은 오디오 파일이 아니라 오데시티 프로젝트용입니다.\n"
@@ -4062,11 +4254,12 @@ msgid "Error Opening Project"
 msgstr "프로젝트 여는 중 오류"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "자동으로 생성된 백업 파일을 열려고 하는 중입니다.\n"
 "이것을 열면 심각한 데이터 손실이 발생할 수 있습니다.\n"
@@ -4174,8 +4367,8 @@ msgid "Automatic database backup failed."
 msgstr "자동 데이터베이스 백업 실패"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "오데시티 %s 버전 사용을 환영합니다"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4388,7 +4581,8 @@ msgstr "모든 환경 설정"
 msgid "SelectionBar"
 msgstr "선택 막대"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "스펙트럼 선택"
 
@@ -4396,46 +4590,55 @@ msgstr "스펙트럼 선택"
 msgid "Timer"
 msgstr "타이머"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "도구"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "전송"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "믹서"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "미터"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "재생 미터"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "녹음 미터"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "편집"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "장치"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "재생 속도"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "스크러빙"
 
@@ -4450,7 +4653,10 @@ msgstr "눈금자"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "트랙들"
 
@@ -4560,7 +4766,8 @@ msgid "Activation level (dB):"
 msgstr "활성화 레벨 (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "오데시티 사용을 환영합니다!"
 
 #: src/SplashDialog.cpp
@@ -4707,9 +4914,9 @@ msgstr ""
 "적당한 드라이브에 대한 정보를 얻으려면 도움말 버튼을 클릭하세요. "
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "오데시티에서 파일을 쓸 수 없습니다:\n"
@@ -4729,9 +4936,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4740,9 +4947,9 @@ msgstr ""
 "파일을 열 수 없습니다."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "오데시티에서 이미지를 파일에 쓸 수 없습니다:\n"
@@ -4759,9 +4966,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4771,9 +4978,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4782,8 +4989,9 @@ msgstr ""
 "잘못된 png 형식이 아닐까요?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "오데시티에서 기본 테마를 읽어올 수 없습니다.\n"
@@ -4820,9 +5028,9 @@ msgstr ""
 "있습니다. 덮어 쓸까요?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "오데시티에서 파일을 저장할 수 없습니다:\n"
@@ -4861,7 +5069,11 @@ msgstr "사용자 정의"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "지속 시간"
 
@@ -4872,7 +5084,8 @@ msgid "Time Track"
 msgstr "시간 트랙"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "오데시티 타이머 기록"
 
 #: src/TimerRecordDialog.cpp
@@ -4946,7 +5159,8 @@ msgstr "현재 프로젝트"
 msgid "Recording start:"
 msgstr "녹음 시작:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "지속 시간:"
 
@@ -4967,7 +5181,8 @@ msgid "Action after Timer Recording:"
 msgstr "타이머 기록 후 동작:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "오데시티 타이머 기록 진행"
 
 #: src/TimerRecordDialog.cpp
@@ -5063,6 +5278,7 @@ msgstr "099일 024시 060분 060초"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "시작 날짜 및 시간"
@@ -5107,7 +5323,8 @@ msgstr "자동 내보내기를 사용할까요?(&E)"
 msgid "Export Project As:"
 msgstr "다른 이름으로 프로젝트 내보내기:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "옵션"
 
@@ -5120,7 +5337,8 @@ msgid "Do nothing"
 msgstr "동작 없음"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "오데시티 종료"
 
 #: src/TimerRecordDialog.cpp
@@ -5144,7 +5362,8 @@ msgid "Scheduled to stop at:"
 msgstr "중단 예정 시간:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "오데시티 타이머 기록 - 시작 대기 중"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5170,7 +5389,8 @@ msgid "Recording Exported:"
 msgstr "녹음 내보내기 완료:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "오데시티 타이머 기록 - 대기 중"
 
 #: src/TrackInfo.cpp
@@ -5366,6 +5586,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s 적용..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "실패"
@@ -5384,13 +5614,15 @@ msgstr "%s 는 %s에서 파라메터로 사용할 수 없음"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "파라메터 '%s' 에 대해 잘못된 값이 입력됨: %s 이어야 함"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "명령"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s 반복하기"
@@ -5517,13 +5749,24 @@ msgstr "클립"
 msgid "Envelopes"
 msgstr "포락선"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "레이블"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "상자"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5533,7 +5776,8 @@ msgstr "간단히"
 msgid "Type:"
 msgstr "형식:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "형식:"
 
@@ -5560,6 +5804,10 @@ msgstr "코멘트"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "명령:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5597,12 +5845,17 @@ msgstr "파일을 내보냅니다."
 msgid "Builtin Commands"
 msgstr "내장 명령"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "오데시티 팀"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "오데시티에 내장 명령을 제공합니다"
 
 #: src/commands/LoadCommands.cpp
@@ -5665,7 +5918,10 @@ msgstr "로그 내용을 지우기"
 msgid "Get Preference"
 msgstr "환경 설정 가져오기"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "이름:"
 
@@ -5713,7 +5969,8 @@ msgstr "전체화면"
 msgid "Toolbars"
 msgstr "도구모음"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "효과"
 
@@ -5853,7 +6110,8 @@ msgstr "설정"
 msgid "Add"
 msgstr "추가"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "제거"
 
@@ -5938,7 +6196,8 @@ msgid "Edited Envelope"
 msgstr "편집된 포락선"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "포락선"
 
@@ -5981,6 +6240,14 @@ msgstr "비율:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "크기조절:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -6030,7 +6297,10 @@ msgstr "팬:"
 msgid "Set Track Visuals"
 msgstr "트랙 가시화 설정"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linear (선형)"
 
@@ -6057,6 +6327,16 @@ msgstr "스케일:"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
 msgstr "세로배율:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom Top:"
+msgstr "세로배율:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom Bottom:"
+msgstr "확대/축소 도구"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Use Spectral Prefs"
@@ -6126,12 +6406,18 @@ msgstr "오디오가 포함되지 않은 트랙을 선택했습니다. 오토 �
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "오토 덕은 반드시 선택된 트랙 아래에 위치하는 제어 트랙이 필요합니다."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "부분 소리 줄이기 볼륨"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "초"
 
@@ -6155,7 +6441,8 @@ msgstr "내부 페이드 내림 길이: (&O)"
 msgid "Inner &fade up length:"
 msgstr "내부 페이드 올림 길이: (&F)"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "임계값 (&T)"
 
@@ -6293,11 +6580,13 @@ msgstr "끝 (Hz)"
 msgid "t&o"
 msgstr "To(&O)"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "퍼센트 변경(&H)"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "퍼센트 변경"
 
@@ -6305,9 +6594,23 @@ msgstr "퍼센트 변경"
 msgid "&Use high quality stretching (slow)"
 msgstr "고품질 늘이기 사용하기 (느림)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "(사용 불가)"
 
@@ -6335,6 +6638,7 @@ msgstr "표준 Vinyl rpm:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "시작 rpm"
@@ -6347,6 +6651,7 @@ msgstr "From (&F)"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "끝 rpm"
@@ -6489,6 +6794,12 @@ msgstr "컴프레서"
 msgid "Compresses the dynamic range of audio"
 msgstr "오디오의 다이내믹 레인지 압축"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6498,6 +6809,20 @@ msgstr "%.2f 초"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f 초"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6612,7 +6937,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "콘트라스트 분석기, 오디오의 두 선택 부분 사이의 RMS 볼륨 차이를 측정."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "끝"
 
@@ -6672,6 +6998,18 @@ msgstr "차이(&D):"
 msgid "&Help"
 msgstr "도움말(&H)"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "영"
@@ -6679,6 +7017,13 @@ msgstr "영"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "알 수 없음"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6732,6 +7077,12 @@ msgstr "현재 차이"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "측정한 전경음 레벨"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f 초"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -7087,7 +7438,9 @@ msgstr "DTMF 시퀀스(&S):"
 msgid "&Amplitude (0-1):"
 msgstr "진폭 (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "지속 시간(&D):"
 
@@ -7100,12 +7453,29 @@ msgid "Duty cycle:"
 msgstr "듀티 사이클:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f 초"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "톤 지속 시간:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "무음 지속 시간:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7115,7 +7485,8 @@ msgstr "에코 (메아리)"
 msgid "Repeats the selected audio again and again"
 msgstr "선택 오디오를 되풀이해서 반복합니다"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "요구되는 값이 메모리 용량을 초과합니다."
 
@@ -7139,7 +7510,8 @@ msgstr "사전설정"
 msgid "Export Effect Parameters"
 msgstr "효과 매개 변수 내보내기"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "파일을 열 수 없습니다: \"%s\""
@@ -7513,6 +7885,10 @@ msgid "Low rolloff for speech"
 msgstr "나레이션을 위한 저주파수 보상 "
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "전화"
 
@@ -7549,12 +7925,35 @@ msgid "Effect Unavailable"
 msgstr "효과 사용 불가"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "최대 dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "최소 dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
 
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
@@ -7889,7 +8288,8 @@ msgid "Builtin Effects"
 msgstr "내장 효과"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "내장 효과를 오데시티에 제공합니다"
 
 #: src/effects/LoadEffects.cpp
@@ -7899,6 +8299,10 @@ msgstr "알 수 없는 내장 효과 이름"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "인식된 볼륨"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7925,6 +8329,19 @@ msgstr "처리 중: %s"
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "정규화(&N)"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -8102,8 +8519,9 @@ msgid "Step 1"
 msgstr "스텝 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "오데시티가 필터할 내용을 알 수 있도록 단지 노이즈만 몇 초를 선택한 다음,\n"
@@ -8155,13 +8573,62 @@ msgstr "윈도우 형식(&W)"
 msgid "Window si&ze:"
 msgstr "윈도우 크기(&Z)"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (기본값)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "윈도우당 스텝(&T)"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8287,6 +8754,7 @@ msgstr "극한의 시간-늘이기나 \"stasis (정체)\" 효과에만 폴스트
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "스트레치 인수:"
@@ -8729,6 +9197,11 @@ msgstr "기본값 사용"
 msgid "Restore Defaults"
 msgstr "기본값 복원"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8887,6 +9360,10 @@ msgstr "무음 감지"
 msgid "Tr&uncate to:"
 msgstr "잘라내기:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "압축 하기 (&O) :"
@@ -8900,7 +9377,8 @@ msgid "VST Effects"
 msgstr "VST 효과"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "오데시티에서 VST 효과를 사용할 수 있게 합니다."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8912,7 +9390,8 @@ msgstr "쉘 VST 검사 중"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "%d / %d 등록 중: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "라이브러리를 불러올 수 없습니다"
 
@@ -8932,7 +9411,8 @@ msgstr "버퍼 크기는 각각의 반복 단계에서 효과에 보내질 샘�
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "버퍼 크기 (8~1048576 샘플)(&B):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "레이턴시 보상"
 
@@ -8940,7 +9420,8 @@ msgstr "레이턴시 보상"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "처리의 일부 과정으로서, 일부 VST 효과는 오데시티에 지연된 반환을 해야만 합니다. 이 지연에 대한 보상을 하지 않으면, 오디오에 짧은 묵음이 들어가게 됩니다. 이 옵션을 활성화하면 보상이 되나, 모든 VST 효과에서 작동하는 것은 아닙니다. "
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "보상을 활성화(&C)"
 
@@ -8974,7 +9455,8 @@ msgid "Standard VST program file"
 msgstr "표준 VST 프로그램 파일"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "오데시티 VST 사전설정 파일"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9001,7 +9483,8 @@ msgstr "VST 사전설정 불러오는 중 오류"
 msgid "Unable to load presets file."
 msgstr "사전설정 파일을 불러올 수 없습니다."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "효과 설정"
 
@@ -9017,6 +9500,12 @@ msgstr "사전설정 파일을 읽을 수 없습니다."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "이 파라메터 파일은 %s 에서 저장된 것입니다. 계속?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -9052,7 +9541,8 @@ msgid "Audio Unit Effects"
 msgstr "오디오 유니트 효과"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "오디오 유니트 효과를 오데시티에 제공합니다"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9068,7 +9558,8 @@ msgid "Audio Unit Effect Options"
 msgstr "오디오 유니트 효과 옵션"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "처리의 일부 과정으로서, 일부 오디오 유니트 효과는 오데시티에 지연된 반환을 해야만 합니다. 이 지연에 대한 보상을 하지 않으면, 오디오에 짧은 묵음들이 들어가게 됩니다. 이 옵션을 활성화하면 보상이 되나, 모든 오디오 유니트 효과에서 작동하는 것은 아닙니다. "
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9212,6 +9703,7 @@ msgstr "오디오 유니트"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA 효과"
@@ -9221,7 +9713,8 @@ msgid "Provides LADSPA Effects"
 msgstr "LADSPA 효과를 제공합니다"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "오데시티는 VST 브릿지를 더 이상 사용하지 않습니다"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9229,12 +9722,30 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA 효과 옵션"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "처리의 일부 과정으로서, 일부 LADSPA 효과는 오데시티에 지연된 반환을 해야만 합니다. 이 지연에 대한 보상을 하지 않으면, 오디오에 짧은 묵음이 들어가게 됩니다. 이 옵션을 활성화하면 보상이 되나, 모든 LADSPA 효과에서 작동하는 것은 아닙니다. "
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr " %s in:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "효과 출력"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA 효과"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9246,7 +9757,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "버퍼 크기 (8에서 %d 샘플)(&B):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "처리의 일부 과정으로서, 일부 LV2 효과는 오데시티에 지연된 반환을 해야만 합니다. 이 지연에 대한 보상을 하지 않으면, 오디오에 짧은 묵음이 들어가게 됩니다. 이 옵션을 활성화하면 보상이 되나, 모든 LV2 효과에서 작동하는 것은 아닙니다. "
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9271,12 +9783,19 @@ msgstr "%s 는 지원하지 않는 옵션 %s을 요구합니다.\n"
 msgid "Generator"
 msgstr "생성기"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 효과"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "LV2 효과 지원을 오데시티에 제공합니다"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9284,7 +9803,8 @@ msgid "Nyquist Effects"
 msgstr "나이키스트 효과"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "나이키스트 효과 지원을 오데시티에 제공합니다"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9512,7 +10032,8 @@ msgstr "파일을 선택하세요"
 msgid "Save file as"
 msgstr "다른 이름으로 저장"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "제목 없음"
 
@@ -9521,7 +10042,8 @@ msgid "Vamp Effects"
 msgstr "뱀프 효과"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "뱀프 효과를 오데시티에 제공합니다"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9543,6 +10065,12 @@ msgstr "플러그인 설정"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "프로그램"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9843,7 +10371,8 @@ msgstr "오디오를 %s로 내보내는 중"
 msgid "Invalid sample rate"
 msgstr "샘플링 주파수 사용불가"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "리샘플링"
 
@@ -9873,6 +10402,14 @@ msgstr "아래 속도 중 하나로 리샘플링해도 좋습니다."
 msgid "Sample Rates"
 msgstr "샘플링 주파수"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "비트레이트:"
@@ -9880,6 +10417,48 @@ msgstr "비트레이트:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "음질 (kbps)"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f 초"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9890,12 +10469,40 @@ msgid "Constrained"
 msgstr "한정됨"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "오디오"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "낮은 지연"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9982,8 +10589,16 @@ msgid "Replace preset '%s'?"
 msgstr "'%s' 프리셋을 바꿀까요?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "메인"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10091,6 +10706,10 @@ msgstr "언어:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "비트 저장소"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10224,6 +10843,11 @@ msgstr ""
 "0 - 기본값\n"
 "최소값 - 1\n"
 "최대값 - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LPC 사용"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10480,6 +11104,42 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (최고품질)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "최고품질, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "표준, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "중간품질, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "중간품질, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (최소 파일크기)"
 
@@ -10509,7 +11169,8 @@ msgstr "미친"
 msgid "Extreme"
 msgstr "극단적"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "표준"
 
@@ -10560,8 +11221,8 @@ msgid "Locate LAME"
 msgstr "LAME 찾기"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "오데시티에서 MP3를 만들려면 %s 파일이 필요합니다."
 
 #: src/export/ExportMP3.cpp
@@ -10589,10 +11250,10 @@ msgid "Where is %s?"
 msgstr "%s은 어디에 있습니까?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "현재 링크하고 있는 파일은 lame_enc.dll v%d.%d임. 이버전은 오데시티 버전 %d.%d.%d 과 호환되지 않음.\n"
 "최신 버전의 'LAME for Audacity' 를 다운로드 하기 바랍니다. "
@@ -10612,6 +11273,11 @@ msgstr "단지 libmp3lame.dylib"
 #: src/export/ExportMP3.cpp
 msgid "Only libmp3lame.so.0"
 msgstr "단지 libmp3lame.so.0"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "AUP3 프로젝트 파일"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -10890,6 +11556,14 @@ msgstr "선택한 오디오를 Ogg Vorbis로 내보내는 중"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "오디오를 Ogg Vorbis로 내보내는 중"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "헤더:"
@@ -10903,9 +11577,10 @@ msgid "Other uncompressed files"
 msgstr "기타 비압축 파일"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "4GB 보다 큰 파일로 WAV 또는 AIFF 파일을 내보내기를 시도하였습니다.\n"
 "오데시티가 지원하지 않습니다. 내보내기 중단되었습니다."
@@ -10915,8 +11590,9 @@ msgid "Error Exporting"
 msgstr "오류 내보내기"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "오데시티에서는 4GB보다 큰 WAV 파일 내보내기가 불가능하여\n"
@@ -10956,11 +11632,11 @@ msgid "All supported files"
 msgstr "지원하는 모든 파일"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10969,11 +11645,11 @@ msgstr ""
 "파일 > 가져오기 > 미디를 눌러 편집할 수 있습니다."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "는 오디오 파일이 아닙니다. \n"
@@ -10984,18 +11660,18 @@ msgid "Select stream(s) to import"
 msgstr "가져오기 스트림 선택"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "이 버전의 오데시티는 %s를 지원하도록 컴파일되지 않았습니다."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 오디오 CD 트랙입니다. \n"
 "오데시티에서 오디오 CD를 직접 열 수는 없습니다. \n"
@@ -11004,10 +11680,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\"는 재생 목록 파일입니다. \n"
@@ -11016,10 +11692,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 윈도우 미디어 오디오 파일입니다. \n"
@@ -11028,10 +11704,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 고급 오디오 코딩 파일입니다. FFmpeg 라이브러리가 없으면, 오데시티는 이 형식의 파일을 열 수 없습니다.\n"
@@ -11039,12 +11715,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 암호화된 오디오 파일입니다. \n"
@@ -11055,10 +11731,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 리얼플레이어 미디어 파일입니다. \n"
@@ -11067,12 +11743,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\"는 오디오 파일이 아니고, 노트 기반의 파일입니다. \n"
 "오데시티에서 이 형식의 파일을 열 수 없습니다. \n"
@@ -11081,10 +11757,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11097,10 +11773,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 Wavpack 오디오 파일입니다. \n"
@@ -11109,10 +11785,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 돌비 디지털 오디오 파일입니다. \n"
@@ -11121,10 +11797,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 Ogg Speex 오디오 파일입니다. \n"
@@ -11133,10 +11809,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"는 비디오 파일입니다. \n"
@@ -11150,9 +11826,9 @@ msgstr "파일 \"%s\" 을 찾을 수 없음"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11168,11 +11844,16 @@ msgstr ""
 "FFmpeg 설치해 보십시오.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, 테스터"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11202,12 +11883,13 @@ msgid "Import Project"
 msgstr "프로젝트 가져오기"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "이 프로젝트는 오데시티 1.0 이전 버전에서 저장되었습니다.\n"
 "이후 버전에서 포맷이 바뀌어 이 프로젝트는 가져올수 없습니다.\n"
@@ -11258,7 +11940,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "프로젝트 데이터 폴더를 찾을 수 없습니다: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "MIDI 트랙이 프로젝트 파일에 있으나, 이 오데시티 빌드는MIDI 지원을 하지 않음, 트랙 무시."
 
 #: src/import/ImportAUP.cpp
@@ -11363,40 +12046,6 @@ msgstr "인덱스[%02x] 코덱[%s], 언어[%s], 비트레이트[%s], 채널[%d],
 msgid "FLAC files"
 msgstr "FLAC 파일"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer 호환 파일"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "디코더를 파이프라인에 추가할 수 없습니다"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer 가져오기"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "스트림을 일시 정지 상태로 설정할 수 없습니다."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "인덱스[%02d], 유형[%s], 채널[%d], 비율[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "파일에 오디오 스트림이 없습니다."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "파일를 가져올 수 없습니다. 상태 변경에 실패했습니다."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer 오류: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "기본 텍스트 형식의 파일 목록"
@@ -11497,6 +12146,191 @@ msgstr "내부 논리 결함"
 #: src/import/ImportPCM.cpp
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF와 기타 비압축 형식"
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 16 bit PCM"
+msgstr "16-비트 PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 24 bit PCM"
+msgstr "24-비트 PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "32 bit float"
+msgstr "32-비트 실수"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "64 bit float"
+msgstr "32-비트 실수"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DWVW"
+msgstr "16비트"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "24 bit DWVW"
+msgstr "24비트"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DPCM"
+msgstr "16-비트 PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "16-비트 PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11631,6 +12465,7 @@ msgstr "%s 오른쪽"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11653,6 +12488,7 @@ msgstr "끝"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11677,7 +12513,8 @@ msgstr "타임 쉬프트한 클립을 오른쪽으로"
 msgid "Time shifted clips to the left"
 msgstr "타임 쉬프트한 클립을 왼쪽으로"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "시간 이동"
 
@@ -11815,7 +12652,8 @@ msgstr "%.2f초부터 %.2f초까지 선택한 오디오 트랙을 도려 냅니�
 msgid "Trim Audio"
 msgstr "오디오 트리밍"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "분할하기"
 
@@ -11940,34 +12778,6 @@ msgid "Ext&ra"
 msgstr "익스트라(&R)"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "믹서(&X)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "재생 볼륨 조절하기(&J)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "재생 볼륨 올리기(&I)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "재생 볼륨 내리기(&D)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "녹음 볼륨 조절하기(&U)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "녹음 볼륨 올리기(&N)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "녹음 볼륨 내리기(&E)"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "장치(&V)"
 
@@ -12003,6 +12813,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "선택한 오디오 내보내기"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "레이블 텍스트"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -12228,8 +13044,9 @@ msgid "&Getting Started"
 msgstr "시작하기(&G)"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "오데시티 메뉴얼 (&M)"
+#, fuzzy
+msgid "&Manual"
+msgstr "매뉴얼(&M)..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12255,11 +13072,8 @@ msgstr "미디 장치 정보(&M)..."
 msgid "Show &Log..."
 msgstr "로그 보기(&L)..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "오데시티 정보(&A)..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "추가된 레이블"
 
@@ -12507,6 +13321,11 @@ msgstr "포커스된 트랙 토글하기(&D)"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "미분류"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "새 파일..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12945,6 +13764,7 @@ msgstr "커서 길게 오른쪽으로(&M)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "탐색(&K)"
@@ -13156,18 +13976,21 @@ msgid "Created new label track"
 msgstr "새 레이블 트랙을 만들었습니다"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "이 버전의 오데시티에서는 각 프로젝트 창에 한 개의 시간 트랙만 사용할 수 있습니다."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "새로운 시간 트랙을 만들었습니다"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "새 샘플링 주파수(Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "입력한 값이 무효합니다"
 
@@ -13424,7 +14247,9 @@ msgstr "재생 중"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "녹음"
 
@@ -13573,10 +14398,6 @@ msgstr "다중 녹음 (켬/끔)(&O)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "소프트웨어 지속 재생 (켬/끔)(&F)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "자동 녹음 레벨 조정 (켬/끔)(&U)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13792,7 +14613,7 @@ msgstr "품질 환경설정"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "오데시티 업데이트"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13839,7 +14660,8 @@ msgstr "호스트(&H):"
 msgid "Using:"
 msgstr "사용 중:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "재생"
 
@@ -13859,7 +14681,8 @@ msgstr "채널(&N):"
 msgid "Latency"
 msgstr "지연 시간"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "밀리초"
 
@@ -13888,7 +14711,8 @@ msgid "2 (Stereo)"
 msgstr "2 (스테레오)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "폴더"
 
@@ -13996,7 +14820,8 @@ msgid "Directory %s is not writable"
 msgstr "%s 폴더는 쓸 수 없습니다"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "임시 폴더 변경은 오데시티를 재시작해야 적용됩니다."
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14027,6 +14852,19 @@ msgstr "출판사순으로 묶음"
 msgid "Grouped by Type"
 msgstr "형식순으로 묶음"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
 #. In the translations of this and other strings, you may transliterate the
@@ -14034,6 +14872,18 @@ msgstr "형식순으로 묶음"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "나이퀴스트(&Y)"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -14056,11 +14906,13 @@ msgid "Plugin Options"
 msgstr "플러그인 옵션"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "오데시티 시작시 플러그인 업데이트 확인"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "오데시티 재실행시 플러그인 다시 검색"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14240,7 +15092,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "선택 영역이 레이블에 스냅시 레이블 유지하기(&T)"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "시스템과 오데시티 테마 조합하기(&L)"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14264,6 +15117,10 @@ msgstr "스크러빙 눈금자 보기"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "\"%s\" 언어를 알 수 없습니다"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14414,7 +15271,8 @@ msgstr ""
 "   *   \"%s\"  (단축키 '%s' 가 \"%s\"에 사용되고 있기 때문)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "오데시티 키보드 단축키를 포함한 XML 파일 선택..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14547,8 +15405,9 @@ msgid "Dow&nload"
 msgstr "다운로드(&N)"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "오데시티가 유효한 FFmpeg 라이브러리를 자동으로 찾았습니다.\n"
@@ -14593,6 +15452,10 @@ msgstr "미디 신디 레이턴시 (ms)(&A):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "미디 신디사이저 레이턴시는 정수여야 합니다"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -14603,8 +15466,9 @@ msgid "Preferences for Module"
 msgstr "Module 환경 설정"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "이것은 실험적인 모듈입니다.\n"
@@ -14612,12 +15476,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "'확인하기'를 선택하면 오데시티가 시작할 때마다 모듈을 로딩할 것인지를 묻습니다. "
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "'실패'를 선택하면, 오데시티는 모듈이 작동하지 않는 것으로 간주하고 실행하지 않습니다."
 
 #. i18n-hint preserve the leading spaces
@@ -14626,7 +15492,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "'신규'를 선택하면 아무 선택도 하지 않았음을 의미"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "설정을 변경한 후 오데시티를 재시작해야 효과가 발생합니다."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14644,6 +15511,10 @@ msgstr "모듈을 찾지 못했습니다"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "모듈"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14685,7 +15556,10 @@ msgstr "왼쪽 드래그"
 msgid "Set Selection Range"
 msgstr "선택 범위 설정"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-왼쪽 클릭"
 
@@ -14772,6 +15646,15 @@ msgstr "-왼쪽 드래그"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "트랙 사이에서 클립을 위아래로 이동"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-왼쪽 드래그"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14896,7 +15779,8 @@ msgid "Always scrub un&pinned"
 msgstr "스크러빙 표시 고정 (&P)"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "오데시티 환경 설정"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14910,6 +15794,11 @@ msgstr "환경설정:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "품질 환경설정"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14999,6 +15888,12 @@ msgstr "레벨 (dB)(&V):"
 msgid "Name newly recorded tracks"
 msgstr "새로 녹음된 트랙의 이름 지정"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "With:"
+msgstr "범위 내:"
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "사용자 정의 트랙 이름으로(&N)"
@@ -15024,39 +15919,6 @@ msgid "System T&ime"
 msgstr "시스템 시간으로(&I)"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "자동 녹음 레벨 조정"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "자동 녹음 레벨 조정을 활성화합니다."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "대상 피크:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "범위 내:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "분석 시간:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "밀리초 (분석 단위 시간)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "연속 분석 수:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0은 무한을 의미함"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "펀치 엔 롤 녹음"
 
@@ -15067,6 +15929,21 @@ msgstr "프리롤 (&L) : "
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "크로스 페이드 (&F) :"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15201,6 +16078,10 @@ msgid "1024 - default"
 msgstr "1024 - 기본값"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - 대부분의 협대역"
 
@@ -15298,13 +16179,14 @@ msgid "Info"
 msgstr "정보"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15487,7 +16369,8 @@ msgstr "샘플"
 msgid "4 Pixels per Sample"
 msgstr "샘플당 4픽셀"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "최대 배율"
 
@@ -15609,16 +16492,24 @@ msgid "Stopped"
 msgstr "멈춤"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "일시 정지"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "처음으로 이동하기"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "끝으로 이동하기"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "일시 정지"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "시작까지 선택"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "끝까지 선택"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15632,20 +16523,17 @@ msgstr "새 트랙 녹음"
 msgid "Append Record"
 msgstr "녹음 덧붙이기"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "끝까지 선택"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "시작까지 선택"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s 일시정지됨."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15725,11 +16613,17 @@ msgstr "선택 오디오 무음 처리"
 msgid "Sync-Lock Tracks"
 msgstr "트랙 동기화-잠금"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "확대"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "축소"
 
@@ -15796,43 +16690,6 @@ msgstr "녹음 레벨 미터 도구모음(&R)"
 msgid "&Playback Meter Toolbar"
 msgstr "재생 레벨 미터 도구모음(&P)"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "녹음 볼륨"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "재생 볼륨"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "녹음 볼륨: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "녹음 볼륨 (이용 불가; 시스템 믹서를 사용하세요.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "재생 음량: %.2f (emulated)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "재생 음량: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "재생 볼륨 (이용 불가; 시스템 믹서를 사용하세요)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "믹서 도구모음(&X)"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "탐색"
@@ -15848,6 +16705,7 @@ msgstr "스크러빙"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "스크러빙 정지"
@@ -15855,6 +16713,7 @@ msgstr "스크러빙 정지"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "스크러빙 시작"
@@ -15862,6 +16721,7 @@ msgstr "스크러빙 시작"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "탐색 정지"
@@ -15869,6 +16729,7 @@ msgstr "탐색 정지"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "탐색 시작"
@@ -15923,7 +16784,9 @@ msgstr "스냅"
 msgid "Length"
 msgstr "길이"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "가운데"
 
@@ -15987,8 +16850,8 @@ msgstr "시간(&T) 도구모음"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "오데시티 %s 도구모음"
 
 #: src/toolbars/ToolBar.cpp
@@ -16015,7 +16878,8 @@ msgstr "시간 이동 도구"
 msgid "Zoom Tool"
 msgstr "확대/축소 도구"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "그리기 도구"
 
@@ -16091,11 +16955,13 @@ msgstr "한 개 이상의 레이블 경계를 드래그하세요."
 msgid "Drag label boundary."
 msgstr "레이블 경계를 드래그하세요."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "수정된 레이블"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "레이블 편집"
 
@@ -16150,31 +17016,42 @@ msgstr "레이블을 편집했습니다"
 msgid "New label"
 msgstr "새 레이블"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "옥타브 올리기(&O)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "옥타브 내리기(&V)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "수직 확대는 클릭, 축소는 Shift-클릭, 확대/축소 영역 지정은 드래그하세요."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "메뉴는 우클릭."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "배율 초기화"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-오른쪽 버튼 클릭"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "왼쪽 클릭/왼쪽 드래그"
 
@@ -16216,7 +17093,8 @@ msgstr "합치기"
 msgid "Expanded Cut Line"
 msgstr "잘라내기 선을 확장했습니다"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "확장"
 
@@ -16239,6 +17117,11 @@ msgstr "샘플을 이동했습니다"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "샘플 편집"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16284,7 +17167,8 @@ msgstr "처리중...\t%i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s'을 %s로 변경했습니다"
@@ -16296,6 +17180,54 @@ msgstr "형식 변경"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "속도(&E)"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16315,7 +17247,8 @@ msgstr "속도 변경"
 msgid "Set Rate"
 msgstr "속도 설정"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "멀티 뷰 (&M)"
 
@@ -16407,14 +17340,23 @@ msgstr "왼쪽, %dHz"
 msgid "Right, %dHz"
 msgstr "오른쪽, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% 왼쪽"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% 오른쪽"
@@ -16532,9 +17474,8 @@ msgstr "로그 보간(&I)"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "트랙을 제시간으로 이동하려면 클릭 후 드래그하세요"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16585,6 +17526,7 @@ msgstr "포락선을 조정했습니다."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "스크러빙(&S)"
@@ -16596,6 +17538,7 @@ msgstr "탐색하기"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "스크러빙 눈금자(&R)"
@@ -16779,6 +17722,24 @@ msgstr "누르기"
 msgid "Button"
 msgstr "버튼"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16812,9 +17773,19 @@ msgstr "비어 있음"
 msgid "Backwards"
 msgstr "뒤로"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "앞으로"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16943,6 +17914,13 @@ msgstr "동작을 선택하세요"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 초"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + 샘플"
+
 #. i18n-hint: Format string for displaying time in hours, minutes and
 #. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
@@ -16951,6 +17929,12 @@ msgstr "01000,01000 초"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s"
 msgstr "0100 시간 060 분 060 초"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -16967,11 +17951,35 @@ msgstr "0100 일 024 시간 060 분 060 초"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + 100분의 1"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 시간 060 분 060 초"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + 1/1000 초"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 시간 060 분 060 초"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16979,9 +17987,22 @@ msgstr "hh:mm:ss + 1/1000 초"
 msgid "hh:mm:ss + samples"
 msgstr "hh:mm:ss + 샘플"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+># samples"
+msgstr "0100 시간 060 분 060 초"
+
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "샘플"
@@ -16999,6 +18020,18 @@ msgstr "01000,01000,01000 샘플|#"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + film frames (24 fps)"
 msgstr "hh:mm:ss + 필름 프레임 (24 fps)"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr "0100 시간 060 분 060 초"
 
 #. i18n-hint: Name of time display format that shows time in frames (lots of
 #. * frames) at 24 frames per second (commonly used for films)
@@ -17021,12 +18054,35 @@ msgstr "01000,01000 프레임|24"
 msgid "hh:mm:ss + NTSC drop frames"
 msgstr "hh:mm:ss + NTSC 드롭 프레임"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr "0100 시간 060 분 060 초"
+
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
 #. * Japanese TV, and doesn't quite match wall time
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + NTSC non-drop frames"
 msgstr "hh:mm:ss + NTSC 비드롭 프레임"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr "01000,01000 프레임|29.97002997"
 
 #. i18n-hint: Name of time display format that shows time in frames at NTSC
 #. * TV frame rate (used for American / Japanese TV
@@ -17049,6 +18105,17 @@ msgstr "01000,01000 프레임|29.97002997"
 msgid "hh:mm:ss + PAL frames (25 fps)"
 msgstr "hh:mm:ss + PAL 프레임 (25 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr "0100 시간 060 분 060 초"
+
 #. i18n-hint: Name of time display format that shows time in frames at PAL
 #. * TV frame rate (used for European TV)
 #: src/widgets/NumericTextCtrl.cpp
@@ -17069,6 +18136,17 @@ msgstr "01000,01000 프레임|25"
 msgid "hh:mm:ss + CDDA frames (75 fps)"
 msgstr "hh:mm:ss + CDDA 프레임(75 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr "0100 시간 060 분 060 초"
+
 #. i18n-hint: Name of time display format that shows time in frames at CD
 #. * Audio frame rate (75 frames per second)
 #: src/widgets/NumericTextCtrl.cpp
@@ -17082,6 +18160,36 @@ msgstr "CDDA 프레임 (75 fps)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 프레임|75"
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "01000,01000,01000 샘플|#"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -17108,6 +18216,15 @@ msgstr "천분의 일 옥타브"
 msgid "semitones + cents"
 msgstr "반음 + 센트"
 
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
 #. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hundredths of cents"
@@ -17118,6 +18235,13 @@ msgstr "백분의 일 센트"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "decades"
 msgstr "디케이드"
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "10>01000 decades|0.434294482"
+msgstr "100.01000 옥타브|1.442695041"
 
 #. i18n-hint: a decade is a tenfold increase of frequency
 #: src/widgets/NumericTextCtrl.cpp
@@ -17131,6 +18255,11 @@ msgstr "(우클릭 메뉴에서 형식을 바꿀 수 있습니다)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "1/100 초"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -17174,6 +18303,11 @@ msgstr "닫기 확인"
 msgid "Unable to write files to directory: %s."
 msgstr "\"%s\"로 부터 사전설정 파일을 읽을 수 없습니다."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17190,6 +18324,10 @@ msgstr "디렉토리 환경설정"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "이 경고를 다시 보이지 않음"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17273,15 +18411,27 @@ msgstr "XML 파싱할 수 없음"
 msgid "Spectral edit multi tool"
 msgstr "스펙트럼 편집 다중 도구"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "필터링..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "GNU 일반 공중 라이선스 버전 2의 규정에 따라 배포됨"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~a주파수를 선택하세요."
@@ -17308,7 +18458,8 @@ msgstr ""
 "                      낮은 주파수 범위를 높이거나~%~\n"
 "                      필터 '너비'를 줄이세요."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "오류.~%"
@@ -17369,6 +18520,25 @@ msgstr "스튜디오 페이드 아웃"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "페이드 적용 중..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "스티븐 존스"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "GNU General Public License Version 2 또는 이후 버전의 라이센스로 배포됨"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17512,6 +18682,10 @@ msgstr "비트 검색기"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "비트 찾는 중..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "오데시티"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17836,13 +19010,38 @@ msgstr "하이패스 필터"
 msgid "Performing High-Pass Filter..."
 msgstr "하이패스 필터 실행..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "주파수(Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "롤 오프 (옥타브 당 dB)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17863,10 +19062,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "사운드 레이블"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "GNU General Public License Version 2 또는 이후 버전의 라이센스로 배포됨"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17927,6 +19122,12 @@ msgstr "최대 끝 묵음"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "소리 ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -17997,6 +19198,10 @@ msgstr ""
 #: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "리미트 값 (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -18102,6 +19307,12 @@ msgstr ""
 "피크는 처음 ~a 초 ~a dB~%에 기반함\n"
 "제안된 임계값은  ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "노치 필터"
@@ -18150,7 +19361,8 @@ msgstr "LISP 파일"
 msgid "HTML file"
 msgstr "HTML 파일"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "텍스트 파일"
 
@@ -18227,6 +19439,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI 값  - C 음계: 36, 48, 60 [중간 C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "플럭 MIDI 피치"
 
@@ -18273,6 +19489,10 @@ msgstr "1 - 20 비트/measure"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "스윙 양"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18341,6 +19561,10 @@ msgstr "물방울 (긴)"
 #: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of strong beat"
 msgstr "강한 비트의 MIDI 피치"
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
@@ -18467,6 +19691,11 @@ msgstr "메시지 보기"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "오류 만"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18962,6 +20191,229 @@ msgstr "레이더 니들의 주파수 (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "오류.~%스테레오 트랙이 필요합니다."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "오데시티 업데이트"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "건너뛰기(&S)"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "업데이트 설치 (&I)"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "변경 로그"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "GitHub의 상세정보를 참조하세요. "
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "업데이트를 위한 오류 점검"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "오데시티 업데이트 서버에 접속할 수 없습니다. "
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "업데이트 데이터가 손실되었습니다."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "업그레이드를 다운로드하는데 오류"
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "오데시티 다운로드 링크를 열 수 없습니다."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "오데시티 %s 를 사용할 수 있습니다."
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "녹음"
+
+#~ msgid "Commit Id:"
+#~ msgstr "제출 ID:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "크로스 플랫폼 GUI 라이브러리"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "GStreamer를 통해 가져오기"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "자동 녹음 레벨 조정 중단. 더 이상 최적화가 불가능합니다. 여전히 너무 높습니다."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "자동 녹음 레벨 조정: 볼륨을 %.2f로 줄였습니다."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "자동 녹음 레벨 조정 중단. 더 이상 최적화가 불가능합니다. 여전히 너무 낮습니다."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "자동 녹음 레벨 조정: 볼륨을 %.2f로 올렸습니다."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "자동 녹음 레벨 조정 중단됨. 알맞은 볼륨을 찾기위한 최대 분석횟수를 초과했습니다. 여전히 너무 높습니다."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "자동 녹음 레벨 조정 중단됨. 알맞은 볼륨을 찾기위한 최대 분석횟수를 초과했습니다. 여전히 너무 낮습니다."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "자동 녹음 레벨 조정 중단: %.2f은 무난한 볼륨인 듯 싶습니다."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "장치를 여는 동안 %d를 받았습니다.\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Portmixer를 열 수 없습니다.\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "사용가능한 믹서:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "사용가능한 녹음 자원:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "사용가능한 재생 볼륨:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "녹음 볼륨이 복사되었습니다\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "녹음 볼륨을 기본으로\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "재생 볼륨이 복사되었습니다\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "재생 볼륨을 기본으로\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "끝 날짜 및 시간"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer 호환 파일"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "디코더를 파이프라인에 추가할 수 없습니다"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer 가져오기"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "스트림을 일시 정지 상태로 설정할 수 없습니다."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "인덱스[%02d], 유형[%s], 채널[%d], 비율[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "파일에 오디오 스트림이 없습니다."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "파일를 가져올 수 없습니다. 상태 변경에 실패했습니다."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer 오류: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "믹서(&X)"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "재생 볼륨 조절하기(&J)..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "재생 볼륨 올리기(&I)"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "재생 볼륨 내리기(&D)"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "녹음 볼륨 조절하기(&U)..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "녹음 볼륨 올리기(&N)"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "녹음 볼륨 내리기(&E)"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "오데시티 메뉴얼 (&M)"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "오데시티 정보(&A)..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "자동 녹음 레벨 조정 (켬/끔)(&U)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "자동 녹음 레벨 조정"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "자동 녹음 레벨 조정을 활성화합니다."
+
+#~ msgid "Target Peak:"
+#~ msgstr "대상 피크:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "분석 시간:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "밀리초 (분석 단위 시간)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "연속 분석 수:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0은 무한을 의미함"
+
+#~ msgid "Recording Volume"
+#~ msgstr "녹음 볼륨"
+
+#~ msgid "Playback Volume"
+#~ msgstr "재생 볼륨"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "녹음 볼륨: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "녹음 볼륨 (이용 불가; 시스템 믹서를 사용하세요.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "재생 음량: %.2f (emulated)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "재생 음량: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "재생 볼륨 (이용 불가; 시스템 믹서를 사용하세요)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "믹서 도구모음(&X)"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "트랙을 제시간으로 이동하려면 클릭 후 드래그하세요"
 
 #~ msgid "Program build date:"
 #~ msgstr "프로그램 빌드 날짜:"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -6,55 +6,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Lithuanian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/lt/>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/tenacity/tenacity/lt/>\n"
 "Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
-"%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,997,-1,-1,-1,-1\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Išeiti iš Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Kanalas"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Klaida bandant iššifruoti failą"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Klaida Užkraunant Metaduomenis"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity Pirmasis paleidimas"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Įrašymas"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -65,9 +27,31 @@ msgstr "Nepavyksta nustatyti"
 msgid "%s bytes"
 msgstr "baitai"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Stiprinama"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -116,6 +100,22 @@ msgstr "&Ieškoti...\tCtrl+F"
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Matching Paren\tF8"
 msgstr "&Vienodi tevai\tF8"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Go to"
@@ -170,7 +170,8 @@ msgid "Script"
 msgstr "Skriptas"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Išvestis"
 
@@ -186,7 +187,12 @@ msgstr "Nyquist skriptai (*.ny)|*.ny|Lisp skriptai (*.lsp)|*.lsp|All files|*"
 msgid "Script was not saved."
 msgstr "Skriptas nebuvo išsaugotas."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Perspėjimas"
 
@@ -199,7 +205,24 @@ msgid "Find dialog"
 msgstr "Rasti dialogą"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Išorinis Audacity modulis kuris leidžia naudotis paprasta kūrimo programa efektų kūrimui."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -222,7 +245,8 @@ msgstr "Be pavadinimo"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist efektų darbastalis - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Naujas"
 
@@ -262,7 +286,8 @@ msgstr "Kopijuoti"
 msgid "Copy to clipboard"
 msgstr "Kopijuoti į iškarpinę"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Iškirpti"
 
@@ -270,7 +295,8 @@ msgstr "Iškirpti"
 msgid "Cut to clipboard"
 msgstr "Iškirpti į iškarpinę"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Įklijuoti"
 
@@ -295,7 +321,8 @@ msgstr "Pasirinkti viską"
 msgid "Select all text"
 msgstr "Pasirinkti visą tekstą"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Atšaukti"
 
@@ -303,7 +330,8 @@ msgstr "Atšaukti"
 msgid "Undo last change"
 msgstr "Atšaukti praeitą pokytį"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Atkurti"
 
@@ -332,25 +360,52 @@ msgid "Top"
 msgstr "Viršus"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Nerasta etikečių eksportavimui."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Į viršų"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to higher S-expr"
+msgstr "Eiti į atitinkantį pagrindą"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Praeitas"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Perkelti į &Praeita Etiketę"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Sekantis"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to next S-expr"
+msgstr "Kaip rasti pagalbos"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Pradėti"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Start script"
 msgstr "Pradėti skriptą"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Stop"
+msgstr "Stop"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Stop script"
@@ -362,17 +417,35 @@ msgstr "Stabdyti skriptą"
 msgid "About %s"
 msgstr "Apie"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Konstrukcijos informacija"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Įjungtas"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Išjungtas"
+
+#. i18n-hint: Information about when audacity was compiled follows
+#: src/AboutDialog.cpp
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Reversuoju"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -383,16 +456,27 @@ msgid "Compiler:"
 msgstr "Kompiliuotojas:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
+msgstr "Nustatymu aplankas: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Nustatymu aplankas: "
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Failo Formato Pagalba"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Įvairių platformų GUI biblioteka"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -406,7 +490,6 @@ msgstr "Šablonų normos keitimas"
 msgid "MP3 Importing"
 msgstr "MP3 Importavimas"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis Importavimas ir Eksportavimas"
@@ -415,7 +498,6 @@ msgstr "Ogg Vorbis Importavimas ir Eksportavimas"
 msgid "ID3 tag support"
 msgstr "ID3 etikečių palaikymas"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC Importavimas ir Eksportavimas"
@@ -433,10 +515,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg Importavimas ir Eksportavimas"
 
 #: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Ypatybės"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Papildinių pagalba"
 
@@ -451,6 +529,10 @@ msgstr "Aukštumo ir Tempo Pokyčių palaikymas"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Ypatingo Aukštumo ir Tempo Pokyčių palaikymas"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Ypatybės"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -564,6 +646,15 @@ msgstr "kūrėjas"
 msgid "%s, graphics"
 msgstr "grafikos kūrėjas"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -573,6 +664,10 @@ msgstr "Audicity yra nemokama, atviros programinės įrangos, pritaikyta įvairi
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Padėkos"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -607,8 +702,16 @@ msgid "%s Team Members"
 msgstr "Audacity komandos nariai"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Bendrininkai"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #  i18n-hint: The translation of "translator_credits" will appear
 #  in the credits in the About Audacity window.  Use this to add
@@ -619,6 +722,7 @@ msgstr "Bendrininkai"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Lithuanian translation by Šarūnas Gliebus ir Aurimas Liaukevičius (Jimmy Leo)"
@@ -641,6 +745,26 @@ msgstr "Ypatingai dėkojam:"
 msgid "%s website: "
 msgstr "Audacity svetainė: "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Bendrininkai"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Spauskite ir temkite santykiniam stereo takelio dydižiui pakeisti."
@@ -651,9 +775,15 @@ msgstr "Spauskite ir temkite santykiniam stereo takelio dydižiui pakeisti."
 msgid "Record/Play head"
 msgstr "Įrašinėjimo pabaiga:"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Priedas 1 iš %i"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Temti ir mesti pavyzdžių redagavimui"
@@ -661,12 +791,57 @@ msgstr "Temti ir mesti pavyzdžių redagavimui"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Paspausti ir tempti norint pradėti Gramdymą"
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Perkelti į &Sekančią Etiketę"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Nuleisti takelį"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Pakelti takelį"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr "Quick-Play išjungtas"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr "Quick-Play išjungtas"
 
 #: src/AdornedRulerPanel.cpp
@@ -674,8 +849,21 @@ msgid "Timeline Options"
 msgstr "Priedas 1 iš %i"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "Paversti apibraukimą tyla"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Lock Play Region"
+msgstr "Gro&jimo Regijonas"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
@@ -689,7 +877,17 @@ msgstr ""
 "Neįmanoma prirakinti regiono toliau nei\n"
 "projekto pabaigoje."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Klaida"
 
@@ -713,7 +911,8 @@ msgstr ""
 "Tai yra vienkartinis klausimas, po 'instaliavimo' kur jūs pasirinkote perrinkti Nuostatas."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Perrinkti Audacity Nuostatas"
 
 #: src/AudacityApp.cpp
@@ -726,6 +925,10 @@ msgstr ""
 "%s nebuvo rastas.\n"
 "\n"
 "Buvo pašalintas iš nesenai atidarytu failų sąrašo."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -750,7 +953,7 @@ msgstr "&Atidaryti..."
 msgid "Open &Recent..."
 msgstr "Atidaryti &Nesenai atidarytus..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Apie Audacity..."
@@ -764,9 +967,10 @@ msgid "&File"
 msgstr "&Failas"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity neranda saugios vietos laikiniems failams laikyti.\n"
@@ -774,20 +978,23 @@ msgstr ""
 "Prašome įvesti tinkama vietą nuostatų dialoge."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity neranda vietos laikiniems failams laikyti.\n"
 "Prašau įrašyti ją Nuostatų dialoge."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity dabar išsijungs. Prašome paleisti Audacity dar karta kad galima būtų naudoti nauja laikinąja vietą."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -796,15 +1003,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity nepavyko uždaryti laikinųjų failų vietos.\n"
 "Šis aplankas gali būti naudojamas kitos įjungtos Audacity kopijos.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Ar vis dar norite paleisti Audacity?"
 
 #: src/AudacityApp.cpp
@@ -812,24 +1021,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "Klaida Uždarant Laikinąjį Aplanką"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Sistema nustatė, kad yra paleista dar viena Audacity kopija.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Naudokite Naujas arba Atidaryti komandas šioje paleistoje Audacity programoje\n"
 "norint atidaryti kelis projektus vienu metu.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity jau paleistas"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity Projekto failai"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -849,7 +1106,8 @@ msgstr "paleisti savo diagnostiką"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "rodyti Audacity versiją"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -859,9 +1117,10 @@ msgid "audio or project file name"
 msgstr "garso arba projekto failo pavadinimas"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -873,24 +1132,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity Projekto failai"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Pranešimas"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "DarkAudacity Pritaikymas"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Pagalba"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Išeiti iš Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity Registras"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -902,7 +1185,8 @@ msgstr "&Išsaugoti..."
 msgid "Cl&ear"
 msgstr "Iš&valyti"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Uždaryti"
 
@@ -957,47 +1241,33 @@ msgid "Error Initializing Midi"
 msgstr "Klaida Inicijuojant Midi"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity Registras"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Neužtenka atminties!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Nepavyko labiau sulyginti. Jis vis dar per aukštas."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automatinis Įrašo Lygio Taisymas pamažino garsumą iki %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Nepavyko labiau sulyginti. Jis vis dar per žemas."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automatinis Įrašo Lygio Taisymas pakėlė garsumą iki %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Analizės skaičiaus riba buvo pasiekta neradus tinkamo garsumo. Vis dar per aukštas."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Analizės skaičiaus riba buvo pasiekta neradus tinkamo garsumo. Vis dar per žemas."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatinis Įrašo Lygio Taisymas sustojo. %.2f atrodo kaip tinkamiausias garsumas."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Įrašymas\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Įrašymas\n"
 
 #: src/AudioIOBase.cpp
@@ -1040,8 +1310,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Įrašinėjimo pabaiga:\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Įrašinėjimo pabaiga:\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Įrašinėjimo pabaiga:\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Įrašinėjimo pabaiga:\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -1055,42 +1335,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Įrašymas\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Įrašymas\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Atkūrimas\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Nepavyksta atidaryti žanro failo.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Atkūrimas\n"
+
+#: src/AudioIOBase.cpp
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Eksportuoti\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
-msgid "%d - %s\n"
-msgstr "Iškirpti: %d - %d \n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Simuliuoti Įrašų Klaidas\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Atkūrimas\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Įrašymas\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Įrašymas\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Atkūrimas\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Atkūrimas\n"
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1098,8 +1376,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Įrašymas\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Įrašymas\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Atkūrimas\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Atkūrimas\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1107,8 +1395,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatinis Išsijungimo Atkūrimas"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1120,12 +1409,14 @@ msgid "Recoverable &projects"
 msgstr "Įmanomi Atkūrimui projektai"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Pasirinkti"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Pavadinimas"
 
@@ -1136,6 +1427,10 @@ msgstr "Pasirinkti"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Pasirinkti"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1172,8 +1467,17 @@ msgid "&Parameters"
 msgstr "&Parametrai"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Atkabinti"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "P&asirinkti komandą"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -1199,6 +1503,22 @@ msgstr "Efe&ktai"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Koregavimo Parametrai"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Koregavimo Parametrai"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1246,6 +1566,10 @@ msgid "Apply %s"
 msgstr "Pritaikyti %s"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "&Valdyti"
 
@@ -1254,6 +1578,17 @@ msgstr "&Valdyti"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Pasirinkti"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Etiketės..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Pritaikyti grandį"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1270,6 +1605,11 @@ msgstr "Pritaikyti &Failams..."
 #: src/BatchProcessDialog.cpp
 msgid "&Files..."
 msgstr "&Failas"
+
+#. i18n-hint: The Expand button makes the dialog bigger, with more in it
+#: src/BatchProcessDialog.cpp
+msgid "&Expand"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "No macro selected"
@@ -1304,13 +1644,33 @@ msgstr "&Atšaukti"
 msgid "Remo&ve"
 msgstr "&Išimti"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "Pervardinti..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "Importuoti..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "Eks&portuoti..."
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Redaguoti Etiketes"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1340,9 +1700,20 @@ msgstr "Pakelti į &Viršų"
 msgid "Move &Down"
 msgstr "Nuleisti &Žemyn"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Išsaugoti"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
+
+#. i18n-hint: This is the last item in a list.
+#: src/BatchProcessDialog.cpp
+msgid "- END -"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 #, c-format
@@ -1413,7 +1784,8 @@ msgid "Run"
 msgstr "Paleisti"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Uždaryti"
 
@@ -1495,6 +1867,10 @@ msgid "Time to perform %d edits: %ld ms\n"
 msgstr "Laikas atlikti %d redagavimus: %ld ms\n"
 
 #: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 #, c-format
 msgid "Track # blocks: %ld\n"
 msgstr "Takelis # blokai: %d\n"
@@ -1553,9 +1929,22 @@ msgid "Benchmark completed successfully.\n"
 msgstr "Palyginimas įvykdytas sėkmingai.\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Pabaigos Data ir Laikas"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1584,6 +1973,18 @@ msgstr "Pasirinkite garsą kad %s galėtų jį naudoti (pavyzdžiui, Ctrl + A no
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Nėra jokio pasirinkto garso"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1629,9 +2030,28 @@ msgid "Checkpointing project"
 msgstr "Dabartinis Projektas"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "Dabartinis Projektas"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Negali rašyti į failą: %s\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity nepavyko rašyti į failą.\n"
+"Galbūt %s nepalaiko rašymo arba diskas yra pilnas."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1652,6 +2072,10 @@ msgid ""
 msgstr ""
 "Nepavyko priregistruoti:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1749,6 +2173,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Kopijuoti į iškarpinę"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Trūkstami Failai"
 
@@ -1757,10 +2186,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Jeigu tesite, jūsų projektas nebus išsaugotas į diską. Ar jūs to norite?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1772,7 +2202,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Priklausomumo Patikra"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nieko"
 
@@ -1780,7 +2213,7 @@ msgstr "Nieko"
 msgid "Rectangle"
 msgstr "Stačiakampis"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trikampis"
 
@@ -1794,17 +2227,58 @@ msgstr "Stačiakampis"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Sveiki atvykę!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg parama nebuvo kompiliuota"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1826,8 +2300,8 @@ msgid "Locate FFmpeg"
 msgstr "Surasti FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity reikalauja failo '%s', kad galėtų importuoti ir eksportuoti garsą per FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -1840,7 +2314,8 @@ msgstr "'%s' vieta:"
 msgid "To find '%s', click here -->"
 msgstr "Norint rasti '%s', spausti čia -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Naršyti..."
 
@@ -1866,8 +2341,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg nerastas"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1887,25 +2363,34 @@ msgstr "Daugiau nerodyti šio įspėjimo"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Nepavyko rasti tinkamų FFmpeg bibliotekų."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity nepavyko atidaryti failo %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity nepavyko skaityti iš failo %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity sėkmingai rašė į failą %s bet nepavyko jo pervadinti į %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1924,7 +2409,30 @@ msgstr "Failo Klaida"
 msgid "Error (file may not have been written): %s"
 msgstr "Klaida (failas gali būti neįrašytas): %s"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy all audio into project (safest)"
+msgstr "Kopijuojama garso duomenis į projektą..."
+
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Visi failai|*"
 
@@ -1933,6 +2441,11 @@ msgstr "Visi failai|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Saugojami projekto duomenų failai"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Bibliotekos"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1945,6 +2458,10 @@ msgstr "Pervadinti failai:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Pervadinti failai:"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1986,6 +2503,14 @@ msgstr "Kubinė Autokorekcija"
 msgid "Enhanced Autocorrelation"
 msgstr "Padidinti Autokorekcija"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spektras"
+
 #  i18n-hint: This refers to a "window function", used in the
 #  Frequency analyze dialog box.
 #  i18n-hint: This refers to a "window function", used in the
@@ -2005,6 +2530,17 @@ msgstr "Linijinis dažnis"
 msgid "Log frequency"
 msgstr "Log dažnis"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Paslinkti"
@@ -2012,6 +2548,15 @@ msgstr "Paslinkti"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Keist Mastelį"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2072,6 +2617,37 @@ msgstr "Per daug audio pasirinkta. Tik %.1f sekundės bus išanalizuotos."
 msgid "Not enough data selected."
 msgstr "Pasirinkta per mažai duomenų."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "spektras.txt"
@@ -2080,7 +2656,8 @@ msgstr "spektras.txt"
 msgid "Export Spectral Data As:"
 msgstr "Eksportuoti Spektro Duomenis Kaip:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Negali rašyti į failą: %s"
@@ -2258,6 +2835,11 @@ msgstr "Išmesti"
 msgid "&Compact"
 msgstr "&Komanda"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2265,19 +2847,19 @@ msgid "&History..."
 msgstr "&Istorija..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Vidinė klaida %s %s linijoje %d.\n"
 "Prašome pranešti Audacity komandai https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Vidinė klaida %s linijoje %d.\n"
 "Prašome pranešti Audacity komandai https://forum.audacityteam.org/."
@@ -2296,7 +2878,9 @@ msgid "Track"
 msgstr "Takelis"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Pavadinimas"
 
@@ -2356,7 +2940,8 @@ msgstr "Įveskite takelio pavadinimą"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Etiketės Takelis"
 
@@ -2367,11 +2952,13 @@ msgstr "Vienos arba daugiau išsaugotų etikečių nepavyksta skaityti."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity Pirmasis Paleidimas"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Pasirinkite Kurią Kalbą Audacity naudoti:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2381,7 +2968,8 @@ msgstr "Pasirinkite Kurią Kalbą Audacity naudoti:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Kalba kurią pasirinkote %s (%s), yra ne tokia pati kaip sistemos kalba %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Patvirtinti"
 
@@ -2399,12 +2987,13 @@ msgstr ""
 "Senasis buvo išsaugotas kaip '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Atidaromas Audacity Projektas"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity Karaokė%s"
 
 #: src/LyricsWindow.cpp
@@ -2455,13 +3044,26 @@ msgid "Mixing and rendering tracks"
 msgstr "Miksuojami ir kraunami takeliai"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity Miksavimo Lenta%sS"
+
+#  i18n-hint: Title of the Gain slider, used to adjust the volume
+#  i18n-hint: Title of the Gain slider, used to adjust the volume
+#. i18n-hint: title of the Gain slider, used to adjust the volume
+#. i18n-hint: Title of the Gain slider, used to adjust the volume
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Gain"
+msgstr "Gain"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Greitumas"
 
@@ -2474,28 +3076,43 @@ msgstr "Muzikos Instrumentas"
 #  i18n-hint: Title of the Pan slider, used to move the sound left or right
 # stereoscopically
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balansas"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Begarso"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Signalo Lygio Matuoklis"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Pajudinta garso slinktis"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Pajudinta greitumo slinktis"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Pajudinta balanso slinktis"
 
@@ -2526,9 +3143,9 @@ msgstr ""
 "Nebus pakrauta."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2561,16 +3178,19 @@ msgstr ""
 "\n"
 "Naudokite modulius tik iš patikimų šaltinių"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Taip"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ne"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacity Modulių Užkrovėjas"
 
 #: src/ModuleManager.cpp
@@ -2592,6 +3212,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Natų Takelis"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2702,7 +3432,8 @@ msgstr "&Pasirinkti Viską"
 msgid "C&lear All"
 msgstr "Iš&valyti Viską"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Naudoti"
 
@@ -2776,6 +3507,21 @@ msgstr ""
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Kad galėčiau nupiešti grafiką, visi pasirinkti takeliai turi būti to pačio dažnio."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Įrašytas Audio"
@@ -2794,10 +3540,11 @@ msgid "Dropouts"
 msgstr "Išsitrynusio įrašo gabaliukai"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -2837,11 +3584,11 @@ msgid "Inspecting project file data"
 msgstr "Tikrinami projekto failo duomenys"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2884,11 +3631,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Įspėjimas - Trūkstami Pervadinti Failai"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Projekto patikra \"%s\" aplanke \n"
@@ -2913,12 +3660,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Įspėjimas - Trūkstami Pervadinti Apibendrinti Failai"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2976,7 +3723,8 @@ msgstr "Įspėjimas - Niekam nepriklausantys failai"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progresas"
 
@@ -3001,6 +3749,11 @@ msgstr "Įspėjimas: Problemos Automatiniame Atkūrime"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<be pavadinimo>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekto Pa&baiga"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3041,11 +3794,98 @@ msgid ""
 msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"Nepavyko priregistruoti:\n"
+"%s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Audacity Projekto Saugojimas"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Nepavyko išsaugoti žanro failo."
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3059,12 +3899,35 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Niekam nepriklausantis failas: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Nepavyksta nustatyti srovės būklės į sustabdytą."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"Nepavyko priregistruoti:\n"
+"%s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3075,9 +3938,9 @@ msgid "Error Writing to File"
 msgstr "Klaida įrašinėjant į failą: \"%s\""
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3088,6 +3951,19 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Sukurtas naujas projektas"
 
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Greitumas"
+
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
@@ -3095,10 +3971,10 @@ msgstr "(Grąžintas)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Šis failas buvo išsaugotas naudojant Audacity %s.\n"
 "Jūs naudojatės Audacity %s. Jums gali reikėti atnaujinti į naujesnę versija norint atidaryti šį failą."
@@ -3106,6 +3982,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Nepavyksta atidaryti projekto failo"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3120,6 +4000,10 @@ msgid "Unable to parse project information."
 msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Klaida Saugojant Projektą"
 
@@ -3128,12 +4012,35 @@ msgid "Error Saving Project"
 msgstr "Klaida Saugojant Projektą"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Įspėjimas - Tuščias Projektas"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3141,8 +4048,23 @@ msgstr ""
 "Laimei šie projektai gali būti automatiškai atkurti:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Kai kurie projektai nebuvo išsaugoti tinkamai paskutini kartai kai Audacity buvo paleista.\n"
+"Laimei šie projektai gali būti automatiškai atkurti:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Projektas buvo grąžintas"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3172,6 +4094,17 @@ msgstr "Įspėjimas - Tuščias Projektas"
 msgid "Insufficient Disk Space"
 msgstr "Disko Talpa"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3191,12 +4124,26 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sIšsaugoti Projektą \"%s\" Kaip..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Išsaugoti Projektą' yra Audacity projektui, ne garso failui.\n"
 "Garso failui kurį atidarinėsite su kitomis programomis naudokite 'Eksportuoti'.\n"
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -3250,11 +4197,12 @@ msgid "Error Opening Project"
 msgstr "Klaida Atidarinėjant Projektą"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Jūs bandote atidaryti automatiškai sukurtą dublinį failą.\n"
 "Taip darant jūs galite prarasti šiuos duomenis.\n"
@@ -3287,6 +4235,12 @@ msgid "Error Opening File or Project"
 msgstr "Klaida Atidarant Failą arba Projektą"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Projektas buvo grąžintas"
 
@@ -3312,12 +4266,33 @@ msgid "Error Importing"
 msgstr "Klaida Importuojant"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Išsaugoti projektą"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Nepavyksta atidaryti projekto failo"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Komanda"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3328,8 +4303,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatinis Saugojimas Įjungtas:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Sveiki atvykę į Audacity versiją %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3389,6 +4364,12 @@ msgstr[2] "%d minučių"
 msgid "%s and %s."
 msgstr "%s ir %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3403,6 +4384,21 @@ msgstr "Horizontali Paslinkties Juosta"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Vertikali Paslinkties Juosta"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -3419,6 +4415,24 @@ msgstr "Aukštos Kokybės"
 #: src/Resample.cpp
 msgid "Best Quality (Slowest)"
 msgstr "Geriausios Kokybės (Lėčiausias)"
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "32-bit float"
+msgstr "32-bit float"
 
 #: src/SampleFormat.cpp
 msgid "Unknown format"
@@ -3508,7 +4522,8 @@ msgstr "Visos Nuostatos"
 msgid "SelectionBar"
 msgstr "Pasirinkimo Juosta"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektro Pasirinkimas"
 
@@ -3516,42 +4531,56 @@ msgstr "Spektro Pasirinkimas"
 msgid "Timer"
 msgstr "Pabaigos laikas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Įrankiai"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Transportuoti"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mikseris"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Matuoklis"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Grojimo Matuoklis"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Įrašymo Matuoklis"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Redaguoti"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Prietaisas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play-at-Speed"
+msgstr "Gro&ti tokiu Greičiu"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Gramdymas"
 
@@ -3566,7 +4595,10 @@ msgstr "Liniuotė"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Takeliai"
 
@@ -3676,7 +4708,8 @@ msgid "Activation level (dB):"
 msgstr "Aktyvacijos garsumas (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Sveiki atvykę į Audacity!"
 
 #: src/SplashDialog.cpp
@@ -3803,10 +4836,24 @@ msgstr "Klaida Išsaugojant Etikečių Failą"
 msgid "Unsuitable"
 msgstr "Netinkamas Modulis"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity nepavyko rašyti į failą:\n"
@@ -3826,9 +4873,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3837,9 +4884,9 @@ msgstr ""
 "rašymui."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity negalėjo rašyti paveikslėlių į failą:\n"
@@ -3856,9 +4903,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3868,9 +4915,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3879,8 +4926,9 @@ msgstr ""
 "Galbūt tai netinkamas png formatas?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity negalėjo nuskaityti savo numatytosios temos.\n"
@@ -3918,13 +4966,42 @@ msgstr ""
 "jau buvo ten.   Ar norite perrašyti?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity negali išsaugoti failo:\n"
 "  %s."
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
+#. i18n-hint: Light meaning opposite of dark
+#: src/Theme.cpp
+#, fuzzy
+msgid "Light"
+msgstr "&Dešinė"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+#, fuzzy
+msgid "High Contrast"
+msgstr "Kontrastas..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Takelio Pavadinimas"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3933,7 +5010,11 @@ msgstr ""
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Trukmė"
 
@@ -3944,7 +5025,8 @@ msgid "Time Track"
 msgstr "Laiko Matuoklis"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity Laikmačio Įrašas"
 
 #: src/TimerRecordDialog.cpp
@@ -4018,7 +5100,8 @@ msgstr "Dabartinis Projektas"
 msgid "Recording start:"
 msgstr "Įrašinėjimo pradžia:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Trukmė:"
 
@@ -4039,7 +5122,8 @@ msgid "Action after Timer Recording:"
 msgstr "Veiksmas po Laikmačio Įrašo:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity Laikmačio Įrašinėjimo Progresas"
 
 #: src/TimerRecordDialog.cpp
@@ -4135,6 +5219,7 @@ msgstr "099 dienos 024 val 060 min 060 sek"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Pradžios Data ir Laikas"
@@ -4179,7 +5264,8 @@ msgstr "Įjungti Automatini &Eksportavimą?"
 msgid "Export Project As:"
 msgstr "Eksportuoti Projektą Kaip:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Nustatymai"
 
@@ -4192,7 +5278,8 @@ msgid "Do nothing"
 msgstr "Nieko nedaryti"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Išeiti iš Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4216,7 +5303,8 @@ msgid "Scheduled to stop at:"
 msgstr "Planuota sustoti šiuo metu:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity Laikmačio Įrašas - Laukiama kol Prasidės"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4224,6 +5312,14 @@ msgstr "Audacity Laikmačio Įrašas - Laukiama kol Prasidės"
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Įrašinėjimas prasidės po:"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -4234,8 +5330,13 @@ msgid "Recording Exported:"
 msgstr "Įrašas Eksportuotas:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity Laikmačio Įrašas - Liaukiama"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -4356,6 +5457,10 @@ msgstr "Perkelti Takelį į Viršų"
 msgid "Move Track Down"
 msgstr "Nuleisti Takelį į Apačią"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4422,20 +5527,61 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Pritaikoma %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Komanda"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Komanda"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Kartoti %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4450,6 +5596,10 @@ msgid "Compares a range on two tracks."
 msgstr "Suspausti remiantis Aukščiausiais Taškais"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Uždelsimo laikas (sek):"
 
@@ -4457,9 +5607,18 @@ msgstr "Uždelsimo laikas (sek):"
 msgid "Decay factor:"
 msgstr "Nykimo faktorius:"
 
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Drag"
 msgstr "Kairysis-Tempimas"
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Panel"
+msgstr "Sekimo Panelė"
 
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
@@ -4473,6 +5632,11 @@ msgstr "Takelis"
 msgid "Track 1"
 msgstr "Takelis"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Lango Dydis:"
@@ -4484,6 +5648,27 @@ msgstr "Iš apm"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Iš apm"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Get Info"
+msgstr "Nuleisti Takelį į Apačią"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Commands"
@@ -4497,17 +5682,51 @@ msgstr "Visi Meniu"
 msgid "Preferences"
 msgstr "&Nuostatos..."
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Sekant&is Apkarpymas"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Amplitudė"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Pavadinimai"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Tipas:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Formato Pakeitimas"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -4517,9 +5736,30 @@ msgstr "Nuleisti Takelį į Apačią"
 msgid "Types:"
 msgstr "Tipas:"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Komentarai"
+
+#: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command:"
+msgstr "Komanda"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4538,6 +5778,11 @@ msgid "Number of Channels:"
 msgstr "Redagavimų skaičius:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Daugialypis Eksportavimas"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Daugialypis Eksportavimas"
 
@@ -4545,9 +5790,26 @@ msgstr "Daugialypis Eksportavimas"
 msgid "Builtin Commands"
 msgstr "Pasirinkti Komandą"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity Pirmasis paleidimas"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Pabaigos Data ir Laikas"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -4589,11 +5851,22 @@ msgstr "&Išsaugoti projektą"
 msgid "Saves a copy of current project."
 msgstr "&Išsaugoti projektą"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Audacity Nuostatos"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Pavadinimas"
 
@@ -4604,6 +5877,18 @@ msgstr "Audacity Nuostatos"
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Vertė"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -4631,6 +5916,12 @@ msgstr "&Pilnas ekranas (Įjungta/Išjungta)"
 #: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "&Įrankių juostos"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "Efe&ktai"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Scriptables"
@@ -4672,6 +5963,10 @@ msgstr "Ilgi Takeliai"
 msgid "All Tracks Plus"
 msgstr "Ilgi Takeliai"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -4691,9 +5986,18 @@ msgid "Background:"
 msgstr "&Fonas:"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Klaida bandant išsaugoti failą: %s"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Ekrano išsaugojimo Įrankiai..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -4714,6 +6018,11 @@ msgstr "Projekto Pa&baiga"
 #: src/commands/SelectCommand.cpp
 msgid "Selection Start"
 msgstr "Pasirinkties Pradži&a"
+
+#: src/commands/SelectCommand.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Selection"
+msgstr "&Pasirinkimas"
 
 #: src/commands/SelectCommand.cpp
 msgid "Selection End"
@@ -4736,6 +6045,10 @@ msgid "High:"
 msgstr "Aukšto dažnio"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "Iš&rikiuoti Takelius"
 
@@ -4747,6 +6060,12 @@ msgstr "Pasirinkti"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "&Pridėti"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&Išimti"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -4765,6 +6084,11 @@ msgid "Selects a time range."
 msgstr "Pasirinkti failą"
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Pasirinkti failą"
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Prašome pasirinkti garso takelį."
 
@@ -4776,9 +6100,37 @@ msgstr "Tyla"
 msgid "Set Clip"
 msgstr "Sekant&is Apkarpymas"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Pradėti"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4797,9 +6149,14 @@ msgid "Edited Envelope"
 msgstr "Amplitudė"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Amplitudė"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4809,6 +6166,10 @@ msgstr "&Trinti Etiketę"
 msgid "Label Index"
 msgstr "Pavadinimo Redagavimas"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Pasirinkti"
@@ -4816,6 +6177,10 @@ msgstr "Pasirinkti"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Pakeistos etiketės"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4830,12 +6195,25 @@ msgid "Resize:"
 msgstr "Keisti dydį į Mažą"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Plotis"
 
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Dešinė "
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Išsaugoti projektą"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4848,6 +6226,10 @@ msgstr "Kanalas"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Status"
 msgstr "Takelio &Pradžia"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
@@ -4864,16 +6246,36 @@ msgid "Gain:"
 msgstr "Gain"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Iš&rikiuoti Takelius"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linijinis"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Per&krauti"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Pabaigos laikas"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Display:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
@@ -4899,9 +6301,20 @@ msgstr "Naudotojų Nuostatos"
 msgid "Spectral Select"
 msgstr "Spektro Pasirinkimas"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Naujas Takelis"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Prašome pasirinkti garso takelį."
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
@@ -4928,6 +6341,10 @@ msgid "Allo&w clipping"
 msgstr "Leisti Iškirpimą"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Sumažina garsumą vieno arba daugiau takelių kai garsumas tam tikro takelio pasiekia tam tikrą aukštį"
 
@@ -4945,12 +6362,18 @@ msgstr "Jūs pasirinkote takelį kuris neturi garso. AutoDuck gali naudoti tik g
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck reikalauja pagrindinio takelio kuris turi būti žemiau pasirinkto takelio."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Duck kiekis:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekundžių"
 
@@ -4974,13 +6397,18 @@ msgstr "Vidinio išblankimo ilgis:"
 msgid "Inner &fade up length:"
 msgstr "Vidinio įblankimo ilgis:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Riba:"
 
 #: src/effects/AutoDuck.cpp
 msgid "Preview not available"
 msgstr "Peržiūra negalima"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
 
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
@@ -5097,6 +6525,10 @@ msgid "from (Hz)"
 msgstr "iš (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "į (Hz)"
 
@@ -5104,11 +6536,13 @@ msgstr "į (Hz)"
 msgid "t&o"
 msgstr "į"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Procentinis Pakeitimas:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Procentinis Pakeitimas"
 
@@ -5117,8 +6551,24 @@ msgid "&Use high quality stretching (slow)"
 msgstr "Naudoti aukštos kokybės tampymą (lėtas)"
 
 #: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
 msgid "78"
 msgstr "8"
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -5144,6 +6594,7 @@ msgstr "Standartinis Vinylo apm(apsisukimai per minutę):"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Iš apm"
@@ -5156,6 +6607,7 @@ msgstr "iš"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Į apm"
@@ -5258,6 +6710,11 @@ msgid "Length in seconds from %s, to"
 msgstr "Ilgis sekundėmis nuo %s, iki"
 
 #: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Trakštelėjimų Pašalinimas..."
+
+#: src/effects/ClickRemoval.cpp
 msgid "Click Removal is designed to remove clicks on audio tracks"
 msgstr "Spustelėjimo Šalinimas yra sukurtas šalinti spustelėjimus garso takeliuose"
 
@@ -5287,8 +6744,19 @@ msgid "Max Spike Width"
 msgstr "Maksimalis Dyglių Plotis"
 
 #: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Kompresorius..."
+
+#: src/effects/Compressor.cpp
 msgid "Compresses the dynamic range of audio"
 msgstr "Suspaudžia dinaminį garso plotį"
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -5298,6 +6766,20 @@ msgstr "%.2f sek"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f sek"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f sek"
 
 #: src/effects/Compressor.cpp
@@ -5415,7 +6897,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Kontrasto Analizuotojas yra RMS garsumo skirtumo matavimui tarp dviejų pasirinktų garsų."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Pabaiga"
 
@@ -5477,6 +6960,18 @@ msgstr "&Skirtumas:"
 msgid "&Help"
 msgstr "&Pagalba"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nulis"
@@ -5484,6 +6979,13 @@ msgstr "nulis"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "nenuspręstas"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -5537,6 +7039,12 @@ msgstr "Dabartinis skirtumas"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Išmatuotas priešakinio plano lygis"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -5606,6 +7114,12 @@ msgstr "Sėkmės kriterijai 1.4.7 WCAG 2.0: Neišlaikyta"
 msgid "Data gathered"
 msgstr "Surinkti duomenys"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Kontrasto Analizė (WCAG 2 sutikimas)"
@@ -5635,6 +7149,10 @@ msgid "Hard Overdrive"
 msgstr "Sunki Perkrova"
 
 #: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Even Harmonics"
 msgstr "Lygios Harmonijos"
 
@@ -5645,6 +7163,101 @@ msgstr "Padidinti ir Suspausti"
 #: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "Lygintojas"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "Iškraipymas"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Tvirtas Iškirpimas"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Vidutinė Perkrova"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Sunki Perkrova"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Sunki Perkrova"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -5667,8 +7280,16 @@ msgid "Distortion"
 msgstr "Iškraipymas"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Iškraipymo tipas:"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -5683,8 +7304,26 @@ msgid "Clipping level"
 msgstr "Kirpimo Lygis"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Pritaikyti Grandį"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Iškarpos riba"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "Iškraipymas"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -5693,6 +7332,33 @@ msgstr "Išvesties lygis"
 #: src/effects/Distortion.cpp
 msgid "Repeat processing"
 msgstr "Kartoti procesavimą"
+
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "Tvirtas Iškirpimas"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Atkūrimas"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Atkūrimas"
 
 #: src/effects/Distortion.cpp
 msgid "(Not Used):"
@@ -5719,8 +7385,18 @@ msgid "(0 to 5):"
 msgstr " (0 iki 5):"
 
 #: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
 msgstr "Generuoja dvigubą tona ir dauginį dažnį (DTMF) tonai kaip tie kurie buvo sukurti telefono klaviatūros"
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -5730,9 +7406,20 @@ msgstr "DTMF seka:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitudė (0-1):"
 
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "&Duration:"
+msgstr "Trukmė:"
+
 #: src/effects/DtmfGen.cpp
 msgid "&Tone/silence ratio:"
 msgstr "Tylos trukmė:"
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 #, c-format
@@ -5742,6 +7429,12 @@ msgstr "%.1f sek"
 #: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Tono trukmė:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
@@ -5761,7 +7454,8 @@ msgstr "Aidas"
 msgid "Repeats the selected audio again and again"
 msgstr "Kartoja pasirinktą garsą vėl ir vėl"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Reikalaujama vertė per didelė atminčiai."
 
@@ -5785,7 +7479,8 @@ msgstr "&Nuostata:"
 msgid "Export Effect Parameters"
 msgstr "&Koregavimo Parametrai"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Negaliu atidaryti failo: \"%s\""
@@ -5822,6 +7517,15 @@ msgstr "Ruošiama peržiūra"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Peržiūra"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -5916,12 +7620,56 @@ msgid "Active State"
 msgstr "Aktyvi Būsena"
 
 #: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Pakelti takelį"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect up in the rack"
+msgstr "Perkelti Pasirinkimą ir Takelius"
+
+#: src/effects/EffectUI.cpp
 msgid "Move Down"
 msgstr "Nuleisti takelį"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect down in the rack"
+msgstr "Perkelti Pasirinkimą ir Takelius"
+
+#: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Remove effect from the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Naujos grandies pavadinimas"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Latency: %4d"
+msgstr "Gaišties laikas: 0"
 
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
@@ -6063,6 +7811,20 @@ msgstr "Stabdyti &Grojimą"
 msgid "Play"
 msgstr "Groti"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Nutylinama"
+
+#: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Equalization"
 msgstr "Sulyginimas"
@@ -6070,6 +7832,22 @@ msgstr "Sulyginimas"
 #: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
 msgid "Filter Curve EQ"
 msgstr "Pasirinkti"
+
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
@@ -6080,12 +7858,34 @@ msgid "Bass Cut"
 msgstr "Bosas"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Treble Boost"
 msgstr "Diskantas"
 
 #: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Diskantas"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -6096,16 +7896,233 @@ msgid "Track sample rate is too low for this effect."
 msgstr "Takeliai per ilgi, kad būtų galima pakartoti apibraukimą."
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Effect Unavailable"
+msgstr "Peržiūra negalima"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "Tipas:"
+
+#: src/effects/Equalization.cpp
+msgid "Draw Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "&Piešimo Įrankis"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Graphic"
+msgstr "grafikos kūrėjas"
+
+#: src/effects/Equalization.cpp
 msgid "Interpolation type"
 msgstr "Greitas Sinc Interpoliavimas"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Linijinis dažnis"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Linijinis dažnis"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "Pritaikomas Fazeris"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Pritaikomas Fazeris"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Pasirinkti"
 
 #: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Pasirinkti"
 
 #: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Invertuoti"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Show grid lines"
+msgstr "Rodyti naujus"
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Processing: "
+msgstr "Natų Takelis"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&efault"
+msgstr "Išankstiniai nustatymai"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "Palyginimas"
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Klaida Užkraunant Metaduomenis"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Vykdomas Sulyginimas"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve not found"
+msgstr "FFmpeg nerastas"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "&Redaguoti Istoriją"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "&Valdyti"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "&Žymeklis"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Pavadinimas..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Ištrinti"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Pasirinkti..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "Nu&matytieji"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -6122,6 +8139,10 @@ msgid "Rename '%s'"
 msgstr "Pervardinti '"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Same name"
 msgstr "Tas pats pavadinimas"
 
@@ -6135,9 +8156,23 @@ msgid "Curve exists"
 msgstr "Kreivė egzistuoja"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Nepavyksta Eksportuoti 'be pavadinimo'"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Ištrinti"
+
+#: src/effects/Equalization.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Deletion"
+msgstr "Patvirtinti"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -6145,8 +8180,55 @@ msgid "Delete %d items?"
 msgstr "Ištrinti Nuostatą"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Pasirinkite kur saugoti failus"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Eksportuoti &Etiketes..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Nepavyksta Eksportuoti 'be pavadinimo'"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr ""
+"%s\n"
+"\n"
+"Įrašas eksportuotas: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "Kreivė egzistuoja"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "Nerasta etikečių eksportavimui."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -6160,13 +8242,76 @@ msgstr "Tylinimas"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Temti ir mesti audio pasirinkimui"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Temti ir mesti audio pasirinkimui"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "Tvirtas Iškirpimas"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Tvirtas Iškirpimas"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "Riba:  %d dB"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "Riba:  %d dB"
+
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "Nėra pakankamai galimos vietos, kad galėtumėt įklijuoti pasirinkimą"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Invertuoti"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Nyquist Efektai"
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normalizuoti"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -6177,9 +8322,39 @@ msgstr "Normalizuoti\n"
 msgid "Analyzing: %s"
 msgstr "&Analizuoti"
 
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "Natų Takelis"
+
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normalizuoti"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -6205,6 +8380,10 @@ msgid "Noise"
 msgstr "Triukšmas"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Triukšmo tipas:"
 
@@ -6224,20 +8403,88 @@ msgid "Old"
 msgstr "Senas"
 
 #: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "256 - įprastas"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "256 - įprastas"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Triukšmo pašalinimas"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Kad galėčiau nupiešti grafiką, visi pasirinkti takeliai turi būti to pačio dažnio."
 
 #: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
 msgstr "Pasirinktas garso profilis per trumpas."
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Noise reduction (dB):"
+msgstr "Bangos Forma (dB)"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
+msgstr "Triukšmo pašalinimas"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Sensitivity:"
+msgstr "Jautrumas"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Sensitivity"
@@ -6259,9 +8506,35 @@ msgstr "Uždelsimo laikas (sek):"
 msgid "Release time"
 msgstr "Pakartota %d kartus"
 
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Frequency smoothing (bands):"
+msgstr "LFO Dažnis (Hz):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Dažnio Analizė"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "Jautrumas"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Old Sensitivity"
+msgstr "Jautrumas"
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 1"
 msgstr "1 Žingsnis"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid ""
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
+"then click Get Noise Profile:"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Get Noise Profile"
@@ -6270,6 +8543,33 @@ msgstr "Gauti Trukšmo Profilį"
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 2"
 msgstr "2 Žingsnis"
+
+#: src/effects/NoiseReduction.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "Triukšmas"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "P&anaikinti Specialų"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Keisti dydį į Mažą"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -6283,25 +8583,170 @@ msgstr "Lango Dydis:"
 msgid "Window si&ze:"
 msgstr "Lango Dydis:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - įprastas"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "256 - įprastas"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Triukšmo pašalinimas"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to remove noise.\n"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise re&duction (dB):"
+msgstr "Bangos Forma (dB)"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "Jautrumas"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Fr&equency smoothing (Hz):"
+msgstr "LFO Dažnis (Hz):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "Atako&s laikas (sek):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Atakos laikas"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&Išimti"
 
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Normalizuoti"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Šalinami DC atsišakojimą...\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Šalinami DC atsišakojimą...\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Šalinami DC atsišakojimą...\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -6311,9 +8756,23 @@ msgstr "Nauja Aukščiausia amplitudė (dB):"
 msgid "Peak amplitude dB"
 msgstr "Nauja Aukščiausia amplitudė (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Ištampyti"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Nykimo faktorius:"
@@ -6322,33 +8781,135 @@ msgstr "Nykimo faktorius:"
 msgid "&Time Resolution (seconds):"
 msgstr "Uždelsimo laikas (sek):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Fazeris"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Pakopos:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Pakopos:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "LFO Dažnis (Hz):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "LFO Dažnis (Hz):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "LFO Pradžios Fazė (laipsn.):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "LFO Pradžios Fazė (laipsn.):"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Gylis:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "Atsakomoji reakcija (%):"
 
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "&Output gain (dB):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Output gain (dB)"
+msgstr "Bosas (dB):"
+
+#: src/effects/Repair.cpp
+msgid "Repair"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Kartoti"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -6372,6 +8933,10 @@ msgstr "Dabartinio pasirinkimo trukme: %s"
 msgid "New selection length: %s"
 msgstr "Naujo pasirinkimo trukmė: %s"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
 msgstr "Vokalas I"
@@ -6385,8 +8950,52 @@ msgid "Bathroom"
 msgstr "Vonia"
 
 #: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#  i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#  know the correct technical word.
+#  i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "Big-endian"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Large Room"
+msgstr "&Didelės piktogramos"
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Cathedral"
 msgstr "Katedra"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Reversavimas"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Dydis"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Uždelsimo laikas (sek):"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -6395,6 +9004,34 @@ msgstr "Atsakomoji reakcija (%):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "Gylis (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Gylis (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Bosas (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Bosas (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Stereo, "
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -6409,6 +9046,25 @@ msgstr "Reversavimas"
 msgid "Reverses the selected audio"
 msgstr "Grąžina pasirinktą grasą"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Žemo dažnio"
@@ -6418,12 +9074,73 @@ msgid "Highpass"
 msgstr "Aukšto dažnio"
 
 #: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Vykdomas Sulyginimas"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "Kad galėčiau nupiešti grafiką, visi pasirinkti takeliai turi būti to pačio dažnio."
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Failo tipas:"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "O&rder:"
+msgstr "Eilė"
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Subtype:"
+msgstr "Kūrimo tipas:"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Cutoff (Hz)"
+msgstr "į (Hz)"
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Perkelti Pabaigą prie Apibraukimo Galo"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Trukmė:"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Trukmė:"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -6432,6 +9149,14 @@ msgstr "Lango Dydis:"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "Lango dydis"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -6448,6 +9173,33 @@ msgstr "Tylos Riba"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
 msgstr "Prieš lygumo Laikas:"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
+msgstr "Prieš lygumo Laikas:"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time:"
+msgstr "Pabaigos laikas"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time"
+msgstr "Pabaigos laikas"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Smooth Time:"
@@ -6469,15 +9221,28 @@ msgstr "256 - įprastas"
 msgid "Restore Defaults"
 msgstr "256 - įprastas"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Tyla"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "Suskaldyti Stereo Takelį"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -6495,6 +9260,46 @@ msgstr "Suskaldyti Stereo Takelį"
 msgid "Sliding Stretch"
 msgstr "Ištampyti"
 
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Tempo Change (%)"
+msgstr "Aukštos Kokybės Tempo Keitimas"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Tempo Change (%)"
+msgstr "Aukštos Kokybės Tempo Keitimas"
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "(%) [-50 to 100]:"
+msgstr " (0 iki 100):"
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "Greitas Sinc Interpoliavimas"
+
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
 msgstr "Sinusoidė"
@@ -6508,8 +9313,24 @@ msgid "Sawtooth"
 msgstr "Pjūklinė"
 
 #: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr "Tonas"
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
 
 #: src/effects/ToneGen.cpp
 msgid "&Waveform:"
@@ -6520,18 +9341,91 @@ msgid "&Frequency (Hz):"
 msgstr "LFO Dažnis (Hz):"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "LFO Dažnis (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "LFO Dažnis (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Stiprumas (0-1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Stiprumas (0-1)"
+
+#: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "Greitas Sinc Interpoliavimas"
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Detected Silence"
+msgstr "Generuoju tylą"
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Tyla"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Generuoju tylą"
 
 #: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Suspausti į:"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "Efe&ktai"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Nepavyko pakrauti bibliotekos"
 
@@ -6543,37 +9437,124 @@ msgstr "Efektų nustatymai"
 msgid "Buffer Size"
 msgstr "Buferio dydis"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Klavišų Kombinacija"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "Klavišų Kombinacija"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Išsaugoti VST išankstinę nuostatą Kaip:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Daugialypis Eksportavimas"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Daugialypis Eksportavimas"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity Projekto failai"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "Vykdomas Efektas: %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Išsaugoti VST išankstinę nuostatą Kaip:"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Pasirinkti failą"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "Vykdomas Efektas: %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Efektų nustatymai"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
 
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "VachVach"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -6584,8 +9565,29 @@ msgid "Reso&nance:"
 msgstr "Rezonansas:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Rezonansas:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Vach Dažnio Ofsetas (%):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Vach Dažnio Ofsetas (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Efektų nustatymai"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Efektų nustatymai"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -6600,16 +9602,47 @@ msgid "Audio Unit Effect Options"
 msgstr "Efektų nustatymai"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Interfeisas"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Sumažinti apibraukimą į dešinę"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Pagauti Pilną Langa"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Generuoti"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Daugialypis Eksportavimas"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "&Nuostata:"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
@@ -6679,6 +9712,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Nepavyko pašalinti %s"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Šablonų normos keitimas"
 
@@ -6689,19 +9727,57 @@ msgstr ""
 "Nepavyko priregistruoti:\n"
 "%s"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Nepavyko pašalinti %s"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Nepavyko pašalinti %s"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Garso Failas"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efe&ktai"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "Efe&ktai"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Efektų nustatymai"
 
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s: %s"
@@ -6712,6 +9788,7 @@ msgstr "Efektų nustatymai"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "Efe&ktai"
@@ -6720,13 +9797,59 @@ msgstr "Efe&ktai"
 msgid "LV2 Effect Settings"
 msgstr "Efektų nustatymai"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "Tono Generatorius"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efe&ktai"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Nyquist Efektai"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -6742,6 +9865,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Neteisingai formatuota Nyquist papildinio antraštė"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Perkelta prie apibraukimo pabaigos"
 
@@ -6754,8 +9895,37 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Atsiprašau, bet negaliu pritaikyti efekto stereo takeliams, kurių takeliai nesutampa."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Nyquist Išvestis: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "Laikmačio Įrašinėjimas baigtas."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -6792,6 +9962,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist Negrąžino audio.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Ši Audacity versija nepalaiko Nyquist papildinio versijos %ld"
@@ -6800,14 +9974,47 @@ msgstr "Ši Audacity versija nepalaiko Nyquist papildinio versijos %ld"
 msgid "Could not open file"
 msgstr "Nepavyko atidaryti failo"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Error in Nyquist code"
+msgstr "Klaida Trukmėje"
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Nepavyko nustatyti kalbos"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Įveskite Nyquist Komandą: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "&Load"
+msgstr "&Užkrauti..."
 
 #. i18n-hint: Nyquist is the name of a programming language
 #: src/effects/nyquist/Nyquist.cpp
@@ -6818,6 +10025,22 @@ msgstr "Paleisti Nyquist skriptą"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Stabdyti skriptą"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Nepavyko atidaryti failo"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "Priešakinis planas dar neišmatuotas"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -6840,13 +10063,53 @@ msgstr "Pasirinkti failą"
 msgid "Save file as"
 msgstr "Pervadinti failai:"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "untitled"
+msgstr "<be pavadinimo>"
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Efe&ktai"
 
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "Atsiprašau, bet negaliu pritaikyti efekto stereo takeliams, kurių takeliai nesutampa."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr "Nepavyko inicijuoti efekto"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "Priedas 1 iš %i"
+
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Efektų nustatymai"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -6861,9 +10124,27 @@ msgid "Exported Tags"
 msgstr "Eksportuoti"
 
 #: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp
 #, c-format
 msgid "Are you sure you want to export the file as \"%s\"?\n"
 msgstr "Ar tikrai norite eksportuoti failą kaip \"%s\"?\n"
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
@@ -6890,8 +10171,40 @@ msgid "Your tracks will be mixed down to one exported file according to the enco
 msgstr "Jūsų eksportuojamo failo takeliai bus sujungti į dviejų stereo kanalų failą."
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Advanced Mixing Options"
+msgstr "Efektų nustatymai"
+
+#: src/export/Export.cpp
 msgid "Format Options"
 msgstr "Efektų nustatymai"
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Channel: %2d"
+msgstr "Kanalas"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Output Channels: %2d"
+msgstr "%d Kanalai"
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "Sekimo Panelė"
 
 #: src/export/Export.cpp
 #, c-format
@@ -6900,10 +10213,35 @@ msgid ""
 "Error %s"
 msgstr "Neįmanoma pašalinti '%s'."
 
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Show output"
+msgstr "Rodyti &Išvestį"
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "Skriptas"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Komanda"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "(external program)"
+msgstr "Vidinė Klaida"
 
 #: src/export/ExportCL.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -6923,15 +10261,44 @@ msgid "Exporting the audio using command-line encoder"
 msgstr "Pasirinktas audio eksportuojamas naudojant komandinės eilutės dekoderį"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "Komanda "
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
 "Jūs pasirinkote failo pavadinimą be failo pratęsimo kategorijos.\n"
 "Ar norite tęsti?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "\"%s\" modulis buvo rastas."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
 
 #  i18n-hint: You do not need to translate "LOF"
 #  i18n-hint: You do not need to translate "LOF"
@@ -6939,14 +10306,141 @@ msgstr "\"%s\" modulis buvo rastas."
 msgid "FFmpeg Error"
 msgstr "LOF Klaida"
 
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Exporting the audio as %s"
 msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Modelio dažnis:"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Peršablonuot"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "Modelio dažnis:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -6955,6 +10449,47 @@ msgstr "Bitų Skaičius:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Kokybė"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f sek"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1024"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1024"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -6965,6 +10500,14 @@ msgid "On"
 msgstr "Atidaryti"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Constrained"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Garsas..."
 
@@ -6972,12 +10515,48 @@ msgstr "&Garsas..."
 msgid "Low Delay"
 msgstr "Užlaikymas"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
 #  i18n-hint: Refers to byte-order.  Don't translate this if you don't
 #  know the correct technical word.
 #  i18n-hint: Refers to byte-order.  Don't translate this if you don't
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Big-endian"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -7000,6 +10579,14 @@ msgid "Application:"
 msgstr "Garso stiprinimas dB"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "Dabartinis Projektas"
 
@@ -7008,30 +10595,585 @@ msgid "Current Codec:"
 msgstr "Dabartinis Projektas"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "Vykdomas Efektas: %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Perrašyti egzistuojančius failus"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "Silpna Perkrova"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "Prašome pasirinkti Natos Takelį."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Vieta %s neegzistuoja. Ar sukurti?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "Pakeisti išankstinę nuostatą '%s'?"
+
+#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#  i18n-hint: One-letter abbreviation for Left, in VU Meter
+#  i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "K"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "Pagrindinis Miksas"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "FFmpeg Importavimas ir Eksportavimas"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Lygis"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Lygis"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Lygis"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "&Nuostata:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Išsaugoti Nuostatą"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Eksportuoti Projektą Kaip:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Eksportuoti Projektą Kaip:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Dabartinis Projektas"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Show All Codecs"
+msgstr "Rodyti viską"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Priedas 1 iš %i"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Kalba:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Quality:"
+msgstr "Kokybė"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Modelio dažnis:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Visi failai|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Nustatymai"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Kompresorius..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Pavadinimas"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Apibraukti iki Pabaigos"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Nustatyti tempą"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "T&akelio Dydis"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "Pakeisti išankstinę nuostatą '%s'?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "Nerasta etikečių eksportavimui."
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "Pasirinkite failus batch apdorojimui..."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16-bit PCM"
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "0 (fastest)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "8 (best)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Level:"
+msgstr "Lygis"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Bit depth:"
+msgstr "Bitų Skaičius:"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "FLAC Files"
+msgstr "Visi failai|*"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Negaliu atidaryti failo: \"%s\""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr "Nepavyko inicijuoti efekto"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the selected audio as FLAC"
+msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the audio as FLAC"
 msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy
+msgid "MP2 Files"
+msgstr "Pervadinti failai:"
+
+#: src/export/ExportMP2.cpp
+msgid "Cannot export MP2 with this sample rate and bit rate"
+msgstr ""
 
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
 msgstr "Negaliu atidaryti failo įrašymui"
 
 #: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#: src/export/ExportMP2.cpp
 #, c-format
 msgid "Exporting the audio at %ld kbps"
 msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
 
 #  i18n-hint: Refers to byte-order.  Don't translate this if you don't
 #  know the correct technical word.
@@ -7040,10 +11182,75 @@ msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
 msgid "Medium"
 msgstr "Big-endian"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "Peržiūra negalima"
+
+#: src/export/ExportMP3.cpp
+msgid "Average"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Constant"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "Nebuvo rasta atitikmenų"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Paversti Stereo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "Bitų Skaičius:"
+
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "Kokybė"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "Kanalas"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Pašalinti takelį"
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Tenacity needs the file %s to create MP3s."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr "'%s' vieta:"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "To find %s, click here -->"
+msgstr "Norint rasti '%s', spausti čia -->"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "To get a free copy of LAME, click here -->"
+msgstr "Norint gauti nemokamą FFmpeg kopiją spausti čia -->"
 
 #  i18n-hint: It's asking for the location of a file, for
 #  example, "Where is lame_enc.dll?" - you could translate
@@ -7057,8 +11264,41 @@ msgid "Where is %s?"
 msgstr "Kur galėčiau rasi  %s?"
 
 #: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Saugojami projekto duomenų failai"
+
+#: src/export/ExportMP3.cpp
 msgid "Extended libraries"
 msgstr "Pagrindinės Bibliotekos"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "Pervadinti failai:"
 
 #: src/export/ExportMP3.cpp
 msgid "Could not open MP3 encoding library!"
@@ -7073,14 +11313,63 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "Negaliojanti arba nepritaikyta MP3 dekodavimo biblioteka!"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Daugialypis Eksportavimas"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
 msgstr "Daugialypis Eksportavimas"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio with VBR quality %s"
+msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 export library not found"
+msgstr "FFmpeg biblioteka nebuvo rasta"
 
 #: src/export/ExportMP3.cpp
 msgid "(Built-in)"
@@ -7095,8 +11384,22 @@ msgid "Cannot Export Multiple"
 msgstr "Daugialypis Eksportavimas"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Eksportavimo vieta:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Create"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Options:"
@@ -7115,6 +11418,11 @@ msgid "First file name:"
 msgstr "Pirmo failo vardas:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Pirmo failo vardas:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "Pervadinti failai:"
 
@@ -7123,7 +11431,22 @@ msgid "Using Label/Track Name"
 msgstr "Naudojantis pavadinimais/Takelio Pavadinimu"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Naudojantis pavadinimais/Takelio Pavadinimu"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Failo prefiksas:"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "Failo prefiksas:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "Failo prefiksas:"
 
 #: src/export/ExportMultiple.cpp
@@ -7131,11 +11454,105 @@ msgid "Overwrite existing files"
 msgstr "Perrašyti egzistuojančius failus"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Choose a location to save the exported files"
 msgstr "Pasirinkite vietą eksportuotiems failams išsaugoti"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr "Failas '%s' jau egzistuoja. Ar tikrai norite jį perrašyti?"
+
+#: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Save As..."
+msgstr "Išsaugoti kaip"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis Files"
+msgstr "Tai ne Ogg Vorbis failas"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
 msgstr "Nepavyksta pakrauti išankstinės nuostatos failo."
 
 #: src/export/ExportOGG.cpp
@@ -7150,17 +11567,69 @@ msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "Header:"
+msgstr ""
+
 #: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
 msgid "Encoding:"
 msgstr "Dekodavimas:"
+
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "Pasirinkite bet kurį nesuspaustą garso failą"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Klaida Importuojant"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
 msgstr "Negaliu eksportuoti audio šiuo formatu."
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "Pasirinktas Audio eksportuojamas kaip Ogg Vorbis"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -7168,13 +11637,184 @@ msgstr "Visi failai |*|Visi palaikomi failai|"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Nepavyko inicijuoti efekto"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Ši Audacity versija buvo sukompiluota be %s palaikymo."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
 
 #: src/import/Import.cpp
 #, c-format
 msgid "File \"%s\" not found."
 msgstr "\"%s\" modulis buvo rastas."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "testuotojas"
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Saugojami projekto duomenų failai"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7189,8 +11829,50 @@ msgid "Import Project"
 msgstr "Eksportuoti Projektą Kaip:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Vidinė klaida pranešta išlyginimo proceso."
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7198,8 +11880,72 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Nepavyko rasti projekto duomenų aplanko: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "&Projekto Pradžia"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7216,13 +11962,20 @@ msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
 msgid "Unable to read %lld samples from %s"
 msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Negaliu baigti"
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Nepavyksta nustatyti srovės būklės į sustabdytą."
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "Visi failai|*"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -7284,6 +12037,29 @@ msgstr "Nepavyko atidaryti %s failo: Neteisingas failo tipas."
 msgid "Could not open file %s."
 msgstr "Nepavyko atidaryti %s."
 
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "Pervadinti failai:"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis files"
+msgstr "Tai ne Ogg Vorbis failas"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
 msgstr "Medijos skaitymo klaida"
@@ -7305,12 +12081,124 @@ msgid "Internal logic fault"
 msgstr "Vidinis logikos gedimas"
 
 #: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -7321,12 +12209,105 @@ msgid "64 bit float"
 msgstr "32-bit float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DWVW"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "MP3 Importavimas"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "Pervadinti failai:"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Nepavyksta išsaugoti prietaiso informacijos"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "Nepavyko pašalinti %s"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Nepavyko išsaugoti žanro failo."
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "Importuoti Raw duomenis"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -7340,6 +12321,22 @@ msgstr "Importuoti Raw duomenis"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Be endianness"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#  i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#  know the correct technical word.
+#  i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Big-endian"
 
 #  i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #  know the correct technical word.
@@ -7363,6 +12360,15 @@ msgstr "2 Kanalai (Stereo)"
 msgid "%d Channels"
 msgstr "%d Kanalai"
 
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Kan&alai:"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
@@ -7385,6 +12391,10 @@ msgstr "Modelio dažnis:"
 msgid "&Import"
 msgstr "&Importuoti"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -7405,6 +12415,7 @@ msgstr "%s dešinė"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -7429,6 +12440,7 @@ msgstr "pabaiga"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -7457,7 +12469,8 @@ msgstr "Laikas perkėlė iškarpas į dešinę"
 msgid "Time shifted clips to the left"
 msgstr "Laikas perkėlė iškarpas į kairę"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Laiko-Perkėlimas"
 
@@ -7468,6 +12481,16 @@ msgstr "Iškarpa nebuvo perkelta"
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
 msgstr "Apkarpyti R&ibas"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Praeit&os Iškarpos Riba"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "Sek&ančios Iškarpos Riba"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -7587,7 +12610,8 @@ msgstr "Apkarpykite pasirinktus garso takelius iš %.2f sekundžių į %.2f seku
 msgid "Trim Audio"
 msgstr "Apkarpyti Garsą"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Praskirti"
 
@@ -7708,32 +12732,8 @@ msgid "Delete Key&2"
 msgstr "Trynimo Mygtukas&2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mik&seris"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Tai&syti grojimo garsą"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Padidinti grojimo garsą"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Sumažinti grojimo garsą"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Tai&syti įrašinėjimo garsą"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Pa&didinti įrašinėjimo garsą"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Su&mažinti įrašinėjimo garsą"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -7827,6 +12827,11 @@ msgid "Select a MIDI file"
 msgstr "Pasirinkti MIDI failą"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Visi failai|*"
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI files"
 msgstr "Pasirinkti MIDI failą"
 
@@ -7905,6 +12910,11 @@ msgid "&Labels..."
 msgstr "&Etiketės..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Eksportuoti MI&DI"
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Raw Duomenys..."
 
@@ -7921,6 +12931,10 @@ msgstr "&Spausdinti..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "I&šeiti"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -7944,9 +12958,20 @@ msgstr "Ar norite išsaugoti pokyčius?"
 msgid "Fix"
 msgstr "Sujungti"
 
+#  i18n-hint: The name of the Help menu
+#  i18n-hint: The name of the Help menu
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "&Greitoji Pagalba"
+
 #: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "Nėra ko atšaukti"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -7959,6 +12984,10 @@ msgstr "Nepavyksta atidaryti projekto failo"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Įrašinėjimo pradžia:"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -7979,8 +13008,9 @@ msgid "&Getting Started"
 msgstr "&Pradedantiesiems"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Žinynas"
 
 #  i18n-hint: The name of the Help menu
 #  i18n-hint: The name of the Help menu
@@ -8008,11 +13038,8 @@ msgstr "&MIDI Prietaiso Informacija..."
 msgid "Show &Log..."
 msgstr "Rodyti &Registrą..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Apie Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Pridėtas pavadinimas"
 
@@ -8214,6 +13241,10 @@ msgid "Move Forward Through Active Windows"
 msgstr "Judėti į priekį per aktyvius langus"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Judėti &atgal iš įrankių juostos į takelius"
 
@@ -8365,6 +13396,16 @@ msgid "Set Track Status..."
 msgstr "Takelio &Pradžia"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Tyla"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Iš&rikiuoti Takelius"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "&Nuostatos..."
 
@@ -8388,9 +13429,20 @@ msgstr "&Redaguoti Etiketes..."
 msgid "Set Project..."
 msgstr "Išsaugoti Projektą &Kaip..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Skriptas"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "Iš&rikiuoti Takelius"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "Nuleisti Takelį į Apačią"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -8457,6 +13509,11 @@ msgstr "Visuose &Takeliuose"
 #: src/menus/SelectMenus.cpp
 msgid "In All &Sync-Locked Tracks"
 msgstr "Visuose &Sinchronizuotai Užrakintuose Takeliuose"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Sinchronizavimo Užraktas Pasirinktas"
 
 #: src/menus/SelectMenus.cpp
 msgid "R&egion"
@@ -8527,8 +13584,16 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Sekantis &Žemesnio Aukščio Dažnis"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Apibraukti iki Pradžios"
+
+#: src/menus/SelectMenus.cpp
+msgid "Store Cursor Pos&ition"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -8669,6 +13734,7 @@ msgstr "Žymeklį Daug&iau į Dešinę"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Ieš&koti"
@@ -8880,18 +13946,21 @@ msgid "Created new label track"
 msgstr "Sukurtas naujas pavadinimo takelis"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Ši Audacity versija leidžia tik viena laiko takelį per vieną projekto langą."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Sukurtas naujas laiko takelis"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Naujas šablono dažnis (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Įvesta vertė yra netinkama"
 
@@ -9148,7 +14217,9 @@ msgstr "Pritaikomas Fazeris"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Įrašymas"
 
@@ -9159,6 +14230,11 @@ msgstr "takelis be etiketės"
 #: src/menus/TransportMenus.cpp
 msgid "no label track at or below focused track"
 msgstr "takelis be etiketės fokusuotame takelyje arba po juo"
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
@@ -9250,6 +14326,10 @@ msgid "&Timer Record..."
 msgstr "&Laikmačio Įrašinėjimas..."
 
 #: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Gro&jimo Regijonas"
 
@@ -9288,10 +14368,6 @@ msgstr "&Įrašinėjimas ant viršaus (Įjungta/Išjungta)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Pro&gramos Pergrojimas (Įjungta/Išjungta)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Auto&matinis Įrašo Garsumo Nustatymas (Įjungta/Išjungta)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -9462,6 +14538,11 @@ msgstr "&Papildomi Meniu (Įjungta/Išjungta)"
 msgid "&Show Clipping (on/off)"
 msgstr "&Rodyti Apkarpymą (Įjungta/Išjungta)"
 
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "Efektai"
+
 #  i18n-hint: This refers to a "window function", used in the
 #  Frequency analyze dialog box.
 #  i18n-hint: This refers to a "window function", used in the
@@ -9487,13 +14568,27 @@ msgstr "&Perkelti Visus į Priekį"
 msgid "Minimize All Projects"
 msgstr "Sumažinti visus projektus"
 
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Įrašas Išsaugotas:"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
+
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
 msgstr "&Nuostatos..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Išeiti iš Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -9501,9 +14596,27 @@ msgstr "Išeiti iš Audacity"
 msgid "&Check for Updates"
 msgstr "&Tikrinti ar yra Atnaujinimų..."
 
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+#, fuzzy
+msgid "Batch"
+msgstr "Prilyginti"
+
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
 msgstr "&Nuostatos..."
+
+#: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Behaviors"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "Prietaisas"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
@@ -9515,7 +14628,18 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Interfeisas"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Using:"
+msgstr "Trūkstami Failai"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Atkūrimas"
 
@@ -9532,6 +14656,17 @@ msgid "Cha&nnels:"
 msgstr "Kan&alai:"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Latency"
+msgstr "Gaišties laikas: 0"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "milliseconds"
+msgstr "sekundžių"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "&Buffer length:"
 msgstr "&Buferio trukme:"
 
@@ -9539,18 +14674,58 @@ msgstr "&Buferio trukme:"
 msgid "&Latency compensation:"
 msgstr "Klavišų Kombinacija"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Pašalinti takeliai(-is)"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No devices found"
+msgstr "Nebuvo rasta atitikmenų\n"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Kanalas (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 Kanalai (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Vietos"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Grąžinti Projektus"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Vietos"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Naršyti..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -9573,6 +14748,24 @@ msgid "Bro&wse..."
 msgstr "Naršyti..."
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "&Macro output:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "Nauja Laikina Vieta"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Veiksmas"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
 msgstr "Naršyti..."
 
@@ -9585,8 +14778,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Pasirinkite kur dėti laikinus failus"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "Pasirinkite kur saugoti failus"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -9603,18 +14805,52 @@ msgid "Directory %s is not writable"
 msgstr "Vieta yra %s neįrašoma"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Laikinos vietos keitimas bus priimtas tik perkrovus Audacity"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Nauja Laikina Vieta"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
 msgstr "&Nuostatos..."
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Effect Name"
+msgstr "Rūšiuoti pagal Pavadinimą"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Publisher and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Type and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "Efe&ktai"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -9624,17 +14860,141 @@ msgstr "Efe&ktai"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "Visi Efektai"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Efektų nustatymai"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Priedas 1 iš %i"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Greitas Sinc Interpoliavimas"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Importuoti"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "&Nuostatos..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Failo tipas:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Eksportuoti Projektą Kaip:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Pakelti į &Viršų"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Nuleisti &Žemyn"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "Pakelti į &Viršų"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Nuleisti &Žemyn"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Ištrinti Etikete Pažymėtą Garsą"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Eksportavimo vieta:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Pasirinkti"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "Ar tikrai norite ištrinti %s?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Įrašinėjimo trukmė:"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -9659,6 +15019,11 @@ msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (PCM diapazonas 8 bitų modeliams)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (PCM diapazonas 16 bitų medeliams)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
 msgstr "-96 dB (PCM diapazonas 16 bitų medeliams)"
 
@@ -9679,21 +15044,150 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (PCM diapazonas 24 bitų modeliams)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Vokalas I"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "Display"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Kalba:"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "'%s' vieta:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Bangos Forma (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "šis pagalbos pranešimas"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Priedas 1 iš %i"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Įrankis"
+
+#: src/prefs/GUIPrefs.cpp
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "Kalba \"%s\" yra nežinoma"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "FFmpeg Importavimas ir Eksportavimas"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "&Nuostatos..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
 msgstr "Suskaldyti Stereo Takelį"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "&Use Advanced Mixing Options"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Seconds"
+msgstr "sekundžių"
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Beats"
 msgstr "Kartoti"
 
 #: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "When exporting tracks to an audio file"
+msgstr "Eksportuojamas Garso Failas"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Eksportuoti Etiketes Kaip:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9705,12 +15199,71 @@ msgid "Preferences for KeyConfig"
 msgstr "&Nuostatos..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Key Bindings"
+msgstr "Klavišų Kombinacija"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "View by:"
 msgstr "Rodyti pagal:"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "&Pavadinimas"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "Rodyti pagal:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "Rodyti pagal:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "Rodyti pagal:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Bindings"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Short cut"
+msgstr "Trumpi Takeliai"
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Nustatymai"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -9720,8 +15273,21 @@ msgstr "Pranešimas: Paspaudus Cmd+Q išeisite. Visi kiti mygtukai galioja."
 msgid "&Import..."
 msgstr "&Importuoti..."
 
+#: src/prefs/KeyConfigPrefs.cpp src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "&Defaults"
+msgstr "Išankstiniai nustatymai"
+
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Pasirinkite XML failą kuriame laikote Audacity klavetūros sparčuosius klavišus..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9730,8 +15296,21 @@ msgstr "Klaida Importuojant Klaviatūros Trumpinius"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Įkelti %d spartieji klavišai\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -9745,6 +15324,38 @@ msgstr "Eksportuoti Sparčiuosius Klavišus Kaip:"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Klaida Eksportuojant Klaviatūros Trumpinius"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "Klavišų Kombinacija"
@@ -9754,20 +15365,75 @@ msgid "Preferences for Library"
 msgstr "&Nuostatos..."
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "MP3 Bibliotekos Versija:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export Library"
+msgstr "FFmpeg Importavimas ir Eksportavimas"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "No compatible FFmpeg library was found"
+msgstr "FFmpeg biblioteka nebuvo rasta"
 
 #: src/prefs/LibraryPrefs.cpp
 msgid "FFmpeg support is not compiled in"
 msgstr "FFmpeg parama nebuvo kompiliuota"
 
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "MP3 Bibliotekos Versija:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "FFmpeg biblioteka nebuvo rasta"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "&Išsaugoti..."
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Dow&nload"
+msgstr "Parsisiųsti"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
 msgstr "Bibliotekos"
 
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "MIDI Prietaiso Informacija"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "&Nuostatos..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Interfeisas"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -9775,13 +15441,80 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Interfeisas"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "&Nuostatos..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Pokyčiai šioms nuostatoms įsigalios tik kai Audacity bus įjungta."
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Ask"
+msgstr "Klauskite manes"
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Failed"
+msgstr "Nepavyko!"
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "No modules were found"
+msgstr "Nebuvo rasta atitikmenų"
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -9823,13 +15556,26 @@ msgstr "Kairysis-Tempimas"
 msgid "Set Selection Range"
 msgstr "Apibraukti"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-Pelės-Kairysis"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Extend Selection Range"
 msgstr "Pratęsti Apibraukimo Ruožą"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Alt-Left-Click"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "Žymeklį ties Takelio &Pabaiga"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
@@ -9848,6 +15594,10 @@ msgid "Zoom in on a Range"
 msgstr "Priartinti Ruožą"
 
 #: src/prefs/MousePrefs.cpp
+msgid "same as right-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Right-Click"
 msgstr "Dešinysis-Paspaudimas"
 
@@ -9860,8 +15610,61 @@ msgid "Right-Drag"
 msgstr "Dešinysis-Tempimas"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "same as left-drag"
+msgstr "toks pat kaip pasirinkimo įrankis"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Kairysis-Tempimas"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom out on a Range"
+msgstr "Priartinti Ruožą"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Kairysis-Paspaudimas"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom default"
+msgstr "256 - įprastas"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip left/right or between tracks"
+msgstr "Pakelti takelį"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Left-Drag"
+msgstr "Kairysis-Tempimas"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
 msgstr "Kairysis-Tempimas"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip up/down between tracks"
+msgstr "Pakelti takelį"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Kairysis-Tempimas"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -9877,6 +15680,11 @@ msgid "Change Sample"
 msgstr "Keisti pavyzdį"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Click"
+msgstr "Kairysis-Paspaudimas"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Smooth at Sample"
 msgstr "Sulieti pavyzdį"
 
@@ -9887,6 +15695,11 @@ msgstr "Keisti kelis pavyzdžius"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Pakeisti tik VIENĄ Modelį"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Multi Įrankis"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -9903,6 +15716,11 @@ msgstr "Bet kuris"
 #: src/prefs/MousePrefs.cpp
 msgid "Scroll tracks up or down"
 msgstr "Paslinkti viršun arba apačion"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Wheel-Rotate"
+msgstr "Ratuko-Pasukimas"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Scroll waveform"
@@ -9929,12 +15747,60 @@ msgid "Preferences for Playback"
 msgstr "&Nuostatos..."
 
 #: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Effects Preview"
+msgstr "Efektų nustatymai"
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "&Length:"
 msgstr "Naujas apibraukimo ilgis:"
 
+#. i18n-hint: (noun) this is a preview of the cut
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Cut Preview"
+msgstr "Groti Iški&rpimo Peržvalga"
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity Nuostatos"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -9945,8 +15811,18 @@ msgid "Preferences for Quality"
 msgstr "&Nuostatos..."
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Kitas..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "Perkeltas Modelis"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Rate:"
@@ -9955,6 +15831,36 @@ msgstr "Įprastas Modelio Dažnis:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Format:"
 msgstr "Įprastas Modelio Formatas:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Šablonų normos keitimas"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Con&verter:"
+msgstr "Šablonų normos keitimas"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Aukštos kokybės Sinc Interpoliavimas"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Conver&ter:"
+msgstr "Šablonų normos keitimas"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -9969,12 +15875,31 @@ msgid "Preferences for Recording"
 msgstr "&Nuostatos..."
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "Pro&gramos Pergrojimas (Įjungta/Išjungta)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Naujas Takelis"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Rasti Pasrovio Išmetimus"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Garsu Aktyvuotas Įrašas"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -9985,9 +15910,19 @@ msgstr "Bangos Forma (dB)"
 msgid "Name newly recorded tracks"
 msgstr "Sukurtas naujas stereo audio takelis"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Takelio Pavadinimas"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Pavadinimo Redagavimas"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -9997,10 +15932,60 @@ msgstr "Įrašytas Audio"
 msgid "&Track Number"
 msgstr "&Takelio Numeris"
 
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "System &Date"
+msgstr "Pradžios Data"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "&Nuostatos..."
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Natų Takelis"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
+msgstr "256 - įprastas"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
 msgstr "256 - įprastas"
 
 #. i18n-hint: Grayscale color scheme for spectrograms
@@ -10019,10 +16004,43 @@ msgstr "Linijinis"
 msgid "Frequencies"
 msgstr "Dažniai"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Nuolydis (EAC)"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be at least 0 Hz"
+msgstr "LFO Dažnis (Hz):"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "LFO Dažnis (Hz):"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -10054,16 +16072,94 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Didžiausias Dažnis (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Bosas (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Pakelti (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Algorithm"
+msgstr "&Algoritmas:"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "A&lgorithm:"
 msgstr "&Algoritmas:"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &size:"
+msgstr "Lango Dydis:"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "256 - įprastas"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr "Lango Dydis:"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Nykimo faktorius:"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Nustatyti Pasirinkimo Tašką"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "FFT Find Notes"
+msgstr "Rasti tekstą"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "Nauja Aukščiausia amplitudė (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Find Notes"
+msgstr "Rasti tekstą"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -10077,9 +16173,118 @@ msgstr "Nustatyti Pasirinkimo Tašką"
 msgid "The maximum frequency must be an integer"
 msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
 
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum frequency must be an integer"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Didžiausias dažnis turi būti sveikasis skaičius"
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/prefs/ThemePrefs.cpp src/prefs/ThemePrefs.h
+msgid "Theme"
+msgstr ""
+
 #: src/prefs/ThemePrefs.cpp
 msgid "Preferences for Theme"
 msgstr "&Nuostatos..."
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Info"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Save Files"
+msgstr "Pervadinti failai:"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Load Files"
+msgstr "Vykdomas Sulyginimas"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+msgid "Tracks Behaviors"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "&Nuostatos..."
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "Perkeltas Modelis"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -10099,8 +16304,34 @@ msgid "Enable &dragging selection edges"
 msgstr "Paversti apibraukimą tyla"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "&Type to create a label"
+msgstr "&Rašykite norint Sukurti Etiketę (įjungta/išjungta)"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Efektų nustatymai"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Mygtukai"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -10114,6 +16345,14 @@ msgstr "Bangos Forma"
 msgid "Spectrogram"
 msgstr "Spektograma"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "&Pritaikyti lange"
@@ -10125,6 +16364,16 @@ msgstr "&Priartinti apibraukimą"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "256 - įprastas"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Minutes"
+msgstr "%d minutė"
+
+#: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Seconds"
+msgstr "sekundžių"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "5ths of Seconds"
@@ -10143,10 +16392,30 @@ msgid "50ths of Seconds"
 msgstr "sekundžių"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "sekundžių"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "sekundžių"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "MilliSeconds"
+msgstr "sekundžių"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Samples"
 msgstr "Perkeltas Modelis"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Keist Mastelį"
 
@@ -10155,12 +16424,42 @@ msgid "Preferences for Tracks"
 msgstr "&Nuostatos..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Įrašinėjimo pabaiga:"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "Įprastas Modelio Dažnis:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Įprastas Modelio Formatas:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "Perkeltas Modelis"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -10183,9 +16482,46 @@ msgstr "Pirmo failo vardas:"
 msgid "Preset 2:"
 msgstr "Pirmo failo vardas:"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "Perspėjimas"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "&Nuostatos..."
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "Klaida Saugojant Projektą"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "Klaida Saugojant Projektą"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "Suskaldyti Stereo Takelį"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "Suskaldyti Stereo Takelį"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -10208,16 +16544,24 @@ msgid "Stopped"
 msgstr "Stop"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pauzė"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Perkelti į Pradžią"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Perkelti į Pabaiga"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pauzė"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Apibraukti iki Pradžios"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Apibraukti iki Pabaigos"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -10231,20 +16575,17 @@ msgstr "Naujas Takelis"
 msgid "Append Record"
 msgstr "Įrašyti"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Apibraukti iki Pabaigos"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Apibraukti iki Pradžios"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pauzė"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s: %s"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -10261,6 +16602,11 @@ msgstr "Atkūrimas"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Įrašymas"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "&Garsas..."
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -10283,8 +16629,18 @@ msgid "Select Playback Device"
 msgstr "Atkūrimas"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Tyla"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Dešinysis kanalas"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "Peržiūra negalima\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -10308,11 +16664,22 @@ msgstr "Nukirpti kas šonuose"
 msgid "Silence audio selection"
 msgstr "Paversti apibraukimą tyla"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "Visuose &Sinchronizuotai Užrakintuose Takeliuose"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Artinti"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Tolinti"
 
@@ -10324,10 +16691,20 @@ msgstr "Išplėsti apibraukimą lange"
 msgid "Fit project to width"
 msgstr "Pritaikyti projektą lange"
 
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "Efektai"
+
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
 msgid "&Edit Toolbar"
 msgstr "&Redaguoti Įrankių Juosta"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "Įrašymas"
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Meter"
@@ -10336,6 +16713,22 @@ msgstr "Įrašymas"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "Atkūrimas"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "Įrašyti"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Play"
+msgstr "Matuoklis"
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Level"
@@ -10357,38 +16750,24 @@ msgstr "&Įrašymų Matavimo Įrankių Juosta"
 msgid "&Playback Meter Toolbar"
 msgstr "&Grojimo Matavimo Įrankių Juosta"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Įrašymas"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Atkūrimas"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Įrankis"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Įrašymas"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Atkūrimas"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Atkūrimas"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Mi&ksavimo Įrankių Juosta"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Sustabdyti Gramdymą"
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Sustabdyti Gramdymą"
@@ -10396,6 +16775,7 @@ msgstr "Sustabdyti Gramdymą"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Pradėti Gramdymą"
@@ -10403,9 +16783,24 @@ msgstr "Pradėti Gramdymą"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Pradėti Ieškoti"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Pradėti Ieškoti"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Įrankis"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -10416,6 +16811,16 @@ msgstr "Gram&dymo Įrankių Juosta"
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "Projekto Norma (Hz)"
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Snap-To"
+msgstr "&Papildomi Meniu (Įjungta/Išjungta)"
+
+#: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
+#, fuzzy
+msgid "Audio Position"
+msgstr "Pozicija"
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
@@ -10433,9 +16838,39 @@ msgstr "Trukmė ir Pabaiga Pasirinkimo"
 msgid "Length and Center of Selection"
 msgstr "Apkirpti failą į apibraukimą"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Show"
+msgstr "Rodyti:"
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Snap To"
+msgstr "&Papildomi Meniu (Įjungta/Išjungta)"
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Length"
+msgstr "Naujas apibraukimo ilgis:"
+
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centrinis"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -10462,6 +16897,10 @@ msgstr "Didinu Boso Dažnį"
 msgid "Center Frequency"
 msgstr "Centrinis Dažnis:"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -10480,13 +16919,18 @@ msgstr "&Prietaisų įrankių Juosta"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity Pirmasis paleidimas"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Spausti ir tempti norint pakeisti įrankių linijos dydį"
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Įrankis"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -10504,13 +16948,19 @@ msgstr "Laiko perkėlimo įrankis"
 msgid "Zoom Tool"
 msgstr "Priartinimo įrankis"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Piešimo įrankis"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Multi-Tool"
 msgstr "Multi Įrankis"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "Apibraukimo Įrankis"
 
 #. i18n-hint: Clicking this menu item shows a toolbar
 #. that has some tools in it
@@ -10550,17 +17000,42 @@ msgstr "&Praeitas Įrankis"
 msgid "&Next Tool"
 msgstr "&Sekantis Įrankis"
 
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "Gro&ti tokiu Greičiu"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Playback Speed"
+msgstr "Atkūrimas"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "&Ciklinti grojimą tokiu Greičiu"
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
 #: src/toolbars/TranscriptionToolBar.cpp
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "Gro&ti tokiu Greičiu"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Pakeistas Pavadinimas"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Pavadinimo Redagavimas"
 
@@ -10580,6 +17055,12 @@ msgstr "Pavadinimo Takelio Šriftas"
 #. i18n-hint: (noun) The name of the typeface
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Face name"
+msgstr "Tas pats pavadinimas"
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
 msgstr "Tas pats pavadinimas"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -10610,31 +17091,42 @@ msgstr "Pakeistos etiketės"
 msgid "New label"
 msgstr "Pridėtas pavadinimas"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Oktava Aukščiau"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Oktava žemiau"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Paspauskite verikaliam Priartinimui, Shift-Paspaudimas — Tolinimui, Temkite konkrečios vietos apibraukimui."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Spausti dešinį pelės klavišą, kad atidaryti meniu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Tolinti"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-Pelės-Kairysis"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-Pelės-Kairysis"
 
@@ -10656,9 +17148,44 @@ msgstr "Užrašų takelis"
 msgid "Stretch"
 msgstr "Ištampyti"
 
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "Tvirtas Iškirpimas"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Expand"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Removed Cut Line"
+msgstr "Pašalinti takelį"
+
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Click and drag to edit the samples"
 msgstr "Temti ir mesti pavyzdžių redagavimui"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
@@ -10668,6 +17195,11 @@ msgstr "Perkeltas Modelis"
 msgid "Sample Edit"
 msgstr "Modelio Redagavimas"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Priartinti tašką"
@@ -10675,6 +17207,16 @@ msgstr "Priartinti tašką"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Spektograma"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -10693,9 +17235,15 @@ msgstr "Keičiams Tempas"
 msgid "Processing...   0%%"
 msgstr "Natų Takelis"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   %i%%"
+msgstr "Natų Takelis"
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Pakeista '%s' į %s"
@@ -10707,6 +17255,54 @@ msgstr "Formato Pakeitimas"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Nustatyti tempą"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -10726,7 +17322,8 @@ msgstr "Dažnio Pakeitimas"
 msgid "Set Rate"
 msgstr "Nustatyti tempą"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Multi"
 
@@ -10745,6 +17342,11 @@ msgstr "Suskaldyti Stereo Takelį"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Suskaldyti Stereo Takelį"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -10795,6 +17397,16 @@ msgid "Split to Mono"
 msgstr "Suskaldyti Stereo Takelį"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Kairys, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Kairys, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Kairys, %dHz"
@@ -10805,10 +17417,25 @@ msgid "Right, %dHz"
 msgstr "Dešinys, %dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "%s dešinė"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -10818,6 +17445,15 @@ msgstr "Spauskite ir temkite santykiniam stereo takelio dydižiui pakeisti."
 msgid "Click and drag to rearrange sub-views"
 msgstr "Temti ir mesti takelių laiko perkėlimui"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Temti ir mesti takelių laiko perkėlimui"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Artinti"
@@ -10826,6 +17462,10 @@ msgstr "Artinti"
 msgid "Zoom x2"
 msgstr "Keist Mastelį"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "Bangos Forma"
@@ -10833,6 +17473,11 @@ msgstr "Bangos Forma"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Bangos Forma"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Muzikos Instrumentas"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -10865,12 +17510,38 @@ msgid "Set Range"
 msgstr "Nustatyti dažnį"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Display"
+msgstr "Sekant&is Apkarpymas"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Greitas Sinc Interpoliavimas"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "Linijinis"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Greitas Sinc Interpoliavimas"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -10882,9 +17553,8 @@ msgstr "Greitas Sinc Interpoliavimas"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Temti ir mesti takelių laiko perkėlimui"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -10935,6 +17605,21 @@ msgstr "Nustatyta amplitudė."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Gramdymas"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Pradėti Ieškoti"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Įrankis"
@@ -10950,6 +17635,11 @@ msgstr "Pakelti takelį"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Nuleisti takelį"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Sustabdyti Gramdymą"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -11006,9 +17696,19 @@ msgstr "Spausti ir tempti norint nustatyti dažnių juostos plotį."
 msgid "Click and drag to select audio"
 msgstr "Temti ir mesti audio pasirinkimui"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Temti ir mesti takelių laiko perkėlimui"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Could not shift between tracks"
+msgstr "Negali rašyti į failą: %s\n"
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Moved clips to another track"
@@ -11023,6 +17723,10 @@ msgstr "Nutildyti pasirinkti takeliai %.2f sekundėm %.2f ruože"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Nutildyti pasirinkti takeliai %.2f sekundėm %.2f ruože"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -11049,6 +17753,12 @@ msgstr "Komandos Veiksmas"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Kairysis-Paspaudimas"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "%s norint pasirinkti arba atšaukti takelio pasirinkimą."
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -11087,6 +17797,16 @@ msgstr "Kairys=Priartinti, Dešinysis=Tolinti, Vidurinis=Normaus"
 msgid "(disabled)"
 msgstr " (išjungtas)"
 
+#: src/widgets/AButton.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Press"
+msgstr "&Nuostata:"
+
+#: src/widgets/AButton.cpp
+#, fuzzy
+msgid "Button"
+msgstr "Mygtukai"
+
 #  i18n-hint: One-letter abbreviation for Left, in the Pan slider
 #  i18n-hint: One-letter abbreviation for Left, in VU Meter
 #  i18n-hint: One-letter abbreviation for Left, in the Pan slider
@@ -11123,6 +17843,62 @@ msgstr "Prašome pasirinkti jau egzistuojantį failą."
 msgid "File type:"
 msgstr "Failo tipas:"
 
+#: src/widgets/FileHistory.cpp
+#, fuzzy
+msgid "&Clear"
+msgstr "Išvalyti"
+
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
+#: src/widgets/Grid.cpp
+msgid "Empty"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Backwards"
+msgstr "Praleisti &Atbulą"
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Praleisti &Priekinį"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Visi Meniu"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click to Start Monitoring"
+msgstr "Perkelti į Pradžią"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click for Monitoring"
+msgstr "Perkelti į Pradžią"
+
 #: src/widgets/Meter.cpp
 msgid "Click to Start"
 msgstr "Perkelti į Pradžią"
@@ -11130,6 +17906,16 @@ msgstr "Perkelti į Pradžią"
 #: src/widgets/Meter.cpp
 msgid "Click"
 msgstr "Kairysis-Paspaudimas"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Stop Monitoring"
+msgstr "Sustabdyti Gramdymą"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Start Monitoring"
+msgstr "Pradėti Gramdymą"
 
 #: src/widgets/Meter.cpp
 msgid "Recording Meter Options"
@@ -11144,6 +17930,45 @@ msgid "Refresh Rate"
 msgstr "Nustatyti tempą"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Style"
+msgstr "Matuoklis"
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Type"
+msgstr "Matuoklis"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Orientation"
+msgstr "Trukmė"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Automatinis Saugojimas"
+
+#: src/widgets/Meter.cpp
 msgid "Horizontal"
 msgstr "Horizontalus Stereo"
 
@@ -11151,11 +17976,95 @@ msgstr "Horizontalus Stereo"
 msgid "Vertical"
 msgstr "Pritaikyti  &Vertikaliai"
 
+#: src/widgets/Meter.cpp
+msgid " Monitoring "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid " Active "
+msgstr "Aktyvi Būsena"
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Prašome pasirinkti garso takelį."
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "val:min:sek + šablonai"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "099 val 060 min 060 sek"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 days 024 h 060 m 060 s"
+msgstr "099 dienos 024 val 060 min 060 sek"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and hundredths of a second (1/100 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + hundredths"
 msgstr "val:min:sek + šimtosios"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "099 val 060 min 060 sek"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
@@ -11163,17 +18072,316 @@ msgstr "val:min:sek + šimtosios"
 msgid "hh:mm:ss + milliseconds"
 msgstr "val:min:sek + milisekundės"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "099 val 060 min 060 sek"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + samples"
 msgstr "val:min:sek + šablonai"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+># samples"
+msgstr "099 val 060 min 060 sek"
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "Perkeltas Modelis"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + film frames (24 fps)"
+msgstr "val:min:sek + šablonai"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr "099 val 060 min 060 sek"
+
+#. i18n-hint: Name of time display format that shows time in frames (lots of
+#. * frames) at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr "val:min:sek + šablonai"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr "099 val 060 min 060 sek"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr "val:min:sek + šimtosios"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr "val:min:sek + šablonai"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr "099 val 060 min 060 sek"
+
+#. i18n-hint: Name of time display format that shows time in frames at PAL
+#. * TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr "val:min:sek + šablonai"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr "099 val 060 min 060 sek"
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
 msgid "octaves"
 msgstr "oktavos"
+
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "sekundžių"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Atleidimo Laikas:"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "Atleidimo Laikas:"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Cancel"
+msgstr "&Atšaukti"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to cancel?"
@@ -11205,6 +18413,11 @@ msgstr "Patvirtinti"
 msgid "Unable to write files to directory: %s."
 msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -11222,15 +18435,65 @@ msgstr "Grąžinti Projektus"
 msgid "Don't show this warning again"
 msgstr "Daugiau nerodyti šio perspėjimo"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Empty value"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Įrašyti"
+
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Priartinti Ruožą"
 
+#  i18n-hint: You do not need to translate "LOF"
+#  i18n-hint: You do not need to translate "LOF"
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Failo Klaida"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Value not in range: %s to %s"
+msgstr "%s Išsaugoti pakeitimus į %s?"
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Value must not be less than %s"
+msgstr "Negali būti be pavadinimo"
+
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Value must not be greater than %s"
 msgstr "Negali būti be pavadinimo"
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
@@ -11240,6 +18503,21 @@ msgstr "Sukurtas naujas projektas"
 msgid "Directory Dialog"
 msgstr "Vietos"
 
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "Rasti dialogą"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "Klaida: "
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Could not load file: \"%s\""
+msgstr "Negaliu atidaryti failo: \"%s\""
+
 #: src/xml/XMLFileReader.cpp
 msgid "Could not parse XML"
 msgstr "Nepavyko atidaryti failo"
@@ -11248,16 +18526,49 @@ msgstr "Nepavyko atidaryti failo"
 msgid "Spectral edit multi tool"
 msgstr "Spektro Pasirinkimas"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Ru"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Dažniai"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Klaida"
@@ -11272,8 +18583,34 @@ msgstr "Bosas (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Linijinis dažnis"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -11287,9 +18624,22 @@ msgstr "Tylinimas"
 msgid "Applying Fade..."
 msgstr "Pritaikoma..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Nustatyti numaty&tus nustatymus"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -11321,8 +18671,16 @@ msgid "S-Curve Down"
 msgstr "Nuleisti takelį"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Pradėti"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #  i18n-hint: Title of the Gain slider, used to adjust the volume
 #  i18n-hint: Title of the Gain slider, used to adjust the volume
@@ -11335,6 +18693,14 @@ msgid "Start (or end)"
 msgstr "Pradėti"
 
 #: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "None Selected"
 msgstr "Pasirinkti"
 
@@ -11345,6 +18711,14 @@ msgstr "Linijinis"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Linijinis"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -11383,6 +18757,24 @@ msgstr "Kreivė egzistuoja"
 msgid "Error~%~%"
 msgstr "Klaida"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Kartoti"
@@ -11390,6 +18782,11 @@ msgstr "Kartoti"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Generuoju tylą"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Audacity Registras"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -11402,6 +18799,23 @@ msgstr "Atkarpą į De&šinę"
 #: plug-ins/clipfix.ny
 msgid "Reconstructing clips..."
 msgstr "Pašalinu spragtelėjimus ir trakštelėjimus..."
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Riba %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
 
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
@@ -11425,6 +18839,11 @@ msgstr ""
 "Netinkamas garso pasirinkimas.\n"
 "Prašome užtikrinti kad garsas yra pasirinktas."
 
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
 msgstr "Natų Takelis"
@@ -11432,6 +18851,18 @@ msgstr "Natų Takelis"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade type"
 msgstr "Failo tipas:"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Gain"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 1"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 2"
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Custom Curve"
@@ -11444,6 +18875,19 @@ msgstr "Takelio Pavadinimas"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade direction"
 msgstr "Garsėjimas"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Delay"
@@ -11462,6 +18906,19 @@ msgid "Regular"
 msgstr "Stačiakampis"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Bangos Forma (dB)"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Uždelsimo laikas (sek):"
 
@@ -11474,12 +18931,24 @@ msgid "Pitch/Tempo"
 msgstr "Skardumas"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
 msgstr "Peržiūrėti efektą"
 
 #: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "Kartojimų skaičius"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -11494,6 +18963,10 @@ msgid "XML file"
 msgstr "Pervadinti failai:"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "Įrašyti"
 
@@ -11506,10 +18979,24 @@ msgstr "Silpna Perkrova"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Nepavyksta atidaryti žanro failo."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Klaida (failas gali būti neįrašytas): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Klaida (failas gali būti neįrašytas): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -11540,10 +19027,50 @@ msgstr "Ilgis (sekundėmis)"
 msgid "Length of label region (seconds)"
 msgstr "Ilgis (sekundėmis)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Pavadinimo Redagavimas"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -11557,6 +19084,11 @@ msgstr "Atkabinti"
 msgid "Warnings only"
 msgstr "Perspėjimas"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -11565,6 +19097,17 @@ msgstr "Pridėtas pavadinimas"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Pakeistos etiketės"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -11578,13 +19121,46 @@ msgstr "Vykdomas Sulyginimas"
 msgid "Dominic Mazzoni"
 msgstr "Triukšmo pašalinimas by Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "LFO Dažnis (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "LFO Dažnis (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -11604,6 +19180,16 @@ msgid "Peak level"
 msgstr "Atkūrimas"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "Atkūrimas"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "Atkūrimas"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "Tylos trukmė:"
 
@@ -11616,18 +19202,65 @@ msgid "Label type"
 msgstr "Pavadinimo Redagavimas"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Point before sound"
+msgstr "Nebuvo rasta atitikmenų"
+
+#: plug-ins/label-sounds.ny
 msgid "Point after sound"
 msgstr "Nebuvo rasta atitikmenų"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Generuoju tylą"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Generuoju tylą"
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Pasirinkimas privalo būti didesnis nei %d šablonai."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -11655,8 +19288,25 @@ msgid "Hard Clip"
 msgstr "Tvirtas Iškirpimas"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Dešinysis kanalas"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Bangos Forma (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -11679,7 +19329,24 @@ msgid "Select Function"
 msgstr "Dažniai"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Stereo Linking"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
+msgstr "Paversti Stereo Takeliu"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
 msgstr "Paversti Stereo Takeliu"
 
 #: plug-ins/noisegate.ny
@@ -11702,6 +19369,44 @@ msgstr "Laikas iki pilno Garso"
 msgid "Decay (ms)"
 msgstr "Uždelsimo laikas (sek):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Pasirinkimas privalo būti didesnis nei %d šablonai."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Pritaikomas Fazeris"
@@ -11713,6 +19418,18 @@ msgstr "Pritaikomas Fazeris"
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Nustatyti numaty&tus nustatymus"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -11735,7 +19452,8 @@ msgstr "Pervadinti failai:"
 msgid "HTML file"
 msgstr "Pervadinti failai:"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Pervadinti failai:"
 
@@ -11752,9 +19470,24 @@ msgid "Disallow"
 msgstr "Nebeleidžiamas"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Nebeleidžiamas"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Nepavyko pašalinti %s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -11765,16 +19498,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Pasirinkti failą"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Eksportavimo vieta:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Pasirinkti failą"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Generuoju Toną"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Failo tipas:"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -11789,12 +19564,40 @@ msgid "Generating Rhythm..."
 msgstr "Generuoju Toną"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Beats per bar"
 msgstr "Taktai per minutę"
 
 #: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Kartojimų skaičius"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -11817,12 +19620,54 @@ msgid "Beat sound"
 msgstr "Kartoti"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Šalinamas Triukšmas"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Triukšmo Riba"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -11845,6 +19690,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Linijinis dažnis"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "LFO Dažnis (Hz):"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Amplitudė (0-1):"
 
@@ -11855,6 +19709,10 @@ msgstr "Modelio Redagavimas"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Pritaikoma..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -11871,6 +19729,10 @@ msgstr "Pervadinti failai:"
 #: plug-ins/sample-data-export.ny
 msgid "HTML files"
 msgstr "Pervadinti failai:"
+
+#: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Count"
@@ -11892,6 +19754,23 @@ msgstr "Minimumas"
 msgid "All"
 msgstr "&Viską"
 
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
+
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
 msgid "L Channel First"
@@ -11905,6 +19784,11 @@ msgstr "šis pagalbos pranešimas"
 msgid "Errors Only"
 msgstr "Klaida: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -11917,6 +19801,46 @@ msgstr "Dešinysis kanalas"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "Perkeltas Modelis"
 
@@ -11924,6 +19848,43 @@ msgstr "Perkeltas Modelis"
 #, lisp-format
 msgid "~a seconds."
 msgstr "sekundžių"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -11942,6 +19903,10 @@ msgid "Value (dB)"
 msgstr "&Garsumas (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Linijinis"
 
@@ -11958,6 +19923,14 @@ msgid "Right (dB)"
 msgstr "Dešinys, %dHz"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Linijinis"
 
@@ -11968,6 +19941,40 @@ msgstr "2 Kanalai (Stereo)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 Kanalas (Mono)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Klaida (failas gali būti neįrašytas): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -11982,8 +19989,40 @@ msgid "Select file"
 msgstr "Pasirinkti failą"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Klaida"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -11993,6 +20032,15 @@ msgstr "Nepavyksta atidaryti žanro failo."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Spektro Pasirinkimas"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -12010,9 +20058,21 @@ msgstr "Pjūklinė"
 msgid "Starting phase (degrees)"
 msgstr "LFO Pradžios Fazė (laipsn.):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Pritaikoma..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -12054,6 +20114,98 @@ msgstr "&Analizuoti"
 msgid "Strength"
 msgstr "į Apibraukimo Pabaigą"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Processing Vocoder..."
+msgstr "Natų Takelis"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Output choice"
 msgstr "Sujungti Išvestį"
@@ -12086,6 +20238,150 @@ msgstr "LFO Dažnis (Hz):"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "LFO Dažnis (Hz):"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Išeiti iš Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Kanalas"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Klaida bandant iššifruoti failą"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Klaida Užkraunant Metaduomenis"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity Pirmasis paleidimas"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Įrašymas"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Įvairių platformų GUI biblioteka"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Nepavyko labiau sulyginti. Jis vis dar per aukštas."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automatinis Įrašo Lygio Taisymas pamažino garsumą iki %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Nepavyko labiau sulyginti. Jis vis dar per žemas."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automatinis Įrašo Lygio Taisymas pakėlė garsumą iki %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Analizės skaičiaus riba buvo pasiekta neradus tinkamo garsumo. Vis dar per aukštas."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automatinis Įrašo Lygio Taisymas sustojo. Analizės skaičiaus riba buvo pasiekta neradus tinkamo garsumo. Vis dar per žemas."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatinis Įrašo Lygio Taisymas sustojo. %.2f atrodo kaip tinkamiausias garsumas."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Nepavyksta atidaryti žanro failo.\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "Iškirpti: %d - %d \n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Simuliuoti Įrašų Klaidas\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Atkūrimas\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Įrašymas\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Įrašymas\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Atkūrimas\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Atkūrimas\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Negaliu baigti"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Nepavyksta nustatyti srovės būklės į sustabdytą."
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mik&seris"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Tai&syti grojimo garsą"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Padidinti grojimo garsą"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Sumažinti grojimo garsą"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Tai&syti įrašinėjimo garsą"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Pa&didinti įrašinėjimo garsą"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Su&mažinti įrašinėjimo garsą"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Apie Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Auto&matinis Įrašo Garsumo Nustatymas (Įjungta/Išjungta)"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Įrašymas"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Atkūrimas"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Įrašymas"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Atkūrimas"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Atkūrimas"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Mi&ksavimo Įrankių Juosta"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Temti ir mesti takelių laiko perkėlimui"
+
 #~ msgid "Program build date:"
 #~ msgstr "Programos sukūrimo data: "
 
@@ -12109,16 +20405,8 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "Nežinomas"
 
 #, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Nepavyksta skaityti išankstinės nuostatos failo."
-
-#, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
 #~ msgstr "Audacity yra nemokama programa sukurta pasaulinio masto komandos [[http://www.audacityteam.org/about/credits|volunteers]]. Audacity pritaikyta [[http://www.audacityteam.org/download|available]] Windows, Mac ir GNU/Linux (ir kitoms Unix sistemoms)."
-
-#, fuzzy
-#~ msgid "available"
-#~ msgstr "Peržiūra negalima"
 
 #, fuzzy
 #~ msgid "If you find a bug or have a suggestion for us, please write, in English, to our %s. For help, view the tips and tricks on our %s or visit our %s."
@@ -12167,9 +20455,6 @@ msgstr "LFO Dažnis (Hz):"
 #, fuzzy
 #~ msgid "Failed to copy tags"
 #~ msgstr "Nepavyko pašalinti %s"
-
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "Pasirinkite bet kurį nesuspaustą garso failą"
 
 #~ msgid ""
 #~ "One or more external audio files could not be found.\n"
@@ -12412,10 +20697,6 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "Importavimas pabaigtas. Paleidžiamas pagal pageidavimą garso formos apskaičiavimas. %2.0f%% jau įvykdyta."
 
 #, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Kompresorius..."
-
-#, fuzzy
 #~ msgid ""
 #~ "MP3 Decoding Failed:\n"
 #~ "\n"
@@ -12563,10 +20844,6 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "įskaitant"
 
 #, fuzzy
-#~ msgid "Click to unpin"
-#~ msgstr "Perkelti į Pradžią"
-
-#, fuzzy
 #~ msgid "Click to pin"
 #~ msgstr "Perkelti į Pradžią"
 
@@ -12684,18 +20961,11 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "neteisingai"
 
 #, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "Garso Failas"
-
-#, fuzzy
 #~ msgid "Nyquist Effects Prompt"
 #~ msgstr "Nyquist Efektai"
 
 #~ msgid "Save Device Info"
 #~ msgstr "Saugojimo Prietaiso Informacija"
-
-#~ msgid "Unable to save device info"
-#~ msgstr "Nepavyksta išsaugoti prietaiso informacijos"
 
 #~ msgid "Save MIDI Device Info"
 #~ msgstr "Išsaugoti MIDI Prietaiso Informaciją"
@@ -12726,10 +20996,6 @@ msgstr "LFO Dažnis (Hz):"
 #, fuzzy
 #~ msgid "Left"
 #~ msgstr "&Kairė"
-
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "&Dešinė"
 
 #~ msgid ""
 #~ "Latency Correction setting has caused the recorded audio to be hidden before zero.\n"
@@ -12895,10 +21161,6 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "Centrinis"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Apibraukti iki Pabaigos"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "į Apibraukimo Pabaigą"
 
@@ -12939,14 +21201,6 @@ msgstr "LFO Dažnis (Hz):"
 #, fuzzy
 #~ msgid "Sequence"
 #~ msgstr "Dažnis  (Hz):"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Stiprumas (0-1)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "Pavadinimas..."
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -12998,10 +21252,6 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "Atsakomoji reakcija (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Dydis"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "Atsakomoji reakcija (%):"
 
@@ -13022,13 +21272,6 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "Garsumas"
 
 #, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Stereo, "
-
-#~ msgid "Order"
-#~ msgstr "Eilė"
-
-#, fuzzy
 #~ msgid "RatePercentChangeStart"
 #~ msgstr "Procentinis Pakeitimas:"
 
@@ -13044,19 +21287,11 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgid "PitchPercentChangeEnd"
 #~ msgstr "Procentinis Pakeitimas:"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Reversuoju"
-
 #~ msgid "Size"
 #~ msgstr "Dydis"
 
 #~ msgid "Fit &Vertically"
 #~ msgstr "Pritaikyti  &Vertikaliai"
-
-#, fuzzy
-#~ msgid "Co&mbined Meter Toolbar"
-#~ msgstr "Įrašymas"
 
 #, fuzzy
 #~ msgid "S&kip to Start"
@@ -13069,10 +21304,6 @@ msgstr "LFO Dažnis (Hz):"
 #, fuzzy
 #~ msgid "Appen&d Record"
 #~ msgstr "Įrašyti"
-
-#, fuzzy
-#~ msgid "&Mono"
-#~ msgstr "Mono"
 
 #, fuzzy
 #~ msgid "&Left Channel"
@@ -13110,20 +21341,8 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgstr "Dešinysis kanalas"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "Pakelti (dB):"
-
-#, fuzzy
 #~ msgid "No wave tracks exist."
 #~ msgstr "Pašalintas takelis '%s.'"
-
-#, fuzzy
-#~ msgid "-Left-Click"
-#~ msgstr "Kairysis-Paspaudimas"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "Alt-Left-Click"
 
 #, fuzzy
 #~ msgid "Zoom in or out on Mouse Pointer"
@@ -13205,9 +21424,6 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgid "Plot Spectrum"
 #~ msgstr "Spektras"
 
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "Aukštos kokybės Sinc Interpoliavimas"
-
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "Greitas Sinc Interpoliavimas"
 
@@ -13249,9 +21465,6 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgid "Change Tempo..."
 #~ msgstr "Keisti Tempą..."
 
-#~ msgid "Click Removal..."
-#~ msgstr "Trakštelėjimų Pašalinimas..."
-
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "Pritaikomas Dinaminis Dažnio Kompresorius..."
 
@@ -13266,9 +21479,6 @@ msgstr "LFO Dažnis (Hz):"
 
 #~ msgid "Equalization..."
 #~ msgstr "Sulyginimas..."
-
-#~ msgid "Performing Equalization"
-#~ msgstr "Vykdomas Sulyginimas"
 
 #~ msgid "Fading In"
 #~ msgstr "Garsinama"
@@ -13298,15 +21508,8 @@ msgstr "LFO Dažnis (Hz):"
 #~ msgid "Applying Phaser"
 #~ msgstr "Pritaikomas Fazeris"
 
-#, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "Reversavimas"
-
 #~ msgid "Applied effect: Generate Silence, %.6lf seconds"
 #~ msgstr "Priimtas efektas: Tylos Generavimas, %.6lf sekundės"
-
-#~ msgid "Tone Generator"
-#~ msgstr "Tono Generatorius"
 
 #, fuzzy
 #~ msgid "Buffer Delay Compensation"
@@ -13341,14 +21544,6 @@ msgstr "LFO Dažnis (Hz):"
 #, fuzzy
 #~ msgid "Change output device"
 #~ msgstr "Keisti Greitį"
-
-#, fuzzy
-#~ msgid "Effect Refresh"
-#~ msgstr "Efektų nustatymai"
-
-#, fuzzy
-#~ msgid "Input Channels"
-#~ msgstr "%d Kanalai"
 
 #, fuzzy
 #~ msgid "Select Input Channels"

--- a/locale/mk.po
+++ b/locale/mk.po
@@ -8,53 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Macedonian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/mk/>\n"
+"Language-Team: Macedonian <https://hosted.weblate.org/projects/tenacity/tenacity/mk/>\n"
 "Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n==1 || n%10==1 ? 0 : 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Аudacity прва употреба"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Канали:"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Грешка при вчитување датотека."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Грешка при вчитување датотека."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Аudacity прва употреба"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Снимање"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -65,9 +28,31 @@ msgstr "Неможно да се пронајде"
 msgid "%s bytes"
 msgstr "бајти"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Засилување"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -78,12 +63,68 @@ msgid "2nd Experimental Command"
 msgstr "Посебна благодарност:"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Применет Nyquist ефект..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Залепи"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Залепи"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Залепи"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Залепи"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Означи"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -94,15 +135,52 @@ msgid "Split &Vertically"
 msgstr "Направи стерео нумера"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Split &Horizontally"
+msgstr "Направи стерео нумера"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show S&cript"
+msgstr "Nyquist јавка..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show &Output"
+msgstr "Ladspa ефект поставки"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "Алатки"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Стоп"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Nyquist јавка..."
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Ladspa ефект поставки"
 
@@ -110,25 +188,89 @@ msgstr "Ladspa ефект поставки"
 msgid "Load Nyquist script"
 msgstr "Nyquist јавка..."
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+msgid "Warning"
+msgstr ""
+
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Nyquist јавка..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Применет Nyquist ефект..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "No matches found"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Применет Nyquist ефект..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Нов"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Nyquist јавка..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
 msgstr "&Отвори..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Open script"
+msgstr "Nyquist јавка..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
 msgid "Save"
@@ -154,7 +296,8 @@ msgstr "Копирај"
 msgid "Copy to clipboard"
 msgstr "Сечи во амбар"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Сечи"
 
@@ -162,13 +305,19 @@ msgstr "Сечи"
 msgid "Cut to clipboard"
 msgstr "Сечи во амбар"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Залепи"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Paste from clipboard"
 msgstr "Залепено од амбар"
+
+#. i18n-hint verb; to empty or erase
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+msgid "Clear"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Clear selection"
@@ -182,7 +331,8 @@ msgstr "Означи"
 msgid "Select all text"
 msgstr "Означи"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Врати"
 
@@ -190,11 +340,79 @@ msgstr "Врати"
 msgid "Undo last change"
 msgstr "Процент на промени:"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "Врати"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Процент на промени:"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Match"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to top S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Previous"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Мрдни нумера угоре"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Next"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Start"
+msgstr "Почетно поместување:"
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Start script"
 msgstr "Nyquist јавка..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Стоп"
 
@@ -202,18 +420,139 @@ msgstr "Стоп"
 msgid "Stop script"
 msgstr "Nyquist јавка..."
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Вклучено"
 
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Disabled"
+msgstr " (откажана)"
+
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Обраќање"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr "прозорец"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "Ladspa ефект поставки"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "Ladspa ефект поставки"
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Sample rate conversion"
 msgstr "Рата на семпл:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "Грешка при внес"
+
+#: src/AboutDialog.cpp
+msgid "Ogg Vorbis Import and Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "FLAC import and export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "MP3 експорт поставки"
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export"
+msgstr "LOF грешка"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "Додавки %i за %i"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "GPL License"
+msgstr ""
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -236,6 +575,18 @@ msgstr "Крива"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Крива"
 
@@ -243,6 +594,54 @@ msgstr "Крива"
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer and support"
+msgstr "Крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Крива"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
 msgstr "Крива"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
@@ -257,25 +656,92 @@ msgstr "Nyquist јавка"
 msgid "%s, web developer"
 msgstr "Крива"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Кредити"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "DarkTenacity Customisation"
 msgstr "Комбинација на типки"
 
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s Contributors"
+msgstr "Крива"
+
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Tenacity Special thanks:"
 msgstr "Посебна благодарност:"
+
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "Именици"
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s includes code from the following projects:"
+msgstr ""
 
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s Team Members"
 msgstr "Аudacity поставки"
+
+#: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Contributors"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
+
+#. i18n-hint: The translation of "translator_credits" will appear
+#. *  in the credits in the About Audacity window.  Use this to add
+#. *  your own name(s) to the credits.
+#. *
+#. *  For example:  "English translation by Dominic Mazzoni."
+#.
+#: src/AboutDialog.cpp
+msgid "translator_credits"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Translators"
+msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "Special thanks:"
@@ -287,6 +753,26 @@ msgstr "Посебна благодарност:"
 msgid "%s website: "
 msgstr "Аudacity прва употреба"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr ""
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Кликни и пушти за да наместиш релативна големина на стерео нумерите."
@@ -297,9 +783,15 @@ msgstr "Кликни и пушти за да наместиш релативна
 msgid "Record/Play head"
 msgstr "Снимање"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Додавка 1 за %i"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Кликни и пушти за уредување семплови"
@@ -307,12 +799,57 @@ msgstr "Кликни и пушти за уредување семплови"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Кликни и пушти за предименизионирање на нумерата."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Мрдни нумера угоре"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Мрдни нумера удолу"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Мрдни нумера угоре"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr " (откажана)"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr " (откажана)"
 
 #: src/AdornedRulerPanel.cpp
@@ -320,20 +857,81 @@ msgid "Timeline Options"
 msgstr "Додавка 1 за %i"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "Тивка селекција"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "Снимање"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Грешка"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy, c-format
+msgid "Failed to remove %s"
+msgstr "Неможно да се пронајде"
+
+#: src/AudacityApp.cpp
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Аudacity поставки"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -352,45 +950,154 @@ msgstr "&Отвори..."
 
 #: src/AudacityApp.cpp
 #, fuzzy
+msgid "Open &Recent..."
+msgstr "&Отвори..."
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
+#, fuzzy
 msgid "&About Tenacity..."
 msgstr "З&а Audacity..."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "&Preferences..."
+msgstr "Аudacity поставки"
 
 #: src/AudacityApp.cpp src/menus/FileMenus.cpp
 msgid "&File"
 msgstr "&Датотека"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity не може да најде место за сместување привремени датотеки.\n"
 "Внесете валиден именик во дијалогот за поставки."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity не може да најде место за сместување привремени датотеки.\n"
 "Внесете валиден именик во дијалогот за поставки."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity сега ќе се исклучи. Ве молиме вклучете го Audacity повторно за да го користи новиот привремен именик."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+msgid ""
+"Running two copies of Tenacity simultaneously may cause\n"
+"data loss or cause your system to crash.\n"
+"\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Do you still want to start Tenacity?"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Грешка при вчитување датотека."
+
+#: src/AudacityApp.cpp
+msgid "The system has detected that another copy of Tenacity is running.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Use the New or Open commands in the currently running Tenacity\n"
+"process to open multiple projects simultaneously.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Аudacity прва употреба"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Аudacity поставки"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
+
+#. i18n-hint: This displays a list of available options
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "this help message"
+msgstr "Вклучено"
+
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+msgid "run self diagnostics"
+msgstr ""
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Аudacity поставки"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -400,29 +1107,95 @@ msgid "audio or project file name"
 msgstr "Неможно да се отвори проектот."
 
 #: src/AudacityApp.cpp
+msgid ""
+"Audacity project (.aup3) files are not currently \n"
+"associated with Tenacity. \n"
+"\n"
+"Associate them, so they open on double-click?"
+msgstr ""
+
+#: src/AudacityApp.cpp
 msgid "Audacity Project Files"
 msgstr "Аudacity поставки"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "Постави од-до..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Десен канал"
 
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Help"
+msgstr "&Помош"
+
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Аudacity прва употреба"
+
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Аudacity прва употреба"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/Tags.cpp
+#, fuzzy
+msgid "&Save..."
+msgstr "Снимено %s"
+
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Затвори"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "Снимено %s"
 
 #: src/AudacityLogger.cpp
 #, c-format
 msgid "Couldn't save log to file: %s"
 msgstr "Неможно да запишам во датотеката:"
+
+#: src/AudioIO.cpp
+msgid "Could not find any audio devices.\n"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid ""
@@ -438,13 +1211,74 @@ msgid "Error: %s"
 msgstr "Грешка"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "Error Initializing Audio"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"Нема да може да свирите или снимате аудио.\n"
+"\n"
+
+#: src/AudioIO.cpp
+msgid "Error Initializing Midi"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Аudacity прва употреба"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "Снимање\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Снимање\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Device info unavailable for: %d\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Device ID: %d\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Device name: %s\n"
+msgstr "Име...\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -467,8 +1301,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Снимање\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Снимање\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Снимање\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Снимање\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -482,37 +1326,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Снимање\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Снимање\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Плејбек\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Неможно да се пронајде\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Снимање\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
 msgstr "Плејбек\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Снимање\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Внесено '%s'\n"
 
 #: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Снимање\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Плејбек\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Плејбек\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -520,14 +1367,47 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Снимање\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Снимање\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
 msgstr "Плејбек\n"
 
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
+msgstr "Плејбек\n"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Automatic Crash Recovery"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
+"\n"
+"After recovery, save the projects to ensure changes are written to disk."
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Recoverable &projects"
+msgstr ""
+
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Означи"
+
+#. i18n-hint: (noun).  It's the name of the project to recover.
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Name"
+msgstr "Име..."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "&Discard Selected"
@@ -538,12 +1418,55 @@ msgid "&Recover Selected"
 msgstr "Означи"
 
 #: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "Недоволно селектирани податоци."
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "Select Command"
+msgstr "Командна акција"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Command"
+msgstr "Командна акција"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Edit Parameters"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Use Preset"
+msgstr "Ladspa ефект поставки"
+
+#: src/BatchCommandDialog.cpp
+msgid "&Parameters"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "Командна акција"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -554,12 +1477,47 @@ msgid "Import Macro"
 msgstr "Внеси &MIDI..."
 
 #: src/BatchCommands.cpp
+#, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr ""
+
+#: src/BatchCommands.cpp
 msgid "Export Macro"
 msgstr "Експорт MP3"
 
 #: src/BatchCommands.cpp
 msgid "Effect"
 msgstr "&Ефект"
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (With Parameters)"
+msgstr ""
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (No Parameters)"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Your batch command of %s was not recognized."
+msgstr ""
+
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Applied Macro"
+msgstr "Применет ефект: %s"
 
 #: src/BatchCommands.cpp
 msgid "Apply Macro"
@@ -576,39 +1534,216 @@ msgstr "Применет ефект: %s"
 msgid "Apply '%s'"
 msgstr "Применет фазер"
 
+#: src/BatchCommands.cpp
+#, c-format
+msgid ""
+"Apply %s with parameter(s)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Test Mode"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Apply %s"
+msgstr "Применет фазер"
+
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Означи"
 
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "Применет фазер"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Применет фазер"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to project"
+msgstr "Применет фазер"
+
 #: src/BatchProcessDialog.cpp
 msgid "&Project"
 msgstr "&Сними проект"
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to files..."
+msgstr "Применет фазер"
+
+#: src/BatchProcessDialog.cpp
 msgid "&Files..."
 msgstr "&Датотека"
+
+#. i18n-hint: The Expand button makes the dialog bigger, with more in it
+#: src/BatchProcessDialog.cpp
+msgid "&Expand"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "No macro selected"
 msgstr "Недоволно селектирани податоци."
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "Applying '%s' to current project"
+msgstr "&Сними проект"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Please save and close the current project first."
+msgstr "&Сними проект"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Select file(s) for batch processing..."
+msgstr "Селекција на крај"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Applying..."
+msgstr "Применет фазер"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "File"
+msgstr "&Датотека"
+
+#: src/BatchProcessDialog.cpp
+msgid "&Cancel"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Remo&ve"
 msgstr "&Тргни нумери"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "Име..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "Внеси"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "Експорт на нас&лови..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Edit Steps"
+msgstr ""
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "Командна акција"
 
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+msgid "Parameters"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp
+msgid "&Insert"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "&Edit..."
 msgstr "&Уреди"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp
+#, fuzzy
+msgid "De&lete"
+msgstr "Означи"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "Move &Up"
+msgstr "Мрдни нумера угоре"
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "Move &Down"
+msgstr "Мрдни нумера удолу"
+
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Снимено %s"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
+
+#. i18n-hint: This is the last item in a list.
+#: src/BatchProcessDialog.cpp
+msgid "- END -"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "%s changed"
+msgstr "Процент на промени:"
+
+#: src/BatchProcessDialog.cpp
+msgid "Do you want to save the changes?"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Enter name of new macro"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Name of new macro"
+msgstr "Број на уредувања:"
+
+#: src/BatchProcessDialog.cpp
+msgid "Name must not be blank"
+msgstr ""
+
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Names may not contain '%c' and '%c'"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of a file.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Are you sure you want to delete %s?"
+msgstr ""
 
 #. i18n-hint: Benchmark means a software speed test
 #: src/Benchmark.cpp
@@ -616,11 +1751,38 @@ msgid "Benchmark"
 msgstr "Почни &брзинар..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Број на уредувања:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Затвори"
 
@@ -635,9 +1797,51 @@ msgid "Export Benchmark Data as:"
 msgstr "Експорт спектар податоци како:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Preparing...\n"
+msgstr "Еквилизација..."
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 #, c-format
 msgid "Performing %d edits...\n"
 msgstr "Подготвувам ехо\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -645,8 +1849,94 @@ msgid "Paste: %lld\n"
 msgstr "Залепи\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Десен канал\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -657,9 +1947,58 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Морате прво да означите нумера."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Недоволно селектирани податоци."
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr "Морате прво да означите нумера."
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr "Морате прво да означите нумера."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -676,9 +2015,26 @@ msgid "Checkpointing project"
 msgstr "Создаден нов проект"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "Создаден нов проект"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Неможно да запишам во датотеката:\n"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -688,11 +2044,143 @@ msgid ""
 "%s"
 msgstr "Неможно да запишам во датотеката:"
 
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to release savepoint:\n"
+"\n"
+"%s"
+msgstr "Неможно да запишам во датотеката:"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Removing Dependencies"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copying audio data into project..."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Project Depends on Other Audio Files"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Dependencies"
+msgstr "Покажувач на почеток на селекцијата"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Audio File"
+msgstr "Аудио нумера"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Disk Space"
+msgstr "Слободен простор:"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "Тивка селекција"
+
+#: src/Dependencies.cpp
+msgid "Cancel Save"
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Наслови нумера"
+
+#: src/Dependencies.cpp
+msgid "Do Not Copy"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Whenever a project depends on other files:"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Ask me"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "Означи MIDI датотека..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Сечи во амбар"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Missing"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Dependency Check"
+msgstr ""
+
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ништо"
 
@@ -700,7 +2188,7 @@ msgstr "Ништо"
 msgid "Rectangle"
 msgstr "Правоаголник"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Триаголник"
 
@@ -712,6 +2200,166 @@ msgstr "Аглесто"
 msgid "Rectangular"
 msgstr "Правоаголно"
 
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Акција"
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "To find '%s', click here -->"
+msgstr ""
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Browse..."
+msgstr "Одбери..."
+
+#: src/FFmpeg.cpp
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
+msgstr ""
+
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "Каде е %s?"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Do not show this warning again"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr "Неможно да се пронајде"
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
+"Perhaps %s is not writable or the disk is full.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
 #: src/FileException.h
 msgid "File Error"
 msgstr "LOF грешка"
@@ -722,7 +2370,29 @@ msgstr "LOF грешка"
 msgid "Error (file may not have been written): %s"
 msgstr "Грешка (датотеката можеби не е снимена): %s"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy all audio into project (safest)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Сите видови (*.*)|*.*"
 
@@ -733,6 +2403,14 @@ msgid "AUP3 project files"
 msgstr "Аudacity поставки"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "Означи MIDI датотека..."
 
@@ -740,12 +2418,24 @@ msgstr "Означи MIDI датотека..."
 msgid "XML files"
 msgstr "Сите видови (*.*)|*.*"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "Сите видови (*.*)|*.*"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -772,6 +2462,14 @@ msgstr "Cuberoot автосооднос"
 msgid "Enhanced Autocorrelation"
 msgstr "Проширен автосооднос"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Спектар"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -788,9 +2486,38 @@ msgstr "Линиска фрекфенција"
 msgid "Log frequency"
 msgstr "Log фрекфенција"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Зум"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Scroll Horizontal"
+msgstr "Зум &нормален"
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -802,12 +2529,33 @@ msgid "Cursor:"
 msgstr "Покажувач лево"
 
 #: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Algorithm:"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Size:"
 msgstr "Големина"
+
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Export..."
+msgstr "Експорт на нас&лови..."
 
 #: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "Акција"
+
+#: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Replot..."
@@ -826,11 +2574,48 @@ msgstr "Премногу аудио се селектирани.  Само пр�
 msgid "Not enough data selected."
 msgstr "Недоволно селектирани податоци."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Спектар"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Експорт спектар податоци како:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Неможно да запишам во датотеката:"
@@ -842,6 +2627,27 @@ msgstr "Фрекфенција (Hz)\tНиво (dB)"
 #: src/FreqWindow.cpp
 msgid "Lag (seconds)\tFrequency (Hz)\tLevel"
 msgstr "Lag (секунди)\tФрекфенција (Hz)\tНиво"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Plot Spectrum..."
+msgstr "Спектар"
+
+#: src/HelpText.cpp
+msgid "Welcome!"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "Применет фазер"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording Audio"
+msgstr "Снимање"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
@@ -857,6 +2663,95 @@ msgstr "Снимање"
 #: src/HelpText.cpp
 msgid "Recording - Setting the Recording Level"
 msgstr "Снимање"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Експорт MP3"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Отворам Audacity проект"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -875,12 +2770,40 @@ msgid "Used Space"
 msgstr "Слободен простор:"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr " (откажана)"
 
 #: src/HistoryWindow.cpp
+msgid "&Levels to discard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Discard"
+msgstr "&Сними проект"
+
+#: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Сними проект"
+
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Compact"
+msgstr "&Сними проект"
+
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
@@ -888,10 +2811,54 @@ msgstr "&Сними проект"
 msgid "&History..."
 msgstr "&Историја"
 
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.h
+#, fuzzy
+msgid "Internal Error"
+msgstr "LOF грешка"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "Даден наслов"
+
+#. i18n-hint: (noun).  A track contains waves, audio etc.
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Track"
+msgstr "Обележи нумера"
+
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Наслови нумера"
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Time"
+msgstr "Ударно време: "
+
+#. i18n-hint: (noun) of a label
+#: src/LabelDialog.cpp src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Time"
+msgstr "Временска нумера"
 
 #. i18n-hint: (noun) of a label
 #: src/LabelDialog.cpp src/toolbars/SpectralSelectionBar.cpp
@@ -903,6 +2870,14 @@ msgstr "Log фрекфенција"
 msgid "High Frequency"
 msgstr "Фрекфенција (Hz):"
 
+#: src/LabelDialog.cpp
+msgid "New..."
+msgstr ""
+
+#: src/LabelDialog.cpp
+msgid "Press F2 or double click to edit cell contents."
+msgstr ""
+
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Select a text file containing labels"
 msgstr "Означи текст датотека што содржи наслови..."
@@ -912,6 +2887,11 @@ msgstr "Означи текст датотека што содржи насло�
 msgid "Could not open file: %s"
 msgstr "Неможно да ја отворам датотеката: \"%s\""
 
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "No labels to export."
+msgstr "Нема наслови за експортирање."
+
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Export Labels As:"
 msgstr "Експорт наслов како:"
@@ -920,15 +2900,52 @@ msgstr "Експорт наслов како:"
 msgid "New Label Track"
 msgstr "Нов нас&лов на нумера"
 
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Enter track name"
+msgstr "Смени го името на нумерата во:"
+
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "Наслови нумера"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Аudacity прва употреба"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Одбери јазик кој Audacity ќе го користи:"
+
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+msgid "Confirm"
+msgstr ""
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "Неможно да запишам во датотеката:"
 
 #: src/Legacy.cpp
 #, c-format
@@ -940,8 +2957,19 @@ msgstr ""
 "Старата датотека ќе биде снимена како '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Отворам Audacity проект"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Посебна благодарност:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Одбери..."
 
 #: src/Menus.cpp
 #, c-format
@@ -961,39 +2989,99 @@ msgstr "&Врати %s"
 msgid "&Redo"
 msgstr "Врати"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr " (откажана)"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
 msgstr "Микс"
 
+#: src/Mix.cpp src/menus/TrackMenus.cpp
+msgid "Mix and Render"
+msgstr ""
+
+#: src/Mix.cpp
+msgid "Mixing and rendering tracks"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr ""
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Засилување"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Панорама"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Онеми"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Соло"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Мрднат семпл"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Мрднат семпл"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Мрднат семпл"
+
+#: src/MixerBoard.cpp
+msgid "&Mixer Board..."
+msgstr ""
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1003,19 +3091,209 @@ msgid ""
 "Error: %s"
 msgstr "Неможно да се пронајде"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Вклучено"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ништо"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Аudacity прва употреба"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Обележи нумера"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, c-format
+msgid "Overwrite the plug-in file %s?"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to register:\n"
+"%s"
+msgstr "Неможно да запишам во датотеката:"
 
 #. i18n-hint A plug-in is an optional added program for a sound
 #. effect, or generator, or analyzer
@@ -1030,9 +3308,29 @@ msgstr[1] "Неможно да се пронајде\n"
 msgid "Enable new plug-ins"
 msgstr "Неможно да се пронајде"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Применет Nyquist ефект..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Неможно да се пронајде"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "Вклучено"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -1059,11 +3357,36 @@ msgstr "Вклучено"
 msgid "E&nabled"
 msgstr "Вклучено"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Вклучено"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Означи"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "C&lear All"
+msgstr "Означи"
+
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Вклучено"
 
@@ -1087,9 +3410,33 @@ msgid ""
 "%s"
 msgstr "Применет ефект: %s"
 
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Effect or Command at %s failed to register:\n"
+"%s"
+msgstr ""
+
+#: src/Printing.cpp
+msgid "There was a problem printing."
+msgstr ""
+
 #: src/Printing.cpp
 msgid "Print"
 msgstr "десно"
+
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+#, c-format
+msgid "Actual Rate: %d"
+msgstr ""
 
 #: src/ProjectAudioManager.cpp src/effects/Effect.cpp
 msgid ""
@@ -1101,6 +3448,21 @@ msgstr "Грешка при пуштање звук. Молам проверет
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "За цртање на спектар сите селектирани нумери треба да се со иста рата."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Снимање"
@@ -1109,11 +3471,187 @@ msgstr "Снимање"
 msgid "Record"
 msgstr "Снимај"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Неможно да се отвори проектот."
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no further changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Прогрес"
+
+#: src/ProjectFSCK.cpp
+msgid "Cleaning up unused directories in project data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "&Сними проект"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1136,6 +3674,14 @@ msgid "Failed to restore connection"
 msgstr "Неможно да се пронајде"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to execute a project file command:\n"
+"\n"
+"%s"
+msgstr "Неможно да се пронајде"
+
+#: src/ProjectFileIO.cpp
 #, c-format
 msgid ""
 "Unable to prepare project file command:\n"
@@ -1144,11 +3690,96 @@ msgid ""
 msgstr "Неможно да се пронајде"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Неможно да се пронајде"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Неможно да се пронајде"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1157,12 +3788,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Неможно да се пронајде"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Неможно да се пронајде"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Неможно да се пронајде"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Неможно да се пронајде"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1173,16 +3830,51 @@ msgid "Error Writing to File"
 msgstr "Неможно да запишам во датотеката:"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write file %s.\n"
+"Perhaps disk is full or not writable.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Compacting project"
 msgstr "Создаден нов проект"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity прва употреба"
+
+#. i18n-hint: E.g this is recovered audio that had been lost.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "(Recovered)"
+msgstr "Снимај"
+
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Неможно да се отвори проектот."
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -1197,12 +3889,99 @@ msgid "Unable to parse project information."
 msgstr "Неможно да се пронајде"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Сними проект"
+
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "&Сними проект"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Покажувач на почеток на селекцијата"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "&Сними проект"
+
+#: src/ProjectFileManager.cpp
+msgid "Insufficient Disk Space"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -1210,14 +3989,56 @@ msgid "Saved %s"
 msgstr "Снимено %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Зачувај го проектот к&ако..."
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
+
+#. i18n-hint: Heading: A warning that a project is about to be overwritten.
+#: src/ProjectFileManager.cpp
+msgid "Overwrite Project Warning"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Зачувај го проектот к&ако..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -1240,6 +4061,23 @@ msgstr "Одберете аудио фајл..."
 msgid "%s is already open in another window."
 msgstr "Тој проект е веќе отворен во друг прозорец."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Грешка при вчитување датотека."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Грешка при вчитување датотека."
@@ -1247,6 +4085,34 @@ msgstr "Грешка при вчитување датотека."
 #: src/ProjectFileManager.cpp
 msgid "Error opening file"
 msgstr "Грешка при вчитување датотека."
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"File may be invalid or corrupted: \n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Грешка при вчитување датотека."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Project was recovered"
+msgstr "Покажувач на почеток на селекцијата"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Recover"
+msgstr "Снимај"
 
 #: src/ProjectFileManager.cpp
 #, c-format
@@ -1266,16 +4132,46 @@ msgid "Error Importing"
 msgstr "Грешка при внес"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Сними проект"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Неможно да се отвори проектот."
 
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Сними проект"
+
 #: src/ProjectHistory.cpp
 msgid "Created new project"
 msgstr "Создаден нов проект"
+
+#: src/ProjectHistory.cpp
+msgid "Automatic database backup failed."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "Welcome to Tenacity version %s"
+msgstr ""
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
 #: src/ProjectManager.cpp
@@ -1286,6 +4182,25 @@ msgstr "Да снимам промени?"
 #: src/ProjectManager.cpp
 msgid "Save project before closing?"
 msgstr "Да снимам измени пред затворање?"
+
+#: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, c-format
+msgid "Disk space remaining for recording: %s"
+msgstr ""
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -1301,9 +4216,53 @@ msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
+#. i18n-hint: This is an experimental feature where the main panel in
+#. Audacity is put on a notebook tab, and this is the name on that tab.
+#. Other tabs in that notebook may have instruments, patch panels etc.
+#: src/ProjectWindow.cpp
+msgid "Main Mix"
+msgstr ""
+
+#: src/ProjectWindow.cpp
+#, fuzzy
+msgid "Horizontal Scrollbar"
+msgstr "Направи стерео нумера"
+
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Направи стерео нумера"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "Квалитет"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -1313,9 +4272,104 @@ msgstr "Квалитет"
 msgid "High Quality"
 msgstr "Квалитет"
 
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+msgid "16-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+msgid "24-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "Одбери локација за сместување на привремениот именик"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "Да снимам промени?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Одбери..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "Големина"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "Големина"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+msgid "White Bkgnd"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr "прозорец"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "прозорец"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "Создаден нов проект"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "Алатки"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -1329,7 +4383,13 @@ msgstr "Сите видови (*.*)|*.*"
 msgid "All Preferences"
 msgstr "Аudacity поставки"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Изборни алатки"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Постави формат на селекција"
 
@@ -1337,20 +4397,220 @@ msgstr "Постави формат на селекција"
 msgid "Timer"
 msgstr "Временска нумера"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Tools"
+msgstr "Алатки"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "Ladspa ефект поставки"
+
+#: src/Screenshot.cpp
+msgid "Mixer"
+msgstr ""
+
+#. i18n-hint: Noun (the meter is used for playback or record level monitoring)
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+msgid "Meter"
+msgstr ""
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Play Meter"
+msgstr "Плејбек"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Record Meter"
+msgstr "Снимање"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&Уреди"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+msgid "Device"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play-at-Speed"
+msgstr "Плејбек"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "Алатки"
+
+#: src/Screenshot.cpp src/TrackPanel.cpp
+#, fuzzy
+msgid "Track Panel"
+msgstr "Број на нумера:"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Обележи нумера"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "Обележи нумера"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "Обележи нумера"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "Свири една секунда"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "Обележи нумера"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "Обележи нумера"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "Обележи нумера"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "Одбери локација за сместување на привремениот именик"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "Вклучено"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
+
+#: src/ShuttleGui.cpp src/effects/EffectUI.cpp
+msgid "&Preview"
+msgstr ""
+
+#: src/ShuttleGui.cpp
+msgid "Dry Previe&w"
+msgstr ""
 
 #: src/ShuttleGui.cpp
 msgid "&Settings"
 msgstr "Ladspa ефект поставки"
 
+#: src/ShuttleGui.cpp
+msgid "Debu&g"
+msgstr ""
+
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Nearest"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+msgid "Sound Activated Record"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "Засилување (dB):"
+
+#: src/SplashDialog.cpp
+msgid "Welcome to Tenacity!"
+msgstr ""
+
+#: src/SplashDialog.cpp
+msgid "Don't show this again at start up"
+msgstr ""
+
 #: src/SqliteSampleBlock.cpp
 msgid "Connection to project file is null"
 msgstr "Неможно да се отвори проектот."
+
+#: src/Tags.cpp
+msgid "Artist Name"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Track Title"
+msgstr "Име на нумера"
+
+#: src/Tags.cpp
+msgid "Album Title"
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Track Number"
@@ -1360,16 +4620,332 @@ msgstr "Број на нумера:"
 msgid "Year"
 msgstr "Година:"
 
+#: src/Tags.cpp
+msgid "Genre"
+msgstr ""
+
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Коментари:"
+
+#: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "Брановидна форма (dB)"
+
+#: src/Tags.cpp
+msgid "&Add"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "&Remove"
+msgstr "&Тргни нумери"
+
+#: src/Tags.cpp
+msgid "Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&Уреди"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "Зум од"
+
+#: src/Tags.cpp
+msgid "Template"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "&Load..."
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "Стандардни краеви"
+
+#: src/Tags.cpp
+msgid "Don't show this when exporting audio"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Edit Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to save genre file."
+msgstr "Неможно да се пронајде"
+
+#: src/Tags.cpp
+msgid "Reset Genres"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Are you sure you want to reset the genre list to defaults?"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to open genre file."
+msgstr "Неможно да се пронајде"
+
+#: src/Tags.cpp
+msgid "Load Metadata As:"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Грешка при вчитување датотека."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Save Metadata As:"
+msgstr "Зачувај го проектот к&ако..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Грешка при вчитување датотека."
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "Вклучено"
 
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
+"  %s."
+msgstr "Неможно да запишам во датотеката:"
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
+"  %s\n"
+"for writing."
+msgstr "Неможно да се отвори бараната датотека за запис"
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write images to file:\n"
+"  %s."
+msgstr "Неможно да запишам во датотеката:"
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not create directory:\n"
+"  %s"
+msgstr "Неможно да запишам во датотеката:\n"
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not save file:\n"
+"  %s"
+msgstr "Неможно да ја отворам датотеката: \"%s\""
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
+#. i18n-hint: Light meaning opposite of dark
+#: src/Theme.cpp
+#, fuzzy
+msgid "Light"
+msgstr "Десен"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Име на нумера"
+
+#. i18n-hint: This string is used to configure the controls which shows the recording
+#. * duration. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The string 'days' indicates that the first number in the control will be the number of days,
+#. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
+#. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
+#. * seconds.
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Duration"
+msgstr "Акција"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "Временска нумера"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record"
+msgstr "Снимање"
+
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
+msgstr "Снимање"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "Десен канал"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Error in Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "Грешка при внес"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
 msgstr "Снимање"
 
 #: src/TimerRecordDialog.cpp
@@ -1380,8 +4956,32 @@ msgstr "Создаден нов проект"
 msgid "Recording start:"
 msgstr "Снимање"
 
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "Акција"
+
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
+msgstr "Снимање"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Action after Timer Recording:"
+msgstr "Снимање"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Снимање"
 
 #: src/TimerRecordDialog.cpp
@@ -1401,6 +5001,14 @@ msgid ""
 msgstr "Снимање"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "Снимање"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
@@ -1408,9 +5016,76 @@ msgid ""
 "Recording exported: %s"
 msgstr "Снимање"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Снимање"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Снимање"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint a format string for days, hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: This string is used to configure the controls for times when the recording is
+#. * started and stopped. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
+#. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date and Time"
+msgstr "Ударно време: "
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "Ударно време: "
+
+#: src/TimerRecordDialog.cpp
+msgid "End Date and Time"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "End Date"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
+msgstr "Неможно да се пронајде"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Project As:"
@@ -1421,10 +5096,20 @@ msgid "Select..."
 msgstr "Означи"
 
 #: src/TimerRecordDialog.cpp
+msgid "Automatic Export"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable Automatic &Export?"
+msgstr "Рата на семпл:"
+
+#: src/TimerRecordDialog.cpp
 msgid "Export Project As:"
 msgstr "Експорт наслов како:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Ladspa ефект поставки"
 
@@ -1433,8 +5118,25 @@ msgid "After Recording completes:"
 msgstr "Снимање"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Аudacity прва употреба"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -1444,11 +5146,23 @@ msgstr "Десен канал"
 msgid "Scheduled to stop at:"
 msgstr "Селекција на почеток"
 
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr ""
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Снимање"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -1457,6 +5171,33 @@ msgstr "Снимање"
 #: src/TimerRecordDialog.cpp
 msgid "Recording Exported:"
 msgstr "Снимање"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
+msgstr "Снимање"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Стерео, "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Име на нумера"
+
+#. i18n-hint: The %d is replaced by the number of the track.
+#. i18n-hint: compose a name identifying an unnamed track by number
+#: src/TrackPanelAx.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "Track %d"
+msgstr "Обележи нумера"
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this track is muted. (The mute button is on.)
@@ -1475,6 +5216,29 @@ msgstr "Соло"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Означи"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Mute On"
+msgstr "Онеми"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Solo On"
+msgstr "Соло"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "Изборни алатки"
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
@@ -1541,25 +5305,129 @@ msgstr "Мрдни нумера угоре"
 msgid "Move Track Down"
 msgstr "Мрдни нумера удолу"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
+#. i18n-hint: Voice key is an experimental/incomplete feature that
+#. is used to navigate in vocal recordings, to move forwards and
+#. backwards by words.  So 'key' is being used in the sense of an index.
+#. This error message means that you've selected too short
+#. a region of audio to be able to use this feature.
+#: src/VoiceKey.cpp
+msgid "Selection is too small to use voice key."
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Results\n"
+msgstr ""
+
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Complete"
+msgstr ""
+
 #: src/WaveClip.cpp
 msgid "Resampling failed."
 msgstr "MP3 внес исклучен"
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to paste the selection"
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to expand the cut line"
+msgstr ""
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Применет фазер"
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Командна акција"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "Командна акција"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "&Врати"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -1569,6 +5437,15 @@ msgstr "Снимање"
 msgid "Threshold:"
 msgstr "Богатство:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "Создадена нова аудио нумера"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Време на доцнење (сек.):"
@@ -1577,9 +5454,17 @@ msgstr "Време на доцнење (сек.):"
 msgid "Decay factor:"
 msgstr "Внеси decay фактор: "
 
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Drag"
 msgstr "Лево влечење"
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+msgid "Panel"
+msgstr ""
 
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
@@ -1593,9 +5478,43 @@ msgstr "Обележи нумера"
 msgid "Track 1"
 msgstr "Обележи нумера"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "прозорец"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Get Info"
+msgstr "Мрдни нумера удолу"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Commands"
@@ -1609,25 +5528,95 @@ msgstr "Сите видови (*.*)|*.*"
 msgid "Preferences"
 msgstr "Аudacity поставки"
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Не дозволувај преку"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Крива"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Наслови нумера"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Тивок почеток"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Процент на промени:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "Мрдни нумера удолу"
 
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "Тивок почеток"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Коментари:"
 
+#: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command:"
+msgstr "Командна акција"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
+
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
 msgstr "Внеси"
+
+#: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "File Name:"
+msgstr "Име..."
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Export2"
@@ -1638,12 +5627,43 @@ msgid "Number of Channels:"
 msgstr "Број на уредувања:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Експорт MP3"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Експорт MP3"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Builtin Commands"
+msgstr "Командна акција"
+
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Аudacity прва употреба"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+msgid "Unknown built-in command name"
+msgstr ""
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "Вклучено"
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Open Project2"
@@ -1665,6 +5685,10 @@ msgstr "Наслови нумера"
 msgid "Save Log"
 msgstr "Снимено %s"
 
+#: src/commands/OpenSaveCommands.cpp
+msgid "Clear Log"
+msgstr ""
+
 #: src/commands/OpenSaveCommands.h
 msgid "Opens a project."
 msgstr "Отворам Audacity проект"
@@ -1677,17 +5701,50 @@ msgstr "&Сними проект"
 msgid "Saves a copy of current project."
 msgstr "&Сними проект"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Аudacity поставки"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Име..."
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "Аudacity поставки"
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "Брановидна форма (dB)"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "Означи"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Window"
@@ -1702,8 +5759,23 @@ msgid "Window Plus"
 msgstr "прозорец"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "Алатки"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "&Ефект"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Сите видови (*.*)|*.*"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -1742,9 +5814,40 @@ msgid "All Tracks Plus"
 msgstr "Временска нумера"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
+#. i18n-hint:  This really means the color, not as in "white noise"
+#: src/commands/ScreenshotCommand.cpp
+msgctxt "color"
+msgid "White"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Неможно да запишам во датотеката:"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "Означи"
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -1766,6 +5869,11 @@ msgstr "Покажувач на почеток на селекцијата"
 msgid "Selection Start"
 msgstr "Покажувач на почеток на селекцијата"
 
+#: src/commands/SelectCommand.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Selection"
+msgstr "Изборни алатки"
+
 #: src/commands/SelectCommand.cpp
 msgid "Selection End"
 msgstr "Покажувач на крај од селекцијата"
@@ -1775,8 +5883,21 @@ msgid "Start Time:"
 msgstr "Ударно време: "
 
 #: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "End Time:"
+msgstr "Ударно време: "
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Frequencies"
 msgstr "Фрекфенција (Hz):"
+
+#: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
@@ -1788,6 +5909,16 @@ msgid "Set"
 msgstr "Означи"
 
 #: src/commands/SelectCommand.cpp
+msgid "Add"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&Тргни нумери"
+
+#: src/commands/SelectCommand.cpp
 msgid "First Track:"
 msgstr "Обележи нумера"
 
@@ -1795,8 +5926,17 @@ msgstr "Обележи нумера"
 msgid "Track Count:"
 msgstr "Наслови нумера"
 
+#: src/commands/SelectCommand.cpp
+msgid "Mode:"
+msgstr ""
+
 #: src/commands/SelectCommand.h
 msgid "Selects a time range."
+msgstr "Означи MIDI датотека..."
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
 msgstr "Означи MIDI датотека..."
 
 #: src/commands/SelectCommand.h
@@ -1811,13 +5951,46 @@ msgstr "Тишина"
 msgid "Set Clip"
 msgstr "Не дозволувај преку"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Почетно поместување:"
 
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
+
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
 msgstr "Крива"
+
+#: src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Time:"
+msgstr "Временска нумера"
 
 #: src/commands/SetEnvelopeCommand.cpp src/menus/EditMenus.cpp
 msgid "Delete"
@@ -1828,9 +6001,14 @@ msgid "Edited Envelope"
 msgstr "Крива"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Крива"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -1840,6 +6018,10 @@ msgstr "&Бриши"
 msgid "Label Index"
 msgstr "Наслови нумера"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Означи"
@@ -1847,6 +6029,10 @@ msgstr "Означи"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Даден наслов"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -1860,9 +6046,26 @@ msgstr "Постави рата"
 msgid "Resize:"
 msgstr "Големина"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Десен"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Сними проект"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -1877,6 +6080,10 @@ msgid "Set Track Status"
 msgstr "Име на нумера"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "Пауза"
 
@@ -1889,16 +6096,40 @@ msgid "Gain:"
 msgstr "Засилување"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Обележи нумера"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Година:"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Зум од"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Временска нумера"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Display:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -1920,16 +6151,36 @@ msgstr "Ladspa ефект поставки"
 msgid "Spectral Select"
 msgstr "Постави формат на селекција"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Обележи нумера"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Создадена нова аудио нумера"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Засилувач"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "Засилување (dB):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "Засилување (dB):"
 
 #: src/effects/Amplify.cpp
@@ -1941,16 +6192,85 @@ msgid "Allo&w clipping"
 msgstr "Не дозволувај преку"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Наслови нумера"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#. i18n-hint: Name of time display format that shows time in seconds
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "seconds"
+msgstr "Време на доцнење (сек.):"
+
+#: src/effects/AutoDuck.cpp
+msgid "Ma&ximum pause:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Богатство:"
+
+#: src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "Preview not available"
+msgstr " (откажана)"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
 
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Селекција збиј лево"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Богатство:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -1959,6 +6279,33 @@ msgstr "Истакнување (dB):"
 #: src/effects/BassTreble.cpp
 msgid "Ba&ss (dB):"
 msgstr "Истакнување (dB):"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "Брановидна форма (dB)"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Наслови нумера"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Volume (dB):"
+msgstr "Брановидна форма (dB)"
+
+#: src/effects/BassTreble.cpp
+msgid "Level"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -1969,13 +6316,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Смени висина без менување темпо"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Квалитет"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Смени висина без менување темпо"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "Висина (EAC)"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -2009,13 +6378,56 @@ msgstr "Полутонови (полустепени):"
 msgid "Frequency"
 msgstr "Фрекфенција (Hz):"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "до"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Процент на промени:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "Процент на промени:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -2033,11 +6445,42 @@ msgstr "Смени брзина менувајќи и темпо и висина
 msgid "&Speed Multiplier:"
 msgstr "Експорт MP3"
 
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
 msgctxt "change speed"
 msgid "&to"
 msgstr "до"
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "Selection Length"
+msgstr "Покажувач на крај од селекцијата"
 
 #: src/effects/ChangeSpeed.cpp
 msgid "C&urrent Length:"
@@ -2046,6 +6489,12 @@ msgstr "Ladspa ефект поставки"
 #: src/effects/ChangeSpeed.cpp
 msgid "Current length of selection."
 msgstr "Отсечи ја селекцијата"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
@@ -2066,8 +6515,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "Смени темпо без менување висина"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "Квалитет"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "Смени темпо без менување висина"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -2082,6 +6556,12 @@ msgstr "Должина (секунди):     од"
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
 msgid "t&o"
 msgstr "до"
 
@@ -2089,6 +6569,108 @@ msgstr "до"
 #, c-format
 msgid "Length in seconds from %s, to"
 msgstr "Должина (секунди):     од"
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Отстранувач на шум..."
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, c-format
+msgid "Selection must be larger than %d samples."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "Богатство:"
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Збивач..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "Ударно време: %.1f сек"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+msgid "&Noise Floor:"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "Лев клик"
+
+#: src/effects/Compressor.cpp
+msgid "&Ratio:"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
+msgstr "Акција"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' where the
@@ -2098,16 +6680,48 @@ msgid "&Attack Time:"
 msgstr "Ударно време: "
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Ударно време: "
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Ударно време: %.1f сек"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "Ударно време: %.1f сек"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "Богатство: %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -2120,43 +6734,439 @@ msgid "Release Time %.1f secs"
 msgstr "Ударно време: %.1f сек"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Создадена нова аудио нумера"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Создадена нова аудио нумера"
+
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Создадена нова аудио нумера"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
+#. i18n-hint noun
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "End"
+msgstr "Панорама"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "Тивка селекција"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background end time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "Тивка селекција"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "Зум од"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "Аudacity поставки"
 
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&Помош"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr "Создаден нов проект"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Експорт наслов како:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "Преименувана '%s' во '%s'"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "&Врати"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "Стандардни краеви"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Тон..."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Clipping"
+msgstr "Не дозволувај преку"
 
 #: src/effects/Distortion.cpp
 msgid "Soft Clipping"
 msgstr "Не дозволувај преку"
 
 #: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Динамичен компресор"
+
+#: src/effects/Distortion.cpp
+msgid "Leveller"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Rectifier Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Не дозволувај преку"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
 msgstr "Богатство:"
 
 #: src/effects/Distortion.cpp
+msgid "Parameter 1"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Parameter 2"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Number of repeats"
 msgstr "Број на уредувања:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion"
+msgstr "Висококвалитетен делач:"
+
+#: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Висококвалитетен делач:"
 
 #: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Threshold controls"
+msgstr "Богатство:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter controls"
 msgstr "Богатство:"
 
 #: src/effects/Distortion.cpp
@@ -2164,8 +7174,25 @@ msgid "Clipping level"
 msgstr "Применет фазер"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Богатство:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "Висококвалитетен делач:"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -2175,6 +7202,71 @@ msgstr "Ladspa ефект поставки"
 msgid "Repeat processing"
 msgstr "&Врати"
 
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "Не дозволувај преку"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Плејбек"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Плејбек"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Фрекфенција (Hz):"
@@ -2183,9 +7275,47 @@ msgstr "Фрекфенција (Hz):"
 msgid "&Amplitude (0-1):"
 msgstr "Амплитуда (0-1)"
 
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "&Duration:"
+msgstr "Акција"
+
 #: src/effects/DtmfGen.cpp
 msgid "&Tone/silence ratio:"
 msgstr "Тон генератор"
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Tone duration:"
+msgstr "Десен канал"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Silence duration:"
+msgstr "Тон генератор"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -2194,6 +7324,11 @@ msgstr "Ехо"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Експорт на селектираното аудио како Ogg Vorbis"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -2204,6 +7339,10 @@ msgid "D&ecay factor:"
 msgstr "Внеси decay фактор: "
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "Ladspa ефект поставки"
 
@@ -2211,7 +7350,8 @@ msgstr "Ladspa ефект поставки"
 msgid "Export Effect Parameters"
 msgstr "Подготвувам Ladspa ефект: %s"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Неможно да ја отворам датотеката: \"%s\""
@@ -2225,11 +7365,31 @@ msgstr "Подготвувам Ladspa ефект: %s"
 msgid "Error writing to file: \"%s\""
 msgstr "Неможно да запишам во датотеката:"
 
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Import Effect Parameters"
+msgstr "Подготвувам Ladspa ефект: %s"
+
 #. i18n-hint %s will be replaced by a file name
 #: src/effects/Effect.cpp
 #, c-format
 msgid "%s: is not a valid presets file.\n"
 msgstr "Неможно да се пронајде\n"
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Preparing preview"
+msgstr "Снимање"
+
+#: src/effects/Effect.cpp
+msgid "Previewing"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -2253,35 +7413,172 @@ msgstr "Применет ефект: %s"
 msgid "Select Preset"
 msgstr "Означи"
 
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "&Preset:"
+msgstr "Ladspa ефект поставки"
+
 #: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
 msgid "User Presets"
+msgstr "Ladspa ефект поставки"
+
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
 msgstr "Ladspa ефект поставки"
 
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
 msgstr "Ladspa ефект поставки"
 
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Factory Defaults"
+msgstr "Стандардни краеви"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "Селекција на крај"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
+
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
 msgstr "&Ефект"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Apply"
+msgstr "Применет фазер"
+
+#: src/effects/EffectUI.cpp
+msgid "Latency: 0"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Порамнето"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Мрдни нумера угоре"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect up in the rack"
+msgstr "Покажувач на крај од селекцијата"
+
+#: src/effects/EffectUI.cpp
 msgid "Move Down"
 msgstr "Мрдни нумера удолу"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect down in the rack"
+msgstr "Покажувач на крај од селекцијата"
+
+#: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Remove effect from the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Name of the effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Latency: %4d"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Командна акција"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "Историја на врати"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Плејбек"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
 #: src/effects/EffectUI.cpp
 msgid "Start &Playback"
 msgstr "Плејбек"
+
+#: src/effects/EffectUI.cpp
+msgid "Preview effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Preview effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Скокни до почеток"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Скокни до почеток"
 
 #: src/effects/EffectUI.cpp
 msgid "Skip forward"
@@ -2299,6 +7596,11 @@ msgstr "Вклучено"
 msgid "Save Preset..."
 msgstr "Зачувај го проектот к&ако..."
 
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "Означи"
+
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
 msgstr "Стандардни краеви"
@@ -2311,20 +7613,90 @@ msgstr "Внеси"
 msgid "Export..."
 msgstr "Експорт на нас&лови..."
 
+#: src/effects/EffectUI.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Options..."
+msgstr "Ladspa ефект поставки"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Тивок почеток"
+
 #: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Име..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Обраќање"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Грешка"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Description: %s"
+msgstr "Изборни алатки"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Are you sure you want to delete \"%s\"?"
+msgstr ""
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "Зачувај го проектот к&ако..."
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Preset name:"
+msgstr "Мудро до семпл"
+
+#: src/effects/EffectUI.cpp
 msgid "You must specify a name"
 msgstr "Морате прво да означите нумера."
+
+#: src/effects/EffectUI.cpp
+msgid ""
+"Preset already exists.\n"
+"\n"
+"Replace?"
+msgstr ""
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
 #: src/effects/EffectUI.cpp
 msgid "Stop &Playback"
 msgstr "Плејбек"
+
+#: src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Play"
+msgstr "Применет фазер"
+
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "Стивнување"
+
+#: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Equalization"
@@ -2334,25 +7706,295 @@ msgstr "Еквилизација"
 msgid "Filter Curve EQ"
 msgstr "Означи"
 
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Истакнување басови..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "Истакнување басови..."
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "Наслови нумера"
 
 #: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Наслови нумера"
 
 #: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
 msgstr "За цртање на спектар сите селектирани нумери треба да се со иста рата."
+
+#: src/effects/Equalization.cpp
+msgid "Track sample rate is too low for this effect."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Effect Unavailable"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "Тивок почеток"
+
+#: src/effects/Equalization.cpp
+msgid "Draw Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Цртачки алатки"
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Interpolation type"
 msgstr "Висококвалитетен делач:"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Линиска фрекфенција"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Линиска фрекфенција"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "Применет фазер"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Применет фазер"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Означи"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Означи"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Вртено"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Processing: "
+msgstr "Обележи нумера"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&efault"
+msgstr "Стандардни краеви"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "Почни &брзинар..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Подготвувам еквилизација"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Историја на врати"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Неможно да се пронајде"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Покажувач лево"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Име..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Означи"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Одбери..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "De&faults"
+msgstr "Стандардни краеви"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -2360,14 +8002,52 @@ msgid "Rename '%s' to..."
 msgstr "Преименувана '%s' во '%s'"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "Име..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "Преименувана '%s' во '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Да снимам промени?"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "Overwrite existing curve '%s'?"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "Мрдни нумера удолу"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Неможно да експортирам на %s"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Означи"
+
+#: src/effects/Equalization.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Deletion"
+msgstr "Тивка селекција"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -2375,8 +8055,49 @@ msgid "Delete %d items?"
 msgstr "Delete копче"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Choose an EQ curve file"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Експорт на нас&лови..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Неможно да експортирам на %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Снимање"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "No curves exported"
+msgstr ""
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -2390,9 +8111,75 @@ msgstr "Тивок крај"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Кликни и пушти за аудио селекција"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Кликни и пушти за аудио селекција"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "Не дозволувај преку"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Не дозволувај преку"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "Богатство: %d dB"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "Богатство: %d dB"
+
+#: src/effects/Generator.cpp
+msgid "There is not enough room available to generate the audio"
+msgstr ""
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Вртено"
+
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Применет Nyquist ефект..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "perceived loudness"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -2403,25 +8190,170 @@ msgstr "Име...\n"
 msgid "Analyzing: %s"
 msgstr "&Анализа"
 
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "Обележи нумера"
+
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Име..."
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
+
+#. i18n-hint: not a color, but "white noise" having a uniform spectrum
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "White"
+msgstr ""
+
+#. i18n-hint: not a color, but "pink noise" having a spectrum with more power
+#. in low frequencies
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Pink"
+msgstr ""
+
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "Noise"
+msgstr "Отстранувач на шум"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "&Noise type:"
+msgstr "Отстранувач на шум"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Median"
 msgstr "Големи краеви"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Second greatest"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hann, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hann, Hann (default)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Отстранувач на шум"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "За цртање на спектар сите селектирани нумери треба да се со иста рата."
 
 #: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
 msgstr "Селекција на почеток"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Noise reduction (dB):"
+msgstr "Брановидна форма (dB)"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
+msgstr "Отстранувач на шум"
+
+#: src/effects/NoiseReduction.cpp
+msgid "&Sensitivity:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Sensitivity"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Attac&k time (secs):"
@@ -2439,9 +8371,34 @@ msgstr "Време на доцнење (сек.):"
 msgid "Release time"
 msgstr "Ударно време: %.1f сек"
 
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Frequency smoothing (bands):"
+msgstr "LFO фрекфенција (Hz):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Анализа на фрекфенции"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "Брановидна форма (dB)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old Sensitivity"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 1"
 msgstr "Чекор 1"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid ""
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
+"then click Get Noise Profile:"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Get Noise Profile"
@@ -2450,6 +8407,33 @@ msgstr "Земи профил на шум"
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 2"
 msgstr "Чекор 2"
+
+#: src/effects/NoiseReduction.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "Отстранувач на шум"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "&Тргни нумери"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Големина"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -2463,13 +8447,171 @@ msgstr "прозорец"
 msgid "Window si&ze:"
 msgstr "прозорец"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "2048 (default)"
+msgstr "Стандардни краеви"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "4 (default)"
+msgstr "Стандардни краеви"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Отстранувач на шум"
 
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to remove noise.\n"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise re&duction (dB):"
+msgstr "Брановидна форма (dB)"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "&Sensitivity (dB):"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Fr&equency smoothing (Hz):"
+msgstr "LFO фрекфенција (Hz):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "Ударно време: %.1f сек"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Ударно време: "
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&Тргни нумери"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalize"
+msgstr "Име..."
+
+#: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Отстранување шум\n"
+
 #: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Отстранување шум\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Отстранување шум\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -2479,9 +8621,23 @@ msgstr "Нов амплитуден врв (dB):"
 msgid "Peak amplitude dB"
 msgstr "Нов амплитуден врв (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Внеси decay фактор: "
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Внеси decay фактор: "
@@ -2490,29 +8646,136 @@ msgstr "Внеси decay фактор: "
 msgid "&Time Resolution (seconds):"
 msgstr "Време на доцнење (сек.):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Фазер"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Патеки:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Патеки:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "LFO фрекфенција (Hz):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "LFO фрекфенција (Hz):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "LFO почетна фаза (степени):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "LFO почетна фаза (степени):"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Длабина:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "Враќање (%):"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "&Output gain (dB):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Output gain (dB)"
+msgstr "Истакнување (dB):"
+
+#: src/effects/Repair.cpp
+msgid "Repair"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
+#: src/effects/Repeat.cpp
+#, fuzzy
+msgid "Repeat"
+msgstr "&Врати"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -2536,6 +8799,67 @@ msgstr "Постави формат на селекција"
 msgid "New selection length: %s"
 msgstr "Постави формат на селекција"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Име на нумера"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "Големи краеви"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Обратно"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Големина"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Време на доцнење (сек.):"
+
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
 msgstr "Враќање (%):"
@@ -2543,6 +8867,34 @@ msgstr "Враќање (%):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "Длабина (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Длабина (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Истакнување (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Истакнување (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Стерео, "
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -2557,13 +8909,116 @@ msgstr "Обратно"
 msgid "Reverses the selected audio"
 msgstr "Локација:"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Подготвувам еквилизација"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "За цртање на спектар сите селектирани нумери треба да се со иста рата."
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Тивок почеток"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Порамни крај со крај на селекција"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Акција"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Акција"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size:"
+msgstr "прозорец"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size"
+msgstr "прозорец"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -2581,6 +9036,32 @@ msgstr "Богатство:"
 msgid "Presmooth Time:"
 msgstr "Мудро до семпл"
 
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
+msgstr "Мудро до семпл"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Line Time:"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time"
+msgstr "Означи MIDI датотека..."
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Smooth Time:"
 msgstr "Мудро до семпл"
@@ -2593,15 +9074,38 @@ msgstr "Мудро до семпл"
 msgid "Smooth Time"
 msgstr "Мудро до семпл"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Use Defaults"
+msgstr "Стандардни краеви"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Restore Defaults"
+msgstr "Стандардни краеви"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Тишина"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "Подели стерео нумера"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -2619,6 +9123,43 @@ msgstr "Подели стерео нумера"
 msgid "Sliding Stretch"
 msgstr "Внеси decay фактор: "
 
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "Висококвалитетен делач:"
+
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
 msgstr "Светло"
@@ -2632,6 +9173,26 @@ msgid "Sawtooth"
 msgstr "Сскање"
 
 #: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Брановидна форма:"
 
@@ -2640,18 +9201,91 @@ msgid "&Frequency (Hz):"
 msgstr "LFO фрекфенција (Hz):"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "LFO фрекфенција (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "LFO фрекфенција (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Амплитуда (0-1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Амплитуда (0-1)"
+
+#: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "Висококвалитетен делач:"
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Detected Silence"
+msgstr "Генератор на тишина"
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Тишина"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Генератор на тишина"
 
 #: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Збивач..."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "&Ефект"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Неможно да отворам библиотека за MP3 енкодирање!"
 
@@ -2659,33 +9293,129 @@ msgstr "Неможно да отворам библиотека за MP3 енк�
 msgid "VST Effect Options"
 msgstr "Ladspa ефект поставки"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Постави формат на селекција"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Комбинација на типки"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "Комбинација на типки"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Зачувај го проектот к&ако..."
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Експорт MP3"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Експорт MP3"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Аudacity поставки"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Зачувај го проектот к&ако..."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Означи MIDI датотека..."
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Неможно да се пронајде"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Ladspa ефект поставки"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Неможно да се пронајде"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Неможно да се пронајде"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -2696,8 +9426,29 @@ msgid "Reso&nance:"
 msgstr "Резонанца:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Резонанца:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Wah фрекфентен поместување (%):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Wah фрекфентен поместување (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Ladspa ефект поставки"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Ladspa ефект поставки"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -2712,16 +9463,47 @@ msgid "Audio Unit Effect Options"
 msgstr "Ladspa ефект поставки"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Интерфејс"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Селекција збиј лево"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "прозорец"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Генерирај"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Експорт MP3"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "Ladspa ефект поставки"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
@@ -2735,6 +9517,11 @@ msgstr "Неможно да ја отворам датотеката: \"%s\""
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Unable to read the preset from \"%s\""
+msgstr "Неможно да се пронајде"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to encode preset from \"%s\""
 msgstr "Неможно да се пронајде"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -2779,15 +9566,80 @@ msgstr "Експорт MP3"
 msgid "Failed to set preset name"
 msgstr "Неможно да се пронајде"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to retrieve preset content"
+msgstr "Неможно да се пронајде"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Неможно да се пронајде"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Рата на семпл:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to write XML preset to \"%s\""
+msgstr "Неможно да се пронајде"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Неможно да се пронајде"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Неможно да запишам во датотеката:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Аудио нумера"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "&Ефект"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "&Ефект"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Ladspa ефект поставки"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -2795,6 +9647,7 @@ msgstr "Ladspa ефект поставки"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "&Ефект"
@@ -2803,13 +9656,59 @@ msgstr "&Ефект"
 msgid "LV2 Effect Settings"
 msgstr "Ladspa ефект поставки"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Генерирај"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "&Ефект"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Применет Nyquist ефект..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -2825,6 +9724,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Nyquist јавка"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Порамнето со крај на селекција"
 
@@ -2837,8 +9754,37 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Прости, Ladspa ефектите не може да биде применет на стерео нумери каде каналите од нумерите не соодветствуваат."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Nyquist јавка"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "Снимање"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -2875,6 +9821,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist не врати аудио.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Оваа верзија на Audacity не е преведена со %s подршка."
@@ -2883,14 +9833,45 @@ msgstr "Оваа верзија на Audacity не е преведена со %s
 msgid "Could not open file"
 msgstr "Неможно да ја отворам датотеката: "
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Неможно да ја отворам датотеката: "
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Неможно да се пронајде\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Внеси Nyquist команда: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "&Load"
+msgstr ""
 
 #. i18n-hint: Nyquist is the name of a programming language
 #: src/effects/nyquist/Nyquist.cpp
@@ -2901,6 +9882,21 @@ msgstr "Nyquist јавка..."
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Nyquist јавка..."
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Неможно да ја отворам датотеката: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -2921,21 +9917,96 @@ msgstr "Означи MIDI датотека..."
 msgid "Save file as"
 msgstr "Снимено %s"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "&Ефект"
 
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "Прости, Ladspa ефектите не може да биде применет на стерео нумери каде каналите од нумерите не соодветствуваат."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "Додавка 1 за %i"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Спектрограм"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Ladspa ефект поставки"
+
 #: src/export/Export.cpp
 msgid "Export Audio"
 msgstr "Експорт MP3"
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp src/menus/EditMenus.cpp
+msgid "Edit Metadata Tags"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "Внесено '%s'"
 
 #: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid "Are you sure you want to export the file as \"%s\"?\n"
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
 msgstr "Прости, имиња на патеки подолги од 256 знаци не се поддржани."
+
+#: src/export/Export.cpp
+#, c-format
+msgid "A file named \"%s\" already exists. Replace?"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Your tracks will be mixed down and exported as one mono file."
@@ -2950,8 +10021,39 @@ msgid "Your tracks will be mixed down to one exported file according to the enco
 msgstr "Вашите нумери ќе бидат споени во два стерео канали при експортирањето."
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Advanced Mixing Options"
+msgstr "Ladspa ефект поставки"
+
+#: src/export/Export.cpp
 msgid "Format Options"
 msgstr "Ladspa ефект поставки"
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Channel: %2d"
+msgstr "Канали:"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Output Channels: %2d"
+msgstr "Канали:"
+
+#: src/export/Export.cpp
+msgid "Mixer Panel"
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -2960,10 +10062,43 @@ msgid ""
 "Error %s"
 msgstr "Неможно да се пронајде"
 
+#: src/export/ExportCL.cpp
+msgid "Show output"
+msgstr ""
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Командна акција"
+
+#: src/export/ExportCL.cpp
+msgid "(external program)"
+msgstr ""
+
 #: src/export/ExportCL.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Cannot export audio to %s"
 msgstr "Неможно да експортирам на %s"
+
+#: src/export/ExportCL.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export"
+msgstr "Експорт на нас&лови..."
 
 #: src/export/ExportCL.cpp
 msgid "Exporting the selected audio using command-line encoder"
@@ -2973,14 +10108,184 @@ msgstr "Експорт на селектираното аудио како mp3"
 msgid "Exporting the audio using command-line encoder"
 msgstr "Експорт на селектираното аудио како mp3"
 
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "Командна акција"
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Неможно да се пронајде"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "LOF грешка"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Експорт на селектираното аудио како Ogg Vorbis"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Exporting the audio as %s"
 msgstr "Експорт на селектираното аудио како Ogg Vorbis"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Рата на семпл:"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample"
+msgstr "Мрднат семпл"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "Рата на семпл:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -2990,9 +10295,59 @@ msgstr "Бит рата:"
 msgid "Quality (kbps):"
 msgstr "Квалитет"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "&Отвори..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Constrained"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -3003,8 +10358,44 @@ msgid "Low Delay"
 msgstr "Тивок крај"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Големи краеви"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -3019,8 +10410,20 @@ msgid "Frame Duration:"
 msgstr "Акција"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Vbr Mode:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "Применет фазер"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
@@ -3031,21 +10434,496 @@ msgid "Current Codec:"
 msgstr "Создаден нов проект"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Преименувана '%s' во '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Confirm Overwrite"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "Создадена нова аудио нумера"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Именикот %s не постои. Да го создадам?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "Преименувана '%s' во '%s'"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Main"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "LOF грешка"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "4-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "8-level"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "Ladspa ефект поставки"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Ladspa ефект поставки"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Експорт наслов како:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Експорт наслов како:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Создаден нов проект"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Додавка 1 за %i"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Јазик:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Quality:"
+msgstr "Квалитет"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Рата на семпл:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Сите видови (*.*)|*.*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Ladspa ефект поставки"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Збивач..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Име..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Селекција на крај"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Постави рата"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "Име на нумера"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "Преименувана '%s' во '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "No presets to export"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file to export presets into"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Неможно да се пронајде"
+
+#: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "0 (fastest)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "8 (best)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "Level:"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Bit depth:"
+msgstr "Бит рата:"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "FLAC Files"
+msgstr "Сите видови (*.*)|*.*"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Неможно да ја отворам датотеката: \"%s\""
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the selected audio as FLAC"
+msgstr "Експорт на селектираното аудио како Ogg Vorbis"
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the audio as FLAC"
 msgstr "Експорт на селектираното аудио како Ogg Vorbis"
 
+#: src/export/ExportMP2.cpp
+#, fuzzy
+msgid "MP2 Files"
+msgstr "Сите видови (*.*)|*.*"
+
+#: src/export/ExportMP2.cpp
+msgid "Cannot export MP2 with this sample rate and bit rate"
+msgstr ""
+
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
 msgstr "Неможно да се отвори бараната датотека за запис"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr "Експорт на селектираното аудио како Ogg Vorbis"
 
 #: src/export/ExportMP2.cpp
 #, c-format
@@ -3053,13 +10931,148 @@ msgid "Exporting the audio at %ld kbps"
 msgstr "Експорт на селектираното аудио како Ogg Vorbis"
 
 #: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "Големи краеви"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr " (откажана)"
+
+#: src/export/ExportMP3.cpp
+msgid "Average"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Constant"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "2 (Стерео)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (Стерео)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "Бит рата:"
 
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "Квалитет"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "Канали:"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "&Тргни нумери"
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Tenacity needs the file %s to create MP3s."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr "Акција"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "To find %s, click here -->"
+msgstr ""
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+msgid "To get a free copy of LAME, click here -->"
+msgstr ""
 
 #. i18n-hint: It's asking for the location of a file, for
 #. * example, "Where is lame_enc.dll?" - you could translate
@@ -3068,6 +11081,43 @@ msgstr "Квалитет"
 #, c-format
 msgid "Where is %s?"
 msgstr "Каде е %s?"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Аudacity поставки"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "Сите видови (*.*)|*.*"
 
 #: src/export/ExportMP3.cpp
 msgid "Could not open MP3 encoding library!"
@@ -3082,14 +11132,66 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "Невалидна или неподдржана MP3 енкодирачка библиотека!"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "Неможно да се пронајде"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Експорт MP3"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
 msgstr "Експорт MP3"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "Експорт на селектираното аудио како Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio with VBR quality %s"
+msgstr "Експорт на селектираното аудио како Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Експорт на селектираното аудио како Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Експорт на селектираното аудио како Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
@@ -3100,23 +11202,176 @@ msgid "Cannot Export Multiple"
 msgstr "Експорт MP3"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Локација:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Create"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Options:"
 msgstr "Ladspa ефект поставки"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Split files based on:"
+msgstr "Создаден нов наслов на нумера"
+
+#: src/export/ExportMultiple.cpp
+msgid "Include audio before first label"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name:"
+msgstr "Неможно да се отвори проектот."
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Неможно да се отвори проектот."
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Name files:"
+msgstr "Снимено %s"
+
+#: src/export/ExportMultiple.cpp
 msgid "Using Label/Track Name"
 msgstr "Име на нумера"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Име на нумера"
+
+#: src/export/ExportMultiple.cpp
+msgid "Numbering after File name prefix"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "File name prefix:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "File name prefix"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Overwrite existing files"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Choose a location to save the exported files"
 msgstr "Одбери локација за сместување на привремениот именик"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Save As..."
+msgstr "Снимено %s"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis Files"
+msgstr "Не е Ogg Vorbis датотека"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Неможно да се пронајде"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Неможно да се пронајде"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Неможно да се пронајде"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Неможно да се пронајде"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
 msgstr "Неможно да се пронајде"
 
 #: src/export/ExportOGG.cpp
@@ -3131,17 +11386,69 @@ msgstr "Експорт на селектираното аудио како Ogg V
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Експорт на селектираното аудио како Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "Header:"
+msgstr ""
+
 #: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
 msgid "Encoding:"
 msgstr "Енкодирање:"
+
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "Одберете која било некомпресирана аудио датотека..."
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Грешка при внес"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
 msgstr "Неможно да експортирам во овој формат."
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "Експорт на селектираното аудио како Ogg Vorbis"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -3149,8 +11456,184 @@ msgstr "Внесено '%s'"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Селекција на крај"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Оваа верзија на Audacity не е преведена со %s подршка."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Аudacity поставки"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -3165,13 +11648,123 @@ msgid "Import Project"
 msgstr "Експорт наслов како:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Неможно да го најдам именикот за проекти: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Покажувач на почеток на селекцијата"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -3188,13 +11781,20 @@ msgstr "Неможно да се пронајде"
 msgid "Unable to read %lld samples from %s"
 msgstr "Неможно да се пронајде"
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Неможно да се пронајде"
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Неможно да се пронајде"
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "Сите видови (*.*)|*.*"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -3248,6 +11848,29 @@ msgstr "Неможно да ја отворам датотеката: "
 msgid "Could not open file %s."
 msgstr "Неможно да ја отворам датотеката: \"%s\""
 
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "Сите видови (*.*)|*.*"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis files"
+msgstr "Не е Ogg Vorbis датотека"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
 msgstr "Нечитлив медиум"
@@ -3267,6 +11890,230 @@ msgstr "Невалидно Vorbis bitstream заглавие"
 #: src/import/ImportOGG.cpp
 msgid "Internal logic fault"
 msgstr "Интерен логички фаул"
+
+#: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 16 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 24 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "Внесено '%s'"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "Означи MIDI датотека..."
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Неможно да се пронајде"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "Неможно да се пронајде"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Неможно да се пронајде"
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "Внеси Raw датотека"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -3309,6 +12156,15 @@ msgstr "2 (Стерео)"
 msgid "%d Channels"
 msgstr "Канали:"
 
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Канали:"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
@@ -3326,6 +12182,15 @@ msgstr "Подготви за внес:"
 #: src/import/ImportRaw.cpp
 msgid "Sample rate:"
 msgstr "Рата на семпл:"
+
+#: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Import"
+msgstr "Внеси"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -3347,12 +12212,23 @@ msgstr "десно"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
 msgid_plural "%s %d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "start"
+msgstr "Почетно поместување:"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "end"
+msgstr "Панорама"
 
 #. i18n-hint:
 #. First two %s are each replaced with the noun "start"
@@ -3362,6 +12238,7 @@ msgstr[1] ""
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -3380,17 +12257,74 @@ msgid_plural "%d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Стивни ја селекцијата за %.2f секунди од %.2f"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the left"
+msgstr "Стивни ја селекцијата за %.2f секунди од %.2f"
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Временска алатка"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "Покажувач на почеток на селекцијата"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Previo&us Clip"
+msgstr "Означи"
 
 #: src/menus/ClipMenus.cpp
 msgid "Select Previous Clip"
 msgstr "Означи"
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "N&ext Clip"
+msgstr "Не дозволувај преку"
+
+#: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Означи"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "Означи"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "Создаден нов проект"
+
+#: src/menus/ClipMenus.cpp
+msgid "Ne&xt Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "Покажувач на почеток на селекцијата"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -3399,6 +12333,11 @@ msgstr "Временска алатка"
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Right"
 msgstr "Временска алатка"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasted text from the clipboard"
+msgstr "Залепено од амбар"
 
 #: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
 msgid "Pasted from the clipboard"
@@ -3422,12 +12361,40 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Избришани %.2f секунди од t=%.2f"
 
 #: src/menus/EditMenus.cpp
+msgid "Pasting one type of track into another is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Copying stereo audio into a mono track is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
 msgid "Duplicated"
 msgstr "Удвоено"
 
 #: src/menus/EditMenus.cpp
 msgid "Duplicate"
 msgstr "Удвоено"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split-cut to the clipboard"
+msgstr "Сечи во амбар"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Cut"
+msgstr "Подели"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Split-deleted %.2f seconds at t=%.2f"
+msgstr "Избришани %.2f секунди од t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Delete"
+msgstr "Постави формат на селекција"
 
 #: src/menus/EditMenus.cpp
 #, c-format
@@ -3445,9 +12412,47 @@ msgstr "Тишина"
 msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
 msgstr "Стивни ја селекцијата за %.2f секунди од %.2f"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "Аудио нумера"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Подели"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split to new track"
+msgstr "Подели стерео нумера"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split New"
+msgstr "Подели"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Joined %.2f seconds at t=%.2f"
+msgstr "Избришани %.2f секунди од t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Избришани %.2f секунди од t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Metadata Tags"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "&Edit"
@@ -3472,6 +12477,69 @@ msgstr "&Копирај"
 msgid "&Paste"
 msgstr "&Залепи"
 
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Duplic&ate"
+msgstr "Удвоено"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "&Тргни нумери"
+
+#. i18n-hint: (verb) Do a special kind of cut
+#: src/menus/EditMenus.cpp
+msgid "Spl&it Cut"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of DELETE
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split D&elete"
+msgstr "Постави формат на селекција"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Tri&m Audio"
+msgstr "Аудио нумера"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/EditMenus.cpp
+msgid "Sp&lit"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Ne&w"
+msgstr "Подели"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+msgid "&Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "Генератор на тишина"
+
+#: src/menus/EditMenus.cpp
+msgid "&Metadata..."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "Аudacity поставки"
+
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
 msgstr "Delete копче"
@@ -3481,28 +12549,12 @@ msgid "Delete Key&2"
 msgstr "Delete копче"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Плејбек"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Плејбек"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Плејбек"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Снимање"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Снимање"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Снимање"
+msgid "De&vice"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "Change &Recording Device..."
@@ -3520,9 +12572,26 @@ msgstr "Смени го името на нумерата во:"
 msgid "Change Recording Cha&nnels..."
 msgstr "Смени висина"
 
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Локација:"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Наслови нумера"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -3537,12 +12606,28 @@ msgid "Please select a Note Track."
 msgstr "Создадена нова аудио нумера"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "Експорт на нас&лови..."
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "Означи MIDI датотека..."
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "Сите видови (*.*)|*.*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "Експорт на нас&лови..."
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -3558,6 +12643,11 @@ msgid "Select a MIDI file"
 msgstr "Означи MIDI датотека..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Сите видови (*.*)|*.*"
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI files"
 msgstr "Означи MIDI датотека..."
 
@@ -3568,6 +12658,18 @@ msgstr "Сите видови (*.*)|*.*"
 #: src/menus/FileMenus.cpp
 msgid "&Dangerous Reset..."
 msgstr "Зачувај го проектот к&ако..."
+
+#. i18n-hint: This is the name of the menu item on Mac OS X only
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Open Recent"
+msgstr "Создаден нов проект"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "Означи MIDI датотека..."
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -3602,6 +12704,11 @@ msgid "&Export Audio..."
 msgstr "Експорт на нас&лови..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Expo&rt Selected Audio..."
+msgstr "Локација:"
+
+#: src/menus/FileMenus.cpp
 msgid "Export &Labels..."
 msgstr "Експорт на нас&лови..."
 
@@ -3614,8 +12721,42 @@ msgid "Export MI&DI..."
 msgstr "Експорт на нас&лови..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "Експорт на нас&лови..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Labels..."
+msgstr "Наслови нумера"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Експорт на нас&лови..."
+
+#: src/menus/FileMenus.cpp
+msgid "&Raw Data..."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Pa&ge Setup..."
 msgstr "Смени брзина..."
+
+#. i18n-hint: (verb) It's item on a menu.
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Print..."
+msgstr "десно"
+
+#. i18n-hint: (verb) It's item on a menu.
+#: src/menus/FileMenus.cpp
+msgid "E&xit"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -3632,12 +12773,25 @@ msgid "Unable to save %s"
 msgstr "Неможно да се пронајде"
 
 #: src/menus/HelpMenus.cpp
+msgid "Do you have these problems?"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Fix"
 msgstr "Микс"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "&Помош"
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "Ништо за врати"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -3652,11 +12806,29 @@ msgid "Recording stops and starts"
 msgstr "Снимање"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "&Помош"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Getting Started"
+msgstr "Покажувач на почеток на селекцијата"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Manual"
 msgstr "Аudacity прва употреба"
 
 #: src/menus/HelpMenus.cpp
@@ -3664,16 +12836,141 @@ msgid "&Quick Help..."
 msgstr "&Помош"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "З&а Audacity..."
+msgid "&Manual..."
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "&Diagnostics"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Даден наслов"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "Мрдни нумера угоре"
+
+#. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
+#. regions.
+#: src/menus/LabelMenus.cpp
+msgid "Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Cut Labeled Audio"
+msgstr "Снимање"
+
+#. i18n-hint: (verb) Audacity has just deleted the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Deleted labeled audio regions"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Delete Labeled Audio"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb) Audacity has just split cut the labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut on the labels
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Cut Labeled Audio"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb) Audacity has just done a special kind of DELETE on
+#. the labeled audio regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Deleted labeled audio regions"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb) Do a special kind of DELETE on labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Delete Labeled Audio"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silenced labeled audio regions"
+msgstr "Тивка селекција"
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
 msgid "Silence Labeled Audio"
+msgstr "Тивка селекција"
+
+#: src/menus/LabelMenus.cpp
+msgid "Copied labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Copy Labeled Audio"
+msgstr "Снимање"
+
+#. i18n-hint: (verb) past tense.  Audacity has just split the labeled
+#. audio (a point or a region)
+#: src/menus/LabelMenus.cpp
+msgid "Split labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Labeled Audio"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+msgid "Joined labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Join Labeled Audio"
+msgstr "Тивка селекција"
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+msgid "Detached labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detach Labeled Audio"
 msgstr "Тивка селекција"
 
 #: src/menus/LabelMenus.cpp
@@ -3693,8 +12990,22 @@ msgid "Add Label at &Playback Position"
 msgstr "Дај наслов на селекција"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "Мрдни нумера угоре"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Снимање"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "&Cut"
+msgstr ""
 
 #: src/menus/LabelMenus.cpp
 msgid "Label Cut"
@@ -3704,13 +13015,50 @@ msgstr "Наслови нумера"
 msgid "Label Delete"
 msgstr "Означи"
 
+#. i18n-hint: (verb) A special way to cut out a piece of audio
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Split Cut"
+msgstr "Подели"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Cut"
+msgstr "Наслови нумера"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Sp&lit Delete"
+msgstr "Постави формат на селекција"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Delete"
+msgstr "Означи"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "Тивка селекција"
+
 #: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "Тишина"
 
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Co&py"
+msgstr ""
+
 #: src/menus/LabelMenus.cpp
 msgid "Label Copy"
 msgstr "Наслови нумера"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Spli&t"
+msgstr "Подели"
 
 #: src/menus/LabelMenus.cpp
 msgid "Label Split"
@@ -3719,6 +13067,23 @@ msgstr "Наслови нумера"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "Наслови нумера"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "Мрдни нумера угоре"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -3741,6 +13106,16 @@ msgid "Move Focus to &Last Track"
 msgstr "Мрдни нумера угоре"
 
 #: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to P&revious and Select"
+msgstr "Мрдни нумера угоре"
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to N&ext and Select"
+msgstr "Мрдни нумера угоре"
+
+#: src/menus/NavigationMenus.cpp
 msgid "&Toggle Focused Track"
 msgstr "Мрдни нумера угоре"
 
@@ -3749,8 +13124,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Мрдни нумера угоре"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "&Помош"
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -3767,12 +13150,31 @@ msgid "&Generate"
 msgstr "&Генерирај"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Generator"
+msgstr "&Врати"
+
+#: src/menus/PluginMenus.cpp
 msgid "Effe&ct"
 msgstr "&Ефект"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "&Врати"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&Анализа"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "&Врати"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -3781,6 +13183,10 @@ msgstr "Алатки"
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Tool"
 msgstr "&Врати"
+
+#: src/menus/PluginMenus.cpp
+msgid "&Macros..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
@@ -3806,6 +13212,10 @@ msgstr "Почни &брзинар..."
 msgid "Simulate Recording Errors"
 msgstr "Снимање"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -3828,12 +13238,27 @@ msgid "Set Track Status..."
 msgstr "Име на нумера"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Тишина"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Обележи нумера"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Аudacity поставки"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Preference..."
 msgstr "Аudacity поставки"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Clip..."
+msgstr "Не дозволувај преку"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Envelope..."
@@ -3847,9 +13272,20 @@ msgstr "Експорт на нас&лови..."
 msgid "Set Project..."
 msgstr "Зачувај го проектот к&ако..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Сите видови (*.*)|*.*"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "Обележи нумера"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "Мрдни нумера удолу"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -3875,21 +13311,96 @@ msgstr "Одбери..."
 msgid "Compare Audio..."
 msgstr "Збивач..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "Означи"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Постави формат на селекција"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Акција"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Постави формат на селекција"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "Означи"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&None"
+msgstr "Ништо"
+
 #: src/menus/SelectMenus.cpp
 msgid "Select None"
 msgstr "Изборни алатки"
+
+#: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Tracks"
+msgstr "Обележи нумера"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "Обележи нумера"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Изборни алатки"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Left at Playback Position"
+msgstr "Дај наслов на селекција"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Selection Left at Play Position"
 msgstr "Постави формат на селекција"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Right at Playback Position"
+msgstr "Дај наслов на селекција"
+
+#: src/menus/SelectMenus.cpp
 msgid "Set Selection Right at Play Position"
 msgstr "Постави формат на селекција"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "Селекција на почеток"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "Селекција на почеток"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "Име на нумера"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -3928,8 +13439,21 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Линиска фрекфенција"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Селекција на почеток"
+
+#: src/menus/SelectMenus.cpp
+msgid "Store Cursor Pos&ition"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "At &Zero Crossings"
+msgstr "Означи"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Zero Crossing"
@@ -3938,6 +13462,18 @@ msgstr "Означи"
 #: src/menus/SelectMenus.cpp
 msgid "&Selection"
 msgstr "Изборни алатки"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Off"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Nearest"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection to &Start"
@@ -4016,6 +13552,11 @@ msgid "Cursor to Project Start"
 msgstr "Покажувач на почеток на селекцијата"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Project E&nd"
+msgstr "Покажувач на почеток на селекцијата"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor to Project End"
 msgstr "Создаден нов проект"
 
@@ -4047,9 +13588,64 @@ msgstr "Покажувач лево"
 msgid "Cursor Long Ju&mp Right"
 msgstr "Покажувач десно"
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "Алатки"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
+
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
 msgstr "Алатки"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr "Отстрани аудио нумера/и"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+msgid "Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr ""
 
 #. i18n-hint: One or more audio tracks have been panned
 #: src/menus/TrackMenus.cpp
@@ -4059,6 +13655,11 @@ msgstr "Отстрани аудио нумера/и"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Track"
 msgstr "Мрдни нумера угоре"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Zero"
+msgstr "Покажувач на крај од селекцијата"
 
 #: src/menus/TrackMenus.cpp
 msgid "Start to &Cursor/Selection Start"
@@ -4172,6 +13773,25 @@ msgid "Align Together"
 msgstr "Порамни ги нумерите меѓусебно"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "Порамни крај со крај на селекција"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted gain"
+msgstr "Наместена крива."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted Pan"
+msgstr "Наместена крива."
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
 msgstr "Создадена нова аудио нумера"
 
@@ -4188,16 +13808,97 @@ msgid "Created new label track"
 msgstr "Создаден нов наслов на нумера"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Создадена нова временска нумера"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Рата на семпл:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "The entered value is invalid"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Resampling track %d"
+msgstr "MP3 внес исклучен"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resampled audio track(s)"
+msgstr "Отстрани аудио нумера/и"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "&Тргни нумери"
 
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "Создадена нова аудио нумера"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "Порамни крај со крај на селекција"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by time"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Time"
+msgstr "Ударно време: "
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by name"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Name"
+msgstr "Број на нумера:"
+
+#: src/menus/TrackMenus.cpp
+msgid "Can't delete track with active audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&Нов"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "Мрдни нумера угоре"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Stereo Track"
+msgstr "Направи стерео нумера"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Label Track"
@@ -4208,8 +13909,25 @@ msgid "&Time Track"
 msgstr "Временска нумера"
 
 #: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Подели стерео нумера"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x and Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix and Render to Ne&w Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Resample..."
+msgstr "Име..."
 
 #: src/menus/TrackMenus.cpp
 msgid "Remo&ve Tracks"
@@ -4218,6 +13936,11 @@ msgstr "&Тргни нумери"
 #: src/menus/TrackMenus.cpp
 msgid "M&ute/Unmute"
 msgstr "Мрдни нумера угоре"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "Временска нумера"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
@@ -4230,6 +13953,10 @@ msgstr "Обележи нумера"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "Временска нумера"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -4256,12 +13983,22 @@ msgid "Pan Center"
 msgstr "Центар"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "Обележи нумера"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
 msgstr "Порамни крај со крај на селекција"
 
 #: src/menus/TrackMenus.cpp
 msgid "Align &Together"
 msgstr "Порамни ги нумерите меѓусебно"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Move Selection with Tracks (on/off)"
+msgstr "Покажувач на крај од селекцијата"
 
 #: src/menus/TrackMenus.cpp
 msgid "Move Sele&ction and Tracks"
@@ -4272,8 +14009,17 @@ msgid "S&ort Tracks"
 msgstr "Обележи нумера"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "By &Start Time"
+msgstr "Ударно време: "
+
+#: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "Име..."
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -4345,7 +14091,9 @@ msgstr "Применет фазер"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Снимање"
 
@@ -4354,8 +14102,32 @@ msgid "no label track"
 msgstr "Создаден нов наслов на нумера"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track at or below focused track"
+msgstr "Создаден нов наслов на нумера"
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Создаден нов наслов на нумера"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -4384,9 +14156,34 @@ msgstr "Ladspa ефект поставки"
 msgid "Pl&aying"
 msgstr "Применет фазер"
 
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "Плејбек"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Пауза"
+
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "Снимање"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "Снимај"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -4397,8 +14194,71 @@ msgid "Record &New Track"
 msgstr "&Тргни нумери"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Снимање"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Снимање"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "Ladspa ефект поставки"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Снимање"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "Ladspa ефект поставки"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&ay"
+msgstr "Применет фазер"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -4433,6 +14293,10 @@ msgid "Play Before an&d After Selection End"
 msgstr "Покажувач на крај од селекцијата"
 
 #: src/menus/TransportMenus.cpp
+msgid "Play C&ut Preview"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "&Play-at-Speed"
 msgstr "Плејбек"
 
@@ -4443,6 +14307,11 @@ msgstr "Плејбек"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play-at-Speed"
+msgstr "Плејбек"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview-at-Speed"
 msgstr "Плејбек"
 
 #: src/menus/TransportMenus.cpp
@@ -4508,6 +14377,20 @@ msgid "&Fit to Width"
 msgstr "&Во прозорец"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&Во прозорец"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Collapse All Tracks"
+msgstr "Временска нумера"
+
+#: src/menus/ViewMenus.cpp
+msgid "E&xpand Collapsed Tracks"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "Sk&ip to"
 msgstr "Скокни до крај"
 
@@ -4524,12 +14407,57 @@ msgid "Skip to Selection End"
 msgstr "Покажувач на крај од селекцијата"
 
 #: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
 msgstr "Не дозволувај преку"
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "&Ефект"
 
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr "прозорец"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Снимање"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -4537,7 +14465,7 @@ msgstr "Аudacity поставки"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Аudacity прва употреба"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -4545,9 +14473,25 @@ msgstr "Аudacity прва употреба"
 msgid "&Check for Updates"
 msgstr "Грешка при вчитување датотека."
 
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+msgid "Batch"
+msgstr ""
+
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
 msgstr "Аudacity поставки"
+
+#: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Behaviors"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "Devices"
+msgstr ""
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
@@ -4559,13 +14503,41 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Интерфејс"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "Using:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Плејбек"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Device:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "De&vice:"
+msgstr ""
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Cha&nnels:"
 msgstr "Канали:"
+
+#: src/prefs/DevicePrefs.cpp
+msgid "Latency"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "milliseconds"
+msgstr "Време на доцнење (сек.):"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "&Buffer length:"
@@ -4576,6 +14548,15 @@ msgid "&Latency compensation:"
 msgstr "Комбинација на типки"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Отстрани аудио нумера/и"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "1 (Моно)"
 
@@ -4584,17 +14565,37 @@ msgid "2 (Stereo)"
 msgstr "2 (Стерео)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Именици"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Аudacity поставки"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Именици"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Одбери..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -4617,6 +14618,24 @@ msgid "Bro&wse..."
 msgstr "Одбери..."
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "&Macro output:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "Нов привремен именик"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Акција"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
 msgstr "Одбери..."
 
@@ -4629,8 +14648,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Одбери локација за сместување на привремениот именик"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "Командна акција"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -4647,18 +14675,52 @@ msgid "Directory %s is not writable"
 msgstr "Именикот %s не е снимлив"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Промените во привремениот именик нема да имаат ефект се додека Audacity не се превклучи."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Нов привремен именик"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
 msgstr "Аudacity поставки"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Effect Name"
+msgstr "Подготвувам Ladspa ефект: %s"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Publisher and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Type and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&Ефект"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -4668,17 +14730,138 @@ msgstr "&Ефект"
 msgid "N&yquist"
 msgstr "Nyquist јавка"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "&Ефект"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Ladspa ефект поставки"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Додавка 1 за %i"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Висококвалитетен делач:"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Внеси"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Аudacity поставки"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Mime-types"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Експорт наслов како:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Мрдни нумера угоре"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Мрдни нумера удолу"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Move f&ilter up"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Мрднато '%s' %s"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Локација:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Локација:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Означи"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Do you really want to delete selected rule?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Десен канал"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -4694,17 +14877,181 @@ msgstr "Интерфејс"
 msgid "Preferences for GUI"
 msgstr "Аudacity поставки"
 
+#: src/prefs/GUIPrefs.cpp
+msgid "-36 dB (shallow range for high-amplitude editing)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-48 dB (PCM range of 8 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-72 dB (PCM range of 12 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-84 dB (PCM range of 14 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-96 dB (PCM range of 16 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-120 dB (approximate limit of human hearing)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-145 dB (PCM range of 24 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Акција"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "Display"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Јазик:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Location of &Manual:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Брановидна форма (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "Вклучено"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Додавка 1 за %i"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Алатки"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "Експорт наслов како:"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Аudacity поставки"
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
 msgstr "Подели стерео нумера"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Use Advanced Mixing Options"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Seconds"
+msgstr "Време на доцнење (сек.):"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Beats"
 msgstr "&Врати"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Експорт наслов како:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -4716,15 +15063,95 @@ msgid "Preferences for KeyConfig"
 msgstr "Аudacity поставки"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Key Bindings"
+msgstr "Комбинација на типки"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "View by:"
 msgstr "&Поглед"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Име..."
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Поглед"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Поглед"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Поглед"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Bindings"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "Ladspa ефект поставки"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Import..."
+msgstr "Внеси"
+
+#: src/prefs/KeyConfigPrefs.cpp src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "&Defaults"
+msgstr "Стандардни краеви"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Селектирајте XML датотека која содржи Audacity кратенки..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -4733,8 +15160,21 @@ msgstr "Експорт кратенки како:"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Вчитана %d кратенката\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -4748,6 +15188,38 @@ msgstr "Експорт кратенки како:"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Експорт кратенки како:"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "Комбинација на типки"
@@ -4757,12 +15229,72 @@ msgid "Preferences for Library"
 msgstr "Аudacity поставки"
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "Верзија на MP3 библиотека:"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "Верзија на MP3 библиотека:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "LOF грешка"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "Име..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "Означи MIDI датотека..."
 
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "Аudacity поставки"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Интерфејс"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -4770,13 +15302,77 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Интерфејс"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "Аudacity поставки"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Промените во привремениот именик нема да имаат ефект се додека Audacity не се превклучи."
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Ask"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -4818,13 +15414,26 @@ msgstr "Лево влечење"
 msgid "Set Selection Range"
 msgstr "Постави регион на селекција"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-лев клик"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Extend Selection Range"
 msgstr "Сменет регион на селекција"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Alt-Лев-Клик"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "Селекција на крај"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
@@ -4843,6 +15452,10 @@ msgid "Zoom in on a Range"
 msgstr "Зум во од-до"
 
 #: src/prefs/MousePrefs.cpp
+msgid "same as right-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Right-Click"
 msgstr "Десен клик"
 
@@ -4855,8 +15468,61 @@ msgid "Right-Drag"
 msgstr "Десно влечење"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "same as left-drag"
+msgstr "Исто како изборни алатки"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Лево влечење"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom out on a Range"
+msgstr "Зум во од-до"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Лев клик"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom default"
+msgstr "Стандардни краеви"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip left/right or between tracks"
+msgstr "Мрдни нумера угоре"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Left-Drag"
+msgstr "Лево влечење"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
 msgstr "Лево влечење"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip up/down between tracks"
+msgstr "Мрдни нумера угоре"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Лево влечење"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -4904,6 +15570,15 @@ msgid "Any"
 msgstr "Сите"
 
 #: src/prefs/MousePrefs.cpp
+msgid "Scroll tracks up or down"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Wheel-Rotate"
+msgstr "Вртливо увце"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Scroll waveform"
 msgstr "Брановидна форма"
 
@@ -4928,12 +15603,59 @@ msgid "Preferences for Playback"
 msgstr "Аudacity поставки"
 
 #: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Effects Preview"
+msgstr "Ladspa ефект поставки"
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "&Length:"
 msgstr "Постави формат на селекција"
 
+#. i18n-hint: (noun) this is a preview of the cut
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Cut Preview"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Аudacity поставки"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -4944,8 +15666,18 @@ msgid "Preferences for Quality"
 msgstr "Аudacity поставки"
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Друго..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "Мрднат семпл"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Rate:"
@@ -4955,13 +15687,73 @@ msgstr "Стандардна рата на семпл:"
 msgid "Default Sample &Format:"
 msgstr "Стандарден формат на семпл:"
 
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Рата на семпл:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Con&verter:"
+msgstr "Рата на семпл:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Висококвалитетен делач:"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Conver&ter:"
+msgstr "Рата на семпл:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
 msgstr "Аudacity поставки"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Обележи нумера"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Снимање"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -4972,9 +15764,19 @@ msgstr "Брановидна форма (dB)"
 msgid "Name newly recorded tracks"
 msgstr "Создадена нова стерео аудио нумера"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Име на нумера"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Наслови нумера"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -4984,11 +15786,67 @@ msgstr "Снимање"
 msgid "&Track Number"
 msgstr "Број на нумера:"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "System &Date"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Аudacity поставки"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Обележи нумера"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "Стандардни краеви"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "Стандардни краеви"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "Година:"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -5000,10 +15858,43 @@ msgstr "Година:"
 msgid "Frequencies"
 msgstr "Фрекфенција (Hz):"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Висина (EAC)"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be at least 0 Hz"
+msgstr "LFO фрекфенција (Hz):"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "LFO фрекфенција (Hz):"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -5022,6 +15913,10 @@ msgstr "Аudacity поставки"
 msgid "&Use Preferences"
 msgstr "Аudacity поставки"
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "LFO фрекфенција (Hz):"
@@ -5031,8 +15926,91 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Максимална фрекфенција (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Истакнување (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Истакнување (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Algorithm"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "A&lgorithm:"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &size:"
+msgstr "прозорец"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "1024 - default"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr "прозорец"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Внеси decay фактор: "
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Постави формат на селекција"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "Нов амплитуден врв (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -5046,9 +16024,118 @@ msgstr "Постави формат на селекција"
 msgid "The maximum frequency must be an integer"
 msgstr "Максималната фрекфенција мора да биде делива"
 
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum frequency must be an integer"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Максималната фрекфенција мора да биде делива"
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/prefs/ThemePrefs.cpp src/prefs/ThemePrefs.h
+msgid "Theme"
+msgstr ""
+
 #: src/prefs/ThemePrefs.cpp
 msgid "Preferences for Theme"
 msgstr "Аudacity поставки"
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Info"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Save Files"
+msgstr "Снимено %s"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Load Files"
+msgstr "Подготвувам еквилизација"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+msgid "Tracks Behaviors"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "Аudacity поставки"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "Мрднат семпл"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
@@ -5068,8 +16155,33 @@ msgid "Enable &dragging selection edges"
 msgstr "Тивка селекција"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Ladspa ефект поставки"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Копчиња"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -5082,6 +16194,14 @@ msgstr "Брановидна форма"
 #: src/prefs/TracksPrefs.cpp
 msgid "Spectrogram"
 msgstr "Спектрограм"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
@@ -5096,10 +16216,52 @@ msgid "Zoom Default"
 msgstr "Стандардни краеви"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Seconds"
+msgstr "Време на доцнење (сек.):"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "5ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "10ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "20ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "50ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "100ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "500ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "MilliSeconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Samples"
 msgstr "Мрднат семпл"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Зум"
 
@@ -5108,12 +16270,42 @@ msgid "Preferences for Tracks"
 msgstr "Аudacity поставки"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Снимање"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "Стандардна рата на семпл:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Стандарден формат на семпл:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "Мрднат семпл"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -5128,9 +16320,55 @@ msgstr "Аудио нумера"
 msgid "Zoom Toggle"
 msgstr "Зум алатка"
 
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preset 1:"
+msgstr "Ladspa ефект поставки"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preset 2:"
+msgstr "Ladspa ефект поставки"
+
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+msgid "Warnings"
+msgstr ""
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "Аudacity поставки"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&Сними проект"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&Сними проект"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "Подели стерео нумера"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "Подели стерео нумера"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -5153,16 +16391,24 @@ msgid "Stopped"
 msgstr "Стоп"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Пауза"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Скокни до почеток"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Скокни до крај"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Пауза"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Селекција на почеток"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Селекција на крај"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -5176,20 +16422,24 @@ msgstr "Обележи нумера"
 msgid "Append Record"
 msgstr "Снимај"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Селекција на крај"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Селекција на почеток"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Пауза"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Изборни алатки"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -5200,6 +16450,11 @@ msgstr "Плејбек"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Снимање"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "Аудио нумера"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -5222,8 +16477,24 @@ msgid "Select Playback Device"
 msgstr "Плејбек"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Тишина"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Десен канал"
+
+#: src/toolbars/DeviceToolBar.cpp
+msgid "Device information is not available."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that manages devices
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "&Device Toolbar"
+msgstr "Алатки"
 
 #: src/toolbars/EditToolBar.cpp
 msgid "Cut selection"
@@ -5241,11 +16512,22 @@ msgstr "Отсечи се вон селекцијата"
 msgid "Silence audio selection"
 msgstr "Тивка селекција"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "Обележи нумера"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Зум во"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Зум од"
 
@@ -5257,6 +16539,22 @@ msgstr "Собери селекција во прозорец"
 msgid "Fit project to width"
 msgstr "Собери цел проект во прозорец"
 
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "&Ефект"
+
+#. i18n-hint: Clicking this menu item shows the toolbar for editing
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "&Edit Toolbar"
+msgstr "Алатки"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "Снимање"
+
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Meter"
 msgstr "Снимање"
@@ -5264,6 +16562,21 @@ msgstr "Снимање"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "Плејбек"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "Снимај"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+msgid "Meter-Play"
+msgstr ""
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Level"
@@ -5285,32 +16598,24 @@ msgstr "Снимање"
 msgid "&Playback Meter Toolbar"
 msgstr "Плејбек"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Снимање"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Плејбек"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Алатки"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Снимање"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Плејбек"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Плејбек"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Nyquist јавка..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Nyquist јавка..."
@@ -5318,6 +16623,7 @@ msgstr "Nyquist јавка..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Nyquist јавка..."
@@ -5325,9 +16631,24 @@ msgstr "Nyquist јавка..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Покажувач на крај од селекцијата"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Покажувач на крај од селекцијата"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Алатки"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -5338,6 +16659,14 @@ msgstr "Алатки"
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "Покажувач на почеток на селекцијата"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap-To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
+msgid "Audio Position"
+msgstr ""
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
@@ -5355,9 +16684,37 @@ msgstr "Покажувач на крај од селекцијата"
 msgid "Length and Center of Selection"
 msgstr "Отсечи ја селекцијата"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Length"
+msgstr "Постави формат на селекција"
+
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Центар"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -5365,6 +16722,13 @@ msgstr "Центар"
 #, c-format
 msgid "Selection %s. %s won't change."
 msgstr "Означи MIDI датотека..."
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for selecting a time range of audio
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "&Selection Toolbar"
+msgstr "Изборни алатки"
 
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Center frequency and Width"
@@ -5378,11 +16742,20 @@ msgstr "Истакнување бас фрекфенции"
 msgid "Center Frequency"
 msgstr "Линиска фрекфенција"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spe&ctral Selection Toolbar"
 msgstr "Изборни алатки"
+
+#: src/toolbars/TimeToolBar.cpp
+#, fuzzy
+msgid "Time"
+msgstr "Временска нумера"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for viewing actual time of the cursor
@@ -5392,13 +16765,18 @@ msgstr "Алатки"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Аudacity прва употреба"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Кликни и пушти за предименизионирање на нумерата."
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Алатки"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -5416,13 +16794,26 @@ msgstr "Временска алатка"
 msgid "Zoom Tool"
 msgstr "Зум алатка"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Цртачки алатки"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Multi-Tool"
 msgstr "Мулти алатки"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "Изборни алатки"
+
+#. i18n-hint: Clicking this menu item shows a toolbar
+#. that has some tools in it
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools Toolbar"
+msgstr "Алатки"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "&Selection Tool"
@@ -5449,8 +16840,28 @@ msgid "&Multi Tool"
 msgstr "Мулти алатки"
 
 #: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Previous Tool"
+msgstr "Изборни алатки"
+
+#: src/toolbars/ToolsToolBar.cpp
 msgid "&Next Tool"
 msgstr "Мулти алатки"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "Менување брзина"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Playback Speed"
+msgstr "Плејбек"
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "Плејбек"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
@@ -5458,9 +16869,24 @@ msgstr "Мулти алатки"
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "Плејбек"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Даден наслов"
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Label Edit"
+msgstr "Наслови нумера"
 
 #: src/tracks/labeltrack/ui/LabelTextHandle.cpp
 msgid "Click to edit label text"
@@ -5474,6 +16900,17 @@ msgstr "Тон..."
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Label Track Font"
 msgstr "Наслови нумера"
+
+#. i18n-hint: (noun) The name of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+msgid "Face name"
+msgstr ""
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
+msgstr "Големина"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Cu&t Label text"
@@ -5496,30 +16933,50 @@ msgid "Deleted Label"
 msgstr "Delete копче"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Edited labels"
+msgstr "Даден наслов"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "New label"
 msgstr "Даден наслов"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Октава угоре"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Октава удолу"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Десен клик"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Зум од"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-лев клик"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-лев клик"
 
@@ -5541,9 +16998,44 @@ msgstr "Обележи нумера"
 msgid "Stretch"
 msgstr "Внеси decay фактор: "
 
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "Не дозволувај преку"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Expand"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Removed Cut Line"
+msgstr "&Тргни нумери"
+
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Click and drag to edit the samples"
 msgstr "Кликни и пушти за уредување семплови"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
@@ -5553,6 +17045,11 @@ msgstr "Мрднат семпл"
 msgid "Sample Edit"
 msgstr "Рата на семпл:"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Зум во на точка"
@@ -5560,6 +17057,16 @@ msgstr "Зум во на точка"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Спектрограм"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -5578,9 +17085,15 @@ msgstr "Менување темпо"
 msgid "Processing...   0%%"
 msgstr "Обележи нумера"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   %i%%"
+msgstr "Обележи нумера"
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Сменето '%s' во %s"
@@ -5592,6 +17105,54 @@ msgstr "Процент на промени:"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Постави рата"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -5611,7 +17172,8 @@ msgstr "Да снимам промени?"
 msgid "Set Rate"
 msgstr "Постави рата"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Мулти"
 
@@ -5703,6 +17265,27 @@ msgstr "Лев,"
 msgid "Right, %dHz"
 msgstr "Десен, "
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "десно"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "Кликни и пушти за да наместиш релативна големина на стерео нумерите."
@@ -5710,6 +17293,15 @@ msgstr "Кликни и пушти за да наместиш релативна
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "Кликни и пушти за движење на нумерата временски"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Кликни и пушти за движење на нумерата временски"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -5719,6 +17311,10 @@ msgstr "Зум во"
 msgid "Zoom x2"
 msgstr "Зум"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "Брановидна форма"
@@ -5726,6 +17322,11 @@ msgstr "Брановидна форма"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Брановидна форма"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -5758,12 +17359,38 @@ msgid "Set Range"
 msgstr "Постави од-до..."
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Display"
+msgstr "Не дозволувај преку"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Висококвалитетен делач:"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "Година:"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Висококвалитетен делач:"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -5775,9 +17402,8 @@ msgstr "Висококвалитетен делач:"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Кликни и пушти за движење на нумерата временски"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -5828,6 +17454,21 @@ msgstr "Наместена крива."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Алатки"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Покажувач на крај од селекцијата"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Алатки"
@@ -5843,6 +17484,16 @@ msgstr "Мрдни нумера угоре"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Мрдни нумера удолу"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Nyquist јавка..."
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Скокни до почеток"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -5895,9 +17546,19 @@ msgstr "Кликни и пушти за аудио селекција"
 msgid "Click and drag to select audio"
 msgstr "Кликни и пушти за аудио селекција"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Кликни и пушти за движење на нумерата временски"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Could not shift between tracks"
+msgstr "Неможно да запишам во датотеката:\n"
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Moved clips to another track"
@@ -5912,6 +17573,10 @@ msgstr "Стивни ја селекцијата за %.2f секунди од %
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Стивни ја селекцијата за %.2f секунди од %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -5938,6 +17603,12 @@ msgstr "Командна акција"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Лев клик"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Создадена нова аудио нумера"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -5976,6 +17647,103 @@ msgstr "Left=Зум во, Right=Зум од, Middle=Нормално"
 msgid "(disabled)"
 msgstr " (откажана)"
 
+#: src/widgets/AButton.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Press"
+msgstr "Ladspa ефект поставки"
+
+#: src/widgets/AButton.cpp
+#, fuzzy
+msgid "Button"
+msgstr "Копчиња"
+
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy
+msgid "Please choose an existing file."
+msgstr "Создадена нова аудио нумера"
+
+#: src/widgets/FileDialog/mac/FileDialogPrivate.mm
+#, fuzzy
+msgid "File type:"
+msgstr "Тивок крај"
+
+#: src/widgets/FileHistory.cpp
+msgid "&Clear"
+msgstr ""
+
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
+
+#: src/widgets/Grid.cpp
+msgid "Empty"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Скокни до почеток"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Сите видови (*.*)|*.*"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click to Start Monitoring"
+msgstr "Скокни до почеток"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click for Monitoring"
+msgstr "Скокни до почеток"
+
 #: src/widgets/Meter.cpp
 msgid "Click to Start"
 msgstr "Скокни до почеток"
@@ -5983,6 +17751,16 @@ msgstr "Скокни до почеток"
 #: src/widgets/Meter.cpp
 msgid "Click"
 msgstr "Лев клик"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Stop Monitoring"
+msgstr "Nyquist јавка..."
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Start Monitoring"
+msgstr "Nyquist јавка..."
 
 #: src/widgets/Meter.cpp
 msgid "Recording Meter Options"
@@ -5997,8 +17775,355 @@ msgid "Refresh Rate"
 msgstr "Постави рата"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter Style"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Type"
+msgstr "Тивок почеток"
+
+#: src/widgets/Meter.cpp
+msgid "Orientation"
+msgstr ""
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+msgid "Automatic"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Horizontal"
+msgstr "Зум &нормален"
+
+#: src/widgets/Meter.cpp
 msgid "Vertical"
 msgstr "Направи стерео нумера"
+
+#: src/widgets/Meter.cpp
+msgid " Monitoring "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Создадена нова аудио нумера"
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + hundredths"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>0100 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + milliseconds"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>01000 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + samples"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+># samples"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "Мрднат семпл"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames (lots of
+#. * frames) at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at PAL
+#. * TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -6006,11 +18131,118 @@ msgstr "Направи стерео нумера"
 msgid "octaves"
 msgstr "Октава удолу"
 
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "Должина (секунди):     од"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Ударно време: %.1f сек"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "Ударно време: %.1f сек"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Cancel"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to cancel?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Cancel"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to stop?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Stop"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to close?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Confirm Close"
+msgstr ""
+
 #. i18n-hint: %s is replaced with a directory path.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Неможно да се пронајде"
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -6023,10 +18255,67 @@ msgstr "Неможно да запишам во датотеката:"
 msgid "Preferences > Directories"
 msgstr "Аudacity поставки"
 
+#: src/widgets/Warning.cpp
+msgid "Don't show this warning again"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Empty value"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Снимај"
+
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Зум во од-до"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "LOF грешка"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Value not in range: %s to %s"
+msgstr "Да снимам промени?"
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be less than %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be greater than %s"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
@@ -6036,6 +18325,21 @@ msgstr "Создаден нов проект"
 msgid "Directory Dialog"
 msgstr "Именици"
 
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "Именици"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "Грешка"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Could not load file: \"%s\""
+msgstr "Неможно да ја отворам датотеката: \"%s\""
+
 #: src/xml/XMLFileReader.cpp
 msgid "Could not parse XML"
 msgstr "Неможно да ја отворам датотеката: "
@@ -6044,16 +18348,49 @@ msgstr "Неможно да ја отворам датотеката: "
 msgid "Spectral edit multi tool"
 msgstr "Постави формат на селекција"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Еквилизација..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Фрекфенција (Hz):"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Грешка"
@@ -6068,8 +18405,34 @@ msgstr "Истакнување (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Линиска фрекфенција"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -6082,6 +18445,32 @@ msgstr "Тивок крај"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Применет фазер"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -6104,12 +18493,32 @@ msgid "S-Curve Down"
 msgstr "Мрдни нумера удолу"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Start/End as"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
 msgstr "Засилување"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Покажувач на крај од селекцијата"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -6122,6 +18531,14 @@ msgstr "Година:"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Година:"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -6160,6 +18577,24 @@ msgstr "Мрдни нумера удолу"
 msgid "Error~%~%"
 msgstr "Грешка"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "&Врати"
@@ -6167,6 +18602,10 @@ msgstr "&Врати"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Генератор на тишина"
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity прва употреба"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -6180,6 +18619,23 @@ msgstr "Покажувач десно"
 msgid "Reconstructing clips..."
 msgstr "Отстранување шум"
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Богатство: %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Обележи нумера"
@@ -6188,6 +18644,21 @@ msgstr "Обележи нумера"
 msgid "Crossfading..."
 msgstr "Обележи нумера"
 
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
 msgstr "Обележи нумера"
@@ -6195,6 +18666,18 @@ msgstr "Обележи нумера"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade type"
 msgstr "Тивок крај"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Gain"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 1"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 2"
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Custom Curve"
@@ -6207,6 +18690,19 @@ msgstr "Име на нумера"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade direction"
 msgstr "Тивок почеток"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Delay"
@@ -6225,16 +18721,49 @@ msgid "Regular"
 msgstr "Правоаголно"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Брановидна форма (dB)"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Време на доцнење (сек.):"
+
+#: plug-ins/delay.ny
+msgid "Pitch change effect"
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Pitch/Tempo"
 msgstr "Висина (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Pitch change per echo (semitones)"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "Број на уредувања:"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -6249,18 +18778,40 @@ msgid "XML file"
 msgstr "Сите видови (*.*)|*.*"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "Снимај"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Грешка при вчитување датотека."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Грешка (датотеката можеби не е снимена): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Грешка (датотеката можеби не е снимена): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -6291,14 +18842,67 @@ msgstr "Должина (секунди):     од"
 msgid "Length of label region (seconds)"
 msgstr "Должина (секунди):     од"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Наслови нумера"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "Комбинација на типки"
+
+#: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Warnings only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -6308,6 +18912,17 @@ msgstr "Даден наслов"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Внеси нас&лови..."
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -6321,13 +18936,46 @@ msgstr "Подготвувам еквилизација"
 msgid "Dominic Mazzoni"
 msgstr "Отстранувач на шум од Dominic Mazzoni"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "LFO фрекфенција (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "LFO фрекфенција (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -6347,6 +18995,16 @@ msgid "Peak level"
 msgstr "Плејбек"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "Плејбек"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "Плејбек"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "Тон генератор"
 
@@ -6359,8 +19017,64 @@ msgid "Label type"
 msgstr "Наслови нумера"
 
 #: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Point after sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Генератор на тишина"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Генератор на тишина"
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
+#. i18n-hint: '~a' will be replaced by a time duration
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Error.~%Selection must be less than ~a."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -6388,8 +19102,29 @@ msgid "Hard Clip"
 msgstr "Не дозволувај преку"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Десен канал"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Брановидна форма (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
 
 #: plug-ins/lowpass.ny
 msgid "Low-Pass Filter"
@@ -6408,7 +19143,24 @@ msgid "Select Function"
 msgstr "Фрекфенција (Hz):"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Stereo Linking"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
+msgstr "Направи стерео нумера"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
 msgstr "Направи стерео нумера"
 
 #: plug-ins/noisegate.ny
@@ -6431,6 +19183,44 @@ msgstr "Ударно време: "
 msgid "Decay (ms)"
 msgstr "Време на доцнење (сек.):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Применет фазер"
@@ -6438,6 +19228,22 @@ msgstr "Применет фазер"
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "Применет фазер"
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -6460,7 +19266,8 @@ msgstr "Сите видови (*.*)|*.*"
 msgid "HTML file"
 msgstr "Сите видови (*.*)|*.*"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Означи MIDI датотека..."
 
@@ -6477,9 +19284,24 @@ msgid "Disallow"
 msgstr " (откажана)"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr " (откажана)"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Неможно да се пронајде"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -6490,16 +19312,62 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Означи MIDI датотека..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Локација:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Означи MIDI датотека..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Генерирање тон"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Тивок крај"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Duration (60s max)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm Track"
@@ -6510,8 +19378,40 @@ msgid "Generating Rhythm..."
 msgstr "Генерирање тон"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Број на уредувања:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -6526,8 +19426,28 @@ msgid "Start time offset"
 msgstr "Почетно поместување:"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Silence before first beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Beat sound"
 msgstr "&Врати"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
@@ -6536,6 +19456,32 @@ msgstr "Отстранување шум"
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Лев клик"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -6546,12 +19492,25 @@ msgid "Generating Risset Drum..."
 msgstr "Генератор на тишина"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Време на доцнење (сек.):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "Линиска фрекфенција"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "LFO фрекфенција (Hz):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -6564,6 +19523,10 @@ msgstr "Рата на семпл:"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "&Анализа"
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -6582,6 +19545,10 @@ msgid "HTML files"
 msgstr "Сите видови (*.*)|*.*"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Рата на семпл:"
 
@@ -6590,8 +19557,34 @@ msgid "Time Indexed"
 msgstr "Наслови нумера"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Неможно да се пронајде"
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Означи &се"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -6606,6 +19599,11 @@ msgstr "Вклучено"
 msgid "Errors Only"
 msgstr "Грешка"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -6618,6 +19616,46 @@ msgstr "Десен канал"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "Мрднат семпл"
 
@@ -6625,6 +19663,43 @@ msgstr "Мрднат семпл"
 #, lisp-format
 msgid "~a seconds."
 msgstr "Време на доцнење (сек.):"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -6643,6 +19718,10 @@ msgid "Value (dB)"
 msgstr "Брановидна форма (dB)"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Година:"
 
@@ -6659,6 +19738,14 @@ msgid "Right (dB)"
 msgstr "Десен, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Година:"
 
@@ -6670,17 +19757,87 @@ msgstr "2 (Стерео)"
 msgid "1 channel (mono)"
 msgstr "1 (Моно)"
 
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Грешка (датотеката можеби не е снимена): %s"
+
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
 msgstr "Рата на семпл:"
+
+#: plug-ins/sample-data-import.ny
+msgid "Reading and rendering samples..."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Select file"
 msgstr "Означи MIDI датотека..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Грешка"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -6690,6 +19847,15 @@ msgstr "Грешка при вчитување датотека."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Постави формат на селекција"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -6707,9 +19873,21 @@ msgstr "Сскање"
 msgid "Starting phase (degrees)"
 msgstr "LFO почетна фаза (степени):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Применет фазер"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -6751,6 +19929,98 @@ msgstr "&Анализа"
 msgid "Strength"
 msgstr "Покажувач на крај од селекцијата"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Processing Vocoder..."
+msgstr "Обележи нумера"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Output choice"
 msgstr "Ladspa ефект поставки"
@@ -6783,6 +20053,96 @@ msgstr "LFO фрекфенција (Hz):"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "LFO фрекфенција (Hz):"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Аudacity прва употреба"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Канали:"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Аudacity прва употреба"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Снимање"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Неможно да се пронајде\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Снимање\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Плејбек\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Снимање\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Снимање\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Плејбек\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Плејбек\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Неможно да се пронајде"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Плејбек"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Плејбек"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Плејбек"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Снимање"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Снимање"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Снимање"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "З&а Audacity..."
+
+#~ msgid "Recording Volume"
+#~ msgstr "Снимање"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Плејбек"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Снимање"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Плејбек"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Плејбек"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Кликни и пушти за движење на нумерата временски"
+
 #~ msgid "Program build date:"
 #~ msgstr "Дата на програмата:"
 
@@ -6795,10 +20155,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Не"
 
 #, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Неможно да се пронајде"
-
-#, fuzzy
 #~ msgid "Audacity Support Data"
 #~ msgstr "Аudacity прва употреба"
 
@@ -6809,10 +20165,6 @@ msgstr "LFO фрекфенција (Hz):"
 #, fuzzy
 #~ msgid "Error.n"
 #~ msgstr "Грешка"
-
-#, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "Одберете која било некомпресирана аудио датотека..."
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -6856,10 +20208,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ "/%s/%s.%s"
 #~ msgstr "Снимање"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "Снимање"
-
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
 #~ msgstr "Ogg Vorbis подршка не е вклучена во оваа верзија на Audacity"
 
@@ -6881,10 +20229,6 @@ msgstr "LFO фрекфенција (Hz):"
 
 #~ msgid "Audacity was unable to convert an Audacity 1.0 project to the new project format."
 #~ msgstr "Audacity не може да конвертира Audacity 1.0 проект во новиотформат."
-
-#, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Збивач..."
 
 #, fuzzy
 #~ msgid ""
@@ -6960,10 +20304,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Грешка при внес"
 
 #, fuzzy
-#~ msgid "Click to unpin"
-#~ msgstr "Скокни до почеток"
-
-#, fuzzy
 #~ msgid "Click to pin"
 #~ msgstr "Скокни до почеток"
 
@@ -7023,10 +20363,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Неможно да ја отворам датотеката: "
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "Име на нумера"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "Отстранување шум"
 
@@ -7059,10 +20395,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Ny"
 
 #, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Применет Nyquist ефект..."
-
-#, fuzzy
 #~ msgid "Unable to save MIDI device info"
 #~ msgstr "Неможно да се пронајде"
 
@@ -7074,22 +20406,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgid "Left"
 #~ msgstr "Лев"
 
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "Десен"
-
-#, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "Изборни алатки"
-
-#, fuzzy
-#~ msgid "&Tools"
-#~ msgstr "Алатки"
-
-#, fuzzy
-#~ msgid "Transcri&ption"
-#~ msgstr "Изборни алатки"
-
 #~ msgid "Your tracks will be mixed down to a single mono channel in the exported file."
 #~ msgstr "Вашите нумери ќе бидат споени во еден моно канал при експортирањето."
 
@@ -7098,10 +20414,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ "Error opening sound device.\n"
 #~ "Try changing the audio host, recording device and the project sample rate."
 #~ msgstr "Грешка при пуштање звук. Молам проверете ги поставките за излезен уред и за проект рата."
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "Снимање"
 
 #, fuzzy
 #~ msgid "Slider Playback"
@@ -7118,17 +20430,6 @@ msgstr "LFO фрекфенција (Hz):"
 #, fuzzy
 #~ msgid "High Frequency:"
 #~ msgstr "Фрекфенција (Hz):"
-
-#~ msgid "Change track name to:"
-#~ msgstr "Смени го името на нумерата во:"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "Алатки"
-
-#, fuzzy
-#~ msgid "and"
-#~ msgstr "Панорама"
 
 #, fuzzy
 #~ msgid "end to end"
@@ -7164,10 +20465,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Центар"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Селекција на крај"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "Покажувач на крај од селекцијата"
 
@@ -7190,24 +20487,8 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Процент на промени:"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "Ударно време: "
-
-#, fuzzy
-#~ msgid "Repeats"
-#~ msgstr "&Врати"
-
-#, fuzzy
 #~ msgid "Sequence"
 #~ msgstr "Фрекфенција (Hz):"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Амплитуда (0-1)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "Име..."
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -7250,10 +20531,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Враќање (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Големина"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "Враќање (%):"
 
@@ -7268,10 +20545,6 @@ msgstr "LFO фрекфенција (Hz):"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Засилување"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Стерео, "
 
 #, fuzzy
 #~ msgid "RatePercentChangeStart"
@@ -7289,16 +20562,8 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgid "PitchPercentChangeEnd"
 #~ msgstr "Процент на промени:"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Обраќање"
-
 #~ msgid "Size"
 #~ msgstr "Големина"
-
-#, fuzzy
-#~ msgid "Co&mbined Meter Toolbar"
-#~ msgstr "Снимање"
 
 #, fuzzy
 #~ msgid "S&kip to Start"
@@ -7352,20 +20617,12 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgstr "Десен канал"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "Истакнување (dB):"
-
-#, fuzzy
 #~ msgid "No wave tracks exist."
 #~ msgstr "Отстранета нумерата '%s.'"
 
 #, fuzzy
 #~ msgid "-Left-Click"
 #~ msgstr "Лев клик"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "Alt-Лев-Клик"
 
 #, fuzzy
 #~ msgid "Zoom in or out on Mouse Pointer"
@@ -7418,9 +20675,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgid "Plug-ins %i to %i"
 #~ msgstr "Додавки %i за %i"
 
-#~ msgid "MP3 Export Setup"
-#~ msgstr "MP3 експорт поставки"
-
 #, fuzzy
 #~ msgid "Export format:"
 #~ msgstr "Некомпресиран експорт формат"
@@ -7443,14 +20697,6 @@ msgstr "LFO фрекфенција (Hz):"
 
 #~ msgid "Using block size of %ld\n"
 #~ msgstr "Користи блок големина од %ld\n"
-
-#, fuzzy
-#~ msgid "Plot Spectrum"
-#~ msgstr "Спектар"
-
-#, fuzzy
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "Висококвалитетен делач:"
 
 #~ msgid "Applied effect: %s %.1f dB"
 #~ msgstr "Применет ефект: %s %.1f dB"
@@ -7480,10 +20726,6 @@ msgstr "LFO фрекфенција (Hz):"
 #~ msgid "Change Tempo..."
 #~ msgstr "Смени темпо..."
 
-#, fuzzy
-#~ msgid "Click Removal..."
-#~ msgstr "Отстранувач на шум..."
-
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "Применета динамичка компресија"
 
@@ -7498,9 +20740,6 @@ msgstr "LFO фрекфенција (Hz):"
 
 #~ msgid "Equalization..."
 #~ msgstr "Еквилизација..."
-
-#~ msgid "Performing Equalization"
-#~ msgstr "Подготвувам еквилизација"
 
 #~ msgid "Fading In"
 #~ msgstr "Извирање"
@@ -7526,10 +20765,6 @@ msgstr "LFO фрекфенција (Hz):"
 
 #~ msgid "Applying Phaser"
 #~ msgstr "Применет фазер"
-
-#, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "Обратно"
 
 #, fuzzy
 #~ msgid "Applied effect: Generate Silence, %.6lf seconds"
@@ -7558,14 +20793,6 @@ msgstr "LFO фрекфенција (Hz):"
 #, fuzzy
 #~ msgid "Change output device"
 #~ msgstr "Смени брзина"
-
-#, fuzzy
-#~ msgid "Effect Refresh"
-#~ msgstr "Ladspa ефект поставки"
-
-#, fuzzy
-#~ msgid "Input Channels"
-#~ msgstr "Канали:"
 
 #, fuzzy
 #~ msgid "Select Input Channels"

--- a/locale/mr.po
+++ b/locale/mr.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Marathi <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/mr/>\n"
+"Language-Team: Marathi <https://hosted.weblate.org/projects/tenacity/tenacity/mr/>\n"
 "Language: mr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,42 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "ऑड्यासिटी मधून बाहेर पडा"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "माध्यम"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "धारिका विसंकेतन करताना त्रुटी आली"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "मेटा माहिती  लोड करण्यात त्रुटी"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "ऑड्यासिटी साधनपट्टी%s"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "ध्वनीमुद्रण(&R)"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -63,6 +26,24 @@ msgstr "निर्धारित करण्यात अक्षम"
 #, c-format
 msgid "%s bytes"
 msgstr "बाइट्स"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -189,7 +170,8 @@ msgid "Script"
 msgstr "लिपी"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "उत्पादित"
 
@@ -205,7 +187,12 @@ msgstr "'नाइक्विस्ट (Nyquist) लिपी्स (*.ny)|*.ny
 msgid "Script was not saved."
 msgstr "लिपी जतन झालेली नाही."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "चेतावणी"
 
@@ -234,7 +221,8 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "(सी) 2009 लेलँड लुसियस यांनी"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "बाह्य ऑड्यासिटी घटक जो प्रभाव लिहिण्यासाठी सोपा एकात्मिक विकास वातावरण (IDE)  प्रदान करतो."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -257,7 +245,8 @@ msgstr "अशीर्षकांकित"
 msgid "Nyquist Effect Workbench - "
 msgstr "'नाइक्विस्ट (Nyquist) प्रभाव कार्य खंडपीठ- "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "नवीन"
 
@@ -297,7 +286,8 @@ msgstr "नक्कल करा"
 msgid "Copy to clipboard"
 msgstr "क्लिपबोर्डवर नक्कल करा"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "कापा"
 
@@ -305,7 +295,8 @@ msgstr "कापा"
 msgid "Cut to clipboard"
 msgstr "कापून क्लिपबोर्डवर घ्या"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "चिटकवा"
 
@@ -330,7 +321,8 @@ msgstr "सर्व निवडा"
 msgid "Select all text"
 msgstr "सर्व मजकूर निवडा"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "पूर्ववत करा"
 
@@ -338,7 +330,8 @@ msgstr "पूर्ववत करा"
 msgid "Undo last change"
 msgstr "शेवटचा बदल पूर्ववत करा"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "पुन्हा करा"
 
@@ -395,7 +388,8 @@ msgid "Go to next S-expr"
 msgstr "पुढच्या एस-एक्सप्रेस वर जा"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "आरंभ करा"
 
@@ -403,7 +397,8 @@ msgstr "आरंभ करा"
 msgid "Start script"
 msgstr "लिपी आरंभ करा"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "थांबा"
 
@@ -418,7 +413,8 @@ msgid "About %s"
 msgstr "विषयी"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "ठीक आहे"
 
@@ -426,11 +422,13 @@ msgstr "ठीक आहे"
 msgid "Build Information"
 msgstr "निर्माण माहिती"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "सक्रिय"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "निष्क्रिय"
 
@@ -440,8 +438,9 @@ msgid "The Build"
 msgstr "त्रुटिसुधार निर्माण"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "कमिट आयडी:"
+#, fuzzy
+msgid "Version:"
+msgstr "आवृत्ती: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -451,22 +450,28 @@ msgstr "निर्माण प्रकार:"
 msgid "Compiler:"
 msgstr "संकलक:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "स्थापनेआधी जोडा: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "समायोजन पुस्तिका: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "समायोजन पुस्तिका: "
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "धारिका स्वरूप समर्थन"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "विविध-ठिकाणी चालणारे जीयूआय ग्रंथालय"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -480,7 +485,6 @@ msgstr "नमूना दर परिवर्तन"
 msgid "MP3 Importing"
 msgstr "एमपी३ (MP3) आयात चालू आहे"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "ओग व्हॉर्बिस(Ogg Vorbis) आयात आणि निर्यात"
@@ -489,7 +493,6 @@ msgstr "ओग व्हॉर्बिस(Ogg Vorbis) आयात आणि �
 msgid "ID3 tag support"
 msgstr "आयडी३ (ID3) टॅग समर्थन"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "एफएलएसी(FLAC) आयात आणि निर्यात"
@@ -507,14 +510,6 @@ msgid "FFmpeg Import/Export"
 msgstr "एफएफएमपीईजी (FFmpeg) आयात / निर्यात"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "जीस्ट्रीमर (GStreamer) कडून आयात करा"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "विशेषता"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "प्लग-इन समर्थन"
 
@@ -529,6 +524,10 @@ msgstr "ध्वनीची उच्चनीचता आणि ध्वन
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "ध्वनीची उच्चनीचता आणि ध्वनीची गतीमधील अत्यंत बदलांचे समर्थन"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "विशेषता"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -642,6 +641,15 @@ msgstr "वेब विकसक"
 msgid "%s, graphics"
 msgstr "रेखाचित्रे"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -651,6 +659,10 @@ msgstr "ऑड्यासिटी हे ध्वनी मुद्रना
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "श्रेयसूची"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -701,6 +713,7 @@ msgstr "संकेतस्थळ आणि रेखाचित्रे"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "भाषांतरकार_श्रेय"
@@ -718,6 +731,22 @@ msgstr "विशेष आभार:"
 #, c-format
 msgid "%s website: "
 msgstr "ऑड्यासिटी संकेतस्थळ: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "योगदानकर्ता"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -740,6 +769,7 @@ msgstr "वेळलाइन"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "शोधणे सुरू करण्यासाठी क्लिक करा किंवा ओढा"
@@ -747,6 +777,7 @@ msgstr "शोधणे सुरू करण्यासाठी क्लि
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "स्क्रब सुरू करण्यासाठी क्लिक करा किंवा ओढा"
@@ -754,6 +785,7 @@ msgstr "स्क्रब सुरू करण्यासाठी क्ल
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "स्क्रबवर क्लिक करा आणि त्यास हलवा. क्लिक करा आणि शोधा वर ओढा."
@@ -761,6 +793,7 @@ msgstr "स्क्रबवर क्लिक करा आणि त्य�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "शोधण्यासाठी वर जा"
@@ -768,6 +801,7 @@ msgstr "शोधण्यासाठी वर जा"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "स्क्रब वर जा"
@@ -824,7 +858,17 @@ msgstr ""
 "प्रकल्पाच्या समाप्तीच्या पलीकडे प्रदेश \n"
 "कुलूप करणे शक्य नाही."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "त्रुटी"
 
@@ -848,7 +892,8 @@ msgstr ""
 "हा प्रश्न 'आस्थापना' नंतर एकदाच विचारला जाईल, जिथे आपण प्रथमच प्राधान्ये संचयित करता."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "ऑड्यासिटी प्राधान्ये पुन्हा निवड करा"
 
 #: src/AudacityApp.cpp
@@ -861,6 +906,10 @@ msgstr ""
 "%s सापडले नाही.\n"
 "\n"
 "ती अलीकडील धारिकेच्या सूचीमधून काढली गेली आहे."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -885,7 +934,7 @@ msgstr "उघडा(&O)..."
 msgid "Open &Recent..."
 msgstr "अलीकडील उघडा (&R)..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "ऑड्यासिटी बद्दल (&A)..."
@@ -899,9 +948,10 @@ msgid "&File"
 msgstr "धारिका(&F)"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "तात्पुरत्या धारिका संचयित करण्यासाठी ऑड्यासिटीला सुरक्षित स्थान सापडले नाही.\n"
@@ -909,20 +959,23 @@ msgstr ""
 "कृपया प्राधान्ये संवाद मध्ये उजवे निर्देशिका प्रविष्ट करा."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "तात्पुरत्या धारिका  संचयित करण्यासाठी ऑड्यासिटीला जागा सापडली नाही.\n"
 "कृपया प्राधान्ये संवाद मध्ये उजवे निर्देशिका प्रविष्ट करा."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "ऑड्यासिटी आता बंद होत आहे. कृपया नवीन तात्पुरती निर्देशिका वापरण्यासाठी ऑड्यासिटी पुन्हा सुरु करा."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -931,15 +984,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "ऑड्यासिटी तात्पुरतीधारिका निर्देशिका कुलूप बंद करू शकली नाही.\n"
 "ही निर्देशिका (पुस्तिका) ऑड्यासिटीच्या दुसर्‍या प्रतीद्वारे वापरली जाऊ शकते\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "आपण अजूनही ऑड्यासिटी सुरू करू इच्छिता का?"
 
 #: src/AudacityApp.cpp
@@ -947,24 +1002,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "तात्पुरती निर्देशिका कुलूप बंद करताना त्रुटी"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "प्रणालीला आढळले आहे की ऑड्यासिटीची आणखी एक प्रत चालली आहे.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "सध्या चालू असलेल्या ऑड्यासिटीमध्ये नवीन किंवा सुरु आज्ञा वापरा\n"
 "नवीन किंवा ओपन आज्ञा वापरा.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "ऑड्यासिटी आधी पासून सुरु आहे"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "ऑड्यासिटी प्रकल्प धारिका"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -984,7 +1087,8 @@ msgstr "आत्म-निदान चालवा"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "ऑड्यासिटी आवृत्ती दाखवा"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -994,9 +1098,10 @@ msgid "audio or project file name"
 msgstr "ध्वनी किंवा प्रकल्प धारिका नाव"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1009,24 +1114,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "ऑड्यासिटी प्रकल्प धारिका"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "संदेश"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "गडद ऑड्यासिटी सानुकूलन"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "मदत"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "ऑड्यासिटी मधून बाहेर पडा"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "ऑड्यासिटी नोंदवही"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1038,9 +1167,14 @@ msgstr "जतन करा(&S)..."
 msgid "Cl&ear"
 msgstr "साफ करा(&e)"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "बंद करा(&C)"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1085,47 +1219,33 @@ msgid "Error Initializing Midi"
 msgstr "एमआयडीआय (MIDI) सुरू करण्यात त्रुटी"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "ऑड्यासिटी नोंदवही"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "मेमरी च्या बाहेर!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. त्यास अधिक अनुकूलन करणे शक्य नव्हते. तरीही खूप जास्त आहे."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "स्वयंचलितमुद्रण स्तर समायोजन आवाज %f पर्यंत कमी झाले."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. त्यास अधिक अनुकूलन करणे शक्य नव्हते. तरीही खूप कमी आहे."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "स्वयंचलित मुद्रण स्तर समायोजन आवाज %.2f पर्यंत वाढवला."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. स्वीकार्य आवाज न शोधता विश्लेषणाची एकूण संख्या ओलांडली आहे. तरीही खूप उंच आहे."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. स्वीकार्य आवाज न शोधता विश्लेषणाची एकूण संख्या ओलांडली आहे. तरीही खूप कमी आहे."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले.%.2f एक स्वीकार्य खंड दिसत आहे."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "मुद्रित उपकरण निवडा\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "मुद्रित उपकरण निवडा\n"
 
 #: src/AudioIOBase.cpp
@@ -1168,8 +1288,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "मुद्रण समाप्त:\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "मुद्रण समाप्त:\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "मुद्रण समाप्त:\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "मुद्रण समाप्त:\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -1183,42 +1313,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "मुद्रित उपकरण निवडा\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "मुद्रित उपकरण निवडा\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "पुनर्मुद्रण उपकरण निवडा\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "शैली धारिका उघडण्यात बंद.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "पुनर्मुद्रण उपकरण निवडा\n"
+
+#: src/AudioIOBase.cpp
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "नमूना रेट\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
-msgid "%d - %s\n"
-msgstr "%s - %s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "ध्वनीमुद्रण त्रुटीचे अनुकरण करा\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "पुन्हा चालू करण्याचा आवाज\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "ध्वनीमुद्रण आवाज\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "ध्वनीमुद्रण आवाज\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "लागोपाठ वाजवाण्याचा आवाज: %s (नक्कल)\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "लागोपाठ वाजवाण्याचा आवाज: %s (नक्कल)\n"
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1226,8 +1354,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "मुद्रित उपकरण निवडा\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "मुद्रित उपकरण निवडा\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "पुनर्मुद्रण उपकरण निवडा\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "पुनर्मुद्रण उपकरण निवडा\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1235,8 +1373,9 @@ msgid "Automatic Crash Recovery"
 msgstr "स्वयंचलित बिघाड पुनर्प्राप्ती"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1248,12 +1387,14 @@ msgid "Recoverable &projects"
 msgstr "पुनर्प्राप्त करण्यायोग्य प्रकल्प"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "निवडा"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "नाव"
 
@@ -1264,6 +1405,10 @@ msgstr "प्रकल्प रद्द करा"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "काहीही निवडलेले नाही"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1338,6 +1483,11 @@ msgstr "प्रभाव"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "मेनू आज्ञा (घटक सोबत)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1475,11 +1625,16 @@ msgstr "काढा(&v)"
 msgid "&Rename..."
 msgstr "पुनर्नामित करा(&R)..."
 
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
 msgid "I&mport..."
 msgstr "आयात करा(&m) ..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "निर्यात...(&x)"
 
@@ -1520,7 +1675,8 @@ msgstr "पुढे जा(&U)"
 msgid "Move &Down"
 msgstr "खाली सरका(&D)"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "जतन करा(&S)"
 
@@ -1603,9 +1759,17 @@ msgid "Run"
 msgstr "चालवा"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "बंद करा"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "बेंचमार्क(Benchmark)"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1737,9 +1901,13 @@ msgid "Benchmark completed successfully.\n"
 msgstr "बेंचमार्क(Benchmark) यशस्वीरित्या पूर्ण झाले.\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "समाप्ती तारीख आणि वेळ"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "निर्माण संस्करण"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1778,6 +1946,18 @@ msgstr "वापरण्यासाठी %s साठी ध्वनी  �
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "कोणताही ध्वनी  निवडलेला नाही"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1827,10 +2007,24 @@ msgstr "चालू प्रकल्प"
 msgid "Checkpointing %s"
 msgstr "%s आयात करीत आहे"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr ":%s धारिकेवर लिहू शकलो नाही\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"आधीच्याप्रमाणेवर लेखन करण्यात ऑड्यासिटी अयशस्वी झाली.\n"
+"कदाचित %s लिहिण्याउजवे नाही किंवा ध्वनीमुद्रिका भरली आहे."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1851,6 +2045,10 @@ msgid ""
 msgstr ""
 "नोंदणी करण्यात अयशस्वी:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1948,6 +2146,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "क्लिपबोर्डवर नावे नक्कल करा(&C)"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "धारिका गहाळ आहे"
 
@@ -1956,10 +2159,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "आपण पुढे गेल्यास, आपला प्रकल्प मुद्रीकेवर जतन केला जाणार नाही. आपल्याला पाहिजे तेच आहे काय?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1971,7 +2175,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "अवलंबन तपासणी"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "काहीही नाही"
 
@@ -1979,7 +2186,7 @@ msgstr "काहीही नाही"
 msgid "Rectangle"
 msgstr "आयत"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "त्रिकोण"
 
@@ -1993,17 +2200,58 @@ msgstr "आयताकृती"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "स्वागत आहे!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Ffmpeg समर्थन संकलित नाही"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2025,8 +2273,8 @@ msgid "Locate FFmpeg"
 msgstr "एफएफएमपीईजी (FFmpeg) शोधा"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "ऑड्यासिटीला एफएफएमपीईजी (FFmpeg) ध्वनी  आयात आणि निर्यात करण्यासाठी धारिका '%s' आवश्यक आहे."
 
 #: src/FFmpeg.cpp
@@ -2039,7 +2287,8 @@ msgstr "%s चे स्थान:"
 msgid "To find '%s', click here -->"
 msgstr "'%s' शोधण्यासाठी, येथे क्लिक करा ->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "ब्राऊज़..."
 
@@ -2065,8 +2314,9 @@ msgid "FFmpeg not found"
 msgstr "एफएफएमपीईजी (Ffmpeg) सापडले नाही"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2086,25 +2336,34 @@ msgstr "हा चेतावणी पुन्हा दर्शवू न�
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "सुसंगत एफएफएमपीईजी (FFmpeg) ग्रंथालय शोधण्यात अयशस्वी."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "ऑड्यासिटी %s मध्ये धारिका  उघडण्यात अयशस्वी."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "ऑड्यासिटी %s मधील धारिका वाचण्यात अयशस्वी."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "ऑड्यासिटी%s मध्ये धारिका  यशस्वीरित्या लिहिली परंतु %s असे पुनर्निर्मित करण्यात अयशस्वी."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2141,7 +2400,9 @@ msgstr "कोणताही ध्वनी नक्कल करू नक�
 msgid "As&k"
 msgstr "विचारा(&k)"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "सर्व धारिका|*"
 
@@ -2150,6 +2411,11 @@ msgstr "सर्व धारिका|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "प्रकल्प माहिती धारिका  जतन करीत आहे"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "संदर्भविभाग"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -2162,6 +2428,10 @@ msgstr "धारिका नाव :"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "एमपी३ (MP3) धारिका"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2228,7 +2498,12 @@ msgstr "नोंदवही वारंवारता"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "डीबी"
 
@@ -2243,7 +2518,9 @@ msgstr "मोठे करा"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "हर्ट्ज"
 
@@ -2306,11 +2583,48 @@ msgstr "बर्‍याच ध्वनी  निवडला गेला. 
 msgid "Not enough data selected."
 msgstr "पुरेसा माहिती निवडलेला नाही."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "वर्णक्रम"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "वर्णक्रमीय माहिती याप्रमाणे निर्यात :"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr ":%s धारिकेवर लिहू शकलो नाही"
@@ -2488,6 +2802,11 @@ msgstr "काढून टाका"
 msgid "&Compact"
 msgstr "आज्ञा(&C)"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2495,19 +2814,19 @@ msgid "&History..."
 msgstr "इतिहास ...(&H)"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s मधील %s रेषे %d वर अंतर्गत त्रुटी.\n"
 "कृपया ऑड्यासिटी संघाला https://forum.audacityteam.org/ वर कळवा."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "अंतर्गत त्रुटी %s रेषे %d वर.\n"
 "कृपया ऑड्यासिटी संघ https://forum.audacityteam.org/ वर कळवा."
@@ -2526,7 +2845,9 @@ msgid "Track"
 msgstr "गीतपट्टा"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "नाव-पट्टी"
 
@@ -2586,7 +2907,8 @@ msgstr "गीतपट्टा नाव प्रविष्ट करा"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "गीतपट्टा नाव"
 
@@ -2597,11 +2919,13 @@ msgstr "एक किंवा अधिक जतन केलेल्या �
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "ऑड्यासिटी पहिल्यांदा सुरुवात"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "ऑड्यासिटी वापरण्यासाठी भाषा निवडा:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2611,7 +2935,8 @@ msgstr "ऑड्यासिटी वापरण्यासाठी भा�
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "तुम्ही निवडलेली भाषा, %s (%s), प्रणालीच्या भाषेप्रमाणे नाही, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "खा‍त्री करा"
 
@@ -2629,12 +2954,13 @@ msgstr ""
 "जुनी धारिका  '%s' म्हणून जतन केली"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "ऑड्यासिटी प्रकल्प उघडत आहे"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "ऑड्यासिटी कराओके(Karaoke)%s"
 
 #: src/LyricsWindow.cpp
@@ -2685,19 +3011,23 @@ msgid "Mixing and rendering tracks"
 msgstr "गीतपट्टाचे मिश्रण आणि प्रस्तुतीकरण"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "ऑड्यासिटी मिश्रण बोर्ड %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "मिळवा"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "वेग"
 
@@ -2706,17 +3036,23 @@ msgid "Musical Instrument"
 msgstr "संगीत वाद्य"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "पॅन"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "मौन"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "एकल"
 
@@ -2724,15 +3060,18 @@ msgstr "एकल"
 msgid "Signal Level Meter"
 msgstr "सिग्नल स्तर मीटर"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "मिळवा घसारपट्टी स्थानांतरित केले"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "गति घसारपट्टी स्थानांतरित केले"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "पॅन स्लायडर स्थानांतरित केले"
 
@@ -2763,9 +3102,9 @@ msgstr ""
 "ते लोड केले जाणार नाही."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2798,16 +3137,19 @@ msgstr ""
 "\n"
 "केवळ विश्वासार्ह स्त्रोतांमधूनच घटक वापरा"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "होय"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "नाही"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "ऑड्यासिटी घटक लोडर"
 
 #: src/ModuleManager.cpp
@@ -2829,6 +3171,118 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "टीप गीतपट्टा"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+#, fuzzy
+msgid "G"
+msgstr "जीबी(GB)"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+#, fuzzy
+msgid "B"
+msgstr "डीबी"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2938,7 +3392,8 @@ msgstr "सर्व निवडा(&S)"
 msgid "C&lear All"
 msgstr "सर्व साफ करा(&l)"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "सक्रीय करा(&E)"
 
@@ -3012,6 +3467,21 @@ msgstr ""
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "चाळण लागू करण्यासाठी, सर्व निवडलेल्या गीतपट्टावर समान नमुना दर असणे आवश्यक आहे."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "मुद्रण केलेले ध्वनी"
@@ -3030,10 +3500,11 @@ msgid "Dropouts"
 msgstr "ड्रॉपआउट्स"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3073,11 +3544,11 @@ msgid "Inspecting project file data"
 msgstr "प्रकल्प धारिका  माहिती निरीक्षण"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3120,11 +3591,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "चेतावणी - गहाळ झालेली उपनाम आधीच्याप्रमाणे"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "\"%s\" पुस्तिकाची प्रकल्प तपासणी\n"
@@ -3149,12 +3620,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "चेतावणी - गहाळ उर्फ ​​सारांश आधीच्याप्रमाणे (ली)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3212,7 +3683,8 @@ msgstr "चेतावणी - अनाथ तुकडा आधीच्य�
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "प्रगती"
 
@@ -3239,6 +3711,11 @@ msgid "<untitled>"
 msgstr "<अनामित>"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "प्रकल्प"
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
 msgstr "कोडेक शोधण्यात अपयश"
 
@@ -3259,6 +3736,14 @@ msgid "Failed to restore connection"
 msgstr "कोडेक शोधण्यात अपयश"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to execute a project file command:\n"
+"\n"
+"%s"
+msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
+
+#: src/ProjectFileIO.cpp
 #, c-format
 msgid ""
 "Unable to prepare project file command:\n"
@@ -3267,12 +3752,97 @@ msgid ""
 msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "ऑड्यासिटी प्रकल्प जतन करत आहे"
+
+#: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
 msgstr "एमपी३ (MP3) प्रवाह सुरू करण्यात बंद"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "चाचणी धारिका उघडण्यात / तयार करण्यात बंद."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "चाचणी धारिका उघडण्यात / तयार करण्यात बंद."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "चाचणी धारिका उघडण्यात / तयार करण्यात बंद."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "चाचणी धारिका उघडण्यात / तयार करण्यात बंद."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "चाचणी धारिका उघडण्यात / तयार करण्यात बंद."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "चाचणी धारिका उघडण्यात / तयार करण्यात बंद."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
+msgstr "चाचणी धारिका उघडण्यात / तयार करण्यात बंद."
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: src/ProjectFileIO.cpp
@@ -3285,12 +3855,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "अनाथ तुकडा धारिका  : '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "विरामित स्थिती स्थिती सेट करण्यात बंद."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "कोडेक शोधण्यात अपयश"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3301,9 +3892,9 @@ msgid "Error Writing to File"
 msgstr "धारिकावर लिहिताना त्रुटी: \"%s\""
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3314,8 +3905,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "पुनर्प्राप्त करण्याउजवे प्रकल्प"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "ऑड्यासिटी"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -3325,10 +3925,10 @@ msgstr "(पुनर्प्राप्त)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "ही धारिका ऑड्यासिटी %s वापरून जतन केली.\n"
 "आपण ऑड्यासिटी %s वापरत आहात. ही धारिका उघडण्यासाठी आपल्याला नवीन आवृत्तीमध्ये श्रेणी सुधारित करण्याची आवश्यकता असू शकते."
@@ -3336,6 +3936,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "प्रकल्प धारिका उघडू शकत नाही"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3350,6 +3954,10 @@ msgid "Unable to parse project information."
 msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "पुनर्प्राप्त करण्याउजवे प्रकल्प"
 
@@ -3358,12 +3966,35 @@ msgid "Error Saving Project"
 msgstr "प्रकल्प जतन करताना त्रुटी आली"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "रिक्त प्रकल्प जतन करत आहे(&e)"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3371,8 +4002,24 @@ msgstr ""
 "सुदैवाने, खालील प्रकल्प स्वयंचलितपणे पुनर्प्राप्त केले जाऊ शकतात:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"मागील वेळी ऑड्यासिटी चालू असताना काही प्रकल्प योग्यरीत्या जतन केले नाहीत.\n"
+"सुदैवाने, खालील प्रकल्प स्वयंचलितपणे पुनर्प्राप्त केले जाऊ शकतात:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "प्रकल्प पुनर्प्राप्त झाला"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "तात्पुरती धारिका  निर्देशिका"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3402,6 +4049,17 @@ msgstr "चेतावणी - रिक्त प्रकल्प"
 msgid "Insufficient Disk Space"
 msgstr "डिस्कवरील जागा"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3421,8 +4079,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sप्रकल्प \"%s\" असा जतन करा..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'प्रकल्प जतन करा' ऑड्यासिटी प्रकल्पासाठी आहे, ध्वनी आधीच्याप्रमाणे नाही.\n"
@@ -3499,11 +4158,12 @@ msgid "Error Opening Project"
 msgstr "प्रकल्प उघडण्यात त्रुटी"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "आपण स्वयंचलितपणे तयार केलेली बॅकअप धारिका उघडण्याचा प्रयत्न करीत आहात.\n"
 "असे केल्याने गंभीर माहिती गमावला जाऊ शकतो.\n"
@@ -3536,6 +4196,12 @@ msgid "Error Opening File or Project"
 msgstr "धारिका किंवा प्रकल्प उघडण्यात त्रुटी"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "प्रकल्प पुनर्प्राप्त झाला"
 
@@ -3561,12 +4227,33 @@ msgid "Error Importing"
 msgstr "आयात करण्यात त्रुटी"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "प्रकल्प स्थापित करा"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "प्रकल्प धारिका उघडू शकत नाही"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "आज्ञा(&C)"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3577,8 +4264,8 @@ msgid "Automatic database backup failed."
 msgstr "स्वयंचलित जतन सुरू:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "ऑड्यासिटी आवृत्ती %s मध्ये आपले स्वागत आहे"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3636,6 +4323,12 @@ msgstr[1] "%d मिनिट"
 msgid "%s and %s."
 msgstr "%s आणि %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3650,6 +4343,21 @@ msgstr "समांतर स्क्रोलबार"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "अनुलंब स्क्रोलबार"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -3770,7 +4478,8 @@ msgstr "सर्व प्राधान्ये"
 msgid "SelectionBar"
 msgstr "निवडपट्टी"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "वर्णक्रमीय निवड"
 
@@ -3778,46 +4487,55 @@ msgstr "वर्णक्रमीय निवड"
 msgid "Timer"
 msgstr "वेळ:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "साधने"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "परिवहन"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "मिश्रण"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "मीटर"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "वाद्य माप"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "ध्वनीमुद्रण मीटर"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "संपादन करा"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "उपकरण"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "गतीने वाजवा"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "स्क्रब"
 
@@ -3832,7 +4550,10 @@ msgstr "मापक"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "गीतपट्टा"
 
@@ -3942,7 +4663,8 @@ msgid "Activation level (dB):"
 msgstr "सक्रियन पातळी (डीबी):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "ऑड्यासिटीमध्ये आपले स्वागत आहे!"
 
 #: src/SplashDialog.cpp
@@ -4069,10 +4791,25 @@ msgstr "टॅग्जधारिका जतन करताना त्र
 msgid "Unsuitable"
 msgstr "घटक अनुपयुक्त"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "तात्पुरती धारिका  निर्देशिका"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "ऑड्यासिटी धारिका लिहू शकले नाही:\n"
@@ -4092,9 +4829,9 @@ msgstr ""
 "   %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4103,9 +4840,9 @@ msgstr ""
 "लेखनासाठी."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "ऑड्यासिटी धारिकेवर प्रतिमा लिहू शकत नाही:\n"
@@ -4122,9 +4859,9 @@ msgstr ""
 " %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4134,9 +4871,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4145,8 +4882,9 @@ msgstr ""
 "खराब png स्वरूप कदाचित?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "ऑड्यासिटी आपली पूर्वनिर्धारित थीम वाचू शकत नाही.\n"
@@ -4184,9 +4922,9 @@ msgstr ""
 "आधीच उपस्थित होते. अधिलिखित करायचे?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "ऑड्यासिटी धारिका  जतन करू शकला नाही:\n"
@@ -4225,7 +4963,11 @@ msgstr "विशिष्ट"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "कालावधी"
 
@@ -4236,7 +4978,8 @@ msgid "Time Track"
 msgstr "वेळ गीतपट्टा"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "ऑड्यासिटी वेळ मोजणेलेली मुद्रण"
 
 #: src/TimerRecordDialog.cpp
@@ -4310,7 +5053,8 @@ msgstr "चालू प्रकल्प"
 msgid "Recording start:"
 msgstr "ध्वनीमुद्रण प्रारंभ:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "कालावधी:"
 
@@ -4331,7 +5075,8 @@ msgid "Action after Timer Recording:"
 msgstr "समयबद्ध ध्वनीमुद्रण नंतरची क्रिया:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "ऑड्यासिटी वेळ मोजणेलेली मुद्रण  प्रगती"
 
 #: src/TimerRecordDialog.cpp
@@ -4427,6 +5172,7 @@ msgstr "099 दिवस 024 ता 060 मी 060 सेकंद"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "प्रारंभ तारीख आणि वेळ"
@@ -4471,7 +5217,8 @@ msgstr "स्वयंचलित निर्यात सक्रिय क
 msgid "Export Project As:"
 msgstr "प्रकल्प म्हणून निर्यात करणे :"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "पर्याय"
 
@@ -4484,7 +5231,8 @@ msgid "Do nothing"
 msgstr "काही करू नका"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "ऑड्यासिटी मधून बाहेर पडा"
 
 #: src/TimerRecordDialog.cpp
@@ -4508,7 +5256,8 @@ msgid "Scheduled to stop at:"
 msgstr "येथे थांबण्याचे वेळापत्रक:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "ऑड्यासिटी वेळ मोजणेलेली मुद्रण  - प्रारंभ होण्याची वाट पहात आहे"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4516,6 +5265,14 @@ msgstr "ऑड्यासिटी वेळ मोजणेलेली मु
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "ध्वनीमुद्रण यापासून प्रारंभ होईल:"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -4526,7 +5283,8 @@ msgid "Recording Exported:"
 msgstr "ध्वनीमुद्रण निर्यात केले:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "ऑड्यासिटी वेळ मोजणेलेली मुद्रण - प्रतीक्षा"
 
 #: src/TrackInfo.cpp
@@ -4652,6 +5410,10 @@ msgstr "गीतपट्टा वर हलवा"
 msgid "Move Track Down"
 msgstr "गीतपट्टा खाली हलवा"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4718,6 +5480,20 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s लागू करत आहे ..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "तुकडी आज्ञा"
@@ -4732,16 +5508,33 @@ msgstr "%s हे %s द्वारे स्वीकारलेले घट
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "अवैध मूल्य घटक '%s' साठी :%s असावे"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "आज्ञा"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s पुन्हा करा"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4848,13 +5641,24 @@ msgstr "फीत"
 msgid "Envelopes"
 msgstr "लिफाफे"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "नावपट्टी"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "बॉक्स"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -4864,7 +5668,8 @@ msgstr "संक्षिप्त"
 msgid "Type:"
 msgstr "प्रभाव:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "स्वरूप:"
 
@@ -4892,9 +5697,17 @@ msgstr "टिप्पण्या"
 msgid "Command:"
 msgstr "आज्ञा:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "आज्ञाला मदत करते."
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4924,12 +5737,17 @@ msgstr "धारिकेमध्ये  निर्यात करणे ."
 msgid "Builtin Commands"
 msgstr "अंगभूत आज्ञा"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "ऑड्यासिटी संघ सदस्य"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "ऑड्यासिटी अंगभूत आज्ञा प्रदान करते"
 
 #: src/commands/LoadCommands.cpp
@@ -4980,11 +5798,22 @@ msgstr "प्रकल्प जनत करा."
 msgid "Saves a copy of current project."
 msgstr "प्रकल्प जनत करा."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "प्राधान्य मिळवा"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "नाव:"
 
@@ -5032,7 +5861,8 @@ msgstr "पूर्ण पडदा"
 msgid "Toolbars"
 msgstr "साधनपट्टी"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "प्रभाव"
 
@@ -5172,7 +6002,8 @@ msgstr "ठेवा"
 msgid "Add"
 msgstr "जोडा"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "काढा"
 
@@ -5257,7 +6088,8 @@ msgid "Edited Envelope"
 msgstr "लिफाफा स्थापित करा"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "लिफाफा"
 
@@ -5300,6 +6132,14 @@ msgstr "बिट रेट:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "आकार परिवर्तन :"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5349,7 +6189,10 @@ msgstr "पॅन:"
 msgid "Set Track Visuals"
 msgstr "गीतपट्टा प्रदर्शन निवड करा"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "रेखीय"
 
@@ -5392,6 +6235,12 @@ msgstr "वर्णक्रमीय प्रीफेस वापरा"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "वर्णक्रमी निवडा"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5447,12 +6296,18 @@ msgstr "आपण एक ध्वनी निवडला आहे, जो �
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "स्वंय डकला एक नियंत्रण ध्वनी आवश्यक आहे जो निवडलेल्या ध्वनी खाली ठेवला पाहिजे."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "डक रक्कम:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "सेकंद"
 
@@ -5476,7 +6331,8 @@ msgstr "अंतर्गत फिका लांबी कमी करा :
 msgid "Inner &fade up length:"
 msgstr "अंतर्गत धुके वाढण्यास लांबी:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "सुरुवात:"
 
@@ -5603,6 +6459,10 @@ msgid "from (Hz)"
 msgstr "(Hz) पासून"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "(Hz)च्यापर्यत"
 
@@ -5610,11 +6470,13 @@ msgstr "(Hz)च्यापर्यत"
 msgid "t&o"
 msgstr "पर्यत"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "टक्के बदल:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "टक्के बदल"
 
@@ -5623,12 +6485,24 @@ msgid "&Use high quality stretching (slow)"
 msgstr "उच्च प्रतीचे ताणून (मंद) वापरा"
 
 #: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
 msgid "45"
 msgstr "4"
 
 #: src/effects/ChangeSpeed.cpp
 msgid "78"
 msgstr "8"
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -5654,6 +6528,7 @@ msgstr "प्रमाणित विनाइल आरपीएम (rpm):"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "आरपीएम पासून"
@@ -5666,6 +6541,7 @@ msgstr "पासून"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "आरपीएम पर्यंत"
@@ -5808,6 +6684,17 @@ msgstr "संकुचित करणारा"
 msgid "Compresses the dynamic range of audio"
 msgstr "\"ध्वनी ची गतिमान श्रेणी संकुचित करा \""
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "% .1f सेकंद"
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
@@ -5942,7 +6829,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "ध्वनी च्या दोन निवडींमधील RMS ध्वनी आवाजमधील फरक मोजणेण्यासाठी कॉन्ट्रास्ट विश्लेषक."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "अंत"
 
@@ -6002,6 +6890,18 @@ msgstr "अंतर(&D) :"
 msgid "&Help"
 msgstr "मदत(&H)"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "शून्य"
@@ -6009,6 +6909,13 @@ msgstr "शून्य"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "अनिश्चित"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6062,6 +6969,12 @@ msgstr "वर्तमान फरक"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "मोजणेलेल्या अग्रभागाची पातळी"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6130,6 +7043,12 @@ msgstr "WCAG २.० मधील यशस्वी निकष १.4.:: अ�
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
 msgstr "मिळालेली माहिती"
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
@@ -6394,6 +7313,12 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "टेलिफोनवर कळफलकद्वारे तयार केल्याप्रमाणे ड्युअल-ध्वनी मल्टी-वारंवारता (DTMF)ध्वनी व्युत्पन्न करते"
 
 #: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "DTMF क्रम:"
 
@@ -6401,7 +7326,9 @@ msgstr "DTMF क्रम:"
 msgid "&Amplitude (0-1):"
 msgstr "मोठेपणा (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "कालावधी(&D):"
 
@@ -6422,6 +7349,12 @@ msgstr "% .1f सेकंद"
 msgid "Tone duration:"
 msgstr "स्वर वेळ:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
+
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "मौन कालावधी:"
@@ -6440,7 +7373,8 @@ msgstr "प्रतिध्वनी"
 msgid "Repeats the selected audio again and again"
 msgstr "ऑड्यासिटी प्राधान्ये पूर्वनिर्धारीत करा"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "विनंती केलेले मूल्य मेमरी क्षमतेपेक्षा जास्त आहे."
 
@@ -6464,7 +7398,8 @@ msgstr "पूर्व-निर्धारित"
 msgid "Export Effect Parameters"
 msgstr "घटक संपादित करा(&E)"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "धारिका उघडू शकले नाही: \"%s\""
@@ -6487,6 +7422,12 @@ msgstr "घटक संपादित करा(&E)"
 #, c-format
 msgid "%s: is not a valid presets file.\n"
 msgstr "प्रेसेट धारिका लोड करण्यात बंद.\n"
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
@@ -6803,6 +7744,10 @@ msgid "Equalization"
 msgstr "बरोबरी"
 
 #: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Filter Curve EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
 msgid "Graphic EQ"
 msgstr "ग्राफ़िक EQ"
 
@@ -6811,12 +7756,32 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "विशिष्ट वारंवारताच्या आवाज पातळी समायोजित करते"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "बेस(dB):"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "बेस"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -6851,8 +7816,17 @@ msgid "Effect Unavailable"
 msgstr "प्रभाव अनुपलब्ध"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "अधिकतम dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
@@ -6861,6 +7835,16 @@ msgstr "न्यूनतम dB"
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "- dB"
 msgstr "- डीबी"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
 
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
@@ -6941,7 +7925,20 @@ msgid "D&efault"
 msgstr "पूर्वनिर्धारित(&e)"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
+msgstr "एसएसई थ्रेडेड(&T)"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "AV&X Threaded"
 msgstr "एसएसई थ्रेडेड(&T)"
 
 #: src/effects/Equalization.cpp
@@ -7183,16 +8180,25 @@ msgid "Builtin Effects"
 msgstr "अंगभूत प्रभाव"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "ऑड्यासिटीला अंगभूत प्रभाव प्रदान करते"
 
 #: src/effects/LoadEffects.cpp
 msgid "Unknown built-in effect name"
 msgstr "अज्ञात अंतर्निहित प्रभाव नाव"
 
+#: src/effects/Loudness.cpp
+msgid "perceived loudness"
+msgstr ""
+
 #: src/effects/Loudness.cpp src/widgets/Meter.cpp
 msgid "RMS"
 msgstr "आरएमएस"
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Sets the loudness of one or more tracks"
@@ -7216,9 +8222,26 @@ msgstr "प्रक्रिया करीत आहे:%s"
 msgid "&Normalize"
 msgstr "नेहमीसारखा"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "स्टीरिओ वाहिनी स्वतंत्रपणे सामान्य करा"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -7264,8 +8287,37 @@ msgid "Second greatest"
 msgstr "दुसरा गीतपट्टा"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "4 (पूर्वनिर्धारित)"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "4 (पूर्वनिर्धारित)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -7360,8 +8412,9 @@ msgid "Step 1"
 msgstr "चरण 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "फक्त आवाजाची काही सेकंद निवडा जेणेकरून ओड्यासीटीला काय चाळण करावे हे माहित असेल,\n"
@@ -7413,13 +8466,63 @@ msgstr "विंडो प्रभाव (&W)"
 msgid "Window si&ze:"
 msgstr "विंडो चा आकार(&s)"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 - (पूर्वनिर्धारित)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "विंडो प्रति चरण(&t)"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7545,6 +8648,7 @@ msgstr "पॉलस्ट्रेच केवळ अत्यंत काल
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "विस्तार गुणक :"
@@ -7987,6 +9091,11 @@ msgstr "पूर्वनिर्धारित वापरा"
 msgid "Restore Defaults"
 msgstr "पूर्वनिर्धारीत करा"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8145,6 +9254,10 @@ msgstr "मौन शोधा"
 msgid "Tr&uncate to:"
 msgstr "यावर काप करा:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "मध्ये संकुचित करा:"
@@ -8158,7 +9271,8 @@ msgid "VST Effects"
 msgstr "VST प्रभाव"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "ऑड्यासिटीमध्ये VST प्रभाव वापरण्याची क्षमता जोडते."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8170,7 +9284,8 @@ msgstr "शोधणे शेल VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "%d  पैकी %d नोंदणी: % -64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "ग्रंथालय लोड करणे शक्य नाही"
 
@@ -8182,15 +9297,25 @@ msgstr "VST प्रभाव विकल्प"
 msgid "Buffer Size"
 msgstr "तात्पुरती साठवण आकार"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "तात्पुरती साठवण आकार (8 ते 1048576 नमुने)(&B):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "प्रलंबित भरपाई"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "भरपाई सक्रिय (&c)"
 
@@ -8216,7 +9341,18 @@ msgid "Save VST Preset As:"
 msgstr "VST प्रेसेट म्हणून जतन करा:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "ध्वनी एकक पूर्व-निर्धारित निर्यात करा"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "ध्वनी एकक पूर्व-निर्धारित निर्यात करा"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "ऑड्यासिटी प्रकल्प धारिका"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8243,7 +9379,8 @@ msgstr "VST प्रेसेट लोड करण्यात त्रु�
 msgid "Unable to load presets file."
 msgstr "प्रेसेट धारिका लोड करण्यात बंद."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "प्रभाव समाजोयन"
 
@@ -8259,6 +9396,12 @@ msgstr "पूर्वनिर्धारितची धारिका व�
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "ही घटक धारिका %s मधून जतन केली गेली. पुढे चालू ठेवायचे?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -8294,7 +9437,8 @@ msgid "Audio Unit Effects"
 msgstr "ध्वनी एकक प्रभाव"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "ऑड्यासिटीला ध्वनी  एकक प्रभाव समर्थन प्रदान करते"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8310,8 +9454,16 @@ msgid "Audio Unit Effect Options"
 msgstr "ध्वनी एकक प्रभाव पर्याय"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "वापरकर्ता मुखपृष्ठ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -8367,6 +9519,14 @@ msgid "Unable to store preset in config file"
 msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not import \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "प्रकल्प माहिती पुस्तिका सापडली नाही: \"%s\""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Export Audio Unit Preset As %s:"
 msgstr "ध्वनी एकक पूर्व-निर्धारित निर्यात करा"
@@ -8374,6 +9534,14 @@ msgstr "ध्वनी एकक पूर्व-निर्धारित �
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Standard Audio Unit preset file"
 msgstr "ध्वनी एकक पूर्व-निर्धारित निर्यात करा"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not export \"%s\" preset\n"
+"\n"
+"%s"
+msgstr "प्रकल्प माहिती पुस्तिका सापडली नाही: \"%s\""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Export Audio Unit Presets"
@@ -8393,6 +9561,11 @@ msgid "Failed to retrieve preset content"
 msgstr "प्रवाहाचे वर्णन पुनर्प्राप्त करण्यात बंद"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "कोडेक शोधण्यात अपयश"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "नमूना दर परिवर्तन"
 
@@ -8403,6 +9576,21 @@ msgstr ""
 "नोंदणी करण्यात अयशस्वी:\n"
 "%s"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "प्रवाहाचे वर्णन पुनर्प्राप्त करण्यात बंद"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "प्रवाहाचे वर्णन पुनर्प्राप्त करण्यात बंद"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
+
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
 #: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
@@ -8411,6 +9599,7 @@ msgstr "ध्वनी  एकक"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA प्रभाव"
@@ -8420,16 +9609,23 @@ msgid "Provides LADSPA Effects"
 msgstr "LADSPA प्रभाव प्रदान करतो"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "ऑड्यासिटी यापुढे VST-ब्रिज वापरणार नाही"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "LADSPA प्रभाव पर्याय"
 
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s: %s"
@@ -8437,6 +9633,14 @@ msgstr "%s: %s"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "प्रभाव उत्पादन"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8446,6 +9650,10 @@ msgstr "LV2 प्रभाव समायोजन"
 #, c-format
 msgid "&Buffer Size (8 to %d) samples:"
 msgstr "तात्पुरती साठवण आकार (8 ते 1048576 नमुने)(&B):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -8469,12 +9677,19 @@ msgstr "%d वक्र %s वर निर्यात केले\n"
 msgid "Generator"
 msgstr "निर्माता"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 प्रभाव"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "ऑड्यासिटीला LV 2 प्रभाव समर्थन प्रदान करते"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8482,7 +9697,8 @@ msgid "Nyquist Effects"
 msgstr "'नाइक्विस्ट (Nyquist) प्रभाव"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "ऑड्यासिटीला 'नाइक्विस्ट (Nyquist) प्रभाव समर्थन प्रदान करते"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8497,6 +9713,12 @@ msgstr "'नाइक्विस्ट (Nyquist) कार्यकर्ता
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "III - निर्मिती 'नाइक्विस्ट (Nyquist) प्लग-इन शीर्षलेख"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -8543,6 +9765,16 @@ msgstr "त्रुटिसुधार उत्पादित: "
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "प्रक्रिया पूर्ण झाली ."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -8623,6 +9855,19 @@ msgid "Could not determine language"
 msgstr "भाषा ठरवू शकलो नाही"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "प्रेसेट धारिका लोड करण्यात बंद.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "'नाइक्विस्ट (Nyquist) आज्ञा प्रविष्ट करा: "
 
@@ -8677,7 +9922,8 @@ msgstr "धारिका निवडा"
 msgid "Save file as"
 msgstr "धारिका जनत करा"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "अशीर्षकांकित"
 
@@ -8686,7 +9932,8 @@ msgid "Vamp Effects"
 msgstr "व्हँप प्रभाव"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "ऑड्यासिटीला व्हँप प्रभाव समर्थन प्रदान करते"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -8793,6 +10040,18 @@ msgstr "स्वरूप पर्याय"
 msgid "Channel: %2d"
 msgstr "वाहिनी:%2d"
 
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
+
 #: src/export/Export.cpp
 #, c-format
 msgid "Output Channels: %2d"
@@ -8867,6 +10126,20 @@ msgstr ""
 "आपण अपरिचित धारिका विस्तारासह धारिका नाव निवडले आहे.\n"
 "आपण सुरू ठेवू इच्छिता?"
 
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "\"%s\" couldn't be found."
+msgstr "घटक \"%s\" आढळले."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "प्रेसेट धारिका लोड करण्यात बंद."
+
 #: src/export/ExportFFmpeg.cpp
 msgid ""
 "Properly configured FFmpeg is required to proceed.\n"
@@ -8912,6 +10185,14 @@ msgid ""
 msgstr ""
 "एफएफएमपीईजी (FFmpeg) ध्वनी सांकेतिक आज्ञावली 0x% x शोधू शकत नाही.\n"
 "या सांकेतिक आज्ञावलीसाठी समर्थन बहुदा संकलित केलेले नाही."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -8977,7 +10258,8 @@ msgstr "%s म्हणून ध्वनी निर्यात करा"
 msgid "Invalid sample rate"
 msgstr "अवैध नमुना दर"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "पुन्हा नमुना"
 
@@ -9007,6 +10289,14 @@ msgstr "आपण खालील दरापैकी एकास पुन�
 msgid "Sample Rates"
 msgstr "नमूना रेट"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "बिट रेट:"
@@ -9014,6 +10304,49 @@ msgstr "बिट रेट:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "गुणवत्ता:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -9028,6 +10361,10 @@ msgid "Constrained"
 msgstr "स्थिर"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "ध्वनी...(&A)"
 
@@ -9036,8 +10373,44 @@ msgid "Low Delay"
 msgstr "विलंबता"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "मध्यम गीतपट्टा"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -9108,8 +10481,17 @@ msgid "Replace preset '%s'?"
 msgstr "पूर्वनिर्धारित '%s' पुनर्स्थित करा?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "&साफ करा\tCtrl+L"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "मुख्य"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9217,6 +10599,10 @@ msgstr "भाषा :"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "बिट तात्पुरती साठवण"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9353,6 +10739,11 @@ msgstr ""
 "0 - पूर्वनिर्धारित\n"
 "मि - 1\n"
 "कमाल - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LPC वापरा"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9512,6 +10903,17 @@ msgstr "निर्यात करण्यासाठी कोणतेह�
 msgid "Select xml file to export presets into"
 msgstr "यामध्ये पूर्वनिर्धारित सेट करण्यासाठी एक्सएमएल धारिका निवडा"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "स्वरूप अंदाज करण्यास असमर्थ"
@@ -9614,8 +11016,23 @@ msgid "145-185 kbps"
 msgstr "मध्यम, 145-185 kbps"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "सामान्य, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "मध्यम, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
 msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
+msgstr "मध्यम, 145-185 kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -9638,7 +11055,17 @@ msgstr "सामान्य, 170-210 kbps"
 msgid "Medium, 145-185 kbps"
 msgstr "मध्यम, 145-185 kbps"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "मानक"
 
@@ -9689,8 +11116,8 @@ msgid "Locate LAME"
 msgstr "Lame शोधा"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "एमपी३ (MP3) तयार करण्यासाठी धोक्यास धारिका%s आवश्यक आहे."
 
 #: src/export/ExportMP3.cpp
@@ -9718,13 +11145,34 @@ msgid "Where is %s?"
 msgstr "%s कुठे आहे?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "आपण lame_enc.dll v%d.%d शी दुवा साधत आहात. ही आवृत्ती ऑड्यासिटी%d.%d.%d सह सुसंगत नाही.\n"
 "कृपया 'लेम फॉर ऑड्यासिटी' ची नवीनतम आवृत्ती डाउनलोड करा."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "प्रकल्प माहिती धारिका  जतन करीत आहे"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -9932,6 +11380,11 @@ msgstr ""
 "\n"
 "आपण ते तयार करू इच्छिता?"
 
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Continue to export remaining files?"
+msgstr "प्रेसेट धारिका लोड करण्यात बंद."
+
 #. i18n-hint: The second %s gives some letters that can't be used.
 #: src/export/ExportMultiple.cpp
 #, c-format
@@ -9970,6 +11423,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "जलद वेळ प्रस्तुत  गुणवत्ता सेट करण्यात बंद"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "प्रेसेट धारिका लोड करण्यात बंद."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "प्रेसेट धारिका लोड करण्यात बंद."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "प्रेसेट धारिका लोड करण्यात बंद."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "प्रेसेट धारिका लोड करण्यात बंद."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "प्रेसेट धारिका लोड करण्यात बंद."
 
@@ -9980,6 +11453,10 @@ msgstr "निवडलेला ध्वनी ओग व्हॉर्बि
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "ध्वनी ओग व्हॉर्बिस(Ogg Vorbis) म्हणून निर्यात करीत आहे"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -9998,8 +11475,28 @@ msgid "Other uncompressed files"
 msgstr "इतर एकत्रित धारिका"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "आयात करण्यात त्रुटी"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -10027,11 +11524,11 @@ msgid "All supported files"
 msgstr "सर्व धारिका | * | सर्व समर्थित धारिका |"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\"\n"
@@ -10040,11 +11537,11 @@ msgstr ""
 "आधीच्याप्रमाणे> आयात करा> एमआयडीआय (MIDI) वर क्लिक करून ते संपादित करा."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\"\n"
 "एमआयडीआय (MIDI) आधीच्याप्रमाणे आहे, ध्वनी आधीच्याप्रमाणे नाही.\n"
@@ -10056,18 +11553,18 @@ msgid "Select stream(s) to import"
 msgstr "आयात करण्यासाठी प्रवाह (रे) निवडा"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "ऑड्यासिटीची ही आवृत्ती%s समर्थनासह संकलित केलेली नाही."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक ध्वनी सीडी गीतपट्टा आहे.\n"
 "ऑड्यासिटी थेट ध्वनी सीडी उघडू शकत नाही.\n"
@@ -10076,10 +11573,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" ही एक वाजवा यादी आधीच्याप्रमाणे आहे.\n"
@@ -10088,10 +11585,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक Windows Media ध्वनी आधीच्याप्रमाणे आहे.\n"
@@ -10100,10 +11597,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक प्रगत ध्वनी सांकेतिक आज्ञावली आधीच्याप्रमाणे आहे.\n"
@@ -10112,12 +11609,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक कूटबद्ध ध्वनी आधीच्याप्रमाणे आहे.\n"
@@ -10128,10 +11625,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक रियलप्लेयर मीडिया आधीच्याप्रमाणे आहे.\n"
@@ -10140,12 +11637,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" एक टीप-आधारित धारिका आहे, ध्वनी धारिका नाही.\n"
 "ऑड्यासिटी या प्रकारची धारिका  उघडू शकत नाही.\n"
@@ -10154,10 +11651,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10170,10 +11667,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक वॅव्हपॅक ध्वनी आधीच्याप्रमाणे आहे.\n"
@@ -10182,10 +11679,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक Dolby डिजिटल ध्वनी आधीच्याप्रमाणे आहे.\n"
@@ -10194,10 +11691,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक ओग स्पेक्स ध्वनी आधीच्याप्रमाणे आहे.\n"
@@ -10206,10 +11703,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" एक व्हिडिओ धारिका  आहे.\n"
@@ -10223,20 +11720,31 @@ msgstr "घटक \"%s\" आढळले."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "ऑड्यासिटीने धारिका '%s' चा प्रभाव ओळखला नाही.\n"
 "एफएफएमपीईजी (FFmpeg) स्थापित करण्याचा प्रयत्न करा. असम्पीडित धारिकासाठी, धारिका> आयात> रॉ माहिती देखील वापरून पहा."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "परीक्षक"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10245,6 +11753,11 @@ msgstr ""
 "आयातदार अशा धारिका  समर्थित मानतातः\n"
 "%s,\n"
 "परंतु त्यापैकी कोणालाही हे धारिका  स्वरूप समजले नाही."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "प्रकल्प माहिती धारिका  जतन करीत आहे"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10259,8 +11772,57 @@ msgid "Import Project"
 msgstr "पूर्वनिर्धारित आयात करा"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "संरेखन प्रक्रियेद्वारे अंतर्गत त्रुटीचा अहवाल दिला."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "अवैध नमुना दर"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10268,11 +11830,24 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "प्रकल्प माहिती पुस्तिका सापडली नाही: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "प्रकल्प प्रारंभ करा"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "अवैध नमुना दर"
 
 #: src/import/ImportAUP.cpp
@@ -10280,9 +11855,59 @@ msgid "Invalid sequence 'numsamples' attribute."
 msgstr "अवैध नमुना दर"
 
 #: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "अवैध नमुना दर"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Failed to open %s"
 msgstr "%s काढून टाकण्यास असमर्थ"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Failed to seek to position %lld in %s"
+msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10302,40 +11927,6 @@ msgstr "सूचकांक[%02x] सांकेतिक आज्ञाव�
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "एफएलएसी(FLAC) धारिका"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "जीस्ट्रीमर (GStreamer)-सुसंगत धारिका"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "पाइपलाइनमध्ये डीसांकेतिक आज्ञावलीर जोडण्यात बंद"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "जीस्ट्रीमर (GStreamer) आयातदार"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "विरामित स्थिती स्थिती सेट करण्यात बंद."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "सूचकांक[%02x] सांकेतिक आज्ञावली[%s], भाषा[%s], बिट-दर[%s], माध्यम[%d], वेळ[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "धारिकेमध्ये कोणताही ध्वनी प्रवाह नाही."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "धारिका आयात करण्यात बंद, बदल अयशस्वी झाला."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "जीस्ट्रीमर (GStreamer)- त्रुटी : %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10393,6 +11984,14 @@ msgstr "धारिका%s उघडू शकली नाही."
 msgid "MP3 files"
 msgstr "एमपी३ (MP3) धारिका"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "ओग व्हॉर्बिस(Ogg Vorbis) धारिका"
@@ -10427,8 +12026,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "डब्ल्यूएवी(WAV), AIFF, आणि इतर संकुचित प्रभाव"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "डब्ल्यूएवी(WAV) (मायक्रोसॉफ्ट) 32-बिट फ्लोट पीसीएम"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-बिट PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -10439,12 +12132,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-बिट PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-बिट PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-बिट PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-बिट दशमलव"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-बिट दशमलव"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "डब्ल्यूएवी(WAV) (मायक्रोसॉफ्ट) 32-बिट फ्लोट पीसीएम"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 बिट्"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -10455,12 +12192,20 @@ msgid "24 bit DWVW"
 msgstr "24 बिट्"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-बिट PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-बिट PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -10571,6 +12316,10 @@ msgstr "नमूना रेट:"
 msgid "&Import"
 msgstr "आयात करा(&I)"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -10591,6 +12340,7 @@ msgstr "%s उजवीकडे"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, fuzzy, c-format
 msgid "%s %d of %d clip %s"
@@ -10614,6 +12364,7 @@ msgstr "समाप्त"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -10640,7 +12391,8 @@ msgstr "वेळ फीत उजवीकडे हलविली"
 msgid "Time shifted clips to the left"
 msgstr "वेळ फीत डावीकडे हलविली"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "समय-स्थानांतरण"
 
@@ -10778,7 +12530,8 @@ msgstr "निवडलेले ध्वनी गीतपट्टा %.2f �
 msgid "Trim Audio"
 msgstr "ट्रिम ध्वनी"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "विभागणे"
 
@@ -10903,34 +12656,6 @@ msgid "Ext&ra"
 msgstr "अतिरिक्त(&r)"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "मिश्रण(&x)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "पुनर्मुद्रण ध्वनी आवाज समायोजित करा ...(&j)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "पुनर्मुद्रण ध्वनी आवाज वाढवा(&I)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "पुनर्मुद्रण ध्वनी आवाज कमी करा(&D)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "ध्वनीमुद्रण आवाज समायोजित करा ..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "ध्वनीमुद्रण आवाज वाढवा (&n)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "ध्वनीमुद्रण आवाज कमी करा(&e)"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "उपकरण(&v)"
 
@@ -10966,6 +12691,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "निवडलेला ध्वनी निर्यात करा"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "नावपट्टीचा मजकूर"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -11015,6 +12746,11 @@ msgstr "नावपट्टी आयात करा"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "एमआयडीआय (MIDI) धारिका निवडा"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "सर्व धारिका|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -11117,6 +12853,10 @@ msgid "E&xit"
 msgstr "बाहेर पडा(&x)"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "एफएलएसी(FLAC) म्हणून निर्यात करा"
 
@@ -11147,6 +12887,10 @@ msgid "Nothing to do"
 msgstr "पूर्ववत करण्यासाठी काहीही नाही"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "केंद्रित गीतपट्टा बंद करा(&C)"
 
@@ -11157,6 +12901,10 @@ msgstr "प्रकल्प धारिका उघडू शकत ना�
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "ध्वनीमुद्रण प्रारंभ:"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -11175,8 +12923,9 @@ msgid "&Getting Started"
 msgstr "प्रारंभ करीत आहे(&G)"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "ऑड्यासिटी मार्गदर्शक-पुस्तिका(&M)"
+#, fuzzy
+msgid "&Manual"
+msgstr "मार्गदर्शक-पुस्तिका... (&M)"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -11202,11 +12951,8 @@ msgstr "एमआयडीआय (MIDI) उपकरण माहिती ...(&
 msgid "Show &Log..."
 msgstr "नोंदी दाखवा...(&L)"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "ऑड्यासिटी बद्दल (&A)..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "जोडलेली नावपट्टी"
 
@@ -11406,6 +13152,10 @@ msgstr "सक्रिय विंडोज माध्यमातून म
 #: src/menus/NavigationMenus.cpp
 msgid "Move Forward Through Active Windows"
 msgstr "सक्रिय विंडोमधून पुढे जा"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -11892,6 +13642,7 @@ msgstr "कर्सरची उजवीकडे लांब उडी(&m)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "शोधा(&k)"
@@ -12103,18 +13854,21 @@ msgid "Created new label track"
 msgstr "नवीन नमित गीतपट्टा तयार केला"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "ऑड्यासिटी ही आवृत्ती प्रत्येक प्रकल्प विंडोसाठी फक्त एक वेळ गीतपट्टा करण्यास अनुमती देते."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "नवीन वेळ गीतपट्टा तयार केला"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "नवीन नमुना दर (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "प्रविष्ट केलेले मूल्य अवैध आहे"
 
@@ -12371,7 +14125,9 @@ msgstr "ध्वनी वाजवणे(&a)"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "ध्वनीमुद्रण(&R)"
 
@@ -12520,10 +14276,6 @@ msgstr "ओवरडब (चालू/बंद)(&O)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "संगणक आज्ञावलीद्वारे(चालू / बंद)(&f)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "स्वयंचलित ध्वनीमुद्रण स्तर अनुकूलन (चालू/बंद) (&u)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -12739,7 +14491,7 @@ msgstr "प्राधान्ये: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "ऑड्यासिटी मधून बाहेर पडा"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -12786,7 +14538,8 @@ msgstr "ध्वनी सूत्रसंचालक(&H)"
 msgid "Using:"
 msgstr "उपयोग :"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "ध्वनी वाजवा"
 
@@ -12806,7 +14559,8 @@ msgstr "वाहिनी (&n):"
 msgid "Latency"
 msgstr "विलंबता"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "मिलीसेकंद"
 
@@ -12835,7 +14589,8 @@ msgid "2 (Stereo)"
 msgstr "2 (स्टिरियो)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "निर्देशिका"
 
@@ -12848,8 +14603,22 @@ msgid "Default directories"
 msgstr "निर्देशिका"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "ब्राऊज़..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -12927,7 +14696,8 @@ msgid "Directory %s is not writable"
 msgstr "निर्देशिका %s लिहिण्यायोग्य नाही"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "ऑड्यासिटी पुन्हा सुरू होईपर्यंत तात्पुरत्या निर्देशिकेत बदल प्रभावी होणार नाहीत"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -12960,9 +14730,16 @@ msgstr "प्रभाव द्वारा समूहीकृत"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -12977,6 +14754,12 @@ msgstr "'नाइक्विस्ट (Nyquist)"
 #: src/prefs/EffectsPrefs.cpp
 msgid "&Vamp"
 msgstr "व्हँप"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -12999,11 +14782,13 @@ msgid "Plugin Options"
 msgstr "प्लगइन विकल्प"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "ऑड्यासिटी सुरू होते तेव्हा अद्यतनित प्लगइनसाठी तपासा"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "पुढच्या वेळी ऑड्यासिटी सुरू झाल्यावर प्लगइन्स रीशोधणे करा"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13183,8 +14968,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "निवड नावपट्टीवर स्नॅप झाल्यास नावपट्टी ठेवा(&t)"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "मिश्रण प्रणाली आणि ऑड्यासिटी थीम(&l)"
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13199,9 +14994,18 @@ msgstr "स्क्रब मोजणेपट्टी दर्शवा"
 msgid "Language \"%s\" is unknown"
 msgstr "भाषा \"%s\" अज्ञात आहे"
 
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "आयात / निर्यात"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "प्राधान्ये: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -13247,6 +15051,10 @@ msgstr "या रुपात नावपट्टी निर्यात �
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "निर्यात केलेल्या Allegro (.gro) धारिका  म्हणून वेळ वाचतो:"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13331,7 +15139,15 @@ msgid "&Defaults"
 msgstr "पूर्वनिर्धारीत करा(&D)"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "ऑड्यासिटी आडमार्ग असलेली एक XML धारिका  निवडा ..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13340,8 +15156,21 @@ msgstr "कळफलक आडमार्ग आयात त्रुटी"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d कळफलक आडमार्ग लोड केले\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -13362,6 +15191,15 @@ msgstr "आपण या प्रविष्टीसाठी की नि�
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "आपण आडमार्ग लागू करण्यापूर्वी बंधनकारक निवडणे आवश्यक आहे"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -13432,12 +15270,17 @@ msgid "Dow&nload"
 msgstr "डाउनलोड करा(&n)"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "ऑड्यासिटी स्वयंचलितपणे वैध एफएफएमपीईजी (FFmpeg) ग्रंथालय आढळल्या.\n"
 "आपण अद्याप त्यांना व्यक्तिचलितपणे शोधू इच्छिता?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -13474,6 +15317,10 @@ msgstr "एमआयडीआय (MIDI) सिंथेसाइज़र वि
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "एमआयडीआय (MIDI) सिंथेसायझर लेटन्सी एक पूर्णांक संख्या असणे आवश्यक आहे"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -13484,8 +15331,9 @@ msgid "Preferences for Module"
 msgstr "प्राधान्ये: "
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "हे प्रायोगिक विभाग आहेत. आपण केवळ ऑड्यासिटी हस्तलिखित वाचल्यास त्यांना सुरू करा\n"
@@ -13493,12 +15341,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "'विचारा' म्हणजे ऑड्यासिटी तुम्हाला विचारेल की प्रत्येक वेळी जेव्हा आपण सुरू करतो तेव्हा घटक लोड करायचे असल्यास."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "'अयशस्वी' म्हणजे ऑड्यासिटी असा विचार करते की घटक तुटलेले आहे आणि ते कार्यान्वित करणार नाही."
 
 #. i18n-hint preserve the leading spaces
@@ -13507,7 +15357,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "'नवीन' म्हणजे अद्याप पर्याय निवडला गेला नाही."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "या समायोजनमधील बदल केवळ ऑड्यासिटी सुरू झाल्यावरच प्रभावी होतील."
 
 #: src/prefs/ModulePrefs.cpp
@@ -13525,6 +15376,10 @@ msgstr "कोणतेही विभाग सापडले नाहीत
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "विभाग"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -13566,7 +15421,10 @@ msgstr "डावे-ओढा"
 msgid "Set Selection Range"
 msgstr "निवड श्रेणी निवड करा"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "शिफ्ट-डावे क्लिक करा"
 
@@ -13653,6 +15511,15 @@ msgstr "- डावे-ओढा"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "गीतपट्टा दरम्यान फीत खाली /वर हलवा"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "- डावे-ओढा"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -13764,8 +15631,21 @@ msgstr "अल्प कालावधी:(&S)"
 msgid "Lo&ng period:"
 msgstr "दीर्घ कालावधी :(&n)"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "ऑड्यासिटी प्राधान्ये"
 
 #: src/prefs/PrefsDialog.cpp
@@ -13779,6 +15659,11 @@ msgstr "प्राधान्ये: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "प्राधान्ये: "
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -13898,41 +15783,12 @@ msgid "System T&ime"
 msgstr "संगणक प्रणाली वेळ(&T)"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "स्वयंचलित ध्वनिमुद्रण स्तर अनुकूलन"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "स्वयंचलित ध्वनिमुद्रण पातळी समायोजन सुरू करा."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "लक्ष्य सर्वोच्च सर्वोच्च बिंदू गाठणे:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "आत :"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "विश्लेषण वेळ:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "मिलीसेकंद (एक विश्लेषण वेळ)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "सलग विश्लेषण संख्या:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 म्हणजे अनंत"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "पंच आणि रोल ध्वनीमुद्रण (&l)"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
@@ -14086,6 +15942,10 @@ msgid "1024 - default"
 msgstr "1024 - सामान्य"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - सर्वाधिक संकुचित"
 
@@ -14183,13 +16043,14 @@ msgid "Info"
 msgstr "माहिती"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14372,7 +16233,8 @@ msgstr "नमुने"
 msgid "4 Pixels per Sample"
 msgstr "प्रति नमुना 4 पिक्सेल"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "कमाल दृश्य मोठे करा"
 
@@ -14399,6 +16261,10 @@ msgstr "पिन केलेले ध्वनिमुद्रण / ला�
 #: src/prefs/TracksPrefs.cpp
 msgid "A&uto-scroll if head unpinned"
 msgstr "शीर्ष अनपिन केले असल्यास स्वयं-स्क्रोल करा(&u)"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -14490,16 +16356,24 @@ msgid "Stopped"
 msgstr "बंद करणे"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "थांबवा"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "प्रारंभ कडे जा"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "शेवटी कडे जा"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "थांबवा"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "आरंभ करण्यासाठी निवडा"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "समाप्त करण्यासाठी निवडा"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -14513,20 +16387,17 @@ msgstr "नवीन गीतपट्टा मुद्रित करा"
 msgid "Append Record"
 msgstr "मुद्रण एकत्र जोडा"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "समाप्त करण्यासाठी निवडा"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "आरंभ करण्यासाठी निवडा"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "थांबले"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s: %s"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -14606,11 +16477,17 @@ msgstr "मौन ध्वनी  निवड"
 msgid "Sync-Lock Tracks"
 msgstr "कुलूप बंद"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "आकार वाढवा"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "आकार कमी करा"
 
@@ -14677,43 +16554,6 @@ msgstr "ध्वनीमुद्रण मीटर साधनपट्ट�
 msgid "&Playback Meter Toolbar"
 msgstr "पुनर्मुद्रण मीटर साधनपट्टी(&P)"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "ध्वनीमुद्रण आवाज"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "पुन्हा चालू करण्याचा आवाज"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "ध्वनीमुद्रण आवाज: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "ध्वनीमुद्रण आवाज(अनुपलब्ध; मिश्रणर  व्यवस्था वापरा)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "लागोपाठ वाजवाण्याचा आवाज: %s (नक्कल)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "लागोपाठ वाजवाण्याचा आवाज: %s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "पुनर्मुद्रण आवाज(अनुपलब्ध; मिश्रणर व्यवस्था वापरा)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "मिश्रक साधनपट्टी(&x)"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "शोधा"
@@ -14729,6 +16569,7 @@ msgstr "घासणे"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "स्क्रबिंग थांबवा"
@@ -14736,6 +16577,7 @@ msgstr "स्क्रबिंग थांबवा"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "स्क्रबिंग प्रारंभ"
@@ -14743,6 +16585,7 @@ msgstr "स्क्रबिंग प्रारंभ"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "शोधणे थांबवा"
@@ -14750,6 +16593,7 @@ msgstr "शोधणे थांबवा"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "शोधणे प्रारंभ"
@@ -14804,7 +16648,9 @@ msgstr "ते स्नॅप करा"
 msgid "Length"
 msgstr "लांबी"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "केंद्र"
 
@@ -14868,8 +16714,8 @@ msgstr "उपकरण साधनपट्टी(&D)"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "ऑड्यासिटी साधनपट्टी%s"
 
 #: src/toolbars/ToolBar.cpp
@@ -14896,7 +16742,8 @@ msgstr "(&T)वेळ विस्थापन साधन"
 msgid "Zoom Tool"
 msgstr "साधन मोठे करा"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "रेखाटण्याचे साधन"
 
@@ -14972,11 +16819,13 @@ msgstr "काठावरुन नाव पट्टी (किंवा प�
 msgid "Drag label boundary."
 msgstr "नावपट्टी सीमा ओढा."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "सुधारित नावपट्टी"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "नावपट्टी संपादन"
 
@@ -15031,31 +16880,42 @@ msgstr "संपादित नावपट्टी"
 msgid "New label"
 msgstr "नवीन नावपट्टी"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "वरील अष्टक (&O)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "पुढील अष्टक(&v )"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "अनुलंब दृश्यरूप आकार वाढविण्यासाठी क्लिक करा. दृश्यरूप आकार कमी करण्यासाठी शिफ्ट-क्लिक करा. दृश्यरूप आकार प्रदेश निर्दिष्ट करण्यासाठी ओढा."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "मेनूसाठी उजवी-क्लिक करा."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "प्रतिमेचे दृष्य आकार पूर्वनिर्धारीत करा"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "शिफ्ट-डावे क्लिक करा"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "दृश्यरूप मोठे करा \t डावे क्लिक किंवा डावे क्लिक ओढा"
 
@@ -15097,7 +16957,8 @@ msgstr "सामील होणे"
 msgid "Expanded Cut Line"
 msgstr "विस्तारित काप लाईन"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "विस्तृत करा"
 
@@ -15120,6 +16981,11 @@ msgstr "नमुने हलवले"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "नमुना संपादन"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15165,7 +17031,8 @@ msgstr "प्रक्रिया करीत आहे:%s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' चे '%s' वर बदलला"
@@ -15244,7 +17111,8 @@ msgstr "दर बदला"
 msgid "Set Rate"
 msgstr "दर ठेवा"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "अनेक"
 
@@ -15337,19 +17205,22 @@ msgid "Right, %dHz"
 msgstr "उजवे ,%dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "% .0f %% डावे"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "% .0f %% अधिकार"
@@ -15361,6 +17232,15 @@ msgstr "स्टिरिओ गीतपट्टाचा सापेक्�
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "वेळेत गीतपट्टा हलविण्यासाठी क्लिक करा आणि ओढा"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "वेळेत गीतपट्टा हलविण्यासाठी क्लिक करा आणि ओढा"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -15459,9 +17339,8 @@ msgstr "लघुगणकीय अंतर्वेषण(&I)"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "वेळेत गीतपट्टा हलविण्यासाठी क्लिक करा आणि ओढा"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15512,6 +17391,7 @@ msgstr "लिफाफा बसवा."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "(&S)स्क्रब"
@@ -15523,6 +17403,7 @@ msgstr "शोधणे"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "स्क्रब (&R) मापक"
@@ -15757,9 +17638,19 @@ msgstr "रिक्त"
 msgid "Backwards"
 msgstr "मागच्या बाजूला"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "आगे"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -15972,6 +17863,7 @@ msgstr "0100 तास  060 मी 060 सेकंद +. # नमुने"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "नमुने"
@@ -16133,6 +18025,16 @@ msgstr "01000,01000  रचना|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000.0100  हर्ट्ज"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "kHz"
+msgstr "हर्ट्ज"
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -16140,6 +18042,10 @@ msgstr "0100000.0100  हर्ट्ज"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000.01000 kHz|0.001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -16205,6 +18111,11 @@ msgstr "(स्वरुपन बदलण्यासाठी संदर्
 msgid "centiseconds"
 msgstr "सेंटीसेकंद"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "लोटलेला वेळ:"
@@ -16247,6 +18158,11 @@ msgstr "बंद"
 msgid "Unable to write files to directory: %s."
 msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -16263,6 +18179,10 @@ msgstr "प्राधान्ये: "
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "ही चेतावणी पुन्हा दर्शवू नका"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -16346,15 +18266,27 @@ msgstr "\"धारिका उघडू शकली नाही.\""
 msgid "Spectral edit multi tool"
 msgstr "वर्णक्रमीय संपादन बहु साधन"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "गाळणे..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "जीएनयू सामान्य सार्वजनिक परवाना आवृत्ती 2 च्या अटींनुसार प्रसिद्ध झाली"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~a कृपया वारंवारता निवडा."
@@ -16381,7 +18313,8 @@ msgstr ""
 "                       कमी वारंवारता ~% बाउंड वाढविण्याचा प्रयत्न करा\n"
 "                       किंवा 'रुंदी' चाळण कमी करा."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "त्रुटी. ~%"
@@ -16443,9 +18376,23 @@ msgstr "स्टूडियो फिकट बाहेर"
 msgid "Applying Fade..."
 msgstr "फिकट लावत आहे ..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "स्टीव डॉल्टन"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "जीएनयू सामान्य सार्वजनिक परवाना आवृत्ती 2 च्या अटींनुसार प्रसिद्ध झाली"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16589,6 +18536,10 @@ msgstr "ताल शोधक"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "ताल शोध ..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "ऑड्यासिटी"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -16743,6 +18694,10 @@ msgid "Allow duration to change"
 msgstr "कालावधी बदलू द्या"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "शेवटचा प्रभाव पुन्हा करा"
 
@@ -16753,6 +18708,10 @@ msgstr "बरोबरी"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "एमपी३ (MP3) धारिका"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -16766,6 +18725,12 @@ msgstr "अधिलिखितची खा‍त्री करुन घ्
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "त्रुटी. ~% धारिका उघडू शकत नाही"
+
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "त्रुटी (धारिका लिहिलेली असू शकत नाही): %s"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
@@ -16855,12 +18820,22 @@ msgid "Begin numbering from"
 msgstr "पासून क्रमांकन सुरू करा"
 
 #: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Message on completion"
+msgstr "प्रलंबित भरपाई"
+
+#: plug-ins/equalabel.ny
 msgid "Details"
 msgstr "तपशील(&D)"
 
 #: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "चेतावणी"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -16870,6 +18845,17 @@ msgstr "नवीन नावपट्टी"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "संपादित नावपट्टी"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -16883,7 +18869,8 @@ msgstr "उच्च-प्रवेश चाळण संपादित क�
 msgid "Dominic Mazzoni"
 msgstr "डॉमिनिक मज्जो़नी"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "वारंवारता (Hz)"
 
@@ -16931,10 +18918,6 @@ msgstr ""
 msgid "Label Sounds"
 msgstr "नावे सामील"
 
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "जीएनयू सामान्य सार्वजनिक परवाना आवृत्ती 2 च्या अटींनुसार प्रसिद्ध झाली"
-
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
 msgstr "सीमा %d dB"
@@ -16976,8 +18959,37 @@ msgid "Point after sound"
 msgstr "संयुक्त स्टिरियो"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "संयुक्त स्टिरियो"
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "मौन शोधत आहे ..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "मौन शोधत आहे ..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -16989,6 +19001,11 @@ msgstr "निवड %d नमुन्यांपेक्षा मोठी 
 #, lisp-format
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "ध्वनी सापडला नाही. मौन ~% पातळी कमी करण्याचा प्रयत्न करा आणि कमीतकमी मौन कालावधी."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -17062,6 +19079,14 @@ msgid "Select Function"
 msgstr "निवड"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Stereo Linking"
 msgstr "शोधणे"
 
@@ -17092,6 +19117,44 @@ msgstr "लागू करण्याची वेळ"
 #: plug-ins/noisegate.ny
 msgid "Decay (ms)"
 msgstr "क्षय (सेकंद)"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "निवड %d नमुन्यांपेक्षा मोठी असणे आवश्यक आहे."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
 
 #: plug-ins/notch.ny
 msgid "Notch Filter"
@@ -17141,7 +19204,8 @@ msgstr "एफएलएसी(FLAC) धारिका"
 msgid "HTML file"
 msgstr "एमपी३ (MP3) धारिका"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "धारिका निवडा"
 
@@ -17158,17 +19222,48 @@ msgid "Disallow"
 msgstr "प्रतिबंधित"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "प्रतिबंधित"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "ऑड्यासिटी %s मध्ये धारिका  उघडण्यात अयशस्वी."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
 msgstr "प्लग-इन समर्थन"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files copied to plug-ins folder:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "न वापरलेले चाळण:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Cannot be written to plug-ins folder:"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
@@ -17238,6 +19333,10 @@ msgstr "1 - 20 ठेका / माप"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "दोलन परिमाण"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -17312,6 +19411,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "जोरदार ठेकाची एमआयडीआय (MIDI) ध्वनीची उच्चनीचता"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "कमकुवत ठेका एमआयडीआय (MIDI) ध्वनीची उच्चनीचतावर"
 
@@ -17384,6 +19487,10 @@ msgid "HTML files"
 msgstr "एमपी३ (MP3) धारिका"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "नमूना #"
 
@@ -17432,6 +19539,11 @@ msgstr "संदेश दर्शवा"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "फक्त चुका"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -17694,6 +19806,11 @@ msgstr "त्रुटी. ~% धारिका उघडू शकत ना�
 msgid "Spectral Delete"
 msgstr "वर्णक्रमी निवडा"
 
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
 #: plug-ins/tremolo.ny
 msgid "Tremolo"
 msgstr "कंपनयुक्त स्वर"
@@ -17923,6 +20040,205 @@ msgstr "रडार सुयाची वारंवारता"
 msgid "Error.~%Stereo track required."
 msgstr "त्रुटी.% स्टीरिओ गीतपट्टा आवश्यक."
 
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "ऑड्यासिटी मधून बाहेर पडा"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "माध्यम"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "धारिका विसंकेतन करताना त्रुटी आली"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "मेटा माहिती  लोड करण्यात त्रुटी"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "ऑड्यासिटी साधनपट्टी%s"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "ध्वनीमुद्रण(&R)"
+
+#~ msgid "Commit Id:"
+#~ msgstr "कमिट आयडी:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "विविध-ठिकाणी चालणारे जीयूआय ग्रंथालय"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "जीस्ट्रीमर (GStreamer) कडून आयात करा"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. त्यास अधिक अनुकूलन करणे शक्य नव्हते. तरीही खूप जास्त आहे."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "स्वयंचलितमुद्रण स्तर समायोजन आवाज %f पर्यंत कमी झाले."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. त्यास अधिक अनुकूलन करणे शक्य नव्हते. तरीही खूप कमी आहे."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "स्वयंचलित मुद्रण स्तर समायोजन आवाज %.2f पर्यंत वाढवला."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. स्वीकार्य आवाज न शोधता विश्लेषणाची एकूण संख्या ओलांडली आहे. तरीही खूप उंच आहे."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले. स्वीकार्य आवाज न शोधता विश्लेषणाची एकूण संख्या ओलांडली आहे. तरीही खूप कमी आहे."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "स्वयंचलित मुद्रण स्तर समायोजन थांबले.%.2f एक स्वीकार्य खंड दिसत आहे."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "शैली धारिका उघडण्यात बंद.\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "%s - %s\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "ध्वनीमुद्रण त्रुटीचे अनुकरण करा\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "पुन्हा चालू करण्याचा आवाज\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "ध्वनीमुद्रण आवाज\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "ध्वनीमुद्रण आवाज\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "लागोपाठ वाजवाण्याचा आवाज: %s (नक्कल)\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "लागोपाठ वाजवाण्याचा आवाज: %s (नक्कल)\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "समाप्ती तारीख आणि वेळ"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "जीस्ट्रीमर (GStreamer)-सुसंगत धारिका"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "पाइपलाइनमध्ये डीसांकेतिक आज्ञावलीर जोडण्यात बंद"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "जीस्ट्रीमर (GStreamer) आयातदार"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "विरामित स्थिती स्थिती सेट करण्यात बंद."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "सूचकांक[%02x] सांकेतिक आज्ञावली[%s], भाषा[%s], बिट-दर[%s], माध्यम[%d], वेळ[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "धारिकेमध्ये कोणताही ध्वनी प्रवाह नाही."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "धारिका आयात करण्यात बंद, बदल अयशस्वी झाला."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "जीस्ट्रीमर (GStreamer)- त्रुटी : %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "मिश्रण(&x)"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "पुनर्मुद्रण ध्वनी आवाज समायोजित करा ...(&j)"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "पुनर्मुद्रण ध्वनी आवाज वाढवा(&I)"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "पुनर्मुद्रण ध्वनी आवाज कमी करा(&D)"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "ध्वनीमुद्रण आवाज समायोजित करा ..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "ध्वनीमुद्रण आवाज वाढवा (&n)"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "ध्वनीमुद्रण आवाज कमी करा(&e)"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "ऑड्यासिटी मार्गदर्शक-पुस्तिका(&M)"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "ऑड्यासिटी बद्दल (&A)..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "स्वयंचलित ध्वनीमुद्रण स्तर अनुकूलन (चालू/बंद) (&u)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "स्वयंचलित ध्वनिमुद्रण स्तर अनुकूलन"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "स्वयंचलित ध्वनिमुद्रण पातळी समायोजन सुरू करा."
+
+#~ msgid "Target Peak:"
+#~ msgstr "लक्ष्य सर्वोच्च सर्वोच्च बिंदू गाठणे:"
+
+#~ msgid "Within:"
+#~ msgstr "आत :"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "विश्लेषण वेळ:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "मिलीसेकंद (एक विश्लेषण वेळ)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "सलग विश्लेषण संख्या:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 म्हणजे अनंत"
+
+#~ msgid "Recording Volume"
+#~ msgstr "ध्वनीमुद्रण आवाज"
+
+#~ msgid "Playback Volume"
+#~ msgstr "पुन्हा चालू करण्याचा आवाज"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "ध्वनीमुद्रण आवाज: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "ध्वनीमुद्रण आवाज(अनुपलब्ध; मिश्रणर  व्यवस्था वापरा)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "लागोपाठ वाजवाण्याचा आवाज: %s (नक्कल)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "लागोपाठ वाजवाण्याचा आवाज: %s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "पुनर्मुद्रण आवाज(अनुपलब्ध; मिश्रणर व्यवस्था वापरा)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "मिश्रक साधनपट्टी(&x)"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "वेळेत गीतपट्टा हलविण्यासाठी क्लिक करा आणि ओढा"
+
 #~ msgid "Program build date:"
 #~ msgstr "संगणकाची आज्ञावली तयार करण्याची तारीख "
 
@@ -17940,10 +20256,6 @@ msgstr "त्रुटी.% स्टीरिओ गीतपट्टा आ�
 #, fuzzy
 #~ msgid "Unknown error"
 #~ msgstr "अज्ञात"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "पूर्वनिर्धारितची धारिका वाचण्यात बंद."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -18211,9 +20523,6 @@ msgstr "त्रुटी.% स्टीरिओ गीतपट्टा आ�
 
 #~ msgid "MB"
 #~ msgstr "एमबी(MB)"
-
-#~ msgid "GB"
-#~ msgstr "जीबी(GB)"
 
 #~ msgid "Text files (*.txt)|*.txt|All files|*"
 #~ msgstr "मजकूर धारिका  (* .txt) | * .txt | सर्व धारिका  | *"

--- a/locale/my.po
+++ b/locale/my.po
@@ -9,53 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Burmese <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/my/>\n"
+"Language-Team: Burmese <https://hosted.weblate.org/projects/tenacity/tenacity/my/>\n"
 "Language: my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "အိုဒေးစီးတီးကို ပိတ်ပါ"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "ချာနယ်"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "ဖိုင် ဖွင့်လှစ်မှု အမှားအယွင်း"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "ဖိုင် ဖွင့်လှစ်မှု အမှားအယွင်း"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "အသံသွင်းနေခြင်း"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -65,6 +28,24 @@ msgstr "မဆုံးဖြတ်နိုင်ဘူး"
 #, c-format
 msgid "%s bytes"
 msgstr "ဘိုက်များ"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -83,12 +64,68 @@ msgid "2nd Experimental Command"
 msgstr "ညွှန်ကြားမှုကို ရွေးပါ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "ပွားယူပါ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "ပွားယူပါ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "ပွားယူပါ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "ပွားယူပါ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "ရွေးချယ်ပါ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -111,15 +148,37 @@ msgid "Show &Output"
 msgstr "ရလဒ်ကို ပြသပါ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "ခလုတ်တန်းများ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "ရပ်နားပါ"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "ကိန်းရှင်"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "ရလဒ် မီတာ"
 
@@ -127,13 +186,38 @@ msgstr "ရလဒ် မီတာ"
 msgid "Load Nyquist script"
 msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "သတိပေးချက်"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Leland Lucius"
@@ -144,16 +228,39 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "လီလဲန် လူစီယက် အားဖြင့်"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "No matches found"
+msgstr "ပူးတွဲထားတဲ့ စတီရီယို"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "အသစ်"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "လတ်တလောအရာကို ဖွင့်ပါ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -187,7 +294,8 @@ msgstr "မိတ္တူကူးပါ"
 msgid "Copy to clipboard"
 msgstr "အောက်ခံကတ်ပြားကို ဖြတ်ယူပါ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "ဖြတ်ယူပါ"
 
@@ -195,7 +303,8 @@ msgstr "ဖြတ်ယူပါ"
 msgid "Cut to clipboard"
 msgstr "အောက်ခံကတ်ပြားကို ဖြတ်ယူပါ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "ပွားယူပါ"
 
@@ -220,7 +329,8 @@ msgstr "ရွေးချယ်ပါ"
 msgid "Select all text"
 msgstr "ရွေးချယ်ပါ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "ပြန်ဖြည်ပါ"
 
@@ -228,9 +338,20 @@ msgstr "ပြန်ဖြည်ပါ"
 msgid "Undo last change"
 msgstr "အမျိုးအစား ပြောင်းလဲမှု"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "ပြန်ပြင်ပါ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "အမျိုးအစား ပြောင်းလဲမှု"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "မှတ်စုများကို ရှာပါ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -241,23 +362,46 @@ msgid "Match"
 msgstr "စုစည်းမှု"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "သို့ -"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "တင်ပို့မဲ့ အမှတ်အသားများ မရှိဘူး။"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "အထက်"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "အလျင် ကိရိယာ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "အလျင် လမ်းကြောင်းဆီ ဗဟိုပြုချက်ကို ရွှေ့ပြီး ရွေးချယ်ပါ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "နောက် ကိရိယာ"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "စတင်မှု"
 
@@ -265,7 +409,8 @@ msgstr "စတင်မှု"
 msgid "Start script"
 msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "ရပ်နားပါ"
 
@@ -273,8 +418,15 @@ msgstr "ရပ်နားပါ"
 msgid "Stop script"
 msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "ကောင်းပြီ"
 
@@ -282,11 +434,13 @@ msgstr "ကောင်းပြီ"
 msgid "Build Information"
 msgstr "တည်ဆောက်မှု အချက်အလက်"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "ဖွင့်ထားတယ်"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "ပိတ်ထားတယ်"
 
@@ -296,8 +450,9 @@ msgid "The Build"
 msgstr "တည်ဆောက်မှုကို စစ်ဆေးပါ"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "ညွှန်ကြားချက် -"
+#, fuzzy
+msgid "Version:"
+msgstr "ပြောင်းပြန်လှန်နေခြင်း"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -307,13 +462,23 @@ msgstr "တည်ဆောက်မှု အမျိုးအစား -"
 msgid "Compiler:"
 msgstr "ဖိသိပ်ကိရိယာ"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "တပ်ဆင်ရေး ရှေ့ဆက် -"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "တပ်ဆင်ချက်များ ဖိုင်တွဲ -"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "တပ်ဆင်ချက်များ ဖိုင်တွဲ -"
 
 #: src/AboutDialog.cpp
@@ -332,7 +497,6 @@ msgstr "နမူနာ အဆင့် အသွင်ပြောင်းခ�
 msgid "MP3 Importing"
 msgstr "MP3 တင်သွင်းနေမှု"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis တင်သွင်းချက်နဲ့ တင်ပို့ချက်"
@@ -341,7 +505,6 @@ msgstr "Ogg Vorbis တင်သွင်းချက်နဲ့ တင်ပိ
 msgid "ID3 tag support"
 msgstr "ID3 စာအမှတ် ပံ့ပိုးမှု"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC တင်သွင်းချက်နဲ့ တင်ပို့ချက်"
@@ -359,14 +522,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg တင်သွင်း/တင်ပို့တဲ့ စုစည်းခန်း"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "QuickTime မှတဆင့် တင်သွင်းပါ"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "အင်္ဂါရပ်များ"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "ယန္တရားငယ် ပံ့ပိုးမှု"
 
@@ -381,6 +536,10 @@ msgstr "အသံပေါက်နဲ့ နရီအနှေးအ​မြ�
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "အသံပေါက်နဲ့ နရီအနှေးအ​မြန် အပြောင်းအလဲ ပံ့ပိုးမှု"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "အင်္ဂါရပ်များ"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -407,6 +566,18 @@ msgstr "စာအိတ်"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "စာအိတ်"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "စာအိတ်"
 
@@ -418,9 +589,51 @@ msgstr "စာအိတ်"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "စာအိတ်"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "စာအိတ်"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "စာအိတ်"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "EQ ရုပ်ကား"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "စာအိတ်"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "စာအိတ်"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -441,8 +654,26 @@ msgid "%s, graphics"
 msgstr "EQ ရုပ်ကား"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "အသိအမှတ်ပြုချက်များ"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -477,14 +708,23 @@ msgid "%s Team Members"
 msgstr "အခြား ဂုဏ်ထူးဆောင် အဖွဲ့၀င်များ"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "အခြား ပါ၀င်ပံ့ပိုးသူများ"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "မြန်မာ့ သတင်းနည်းပညာ ဆက်သွယ်ရေးအဖွဲ့ (ဘီအိုင်တီ)"
@@ -503,6 +743,26 @@ msgstr "အထူး ကျေးဇူးတင်ချက်များ -"
 msgid "%s website: "
 msgstr "အိုဒေးစီးတီး ပထမဆုံး လည်ပတ်မှု"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "အခြား ပါ၀င်ပံ့ပိုးသူများ"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "စတီရီယို အသံလမ်းကြောများရဲ့ သက်ဆိုင်ရာ အရွယ်ကို ချိန်ညှိဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ။"
@@ -520,6 +780,7 @@ msgstr "အချိန်ဇယား ပြောင်းကိရိယာ"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "နမူနာများကို တည်းဖြတ်ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
@@ -527,17 +788,66 @@ msgstr "နမူနာများကို တည်းဖြတ်ဖို�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "အသံလမ်းကြောကို အရွယ်ညှိဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ။"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "ဗဟိုပြုချက်ကို နောက် လမ်းကြောင်းဆီ ရွှေ့ပြီး ရွေးချယ်ပါ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "အသံလမ်းကြောကို အောက် ရွှေ့ပါ"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "ဗဟိုပြုထားတဲ့ အသံလမ်းကြောကို ပိတ်ပါ"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr "(ပိတ်ထားချက်)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr "(ပိတ်ထားချက်)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "ယန္တရားငယ် တပ်ဆင်ချက်များ"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -555,7 +865,23 @@ msgstr "နယ်ပယ်ကို ဖွင့်ပါ"
 msgid "Pinned Play Head"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "အမှားအယွင်း"
 
@@ -565,8 +891,36 @@ msgid "Failed to remove %s"
 msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "အိုဒေးစီးတီး ဦးစားပေးချက်များ"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -587,7 +941,7 @@ msgstr "ဖွင့်ပါ..."
 msgid "Open &Recent..."
 msgstr "လတ်တလောကို ဖွင့်ပါ..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "အိုဒေးစီးတီး အကြောင်း..."
@@ -601,29 +955,33 @@ msgid "&File"
 msgstr "ဖိုင်"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "အိုဒေးစီးတီးက ယာယီဖိုင်များကို သိုထားမဲ့ နေရာတခု မတွေ့နိုင်ဘူး။\n"
 "ဦးစားပေးချက်များ အညွှန်းစာမျက်နှာထဲမှာ သင့်လျှော်တဲ့ ဖိုင်တွဲတခုကို ရေးသွင်းပါ။"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "အိုဒေးစီးတီးက ယာယီဖိုင်များကို သိုထားမဲ့ နေရာတခု မတွေ့နိုင်ဘူး။\n"
 "ဦးစားပေးချက်များ အညွှန်းစာမျက်နှာထဲမှာ သင့်လျှော်တဲ့ ဖိုင်တွဲတခုကို ရေးသွင်းပါ။"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "အိုဒေးစီးတီးဟာ ယခု ထွက်ခွါတော့မယ်။ ယာယီ ဖိုင်တွဲ အသစ်တခုကို သုံးစွဲဖို့ အိုဒေးစီးတီးကို ပြန်ဖွင့်ပါ။"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -632,36 +990,91 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "အိုဒေးစီးတီးက ယာယီဖိုင်များ ဖိုင်တွဲကို သော့ မခတ်ထားနိုင်ဘူး။\n"
 "ဒီဖိုင်တွဲကို အခြား အိုဒေးစီးတီး မိတ္တူတခုက သုံးစွဲနိုင်တယ်။\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "အိုဒေးစီးတီးကို သင် စတင် လိုသေးသလား။"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "ဖိုင် ဖွင့်လှစ်မှု အမှားအယွင်း"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "အခြား အိုဒေးစီးတီး မိတ္တူ တခု လည်ပတ်နေမှုကို စက်က တွေ့ရှိသွားတယ်။\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "စီမံချက်များ အများအပြား တပြိုင်တည်း ဖွင့်ဖို့ လက်ရှိ လည်ပတ်နေတဲ့ အိုဒေးစီးတီး\n"
 "လုပ်ငန်းစဉ်ထဲမှ အသစ် (သို့) အဖွင့် အမိန့်ပေးချထက်များကို သုံးစွဲပါ။\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "အိုဒေးစီးတီးကို ဖွင့်ထားနေပြီ"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "အိုဒေးစီးတီး စီမံချက် ဖိုင်များ"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -681,7 +1094,8 @@ msgstr "\t-test (အလိုလို ချို့ယွင်းချက�
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (အိုဒေးစီးတီး မူအဆင့်ကို ပြသပါ)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -691,9 +1105,10 @@ msgid "audio or project file name"
 msgstr "စီမံချက်ဖိုင်ကို မဖွင့်နိုင်ဘူး"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -706,29 +1121,68 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "အိုဒေးစီးတီး စီမံချက် ဖိုင်များ"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "နမူနာပြန်တင်ပါ..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "အသံသွင်းနေတယ်"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "အကူအညီ"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "အိုဒေးစီးတီးကို ပိတ်ပါ"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "သိမ်းဆည်းပါ..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "ပိတ်ပါ"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -761,7 +1215,26 @@ msgid "Error Initializing Audio"
 msgstr "အသံ အစပြုမှု အမှားအယွင်း"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"သင်ဟာ အသံကို ဖွင့်နိုင် (သို့) အသံသွင်းနိုင်မှာ မဟုတ်ဘူး။\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "အသံ အစပြုမှု အမှားအယွင်း"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -772,24 +1245,26 @@ msgid ""
 msgstr "အသံ ကိရိယာကို ဖွင့်နေစဉ် အမှားအယွင်း။"
 
 #: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+msgid "Out of memory!"
+msgstr ""
 
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -827,8 +1302,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -842,37 +1327,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "အမြန်နှုန်းကို ပြန်ဖွင့်ပါ\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "အမျိုအစားဖိုင်ကို မဖွင့်နိုင်ဘူး။\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "အမြန်နှုန်းကို ပြန်ဖွင့်ပါ\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "အသံသွင်းနေခြင်း\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "နမူနာ နှုန်းထားများ\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "ပြန်ဖွင့်ချက်\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "ပြန်ဖွင့်ချက်\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "ပြန်ဖွင့်ချက်\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -880,8 +1368,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "အမြန်နှုန်းကို ပြန်ဖွင့်ပါ\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "အမြန်နှုန်းကို ပြန်ဖွင့်ပါ\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -889,8 +1387,9 @@ msgid "Automatic Crash Recovery"
 msgstr "ပျက်စီးမှု အလိုအလျှောက် ဆယ်တင်ရေး"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -902,12 +1401,14 @@ msgid "Recoverable &projects"
 msgstr "ဆယ်တင်နိုင်တဲ့ စီမံချက်များ"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "ရွေးချယ်ပါ"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "အမည်"
 
@@ -918,6 +1419,10 @@ msgstr "ရွေးချယ်ပါ"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "ရွေးချယ်ပါ"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -951,6 +1456,10 @@ msgstr "ကြိုတင်သတ်မှတ်ချက်ကို သိ�
 #: src/BatchCommandDialog.cpp
 msgid "&Parameters"
 msgstr "ပါရာမီတာများ"
+
+#: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Choose command"
@@ -987,6 +1496,22 @@ msgstr "သက်ရောက်မှု"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "ပါရာမီတာများကို တည်းဖြတ်ပါ"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "ပါရာမီတာများကို တည်းဖြတ်ပါ"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1033,11 +1558,30 @@ msgstr "စမ်းသပ်မှု စနစ်"
 msgid "Apply %s"
 msgstr "%s ကို အသုံးချပါ"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "ကြိုတင်သတ်မှတ်ချက်ကို ပယ်ဖျက်ပါ"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "အမှတ်အသားများ..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "ချိန်းကြိုးကို အသုံးချပါ"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1093,9 +1637,25 @@ msgstr "ရပ်ဆိုင်းပါ"
 msgid "Remo&ve"
 msgstr "ဖယ်ရှားပါ"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "နမူနာပြန်တင်ပါ..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Re&store"
 msgstr "နယ်ပယ်ကို ပြနပေးအပ်မှု"
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "တင်သွင်းပါ..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "တင်ပို့ပါ..."
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
@@ -1134,9 +1694,15 @@ msgstr "အထက်ကို ရွှေ့ပါ"
 msgid "Move &Down"
 msgstr "အောက်ကို ရွှေ့ပါ"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "သိမ်းဆည်းပါ"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1182,11 +1748,38 @@ msgid "Benchmark"
 msgstr "စံအမှတ်ကို လည်ပတ်ပါ..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "ထပ်လုပ်မဲ့ အကြိမ် အရေအတွက် -"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "ပိတ်ပါ"
 
@@ -1201,12 +1794,32 @@ msgid "Export Benchmark Data as:"
 msgstr "ရောင်စဉ် ဒေတာကို တင်ပို့မဲ့ ပုံစံ -"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "မှတ်စုများရဲ့ အများဆုံး အရေအတွက်ဟာ ၁...၁၂၈ အတိုင်းအတာထဲမှာ ရှိရမယ်"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "မှတ်စုများရဲ့ အများဆုံး အရေအတွက်ဟာ ၁...၁၂၈ အတိုင်းအတာထဲမှာ ရှိရမယ်"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "မှတ်စုများရဲ့ အများဆုံး အရေအတွက်ဟာ ၁...၁၂၈ အတိုင်းအတာထဲမှာ ရှိရမယ်"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "အစမ်းမြင်ကွင်းကို ပြင်ဆင်နေတယ်\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1215,17 +1828,104 @@ msgstr "ထပ်မံ လု​ပ်ဆောင်နေတယ်\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "ပွားယူပါ\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "အသံသွင်းနေတယ်\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "ရက်စွဲနဲ့ အချိန်ကို အသုံးသတ်ပါ"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "တည်ဆောက်မှုကို ထုတ်ပြန်ပါ"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1246,9 +1946,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "ဒီအရာကို သုံးစွဲဖို့ အချို့ အသံကို သင် ပထမဦးဆုံး ရွေးရမယ်။"
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "ချိန်ကြိုးများကို မရွေးထားဘူး"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1274,6 +1998,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "ကိုဓကို ​ရှာဖွေဖို့ မအောင်မြင်ဘူး"
 
@@ -1291,10 +2020,24 @@ msgstr "လက်ရှိ စီမံချက်မှာ အသုံးခ�
 msgid "Checkpointing %s"
 msgstr "%s ကို တင်သွင်းနေခြင်း"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "ရေးလို့ မရတဲ့ ဖိုင် -\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"စီမံချက်ကို မသိမ်းဆည်းနိုင်ဘူး။ %s ကို မသိမ်းဆည်းနိုင်တာ\n"
+"(သို့) ဓါတ်ပြား ပြည့်သွားတာ ဖြစ်နိုင်တယ်။"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1312,6 +2055,10 @@ msgid ""
 "%s"
 msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "မှီခို အားပြုချက်များကို ဖယ်ရှားပါ"
@@ -1319,6 +2066,25 @@ msgstr "မှီခို အားပြုချက်များကို �
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "အသံ အချက်အလက်ကြမ်းကို စီမံချက်ထဲမှာ မိတ္တူကူးနေခြင်း..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "စီမံချက် တခုကို သိမ်းဆည်းတဲ့အခါ အခြား အသံဖိုင်များ အပေါ် မူတည်တယ်"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1333,8 +2099,27 @@ msgid "Disk Space"
 msgstr "ဓါတ်ပြား နေရာ"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "ရွေးချယ်မှု"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "သိမ်းဆည်းမှုကို ရပ်ဆိုင်းပါ"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "အမှတ်အသား"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Do Not Copy"
+msgstr "မဆယ်တင်နဲ့"
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1346,9 +2131,32 @@ msgstr "ဘယ်အချိန်မဆို စီမံချက် တခ�
 msgid "Ask me"
 msgstr "ကျွန်ပ်ကို မေးပါ"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "အောက်ခံကတ်ပြားကို ဖြတ်ယူပါ"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1359,10 +2167,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "သင် ဆက်လက် ဆောင်​ရွတ်ရင်၊ သင့်ရဲ့ စီမံချက်ကို ဓါတ်ပြားထဲ သိမ်းဆည်းထားမှာ မဟုတ်ဘူး။ ဒါဟာ သင်လိုချင်တဲ့ အရာလား။"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "မှီခိုအားပြုချက် စစ်ဆေးမှု"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "ဘာမျှမရှိ"
 
@@ -1370,7 +2190,7 @@ msgstr "ဘာမျှမရှိ"
 msgid "Rectangle"
 msgstr "စတုဂံပုံ"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "တြိဂံပုံ"
 
@@ -1384,17 +2204,58 @@ msgstr "စတုဂံပုံ"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "ကြိုဆိုပါတယ်!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg ပံ့ပိုးချက်ကို မပြုစုတဲ့နေရာ"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1416,11 +2277,22 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg ကို ရှာပါ"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "အိုဒေးစီးတီးက အသံကို FFmpeg ကတဆင့် တင်သွင်းပြီး တင်ပို့ဖို့ %s ဖိုင်ကို လိုအပ်တယ်။"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "%s ရဲ့ တည်နေရာ -"
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "To find '%s', click here -->"
+msgstr "%s ကို ရှာတွေ့ဖို့၊ ဒီနေရာကို နှိုပ်ပါ -->"
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "လှော်လှန်ပါ..."
 
@@ -1433,13 +2305,22 @@ msgstr "FFmpeg အခမဲ့ မိတ္တူတခုကို ရယူဖ
 msgid "Download"
 msgstr "ဆွဲချပါ"
 
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "%s ဘယ်မှာ ရှိလဲ။"
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg not found"
 msgstr "FFmpeg ကို မတွေ့ရှိဘူး"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1459,24 +2340,38 @@ msgstr "ဒီသတိပေးချက်ကို နောက်တကြ�
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "လိုက်ဖက်တဲ့ FFmpeg စုစည်းချက်များကို မတွေ့နိုင်ဘူး"
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"အိုဒေးစီးတီးက မရေးသားနိုင်တဲ့ ဖိုင် -\n"
+"  %s။"
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "အိုဒေးစီးတီးက မရေးသားနိုင်တဲ့ ဖိုင် -\n"
 "  %s။"
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"အိုဒေးစီးတီးက မရေးသားနိုင်တဲ့ ဖိုင် -\n"
-"  %s။"
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1505,7 +2400,17 @@ msgstr "ဖိသိပ်မထားတဲ့ အသံဖိုင်မျ�
 msgid "&Copy all audio into project (safest)"
 msgstr "အသံ အချက်အလက်ကြမ်းကို စီမံချက်ထဲမှာ မိတ္တူကူးနေခြင်း..."
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "ဖိုင်များ အားလုံး (*)|*"
 
@@ -1514,6 +2419,11 @@ msgstr "ဖိုင်များ အားလုံး (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "စီမံချက် အချက်အလက်ကြမ်း ဖိုင်များကို သိမ်းဆည်းနေတယ်"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "စုစည်းခန်းများ"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1526,6 +2436,10 @@ msgstr "ဖိုင်များကို အမည်ပေးပါ -"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3 ဖိုင်များ"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1590,9 +2504,34 @@ msgstr "အစဉ်လိုက် ကြိမ်နှုန်း"
 msgid "Log frequency"
 msgstr "လော့ဂ် ကြိမ်နှုန်း"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "ချဲ့ထွင်ပါ"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1607,6 +2546,10 @@ msgstr "ပြင်ညီ စတီရီယို"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "ခါဆာ ဘယ်ဖက်"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1649,11 +2592,48 @@ msgstr "ရွေးထားတဲ့ အသံ အရမ်းများလ�
 msgid "Not enough data selected."
 msgstr "ဒေတာ ရွေးထားတဲ့ မလုံလောက်ဘူး။"
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "ရောင်စဉ်"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "ရောင်စဉ် ဒေတာကို တင်ပို့မဲ့ ပုံစံ -"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "ရေးလို့ မရတဲ့ ဖိုင် -"
@@ -1716,12 +2696,75 @@ msgstr "အိုဒေးစီးတီး စီမံချက် တခု�
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
 msgid "Burn to CD"
 msgstr "စီဒီထဲ ကူးရေးပါ"
 
 #: src/HelpText.cpp
 msgid "No Local Help"
 msgstr "အနီးအနား အကူအညီ မရှိဘူး"
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1740,6 +2783,10 @@ msgid "Used Space"
 msgstr "ဓါတ်ပြား နေရာ"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "ရနိုင်တဲ့ အဆင့်များကို ပြန်ဖြည်ပါ"
 
@@ -1753,6 +2800,10 @@ msgid "&Discard"
 msgstr "စွန့်ပစ်ပါ"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "စွန့်ပစ်ပါ"
 
@@ -1760,15 +2811,39 @@ msgstr "စွန့်ပစ်ပါ"
 msgid "&Compact"
 msgstr "ညွှန်ကြားမှု"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "မှတ်တမ်း..."
 
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
 #: src/InconsistencyException.h
 msgid "Internal Error"
 msgstr "(ပြင်ပ ပရိုဂရမ်)"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "တည်းဖြတ်ထားတဲ့ အမှတ်အသားများ"
 
 #. i18n-hint: (noun).  A track contains waves, audio etc.
 #: src/LabelDialog.cpp
@@ -1776,7 +2851,9 @@ msgid "Track"
 msgstr "အသံလမ်းကြော"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "အမှတ်အသား"
 
@@ -1833,19 +2910,47 @@ msgstr "အမှတ်အသား အသံလမ်းကြောသစ်"
 msgid "Enter track name"
 msgstr "အသံလမ်းကြော အမည် ရေးသွင်းပါ"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "အသံလမ်းကြောကို စာတန်းတပ်ပါ"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "အိုဒေးစီးတီး ပထမဆုံး လည်ပတ်မှု"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "အိုဒေးစီးတီး အတွက် သုံးစွဲမဲ့ ဘာသာ စကားကို ရွေးချယ်ပါ -"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "အတည်ပြုပါ"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "ဖိုင်ထဲ ရိုက်ထည့်မှု အမှားအယွင်း -"
 
 #: src/Legacy.cpp
 #, c-format
@@ -1857,8 +2962,19 @@ msgstr ""
 "ဖိုင်ဟောင်းကို '%s' အဖြစ် သိမ်းဆည်းထားတယ်။"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "အိုဒေးစီးတီး စီမံချက်ကို ဖွင့်နေတယ်"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "အထူး ကျေးဇူးတင်ချက်များ -"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "လှော်လှန်ပါ..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1903,34 +3019,78 @@ msgstr "ပေါင်းစပ်ပြီး တင်ဆက်ပါ"
 msgid "Mixing and rendering tracks"
 msgstr "အသံလမ်းကြောများကို ပေါင်းစပ်ခြင်းနဲ့ တင်ဆက်ခြင်း"
 
+#: src/MixerBoard.cpp
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း"
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "တိုးတက်မှု"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Velocity"
+msgstr "အလျင်ကို မှတ်သားပါ"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "Musical Instrument"
+msgstr "တန်ဆာပလာ"
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "တပြင်လုံး"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "အသံပိတ်ပါ"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "တပင်တိုင်"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "ရွှေ့ထားတဲ့ တိုးတက်မှု စလိုင်ဒါ"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "ရွှေ့ထားတဲ့ တိုးတက်မှု စလိုင်ဒါ"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "ရွှေ့ထားတဲ့ တပြင်လုံး စလိုင်ဒါ"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "အချိန်တိုင်းကိရိယာ မှတ်တမ်း..."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1940,13 +3100,73 @@ msgid ""
 "Error: %s"
 msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "ဖွင့်ထားတယ်"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy, c-format
+msgid "Module \"%s\" found."
+msgstr "FFmpeg ကို မတွေ့ရှိဘူး"
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "ဘာမျှမရှိ"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "အသံညှိကိရိယာ"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1956,18 +3176,126 @@ msgstr "အသံလမ်းကြောကို မှတ်သားပါ"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "တည်ရှိနေတဲ့ ဖိုင်များကို ထပ်ရေးပါ"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -1988,9 +3316,24 @@ msgstr[0] "၀မ်းနည်းပါတယ်၊ ပိုင်းလု�
 msgid "Enable new plug-ins"
 msgstr "၀မ်းနည်းပါတယ်၊ ပိုင်းလုံး ယန္တရားငယ်ကို ဖွင့်ဖို့ မအောင်မြင်ဘူး။"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "၀မ်းနည်းပါတယ်၊ ပိုင်းလုံး ယန္တရားငယ်ကို ဖွင့်ဖို့ မအောင်မြင်ဘူး။"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "ကိုဓများ အားလုံးကို ပြသပါ"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -2022,6 +3365,25 @@ msgstr "ဖွင့်ထားတယ်"
 msgid "E&nabled"
 msgstr "ဖွင့်ထားတယ်"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "ဖွင့်ထားတယ်"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "ရွေးချယ်ပါ"
@@ -2030,7 +3392,8 @@ msgstr "ရွေးချယ်ပါ"
 msgid "C&lear All"
 msgstr "ရှင်းလင်းပါ"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "ဖွင့်ထားတယ်"
 
@@ -2071,6 +3434,14 @@ msgstr "ပုံနှိုပ်တဲ့ ပြဿနာတရပ် ရှ�
 msgid "Print"
 msgstr "ပုံနှိုပ်ပါ"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgid "Actual Rate: %d"
@@ -2086,6 +3457,21 @@ msgstr "အသံ ကိရိယာကို ဖွင့်နေစဉ် အ
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "ရောင်စဉ်ကို ရေးမှတ်ဖို့၊ ရွေးထားတဲ့ အသံလမ်းကြောများ အားလုံးဟာ တူညီတဲ့ နမူနာ အဆင့်ဖြစ်ရမယ်။"
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "အသံသွင်းထားချက်"
@@ -2094,9 +3480,99 @@ msgstr "အသံသွင်းထားချက်"
 msgid "Record"
 msgstr "မှတ်တမ်းတင်ပါ"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "စီမံချက်ကို ပြင်ဆင်ချက်များ မပြုပဲ ချက်ခြင်း ပိတ်ပါ"
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "စီမံချက်ဖိုင်ကို မဖွင့်နိုင်ဘူး"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Treat missing audio as silence (this session only)"
+msgstr "ပျောက်ဆုံးနေတဲ့ ဒေတာ ပြသမှုအတွက် တိတ်ဆိတ်ပြီး ဖြည့်ဆည်းပါ [ဒီ အခန်း အတွက်သာ]"
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Fill in silence for missing display data (this session only)"
@@ -2106,11 +3582,88 @@ msgstr "ပျောက်ဆုံးနေတဲ့ ဒေတာ ပြသမ�
 msgid "Close project immediately with no further changes"
 msgstr "စီမံချက်ကို နောက်ထပ် ပြင်ဆင်ချက်များ ချက်ခြင်း မပြုပဲ ပိတ်ပါ"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "တိုးတက်မှု"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "ယာယီသိမ်းဆည်းခန်း ဖိုင်တွဲများကို ရှင်းလင်းနေတယ်"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Warning: Problems in Automatic Recovery"
+msgstr "ကြာမြင့်ချိန်ထဲက အမှားအယွင်း"
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "စီမံချက်များ"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2149,11 +3702,96 @@ msgid ""
 msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "အိုဒေးစီးတီး စီမံချက် တခုကို သိမ်းဆည်းနေတယ်"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2162,12 +3800,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "MP3 စီးကြောင်းကို အစပြုလို့ မရဘူး"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "'%s' ကို '%s' အဖြစ် အမည် မပြောင်းနိုင်ဘူး"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "ကိုဓကို ​ရှာဖွေဖို့ မအောင်မြင်ဘူး"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2178,9 +3842,9 @@ msgid "Error Writing to File"
 msgstr "ဖိုင်ထဲ ရိုက်ထည့်မှု အမှားအယွင်း -"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2191,8 +3855,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "ဖန်တီးခဲ့တဲ့ စီမံချက် အသစ်"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2200,9 +3873,21 @@ msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
 msgid "(Recovered)"
 msgstr "(ပြန်ဆယ်တင်ချက်)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "စီမံချက်ဖိုင်ကို မဖွင့်နိုင်ဘူး"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2217,12 +3902,49 @@ msgid "Unable to parse project information."
 msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
 
-#: src/ProjectFileManager.cpp
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း တိုးတက်မှု"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2230,8 +3952,24 @@ msgstr ""
 "ကံအားလျှော်စွ၍၊ အောက်ပါ စီမံချက်များကို အလိုအလျှောက် ဆယ်တင်နိုင်တယ် -"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"အိုဒေးစီးတီးကို နောက်ဆုံးအချိန် သုံးစွဲ​စဉ် အချို့ စီမံချက်များကို ကောင်းကောင်း မသိဘူး။\n"
+"ကံအားလျှော်စွ၍၊ အောက်ပါ စီမံချက်များကို အလိုအလျှောက် ဆယ်တင်နိုင်တယ် -"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "စီမံချက်ကို ပြန်ဆယ်တင်ထားပြီ"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "ယာယီ ဖိုင်များ ဖိုင်တွဲ"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2254,8 +3992,24 @@ msgstr ""
 "ဘာပဲဖြစ်ဖြစ် သိမ်းဆည်းမလား။"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "အိုဒေးစီးတီး စီမံချက် တခုကို သိမ်းဆည်းနေတယ်"
+
+#: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "ဓါတ်ပြား နေရာ"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -2263,9 +4017,34 @@ msgid "Saved %s"
 msgstr "သိမ်းဆည်းချက် %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "စီမံချက်ကို သိမ်းဆည်းမဲ့ ပုံစံ..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2273,9 +4052,21 @@ msgid "Overwrite Project Warning"
 msgstr "တည်ရှိနေတဲ့ ဖိုင်များကို ထပ်ရေးပါ"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "စီမံချက်ရဲ့ ဖိသိပ်ထားတဲ့ မိတ္တူကို သိမ်းဆည်းပါ..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -2298,17 +4089,27 @@ msgstr "အသံတခု (သို့) အများကို ရွေး�
 msgid "%s is already open in another window."
 msgstr "%s ကို အခြား ၀င်းဒိုးမှာ ဖွင့်ထားပြီး။"
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "ဖိုင် ဖွင့်လှစ်မှု အမှားအယွင်း"
+
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "သင်ဟာ အလိုအလျှောက် ဖန်တီးခဲ့တဲ့ အရန်သင့် သိမ်းဆည်းချက် ဖိုင်တခုကို ဖွင့်ဖို့ ကြိုးစားနေတယ်။\n"
 "ဒီလိုလုပ်ခြင်းက ကြီးမားတဲ့ ဒေတာ ဆုံးရှုံးမှု ရလဒ်ကို ဖြစ်စေနိုင်တယ်။\n"
 "\n"
 "တကယ့် အိုဒေးစီးတီး စီမံချက် ဖိုင်ကို အစားထိုး ဖွင့်ပါ။"
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
@@ -2326,6 +4127,17 @@ msgid ""
 msgstr ""
 "ဖိုင်ဟာ မမှန်တာ (သို့) ပျက်စီးတာ ဖြစ်နိုင်တယ် -\n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "ဖိုင် ဖွင့်လှစ်မှု အမှားအယွင်း"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -2353,12 +4165,33 @@ msgid "Error Importing"
 msgstr "တင်သွင်းနေတဲ့ အမှားအယွင်း"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "စီမံချက်ဖိုင်ကို မဖွင့်နိုင်ဘူး"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "ညွှန်ကြားမှု"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2369,8 +4202,8 @@ msgid "Automatic database backup failed."
 msgstr "ပျက်စီးမှု အလိုအလျှောက် ဆယ်တင်ရေး"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "အိုဒေးစီးတီး မူအဆင့် %s မှ ကြိုဆိုပါတယ်"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2405,6 +4238,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "အသံသွင်းမှု %d မိနစ်အတွက် ကျန်တဲ့ ဓါတ်ပြား နေရာလပ်"
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -2417,6 +4254,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2432,6 +4281,26 @@ msgstr "ပြင်ညီ စတီရီယို"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "ဒေါင်လိုက် စတီရီယို"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(အကောင်းဆုံး အရည်အသွေး)"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -2459,6 +4328,10 @@ msgstr "၁၄-ဘစ် PCM"
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
 msgstr "၃၂-ဘစ် PCM"
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -2544,7 +4417,8 @@ msgstr "ဦးစားပေးချက်များ..."
 msgid "SelectionBar"
 msgstr "ရွေးချယ်မှုတန်းလျာ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "ရွေးချယ်မှု"
 
@@ -2552,40 +4426,59 @@ msgstr "ရွေးချယ်မှု"
 msgid "Timer"
 msgstr "အချိန်"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "ကိရိယာများ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "တင်ပို့ပါ"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "ပေါင်းစပ်ကိရိယာ"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "မီတာ"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "မီတာကို ဖွင့်ပြပါ"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "အသံသွင်းမှု မီတာ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "တည်းဖြတ်ပါ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "ကိရိယာ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "အရှိန်-နဲ့-ဖွင့်ပြပါ"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "ခလုတ်တန်းများ"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -2598,7 +4491,10 @@ msgstr "ပေတံ"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "အသံလမ်းကြောများ"
 
@@ -2650,6 +4546,26 @@ msgstr "အသံလမ်းကြောမြင့်များ"
 msgid "Choose a location to save screenshot images"
 msgstr "မျက်နှာပြင်ရိုက်ချက် ရုပ်ပုံများ သိမ်းဆည်းဖို့ တည်နေရာ တခုကို ရွေးပါ"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (ဒီသတင်းတို အတွက်)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
+
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
 msgstr "အစမ်းမြင်ကွင်း"
@@ -2666,6 +4582,19 @@ msgstr "ရွေးစရာများ..."
 msgid "Debu&g"
 msgstr "ပြဿနာဖြေရှင်းပါ"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "အဖွင့်ဆီ ကူးသွားပါ"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
 #: src/SoundActivatedRecord.cpp
 msgid "Sound Activated Record"
 msgstr "အသံက အသံသွင်းမှုကို သက်၀င်စေတယ်"
@@ -2675,7 +4604,8 @@ msgid "Activation level (dB):"
 msgstr "သက်၀င်မှု အဆင့် (dB) -"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "အိုဒေးစီးတီးမှ ကြိုဆိုပါတယ်။"
 
 #: src/SplashDialog.cpp
@@ -2719,6 +4649,16 @@ msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
 msgstr "နေရာကွက်များကို ကူးသန်းကြည့်ရှုဖို့ မြှား ခလုတ်များ ((သို့) တည်းဖြတ်အပြီးမှာ RETURN ခလုတ်) ကို သုံးပါ။"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Tag"
+msgstr "စာအမှတ် -"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "အဆင့် -"
+
+#: src/Tags.cpp
 msgid "&Add"
 msgstr "ပေါင်းထည့်ပါ"
 
@@ -2745,6 +4685,11 @@ msgstr "ပုံစံခွက်"
 #: src/Tags.cpp
 msgid "&Load..."
 msgstr "ဖွင့်ပါ..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "စံထားချက်များ"
 
 #: src/Tags.cpp
 msgid "Don't show this when exporting audio"
@@ -2775,26 +4720,62 @@ msgid "Load Metadata As:"
 msgstr "မက်တာဒေတာကို ဖွင့်မဲ့ ပုံစံ -"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "မက်တာဒေတာကို တည်းဖြတ်ပါ"
+
+#: src/Tags.cpp
 msgid "Save Metadata As:"
 msgstr "မက်တာဒေတာ သိမ်းဆည်းမဲ့ ပုံစံ -"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "ဖိုင် ဖွင့်လှစ်မှု အမှားအယွင်း"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "ဖွင့်ထားတယ်"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "ယာယီ ဖိုင်များ ဖိုင်တွဲ"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "အိုဒေးစီးတီးက မရေးသားနိုင်တဲ့ ဖိုင် -\n"
 "  %s။"
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2803,18 +4784,26 @@ msgstr ""
 "ဖိုင်ကို မဖွင့်နိုင်ဘူး။"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "အိုဒေးစီးတီးက ရုပ်ပုံများကို မရေးသားနိုင်တဲ့ ဖိုင် -\n"
 "  %s။"
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -2824,9 +4813,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -2835,8 +4824,9 @@ msgstr ""
 "မကောင်းတဲ့ png အမျိုးအစား ဖြစ်နိုင်တယ်။"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "အိုဒေးစီးတီးက ၄င်းရဲ့ စံထားချက် အခင်းအကျင်းကို မဖတ်နိုင်ဘူး။\n"
@@ -2874,24 +4864,40 @@ msgstr ""
 "မှာ ရှိနေကြပြီ။"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "အိုဒေးစီးတီးက မသိမ်းဆည်းနိုင်တဲ့ ဖိုင် -\n"
 "  %s"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "ပေါ့ပါးတယ်"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "ခြားနားပါ..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "အသံလမ်းကြော အမည်"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2900,17 +4906,36 @@ msgstr "ခြားနားပါ..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "ကြာမြင့်ချိန်"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "အချိန် လမ်းကြော"
+
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
 msgstr "အသံသွင်းနေခြင်း"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
@@ -2925,12 +4950,38 @@ msgid "Error in Duration"
 msgstr "ကြာမြင့်ချိန်ထဲက အမှားအယွင်း"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "ပျက်စီးမှု အလိုအလျှောက် ဆယ်တင်ရေး"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "ကြာမြင့်ချိန်ထဲက အမှားအယွင်း"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "စိတ်ကြိုက်ဖန်တီးတဲ့ FFmpeg တင်ပို့မှု"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "ကြာမြင့်ချိန်ထဲက အမှားအယွင်း"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "အချိန်တိုင်းကိရိယာ မှတ်တမ်း..."
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -2940,7 +4991,8 @@ msgstr "လက်ရှိ စီမံချက်မှာ အသုံးခ�
 msgid "Recording start:"
 msgstr "အသံသွင်းခြင်း စတင်မှု"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "ကြာမြင့်ချိန် -"
 
@@ -2961,7 +5013,8 @@ msgid "Action after Timer Recording:"
 msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း တိုးတက်မှု"
 
 #: src/TimerRecordDialog.cpp
@@ -2996,6 +5049,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း တိုးတက်မှု"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "အသံသွင်းနေခြင်း"
@@ -3015,6 +5092,7 @@ msgstr "0100 ​ရက်စွဲများ 024 နာရီ 060 မိနစ
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "ရက်စွဲနဲ့ အချိန်ကို စတင်ပါ"
@@ -3059,7 +5137,8 @@ msgstr "မတင်ပို့နိုင်ဘူး"
 msgid "Export Project As:"
 msgstr "ကြိုတင်သတ်မှတ်ချက်များကို တင်ပို့ပါ"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "ရွေးစရာများ..."
 
@@ -3068,8 +5147,21 @@ msgid "After Recording completes:"
 msgstr "အသံသွင်းမှု မီတာ"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "အိုဒေးစီးတီးကို ပိတ်ပါ"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3084,7 +5176,8 @@ msgid "Scheduled to stop at:"
 msgstr "အစပြုဖို့ ရွေးချယ်ခြင်း"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း - စတင်ဖို့ စောင့်နေတယ်"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3092,6 +5185,14 @@ msgstr "အိုဒေးစီးတီး အချိန်တိုင်�
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3102,12 +5203,18 @@ msgid "Recording Exported:"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "အိုဒေးစီးတီး အချိန်တိုင်းကိရိယာ မှတ်တမ်း - စတင်ဖို့ စောင့်နေတယ်"
 
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "စတီရီယို၊ ၉၉၉၉၉၉Hz"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3137,6 +5244,15 @@ msgstr "တပင်တိုင်"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "ရွေးချယ်ပါ"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "ငြိမ်သက်မှု-ရွေးပါ"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -3215,6 +5331,10 @@ msgstr "အသံလမ်းကြောကို အထက် ရွှေ့�
 msgid "Move Track Down"
 msgstr "အသံလမ်းကြောကို အောက် ရွှေ့ပါ"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3260,25 +5380,79 @@ msgstr "ရွေးချယ်ချက်ကို ပွားယူဖိ�
 msgid "There is not enough room available to expand the cut line"
 msgstr "ဖြတ်ယူတဲ့ လိုင်းကို ချဲ့ကားဖို့ ရနိုင်တဲ့ နေရာ မလုံလောက်ဘူး"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "အသုံးချနေတယ်..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "ညွှန်ကြားချက်"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "ညွှန်ကြားချက်"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s ကို ထပ်လုပ်ပါ"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -3288,6 +5462,15 @@ msgstr "အမှတ်အသားများကို မိတ္တူက�
 msgid "Threshold:"
 msgstr "အတိုင်းအတာ -"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "နှောင့်နှေးချိန် (စက္ကန့်များ) -"
@@ -3295,6 +5478,10 @@ msgstr "နှောင့်နှေးချိန် (စက္ကန့်�
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "ယိုယွင်းမှု အကြောင်းရင်း -"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -3316,6 +5503,11 @@ msgstr "အသံလမ်းကြော"
 msgid "Track 1"
 msgstr "အသံလမ်းကြော"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "၀င်းဒိုး အရွယ်"
@@ -3327,6 +5519,22 @@ msgstr "မှ -"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "မှ -"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -3352,13 +5560,42 @@ msgstr "တွဲညှပ်ခြင်း"
 msgid "Envelopes"
 msgstr "စာအိတ်"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "အမှတ်အသားများ"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "စစ်ထုတ်ကိရိယာ"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "အမျိုးအစား -"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -3368,6 +5605,10 @@ msgstr "အသံလမ်းကြောကို အောက် ရွှေ�
 msgid "Types:"
 msgstr "စစ်ထုတ်ကိရိယာ"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "မှတ်ချက်များ"
@@ -3375,6 +5616,18 @@ msgstr "မှတ်ချက်များ"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "ညွှန်ကြားချက် -"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -3393,6 +5646,11 @@ msgid "Number of Channels:"
 msgstr "ထပ်လုပ်မဲ့ အကြိမ် အရေအတွက် -"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "အမျိုးစုံကို တင်ပို့ပါ"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "အမျိုးစုံကို တင်ပို့ပါ"
 
@@ -3400,9 +5658,26 @@ msgstr "အမျိုးစုံကို တင်ပို့ပါ"
 msgid "Builtin Commands"
 msgstr "ညွှန်ကြားမှုကို ရွေးပါ"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "အိုဒေးစီးတီး %s ပံ့ပိုးရေး အဖွဲ့"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "ရက်စွဲနဲ့ အချိန်ကို အသုံးသတ်ပါ"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -3444,17 +5719,45 @@ msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
 msgid "Saves a copy of current project."
 msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "ဦးစားပေးချက်များ..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "အမည်"
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "ဦးစားပေးချက်များ..."
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "အဆင့် -"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3479,6 +5782,12 @@ msgstr "မျက်နှာပြင်အပြည့် ဖွင့်/ပ�
 #: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "ခလုတ်တန်းများ"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "သက်ရောက်မှု"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Scriptables"
@@ -3520,6 +5829,10 @@ msgstr "အသံလမ်းကြောမြင့်များ"
 msgid "All Tracks Plus"
 msgstr "အသံလမ်းကြောမြင့်များ"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -3527,13 +5840,30 @@ msgid "White"
 msgstr "အဖြူရောင်"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "နောက်ခံ -"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "ဖိုင်ထဲ ရိုက်ထည့်မှု အမှားအယွင်း -"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "မျက်နှာပြင်ရိုက်ချက် ကိရိယာများ..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -3580,6 +5910,10 @@ msgid "High:"
 msgstr "အမြင့်ဖြတ်သန်းမှု"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "အသံလမ်းကြောတိုများ"
 
@@ -3591,6 +5925,12 @@ msgstr "ရွေးချယ်ပါ"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "ပေါင်းထည့်ပါ"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "ဖယ်ရှားပါ"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -3609,6 +5949,11 @@ msgid "Selects a time range."
 msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
 
@@ -3620,9 +5965,37 @@ msgstr "အသံတိတ်စေပါ"
 msgid "Set Clip"
 msgstr "နောက် ကိရိယာ"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "စတင်မှု"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -3641,9 +6014,14 @@ msgid "Edited Envelope"
 msgstr "စာအိတ်"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "စာအိတ်"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -3653,6 +6031,10 @@ msgstr "အမှတ်အသားများကို ခွဲခြမ်�
 msgid "Label Index"
 msgstr "အမှတ်အသား တည်းဖြတ်မှု"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "ရွေးချယ်ပါ"
@@ -3660,6 +6042,10 @@ msgstr "ရွေးချယ်ပါ"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "တည်းဖြတ်ထားတဲ့ အမှတ်အသားများ"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -3673,9 +6059,26 @@ msgstr "နှုန်းထားကို ချမှတ်ပါ"
 msgid "Resize:"
 msgstr "သေးငယ်အောင် အရွယ်ညှိပါ"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "ပေါ့ပါးတယ်"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -3690,6 +6093,10 @@ msgid "Set Track Status"
 msgstr "အသံလမ်းကြောအတွက် အစပြုမှု"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "ခေတ္တရပ်နားပါ"
 
@@ -3702,10 +6109,17 @@ msgid "Gain:"
 msgstr "တိုးတက်မှု"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "အသံလမ်းကြောတိုများ"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "အစဉ်လိုက်"
 
@@ -3716,6 +6130,10 @@ msgstr "ပြန်ချိန်ပါ"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "အချိန်"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -3745,13 +6163,28 @@ msgstr "အသံလှိုင်းစဉ် ပရိုဆက်ဆာ"
 msgid "Spectral Select"
 msgstr "ရွေးချယ်မှု"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "အသံလမ်းကြော အသစ်"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "ချဲ့ထွင်ပါ"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -3773,6 +6206,10 @@ msgstr "တွဲညှပ်မှုကို ခွင့်ပြုပါ"
 msgid "Auto Duck"
 msgstr "အော်တို ဒတ်"
 
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -3787,12 +6224,18 @@ msgstr "အသံမပါတဲ့ အသံလမ်းကြောတခု�
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "အော်တို ဒတ်က ရွေးချယ်ထားတဲ့ အသံလမ်းကြော(များ) အောက်မှာ ထားရှိရမဲ့ ထိန်းချုပ်မှု အသံလမ်းကြော တခု လိုအပ်တယ်။"
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "ဒတ် ပမာဏ -"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "စက္ကန့်များ"
 
@@ -3816,7 +6259,8 @@ msgstr "အတွင်းပိုင်း မှေးမှိန်မှ�
 msgid "Inner &fade up length:"
 msgstr "အတွင်းပိုင်း မှေးမှိန်မှု မြင့်တက်တဲ့ အလျား -"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "အတိုင်းအတာ -"
 
@@ -3825,8 +6269,17 @@ msgid "Preview not available"
 msgstr "အစမ်းမြင်ကွင်း မရနိုင်ဘူး"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "ရွေးချယ်မှု ဘယ်ဖက် ကျုံ့သွားမှု"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "ဆူညံသံအတွက် အတိုင်းအတာ -"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3837,12 +6290,31 @@ msgid "Ba&ss (dB):"
 msgstr "မြှင့်တင်ချက် (dB) -"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "ဘေ့စ် မြှင့်တင်ချက်"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "အဆင့် -"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "အမှတ်အသား တည်းဖြတ်မှု"
+
+#: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
 msgstr "အဆင့် -"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "အဆင့် -"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -3853,8 +6325,18 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "အသံပေါက်ကို နရီအနှေးအမြန် မပြောင်းလဲပဲ ပြောင်းလဲပါ"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "နောက်ဆုံး နရီအနှေးအမြန် ပြောင်း​လဲမှု (%)"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "အသံပေါက်ကို နရီအနှေးအမြန် မပြောင်းလဲပဲ ပြောင်းလဲပါ"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
@@ -3909,17 +6391,36 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 msgid "from (Hz)"
 msgstr "မှ"
 
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "to (Hz)"
+msgstr "မှ"
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "သို့"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "ရာနှုန်း ပြောင်းလဲမှု -"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "ရာနှုန်း ပြောင်းလဲမှု"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -3931,7 +6432,9 @@ msgstr "၄၈"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "ဘာမှမရှိ"
 
@@ -3959,6 +6462,7 @@ msgstr "စံညွှန်း Vinyl RPM:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "RPM မှ"
@@ -3968,6 +6472,14 @@ msgstr "RPM မှ"
 msgctxt "change speed"
 msgid "&from"
 msgstr "မှ"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "RPM မှ"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4071,6 +6583,19 @@ msgid "Click Removal"
 msgstr "ဖယ်ရှားမှုကို နှိုပ်ပါ"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "အမည်ဟာ ဗလာ မဖြစ်ရဘူး"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "အတိုင်းအတာကို ရွေးချယ်ပါ (အောက်ပိုင်းဟာ ပိုပြီး အာရုံခံနိုင်တယ်) -"
 
@@ -4090,6 +6615,16 @@ msgstr "စပိုက်ရဲ့ အများဆုံး အကျယ်"
 msgid "Compressor"
 msgstr "ဖိသိပ်ကိရိယာ"
 
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -4098,6 +6633,20 @@ msgstr "%.1f စက္ကန့်"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f စက္ကန့်"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f စက္ကန့်"
 
 #: src/effects/Compressor.cpp
@@ -4109,6 +6658,16 @@ msgstr "အချိုး %.0f မှ 1 သို့"
 #, c-format
 msgid "Ratio %.1f to 1"
 msgstr "အချိုး %.1f မှ 1 သို့"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "ဆူညံမှု အမျိုးအစား"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "ဆူညံသံ..."
 
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
@@ -4151,10 +6710,21 @@ msgstr "တည်ဆောက်မှုကို ထုတ်ပြန်ပ�
 msgid "Ma&ke-up gain for 0 dB after compressing"
 msgstr "ဖိသိပ်မှု ပြီးနောက် 0dB အတွက် တိုးတက်မှုကို အစားပေးပါ"
 
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "အတိုင်းအတာ %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -4167,11 +6737,35 @@ msgid "Release Time %.1f secs"
 msgstr "ယိုယွင်း ချိန် %.1f စက္ကန့်"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "ပြီးဆုံးမှု"
 
@@ -4231,6 +6825,27 @@ msgstr "ခြားနားချက် -"
 msgid "&Help"
 msgstr "အကူအညီ"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "မဆုံးဖြတ်နိုင်ဘူး"
+
 #. i18n-hint: dB abbreviates decibels
 #. * RMS abbreviates root mean square, a certain averaging method
 #: src/effects/Contrast.cpp
@@ -4242,6 +6857,11 @@ msgstr "%.1f dB"
 #: src/effects/Contrast.cpp
 msgid "Infinite dB difference"
 msgstr "လက်ရှိ ခြားနားချက်"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Difference is indeterminate."
+msgstr "ကွဲပြားချက် = %.1f ပျမ်းမျှ rms dB။"
 
 #. i18n-hint: dB abbreviates decibels
 #. RMS abbreviates root mean square, a certain averaging method
@@ -4263,6 +6883,10 @@ msgstr "အနီးကပ်မြင်ကွင်း ပြီးဆုံ�
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "နောက်ခံ ပြီးဆုံးချိန်"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -4290,12 +6914,22 @@ msgid "%.2f dB"
 msgstr "%.1f dB"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "No foreground measured"
+msgstr "အနီးကပ်မြင်ကွင်း ပြီးဆုံးချိန်"
+
+#: src/effects/Contrast.cpp
 msgid "Foreground not yet measured"
 msgstr "အနီးကပ်မြင်ကွင်း ပြီးဆုံးချိန်"
 
 #: src/effects/Contrast.cpp
 msgid "Measured background level"
 msgstr "တိုင်းတာထားတဲ့ နောက်ခံ အဆင့်"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "No background measured"
+msgstr "နောက်ခံ ပြီးဆုံးချိန်"
 
 #: src/effects/Contrast.cpp
 msgid "Background not yet measured"
@@ -4349,6 +6983,16 @@ msgstr "WCAG ၂.၀ ရဲ့ အောင်မြင်မှု စံညွ
 msgid "Data gathered"
 msgstr "ဒေတာ စုဆောင်းချက်"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast..."
 msgstr "ခြားနားပါ..."
@@ -4370,6 +7014,19 @@ msgid "Medium Overdrive"
 msgstr "ထပ်ရေးချက်ကို အတည်ပြုပါ"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "ထပ်ရေးချက်ကို အတည်ပြုပါ"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "တက်ကြွတဲ့ အတိုင်းအတာ ဖိသိပ်ကိရိယာ"
 
@@ -4380,6 +7037,96 @@ msgstr "ချိန်ညှိကိရိယာ"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "တွန့်လိမ်ခြင်း"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "ကန့်သတ်ကိရိယာ"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "ထပ်ရေးချက်ကို အတည်ပြုပါ"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "ထပ်ရေးချက်ကို အတည်ပြုပါ"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "ထပ်ရေးချက်ကို အတည်ပြုပါ"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -4402,8 +7149,16 @@ msgid "Distortion"
 msgstr "တွန့်လိမ်ခြင်း"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "တွန့်လိမ်ခြင်း"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -4418,8 +7173,21 @@ msgid "Clipping level"
 msgstr "တွဲညှပ်ခြင်း"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "ချိန်းကြိုးကို အသုံးချပါ"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "အတိုင်းအတာကို ရွေးချယ်ပါ"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -4434,6 +7202,14 @@ msgid "Repeat processing"
 msgstr "ရိုးရှင်းတဲ့ဟောပြောမှု အစုအစည်း စီမံဆောင်ရွယ်ခြင်း"
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "ချိန်ညှိခြင်း ဒီဂရီ"
 
@@ -4445,9 +7221,48 @@ msgstr "ကန့်သတ်ကိရိယာ"
 msgid "Wet level"
 msgstr "၂-အဆင့်"
 
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "၂-အဆင့်"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "DTMF အသံများ..."
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -4457,7 +7272,9 @@ msgstr "DTMF အစီအစဉ် -"
 msgid "&Amplitude (0-1):"
 msgstr "ကျယ်ပြန့်မှု (၀-၁)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "ကြာမြင့်ချိန် -"
 
@@ -4502,6 +7319,11 @@ msgstr "ပဲ့တင်သံ"
 msgid "Repeats the selected audio again and again"
 msgstr "ရွေးထားတဲ့ အသံကို %s အဖြစ် တင်ပို့နေတယ်"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "နှောင့်နှေးချိန် (စက္ကန့်များ) -"
@@ -4522,7 +7344,8 @@ msgstr "ကြိုတင်သတ်မှတ်ချက်"
 msgid "Export Effect Parameters"
 msgstr "ပါရာမီတာများကို တည်းဖြတ်ပါ"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "မဖွင့်နိုင်တဲ့ ဖိုင် - \"%s\""
@@ -4545,6 +7368,12 @@ msgstr "ပါရာမီတာများကို တည်းဖြတ်�
 #, c-format
 msgid "%s: is not a valid presets file.\n"
 msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး\n"
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
@@ -4597,10 +7426,30 @@ msgid "Factory Defaults"
 msgstr "စံထားချက်များ"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr ""
 "FLAC စာဝှက်ရေးကိရိယာက အနေအထားကို အစပြုဖို့\n"
 " မအောင်မြင်ဘူး - %d"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -4625,6 +7474,23 @@ msgid "&Bypass"
 msgstr "အုပ်စုဖြတ်သန်းမှု"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "တန်းညှိချက်"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "အထက်ကို ရွှေ့ပါ"
 
@@ -4641,6 +7507,24 @@ msgid "Move effect down in the rack"
 msgstr "အခြား အသံလမ်းကြောကို ရွှေ့တဲ့ တွဲညှပ်"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "အခြား အသံလမ်းကြောကို ရွှေ့တဲ့ တွဲညှပ်"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "ချိန်ကြိုး အသစ်ရဲ့ အမည်ကို ရေးသွင်းပါ"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "ငုပ်အောင်းနေမှု"
@@ -4648,6 +7532,20 @@ msgstr "ငုပ်အောင်းနေမှု"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "ညွှန်ကြားမှုကို ရွေးပါ"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "မှတ်တမ်းကို စီမံပါ"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "ပြန်ဖွင့်ချက်"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -4708,14 +7606,33 @@ msgid "Options..."
 msgstr "ရွေးစရာများ..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "စစ်ထုတ်ကိရိယာ"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "အမည်"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "ပြောင်းပြန်လှန်နေခြင်း"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "အမှားအယွင်း -"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "ရေးမှတ်ခြင်း"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -4777,6 +7694,18 @@ msgid "Graphic EQ"
 msgstr "EQ ရုပ်ကား"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "ဘေ့စ် မြှင့်တင်ချက်"
 
@@ -4785,8 +7714,35 @@ msgid "Bass Cut"
 msgstr "ဘေ့စ် မြှင့်တင်ချက်"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "အမှတ်အသား တည်းဖြတ်မှု"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "အမှတ်အသား တည်းဖြတ်မှု"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -4801,6 +7757,10 @@ msgid "Effect Unavailable"
 msgstr "အစမ်းမြင်ကွင်း မရနိုင်ဘူး"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "အများဆုံး dB"
 
@@ -4813,6 +7773,26 @@ msgstr "%3d dB"
 msgid "Min dB"
 msgstr "အနည်းဆုံး dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "စစ်ထုတ်ကိရိယာ"
@@ -4820,6 +7800,11 @@ msgstr "စစ်ထုတ်ကိရိယာ"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "မျဉ်းခုံးများကို ရေးဆွဲပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "ရေးဆွဲ ကိရိယာ"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -4830,8 +7815,46 @@ msgid "Interpolation type"
 msgstr "ပေါင်းစပ်ဖြည့်စွတ်ခြင်း -"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "အစဉ်လိုက် ကြိမ်နှုန်း"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "အစဉ်လိုက် ကြိမ်နှုန်း"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "အစမ်းမြင်ကွင်း အရှည် -"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "အစမ်းမြင်ကွင်း အရှည် -"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "ကြိုတင်သတ်မှတ်ချက်ကို ပယ်ဖျက်ပါ"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "ကြိုတင်သတ်မှတ်ချက်ကို ပယ်ဖျက်ပါ"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "ပြောင်းပြန်လှန်ပါ"
 
 #: src/effects/Equalization.cpp
 msgid "Show grid lines"
@@ -4850,12 +7873,106 @@ msgid "D&efault"
 msgstr "စံထားချက်များ"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "စံအမှတ်ကို လည်ပတ်ပါ..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "ကြိုတင်သတ်မှတ်ချက်ကို ဖွင့်ပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "ညီမျှစေခြင်းကို လုပ်ဆောင်နေတယ်"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Curve not found"
 msgstr "FFmpeg ကို မတွေ့ရှိဘူး"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "မှတ်တမ်းကို စီမံပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "မျဉ်းခုံးများကို ရေးဆွဲပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "ခါဆာ ဘယ်ဖက်"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "အမည်"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "ပယ်ဖျက်ပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "ရွေးချယ်ပါ..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "စံထားချက်များ"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4863,14 +7980,43 @@ msgid "Rename '%s' to..."
 msgstr "'%s' မှ '%s' သို့ အမည်ပြောင်းထားချက်"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "နမူနာပြန်တင်ပါ..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "'%s' မှ '%s' သို့ အမည်ပြောင်းထားချက်"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "ဖောင့် အမည်"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr "တည်ရှိနေတဲ့ ဖိုင်များကို ထပ်ရေးပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "အောက်ကို ရွှေ့ပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "You cannot delete the 'unnamed' curve."
+msgstr "ကြိုတင်သတ်မှတ်ချက် တခုကို အမည်မပါပဲ သင် မပယ်ဖျက်နိုင်ဘူး"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "အသံဖိုင်ကို %s ထံ မတင်ပို့နိုင်ဘူး"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -4887,8 +8033,52 @@ msgid "Delete %d items?"
 msgstr "ထပ်လုပ်တဲ့ %d အကြိမ်"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "ဖိုင်များကို သိမ်းဆည်းမဲ့​ တည်နေရာကို ရွေးပါ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "အမှတ်အသားများကို တင်ပို့ပါ..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "အသံဖိုင်ကို %s ထံ မတင်ပို့နိုင်ဘူး"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "FFmpeg ကို မတွေ့ရှိဘူး"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "တင်ပို့မဲ့ အမှတ်အသားများ မရှိဘူး။"
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -4902,9 +8092,18 @@ msgstr "မှေးမှိန်ပျောက်ကွယ်စေပါ"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "အသံကို ရွေးချယ်ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "အသံကို ရွေးချယ်ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "တွဲညှပ်မှုကို ​ရှာ​ပါ"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -4918,17 +8117,46 @@ msgstr "အတိုင်းအတာကို စတင်ပါ (နမူန
 msgid "St&op threshold (samples):"
 msgstr "အတိုင်းအတာကို ရပ်တန့်ပါ (နမူနာများ) -"
 
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "ရွေးချယ်ချက်ကို ပွားယူဖို့ ရနိုင်တဲ့ နေရာ မလုံလောက်ဘူး"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "ပြောင်းပြန်လှန်ပါ"
+
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
 
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "အများဆုံး ကျယ်ပြန့်မှုကို ပုံမှန်ဖြစ်စေမဲ့နေရာ -"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -4947,6 +8175,27 @@ msgstr "အော်တို ဒတ်ကို ဆောင်ရွတ်န�
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "ပုံမှန်ဖြစ်စေပါ"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -4976,6 +8225,10 @@ msgid "Noise"
 msgstr "ဆူညံသံ..."
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "ဆူညံမှု အမျိုးအစား"
 
@@ -4988,16 +8241,73 @@ msgid "Second greatest"
 msgstr "ဒုတိယ အသံလမ်းကြော"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "ချဲ့ထွင်မှု စံထားချက်"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "ချဲ့ထွင်မှု စံထားချက်"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "ဆူညံသံ လျှော့ချခြင်း"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "အသံလမ်းကြောများ အားလုံးမှာ တူညီတဲ့ နမူနာ နှုန်း ရှိရမယ်"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -5056,8 +8366,9 @@ msgid "Step 1"
 msgstr "အဆင့် ၁"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "အိုဒေးစီးတီးက စစ်ထုတ်တဲ့ အရာကို သိရှိဖို့ ဆူညံသံ အနည်းငယ်မျှကို ရွေးပြီး၊ \n"
@@ -5078,6 +8389,27 @@ msgid ""
 msgstr ""
 "သင် စစ်ထုတ်လိုတဲ့ အသံ အားလုံးကို ရွေးပြီး၊ သင် စစ်ထုတ်လိုတဲ့ ဆူညံသံ အတိုင်းအတာကို \n"
 "ရွေးပြီးနောက်၊ ဆူညံသံကို ဖယ်ရှားဖို့ 'ကောင်းပြီး'ကို နှိုပ်ပါ။\n"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "ဆူညံသံ..."
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "အသံလမ်းကြောများကို ဖယ်ရှားပါ"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "သေးငယ်အောင် အရွယ်ညှိပါ"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -5112,6 +8444,10 @@ msgid "128"
 msgstr "၁၂၈"
 
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "512"
 msgstr "၅၁၂"
 
@@ -5135,7 +8471,12 @@ msgstr "၈၁၉၂"
 msgid "16384"
 msgstr "၁၆၃၈၄"
 
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
 msgid "2"
 msgstr "၂"
 
@@ -5143,9 +8484,17 @@ msgstr "၂"
 msgid "4 (default)"
 msgstr "ချဲ့ထွင်မှု စံထားချက်"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "ဆူညံသံ ဖယ်ရှားမှု"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -5160,6 +8509,11 @@ msgid "Noise re&duction (dB):"
 msgstr "ဆူညံသံ လျှော့ချခြင်း (dB) -"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "အာရုံခံနိုင်မှု"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr "ကြိမ်နှုန်း ချောမွေ့စေခြင်း (Hz) -"
 
@@ -5171,13 +8525,61 @@ msgstr "တိုက်ခိုက်/ယိုယွင်းတဲ့ အခ�
 msgid "Attack/decay time"
 msgstr "တိုက်ခိုက်/ယိုယွင်းတဲ့ အချိန်"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "ဖယ်ရှားပါ"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "ပုံမှန်ဖြစ်စေပါ"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "ဆူညံသံ ဖယ်ရှားခြင်း\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "ဆူညံသံ ဖယ်ရှားခြင်း\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "ဆူညံသံ ဖယ်ရှားခြင်း\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Remove DC offset (center on 0.0 vertically)"
@@ -5191,9 +8593,23 @@ msgstr "အများဆုံး ကျယ်ပြန့်မှုကိ�
 msgid "Peak amplitude dB"
 msgstr "အထွတ်အထိပ် ကျယ်ပြန့်မှု အသစ် (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "ယိုယွင်းမှု အကြောင်းရင်း -"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "ယိုယွင်းမှု အကြောင်းရင်း -"
@@ -5202,9 +8618,43 @@ msgstr "ယိုယွင်းမှု အကြောင်းရင်း -
 msgid "&Time Resolution (seconds):"
 msgstr "နှောင့်နှေးချိန် (စက္ကန့်များ) -"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "ဖေးဇာ"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -5267,6 +8717,10 @@ msgid "Repair"
 msgstr "ပြုပြင်ပါ"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -5295,6 +8749,10 @@ msgid "Repeat"
 msgstr "ထပ်လုပ်ပါ"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "ထပ်လုပ်မဲ့ အကြိမ် အရေအတွက် -"
 
@@ -5316,13 +8774,64 @@ msgstr "ရွေးချယ်မှု အရှည် အသစ် -"
 msgid "New selection length: %s"
 msgstr "ရွေးချယ်မှု အရှည် အသစ် -"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "အသံလမ်းကြော ဖယ်ရှားမှု"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "အလယ်အလတ်"
 
 #: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "ပဲ့တင်ထပ်စေပါ"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "အရွယ်"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "တိုက်ခိုက်/ယိုယွင်းတဲ့ အချိန်"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -5331,6 +8840,34 @@ msgstr "တုံ့ပြန်ချက် (%) -"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "အနက် (%) -"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "အနက် (%) -"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "ရလဒ် ချာနယ်များ - %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "ရလဒ် ချာနယ်များ - %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "စတီရီယို"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -5345,6 +8882,25 @@ msgstr "ပြောင်းပြန်လှန်ပါ"
 msgid "Reverses the selected audio"
 msgstr "ရွေးထားတဲ့ အသံကို %s အဖြစ် တင်ပို့နေတယ်"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "အနိမ့်ဖြတ်သန်းမှု"
@@ -5354,12 +8910,35 @@ msgid "Highpass"
 msgstr "အမြင့်ဖြတ်သန်းမှု"
 
 #: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "ဖိုင်ကို တင်ပို့ပါ..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "ရောင်စဉ်ကို ရေးမှတ်ဖို့၊ ရွေးထားတဲ့ အသံလမ်းကြောများ အားလုံးဟာ တူညီတဲ့ နမူနာ အဆင့်ဖြစ်ရမယ်။"
 
 #: src/effects/ScienFilter.cpp
 msgid "&Filter Type:"
 msgstr "စစ်ထုတ်ကိရိယာ"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
@@ -5369,9 +8948,32 @@ msgstr "တည်ဆောက်မှု အမျိုးအစား -"
 msgid "Cutoff (Hz)"
 msgstr "မှ"
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "C&utoff:"
+msgstr "မှ"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "MIDI ကို အသံနဲ့ တပြိုင်တည်း လုပ်ဆောင်ပါ"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "ကြာမြင့်ချိန် -"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "ကြာမြင့်ချိန် -"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -5380,6 +8982,14 @@ msgstr "၀င်းဒိုး အရွယ်"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "၀င်းဒိုး အရွယ်"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -5395,6 +9005,15 @@ msgstr "အတိုင်းအတာကို ရွေးချယ်ပါ"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "အချိန်အလက် မျိုးတူစုပါ"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "အချိန်အလက် မျိုးတူစုပါ"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -5433,11 +9052,20 @@ msgstr "စံထားချက်များ"
 msgid "Restore Defaults"
 msgstr "စံထားချက်များ"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "ငြိမ်သက်စေပါ"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -5464,12 +9092,38 @@ msgid "Sliding Stretch"
 msgstr "ယိုယွင်းမှု အကြောင်းရင်း -"
 
 #: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
 msgstr "အစပိုင်း နရီအနှေးအမြန် ပြောင်း​လဲမှု (%)"
 
 #: src/effects/TimeScale.cpp
 msgid "Final Tempo Change (%)"
 msgstr "နောက်ဆုံး နရီအနှေးအမြန် ပြောင်း​လဲမှု (%)"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Pitch Shift"
+msgstr "အသံပေါက် ရွှေ့ပြောင်းကိရိယာ"
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Pitch Shift"
+msgstr "အသံပေါက် ရွှေ့ပြောင်းကိရိယာ"
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
 
 #: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
 msgid "Logarithmic"
@@ -5498,6 +9152,14 @@ msgstr "မြည်သံ..."
 #: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr "အသံ..."
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
 
 #: src/effects/ToneGen.cpp
 msgid "&Waveform:"
@@ -5532,8 +9194,20 @@ msgid "Truncate Detected Silence"
 msgstr "တိတ်ဆိတ်မှုကို တိဖြတ်ပါ"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "တိတ်ဆိတ်မှုကို တိဖြတ်ပါ"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -5543,11 +9217,38 @@ msgstr "တိတ်ဆိတ်မှုများမှာ ဖြတ်ထ�
 msgid "Tr&uncate to:"
 msgstr "တိတ်ဆိတ်မှုကို တိဖြတ်ပါ"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "ဖိသိပ်ကိရိယာ"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "သက်ရောက်မှု"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "MP3 စာဝှက်ရေးသားတဲ့ စုစည်းခန်းကို မဖွင့်နိုင်ဘူး။"
 
@@ -5555,11 +9256,30 @@ msgstr "MP3 စာဝှက်ရေးသားတဲ့ စုစည်းခ�
 msgid "VST Effect Options"
 msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "အရှည်"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "ဖိသိပ်မှုကို ငြိမ်သက်​စေပါ -"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "ဖိသိပ်မှုကို ငြိမ်သက်​စေပါ -"
 
@@ -5568,16 +9288,44 @@ msgid "Graphical Mode"
 msgstr "EQ ရုပ်ကား"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "VST ပရိုဂရမ် သိမ်းဆည်းမဲ့ ပုံစံ -"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "VST ပရိုဂရမ်ကို ဖွင့်ပါ -"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "VST ပရိုဂရမ်ကို ဖွင့်ပါ -"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "အိုဒေးစီးတီး စီမံချက် ဖိုင်များ"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "ကြိုတင်သတ်မှတ်ချက်ကို ဖွင့်ပါ"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Load VST Preset:"
@@ -5595,9 +9343,15 @@ msgstr "ကြိုတင်သတ်မှတ်ချက်ကို ဖွ�
 msgid "Unable to load presets file."
 msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
@@ -5608,9 +9362,19 @@ msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိ�
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "ဒီ ပါရာမီတာ ဖိုင်ကို %s မှ သိမ်းဆည်းထားတယ်။ ဆက်လုပ်မလား?"
 
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "ဝါဝါ"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -5632,6 +9396,17 @@ msgstr "ဝါ ကြိမ်နှုန်း အော့ဖ်ဆက် (%)
 msgid "Wah frequency offset in percent"
 msgstr "ရာခိုင်နှုန်းအလိုက် ဝါ ကြိမ်နှုန်း အော့ဖ်ဆက်"
 
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "ဖိုင်ကို မဖွင့်နိုင်ဘူး"
@@ -5645,20 +9420,41 @@ msgid "Audio Unit Effect Options"
 msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "ကြားခံမြင်ကွင်း"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "ထည့်သွင်း ကိရိယာ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "အုပ်စုမျိုးစု"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "ထုတ်လုပ်ပါ"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "ကြိုတင်သတ်မှတ်ချက်များကို တင်သွင်းပါ"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -5734,6 +9530,11 @@ msgid "Failed to retrieve preset content"
 msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "နမူနာ အဆင့် အသွင်ပြောင်းခြင်း"
 
@@ -5742,15 +9543,60 @@ msgstr "နမူနာ အဆင့် အသွင်ပြောင်းခ�
 msgid "Failed to write XML preset to \"%s\""
 msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "အသံ ဖိုင်"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "သက်ရောက်မှု"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "သက်ရောက်မှု"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -5758,6 +9604,7 @@ msgstr "သက်ရောက်မှု တပ်ဆင်ချက်မျ�
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "သက်ရောက်မှု"
@@ -5767,16 +9614,57 @@ msgid "LV2 Effect Settings"
 msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
 
 #: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Generator"
 msgstr "ထုတ်လုပ်ကိရိယာ"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
 
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "သက်ရောက်မှု"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -5792,6 +9680,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "နိုင်ခွီးစ်ထ် ရလဒ် -"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "ရွေးချယ်ချက်နဲ့ တန်းညှိထားတဲ့ ပြီးဆုံးမှု"
 
@@ -5804,12 +9710,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "၀မ်းနည်းပါတယ်၊ အသံလမ်းကြောများ မကိုက်ညီတဲ့ နေရာမှ စတီရိယို အသံလမ်းကြောများပေါ်မှာ သက်ရောက်မှုကို အသုံးမချနိုင်ဘူး။"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "နိုင်ခွီးစ်ထ် ရလဒ် -"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "အော်တို ဒတ်ကို ဆောင်ရွတ်နေတယ်..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -5852,6 +9776,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "နိုင်ခွီးစ်ထ်က အသံကို မထုတ်ပေးခဲ့ဘူး။\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "အိုဒေးစီးတီးရဲ့ ဒီမူအဆင့်ကို %s ပံ့ပိုးမှုနဲ့ ပြုစုမထားဘူး"
@@ -5860,10 +9788,38 @@ msgstr "အိုဒေးစီးတီးရဲ့ ဒီမူအဆင်�
 msgid "Could not open file"
 msgstr "ဖိုင်ကို မဖွင့်နိုင်ဘူး"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Error in Nyquist code"
+msgstr "ကြာမြင့်ချိန်ထဲက အမှားအယွင်း"
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "ဖိုင်ကို မဖွင့်နိုင်ဘူး -"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -5884,6 +9840,22 @@ msgid "Lisp scripts"
 msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "ဖိုင်ကို မဖွင့်နိုင်ဘူး"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "အနီးကပ်မြင်ကွင်း ပြီးဆုံးချိန်"
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -5902,9 +9874,18 @@ msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
 msgid "Save file as"
 msgstr "ဖိုင်များကို သိမ်းဆည်းပါ"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "သက်ရောက်မှု"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -5925,6 +9906,17 @@ msgstr "ယန္တရားငယ် တပ်ဆင်ချက်မျာ�
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "ပရိုဂရမ်"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -6032,10 +10024,25 @@ msgstr "မတင်ပို့နိုင်ဘူး"
 msgid "Show output"
 msgstr "ရလဒ်ကို ပြသပါ"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "ကိန်းရှင်"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "ညွှန်ကြားချက်"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -6073,9 +10080,18 @@ msgstr ""
 "သင် ဆက်လက် လုပ်ဆောင်လိုသလား။"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "FFmpeg ကို မတွေ့ရှိဘူး"
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -6086,8 +10102,32 @@ msgstr ""
 "၄င်းကို ဦးစားပေးချက်များ > စုစည်းခန်းများ မှာ သင် စီစဉ်ဖန်တီးနိုင်တယ်။"
 
 #: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "FFmpeg စုစည်းခန်း -"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -6098,6 +10138,64 @@ msgid ""
 msgstr ""
 "FFmpeg က အသံ ကုဓ 0x%x ကို မတွေ့နိုင်ဘူး။\n"
 "ဒီကုဓ အတွက် ပံ့ပိုးမှုကို ပြုစုမထားတဲ့ ဖြစ်နိုင်တယ်။"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -6113,7 +10211,8 @@ msgstr "ရွေးထားတဲ့ အသံကို တင်ပို့�
 msgid "Invalid sample rate"
 msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "နမူနာပြန်တင်ပါ"
 
@@ -6143,7 +10242,8 @@ msgstr "နမူနာ နှုန်းထားများ"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "kbps"
@@ -6155,6 +10255,12 @@ msgstr "ဘစ် နှုန်းထား -"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "အရည်​​အသွေး -"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "kbps"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "0"
@@ -6201,6 +10307,10 @@ msgid "Constrained"
 msgstr "အမြဲတမ်း"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "အသံ..."
 
@@ -6209,8 +10319,44 @@ msgid "Low Delay"
 msgstr "နှောင့်နှေးစေပါ"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "အလယ်အလတ်"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -6231,6 +10377,11 @@ msgstr "စနစ်များ"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "dB ကို ချဲ့ထွင်ခြင်း"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Cutoff:"
+msgstr "မှ"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Open custom FFmpeg format options"
@@ -6277,12 +10428,30 @@ msgid "Replace preset '%s'?"
 msgstr "ကြိုတင်သတ်မှတ်ချက် '%s' ကို ပယ်ဖျက်မလား?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "ပင်မ ပေါင်းစပ်မှု"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
 msgstr "M4A (AAC) ဖိုင်များ (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "AC3 Files (FFmpeg)"
 msgstr "AC3 ဖိုင်များ (FFmpeg)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr "WMA (မူအဆင့် ၂) ဖိုင်များ (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Opus (OggOpus) Files (FFmpeg)"
@@ -6346,12 +10515,21 @@ msgid "Codec:"
 msgstr "ကိုဓ -"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Formats"
 msgstr "အမျိုးအစားများ အားလုံးကို ပြသပါ"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Codecs"
 msgstr "ကိုဓများ အားလုံးကို ပြသပါ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "ယန္တရားငယ် တပ်ဆင်ချက်များ"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -6366,6 +10544,14 @@ msgstr ""
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "ဘာသာစကား -"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -6465,6 +10651,11 @@ msgstr ""
 "အများဆုံး - ၁၀ (နှေးကွေးတဲ့ စာဝှက်ရေးသားခြင်း၊ ရလဒ် ဖိုင် အငယ်)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "ဖိသိပ်ကိရိယာ"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Frame size\n"
 "Optional\n"
@@ -6477,6 +10668,11 @@ msgstr ""
 "၀ - စံထားချက်\n"
 "အနည်းဆုံး - ၁၆\n"
 "အများဆုံး - ၆၅၅၃၅"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "အမည်"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -6493,6 +10689,11 @@ msgstr ""
 "အများဆုံး - ၁၅"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LPC ကို သုံးစွဲပါ"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -6503,6 +10704,10 @@ msgstr ""
 "ခန့်မှန်းချက် - အမြန်ဆုံး၊ ပိုနိမ့်တဲ့ ဖိသိပ်မှု\n"
 "လော့ဂ် ရှာဖွေမှု - အနှေးဆုံး၊ အကောင်းဆုံး ဖိသိပ်မှု\n"
 "အပြည့်အစုံ ရှာဖွေမှု - စံထားချက်"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -6516,6 +10721,10 @@ msgstr ""
 "ရွေးချယ်နိုင်တယ်\n"
 "-၁ - စံထားချက်\n"
 "အနည်းဆုံး - ၀အများဆုံး - ၃၂ (LPC နဲ့အတူ) (သို့) ၄ (LPC မပါပဲ)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -6532,6 +10741,10 @@ msgstr ""
 "အများဆုံး - ၃၂ (LPC နဲ့အတူ) (သို့) ၄ (LPC မပါပဲ)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Minimal partition order\n"
 "Optional\n"
@@ -6546,6 +10759,10 @@ msgstr ""
 "အများဆုံး - ၈"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal partition order\n"
 "Optional\n"
@@ -6558,6 +10775,10 @@ msgstr ""
 "-၁ - စံထားချက်\n"
 "အနည်းဆုံး - ၀\n"
 "အများဆုံး - ၈"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
 
 #. i18n-hint:  Abbreviates "Linear Predictive Coding",
 #. but this text needs to be kept very short
@@ -6628,6 +10849,17 @@ msgstr "တင်ပို့မဲ့ အမှတ်အသားများ �
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Select xml file to export presets into"
 msgstr "XML ဖိုင်ကို ကြိုတင်သတ်မှတ်ချက်များထဲ တင်ပို့ဖို့ ရွေးချယ်ပါ"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
@@ -6715,8 +10947,57 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(အကောင်းဆုံး အရည်အသွေး)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(ပိုသေးငယ်တဲ့ ဖိုင်များ)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -6727,7 +11008,8 @@ msgstr "မိုက်မဲတယ်"
 msgid "Extreme"
 msgstr "လွန်ကဲတယ်"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "စံညွှန်း"
 
@@ -6768,14 +11050,19 @@ msgstr "အရည်အသွေး"
 msgid "Channel Mode:"
 msgstr "ချာနယ် စနစ် -"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "ဖယ်ရှားထားတဲ့ ဖြတ်ယူမှု လိုင်း"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "လမ်ကို ရှာဖွေပါ"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "အိုဒေးစီးတီးက MP3များကို ဖန်တီးဖို့ %s ဖိုင် လိုအပ်တယ်။"
 
 #: src/export/ExportMP3.cpp
@@ -6803,13 +11090,34 @@ msgid "Where is %s?"
 msgstr "%s ဘယ်မှာ ရှိလဲ။"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "သင်ဟာ lame_enc.dll v%d.%d ကို ချိတ်ဆက်နေတယ်။ ဒီမူအဆင့်ဟာ အိုဒေးစီးတီး %d.%d.%d နဲ့ မလိုက်ဖက်ဘူး။\n"
 "လမ် MP3 စုစည်းခန်း နောက်ဆုံး မူအဆင့်ကို ဆွဲချပါ။"
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "စီမံချက် အချက်အလက်ကြမ်း ဖိုင်များကို သိမ်းဆည်းနေတယ်"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -6905,8 +11213,18 @@ msgid "Cannot Export Multiple"
 msgstr "အမျိုးစုံကို တင်ပို့ပါ"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "တည်နေရာ တင်ပို့ပါ -"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -6939,6 +11257,16 @@ msgstr "ဖိုင်များကို အမည်ပေးပါ -"
 #: src/export/ExportMultiple.cpp
 msgid "Using Label/Track Name"
 msgstr "အမှတ်အသား/အသံကြော အမည်ကို သုံးစွဲခြင်း"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "အမှတ်အသား/အသံကြော အမည်ကို သုံးစွဲခြင်း"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "ဖိုင်အမည် ရှေ့ဆက်"
 
 #: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
@@ -7001,6 +11329,27 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "သိမ်းဆည်းမဲ့ ပုံစံ..."
@@ -7008,6 +11357,31 @@ msgstr "သိမ်းဆည်းမဲ့ ပုံစံ..."
 #: src/export/ExportOGG.cpp
 msgid "Ogg Vorbis Files"
 msgstr "အော့ဂျ် ဝေါဘီးစ် ဖိုင်များ"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -7020,6 +11394,10 @@ msgstr "အော့ဂျ် ဝေါဘီးစ် အဖြစ် ရွေ
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "အော့ဂျ် ဝေါဘီးစ် အဖြစ် ရွေးထားတဲ့ အသံကို တင်ပို့နေခြင်း"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -7038,8 +11416,28 @@ msgid "Other uncompressed files"
 msgstr "တခြား ဖိသိပ်မထားတဲ့ ဖိုင်များ"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "တင်သွင်းနေတဲ့ အမှားအယွင်း"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -7050,16 +11448,26 @@ msgstr "အသံကို ဒီအမျိုးအစားနဲ့ မတ�
 msgid "Exporting the selected audio as %s"
 msgstr "ရွေးထားတဲ့ အသံကို %s အဖြစ် တင်ပို့နေတယ်"
 
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
 #: src/import/Import.cpp
 msgid "All supported files"
 msgstr "ဖိုင်များ အားလုံး|*|ပံ့ပိုးထားတဲ့ ဖိုင်များ အားလုံး|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -7068,11 +11476,11 @@ msgstr ""
 "ဖိုင် > တင်သွင်းပါ > MIDI ကို နှိုပ်ပြီး ၄င်းကို သင် တည်းဖြတ်နိုင်တယ်။"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "အသံဖိုင်တခု မဟုတ်တဲ့၊ MIDI ဖိုင် တခုဖြစ်တယ် \n"
@@ -7084,18 +11492,18 @@ msgid "Select stream(s) to import"
 msgstr "တင်သွင်းဖို့ စီးကြောင်း(များ)ကို ရွေးချယ်ပါ"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "အိုဒေးစီးတီးရဲ့ ဒီမူအဆင့်ကို %s ပံ့ပိုးမှုနဲ့ ပြုစုမထားဘူး"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ အသံ စီဒီ အသံလမ်းကြော တခု ဖြစ်တယ်။ \n"
 "အိုဒေးစီးတီးက အသံ စီဒီများကို တိုက်ရိုက် မဖွင့်နိုင်ဘူး။\n"
@@ -7104,10 +11512,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" ဟာ ဖွင့်ပြစာရင်း ဖိုင်တခု ဖြစ်တယ်။\n"
@@ -7116,10 +11524,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ ၀င်းဒိုး မီဒီယာ အသံဖိုင်တခု ဖြစ်တယ်။\n"
@@ -7129,10 +11537,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ အဆင့်မြင့် အသံ ကုဒ်ရေးသားခြင်း ဖိုင်တခု ဖြစ်တယ် \n"
@@ -7142,12 +11550,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ စာဝှက်ထားတဲ့ အသံဖိုင် တခု ဖြစ်တယ်။ \n"
@@ -7158,10 +11566,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ RealPlayer မီဒီယာ ဖိုင်တခု ဖြစ်တယ် \n"
@@ -7171,12 +11579,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" ဟာ အသံဖိုင်တခု မဟုတ်ပဲ၊ နုတ်များ-အခြေပြုဖိုင်တခု ဖြစ်တယ်။\n"
 "ဒီလို ဖိုင် အမျိုးအစားကို အိုဒေးစီးတီးက မဖွင့်နိုင်ဘူး။\n"
@@ -7185,10 +11593,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -7201,10 +11609,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ ဝဲပက် အသံဖိုင် တခု ဖြစ်တယ်။ \n"
@@ -7214,10 +11622,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ ဒေါဘီ ဒစ်ဂျစ်တယ် အသံဖိုင် တခု ဖြစ်တယ်။\n"
@@ -7227,10 +11635,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ အော့ဂျ် စပစ် အသံဖိုင် တခု ဖြစ်တယ်။\n"
@@ -7240,10 +11648,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" ဟာ ဗွီဒီယို ဖိုင် တခု ဖြစ်တယ်။\n"
@@ -7258,14 +11666,40 @@ msgstr "FFmpeg ကို မတွေ့ရှိဘူး"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "အိုဒေးစီးတီးက '%s' ဖိုင်အမျိုးအစားကို အသိအမှတ်မပြုဘူး။\n"
 "၄င်းကို ဖိသိပ်မထားရင်၊ \"တင်သွင်းချက် အကြမ်း\" ကို သုံးပြီး ၄င်းကကို တင်သွင်းကြည့်ပါ။"
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "စီမံချက် အချက်အလက်ကြမ်း ဖိုင်များကို သိမ်းဆည်းနေတယ်"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7282,21 +11716,132 @@ msgid "Import Project"
 msgstr "ကြိုတင်သတ်မှတ်ချက်များကို တင်သွင်းပါ"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "စီမံချက် ဒေတာ ဖိုင်တွဲကို မတွေ့နိုင်ဘူး - \"%s\""
+
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "စီမံချက်များ"
 
 #: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
 msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "မမှန်တဲ့ နမူနာ နှုန်းထား"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7326,36 +11871,6 @@ msgstr "အညွှန်း[%02x] ကိုဓ[%s], ဘာသာစကား[%
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC ဖိုင်များ"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "ဂျီစထရီးမား-လိုက်ဖက်တဲ့ ဖိုင်များ"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "ဂျီစထရီးမား အစပြုမှု မအောင်မြင်ဘူး"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "'%s' ကို '%s' အဖြစ် အမည် မပြောင်းနိုင်ဘူး"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "အညွှန်း[%02x] ကိုဓ[%s], ဘာသာစကား[%s], ဘစ်နှုန်းထား[%s], ချာနယ်များ[%d], ကြာမြင့်ချိန်[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "ဂျီစထရီးမား %s: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -7415,6 +11930,14 @@ msgstr "ဖိုင်ကို မဖွင့်နိုင်ဘူး"
 msgid "MP3 files"
 msgstr "MP3 ဖိုင်များ"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "အော့ဂျ် ဝေါဘီးစ် ဖိုင်များ"
@@ -7449,8 +11972,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, နဲ့ အခြား ဖိသိပ်မထားတဲ့ အမျိုးအစားများ"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (မိုက်ခရိုဆော့ဗ်) စာချုပ်ထား ၁၆ ဘစ် PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "၁၆-ဘစ် PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -7461,12 +12078,56 @@ msgid "Signed 24 bit PCM"
 msgstr "၁၄-ဘစ် PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "၁၄-ဘစ် PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "၁၆-ဘစ် PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "၃၂-ဘစ် PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "၃၂-ဘစ် PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (မိုက်ခရိုဆော့ဗ်) စာချုပ်ထား ၁၆ ဘစ် PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "၁၆ ဘစ်"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -7477,12 +12138,20 @@ msgid "24 bit DWVW"
 msgstr "၂၄ ဘစ်"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "၁၆-ဘစ် PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "၁၆-ဘစ် PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -7492,6 +12161,33 @@ msgstr "%s ကို တင်သွင်းနေခြင်း"
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "QuickTime ဖိုင်များ"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "အမျိုးအစား ဖိုင်ကို မသိမ်းဆည်းနိုင်ဘူး။"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "အမျိုးအစား ဖိုင်ကို မသိမ်းဆည်းနိုင်ဘူး။"
 
 #. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
 #: src/import/ImportRaw.cpp
@@ -7569,6 +12265,10 @@ msgstr "နမူနာ နှုန်းထား -"
 msgid "&Import"
 msgstr "တင်သွင်းပါ"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -7589,6 +12289,7 @@ msgstr "ညာဖက်"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -7612,6 +12313,7 @@ msgstr "ပြီးဆုံးမှု"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -7631,12 +12333,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "အသံလမ်းကြောများ/တွဲညှပ်များ ရွှေ့ပြောင်းတဲ့ အချိန် %s %.02f စက္ကန့်"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "အသံလမ်းကြောများ/တွဲညှပ်များ ရွှေ့ပြောင်းတဲ့ အချိန် %s %.02f စက္ကန့်"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "အချိန်-ရွှေ့ပြောင်းမှု"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "ရွေးချယ်မှုအတွက် အစပြုမှု"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -7653,6 +12378,26 @@ msgstr "နောက် ကိရိယာ"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "နောက် ကိရိယာ"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "အလျင် ကိရိယာ"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "ခါဆာမှ အသံလမ်းကြော ပြီးဆုံးပြီ"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "နောက် ကိရိယာ"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "ရွေးချယ်မှုအတွက် အစပြုမှု"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -7740,7 +12485,8 @@ msgstr "%.2f စက္ကန့်နေရာ %.2f အတွက် ငြိမ
 msgid "Trim Audio"
 msgstr "အသံသွင်းနေတယ်"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "ခွဲခြမ်းပါ"
 
@@ -7760,6 +12506,15 @@ msgstr "ဆက်စပ်ထားမှု %.2f စက္ကန့်နေရ
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "ဆက်စပ်ပါ"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "ပယ်ဖျက်ထားချက် %.2f စက္ကန့်နေရာ t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
@@ -7792,6 +12547,11 @@ msgstr "ပွားယူပါ"
 #: src/menus/EditMenus.cpp
 msgid "Duplic&ate"
 msgstr "ပုံတူပွားပါ"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "အသံလမ်းကြောများကို ဖယ်ရှားပါ"
 
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
@@ -7848,32 +12608,8 @@ msgid "Delete Key&2"
 msgstr "ပယ်ဖျက်ခလုတ်၂"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "ပေါင်းစပ်ကိရယာ ခလုတ်တန်း"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "ပြန်ဖွင့်ချက်"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "ပြန်ဖွင့်ချက်"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "ပြန်ဖွင့်ချက်"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -7900,8 +12636,21 @@ msgid "&Full Screen (on/off)"
 msgstr "မျက်နှာပြင်အပြည့် ဖွင့်/ပိတ်ပါ"
 
 #: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "ရွေးထားတဲ့ အသံကို တင်ပို့နေတဲ့ ပုံစံ %s"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "အမှတ်အသား တည်းဖြတ်မှု"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -7951,6 +12700,11 @@ msgstr "အမှတ်အသားများကို တင်သွင်�
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "ဖိုင်များ အားလုံး (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -8031,6 +12785,11 @@ msgid "&Labels..."
 msgstr "အမှတ်အသားများ..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "MIDI ကို တင်ပို့ပါ..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "ဒေတာ အကြမ်း..."
 
@@ -8047,6 +12806,10 @@ msgstr "ပုံနှိုပ်ပါ..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "ထွက်ခွါပါ"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -8079,6 +12842,10 @@ msgid "Nothing to do"
 msgstr "ပြန်ဖြည်ဖို့ မရှိဘူး"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "ဗဟိုပြုထားတဲ့ အသံလမ်းကြောကို ပိတ်ပါ"
 
@@ -8091,6 +12858,18 @@ msgid "Recording stops and starts"
 msgstr "အသံသွင်းခြင်း စတင်မှု"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "အကူအညီ"
 
@@ -8099,7 +12878,8 @@ msgid "&Getting Started"
 msgstr "ရွေးချယ်မှု စတင်ခြင်း -"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
 
 #: src/menus/HelpMenus.cpp
@@ -8107,20 +12887,34 @@ msgid "&Quick Help..."
 msgstr "အကူအညီ"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
 msgstr "\t-test (အလိုလို ချို့ယွင်းချက် ရှာဖွာမှုကို လည်ပတ်ပါ)"
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
 msgid "Show &Log..."
 msgstr "လော့ဂ်ကို ပြပါ..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "အိုဒေးစီးတီး အကြောင်း..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "ပေါင်းထည့်ထားတဲ့ အမှတ်အသား"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "ဗဟိုပြုချက်ကို နောက် လမ်းကြောင်းဆီ ရွှေ့ပြီး ရွေးချယ်ပါ"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -8236,6 +13030,15 @@ msgid "Add Label at &Playback Position"
 msgstr "အမှတ်အသားကို ပြန်ဖွင်ချက် တည်နေရာမှာ ပေါင်းထည့်ပါ"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "ဗဟိုပြုချက်ကို နောက် လမ်းကြောင်းဆီ ရွှေ့ပြီး ရွေးချယ်ပါ"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "စာတန်းတပ်ထားတဲ့ နယ်ပယ်များ"
 
@@ -8270,6 +13073,11 @@ msgid "Label Split Delete"
 msgstr "ပယ်ဖျက်မှုကို ခွဲခြမ်းပါ"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "အသံတိတ်စေပါ"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "ငြိမ်သက်စေပါ"
 
@@ -8294,6 +13102,18 @@ msgstr "အမှတ်အသား တည်းဖြတ်မှု"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "အမှတ်အသား တည်းဖြတ်မှု"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -8336,8 +13156,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "ဗဟိုပြုထားတဲ့ အသံလမ်းကြောကို ထိန်းပါ"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "အသစ်..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -8352,6 +13180,10 @@ msgstr "ယန္တရားငယ်များ %i မှ %i သို့"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "ထုတ်လုပ်ပါ"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -8435,6 +13267,16 @@ msgid "Set Track Status..."
 msgstr "အသံလမ်းကြောအတွက် အစပြုမှု"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "အသံတိတ်စေပါ"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "အသံလမ်းကြောတိုများ"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "ဦးစားပေးချက်များ..."
 
@@ -8458,9 +13300,20 @@ msgstr "အမှတ်အသားများကို တည်းဖြတ�
 msgid "Set Project..."
 msgstr "စီမံချက်ကို သိမ်းဆည်းမဲ့ ပုံစံ..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "ကိန်းရှင်"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "အသံလမ်းကြောတိုများ"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "အချက်အလက်"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -8491,6 +13344,21 @@ msgstr "ဖိသိပ်ကိရိယာ..."
 msgid "Screenshot (short format)..."
 msgstr "မျက်နှာပြင်ရိုက်ချက် ကိရိယာများ..."
 
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "ရွေးချယ်မှု အမှတ် ချမှတ်ပါ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "အသံ တည်နေရာ -"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "ရွေးချယ်မှု အမှတ် ချမှတ်ပါ"
+
 #. i18n-hint: (verb) It's an item on a menu.
 #: src/menus/SelectMenus.cpp
 msgid "&Select"
@@ -8507,6 +13375,15 @@ msgstr "ရွေးချယ်မှု"
 #: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
 msgid "&Tracks"
 msgstr "အသံလမ်းကြေားများ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "အသံလမ်းကြောမြင့်များ"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Sync-Locked"
@@ -8581,8 +13458,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "အစဉ်လိုက် ကြိမ်နှုန်း"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "အစပြုဖို့ ရွေးချယ်ခြင်း"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "အသံ တည်နေရာ -"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -8719,6 +13605,14 @@ msgstr "ခါဆာ ဘယ်ဖက် ရေရှည် ခုန်တက်
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "ခါဆာ ညာဖက် ရေရှည် ခုန်တက်မှု"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
@@ -8899,6 +13793,11 @@ msgid "Synchronize MIDI with Audio"
 msgstr "MIDI ကို အသံနဲ့ တပြိုင်တည်းလုပ်ဆောင်ပါ"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr "MIDI ကို အသံနဲ့ တပြိုင်တည်းလုပ်ဆောင်ပါ"
+
+#: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
 msgstr "ချိန်ညှိထားတဲ့ တိုးတက်မှု"
 
@@ -8923,14 +13822,20 @@ msgid "Created new label track"
 msgstr "ဖန်တီးထားတဲ့ အမှတ်အသား လမ်းကြောင်းသစ်"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "ဖန်တီးထားတဲ့ အချိန်လမ်းကြောသစ်"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "နမူနာ နှုန်းအသစ် (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "ရေးသွင်းထားတဲ့ တန်ဖိုးဟာ မမှန်ဘူး"
 
@@ -8952,8 +13857,22 @@ msgid "Please select at least one audio track and one MIDI track."
 msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
 
 #: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Sync MIDI with Audio"
 msgstr "MIDI ကို အသံနဲ့ တပြိုင်တည်း လုပ်ဆောင်ပါ"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -8996,6 +13915,11 @@ msgid "&Time Track"
 msgstr "အချိန် လမ်းကြော"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "ပေါင်းစပ်ကိရယာ ခလုတ်တန်း"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "စတီရီယိုကို မိုနိုအဖြစ် ခွဲခြမ်းပါ"
 
@@ -9034,6 +13958,10 @@ msgstr "အသံလမ်းကြောများ အားလုံးက�
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "အသံလမ်းကြောများ အားလုံးကို အသံဖွင့်ပါ"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -9090,6 +14018,11 @@ msgstr "စတင်ချိန် အလိုက်"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "အမည် အလိုက်"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "အခြား အသံလမ်းကြောကို ရွှေ့တဲ့ တွဲညှပ်"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -9161,7 +14094,9 @@ msgstr "ဖွင့်ပါ"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "အသံသွင်းနေခြင်း"
 
@@ -9174,8 +14109,27 @@ msgid "no label track at or below focused track"
 msgstr "ဗဟိုပြုထားတဲ့ အသံလမ်းကြောပေါ်မှ ဘယ်ဖက် တပြင်လုံး"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "ဖန်တီးထားတဲ့ အမှတ်အသား လမ်းကြောင်းသစ်"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -9243,6 +14197,11 @@ msgid "&Timer Record..."
 msgstr "အချိန်တိုင်းကိရိယာ မှတ်တမ်း..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "အသံက အသံသွင်းမှုကို သက်၀င်စေတယ်"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "နယ်ပယ်ကို ဖွင့်ပါ"
 
@@ -9253,6 +14212,11 @@ msgstr "သော့ခတ်ပါ"
 #: src/menus/TransportMenus.cpp
 msgid "&Unlock"
 msgstr "သော့ဖွင့်ပါ"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
 
 #: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
@@ -9267,16 +14231,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "အိုဗာဒုတ် (အဖွင့်/အပိတ်)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "ဆော့ဗ်ဝဲ ဆက်လက်ဖွင့်ပြမှု (အဖွင့်/အပိတ်)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -9286,6 +14251,11 @@ msgstr "တင်ပို့ပါ"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "ဖွင့်ပါ/ရပ်တန့်ပါ"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -9403,6 +14373,11 @@ msgid "&Fit to Width"
 msgstr "၀င်းဒိုးမှာ အံကိုက်ဖြစ်စေပါ"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "၀င်းဒိုးမှာ အံကိုက်ဖြစ်စေပါ"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "အသံလမ်းကြောများ အားလုံးကို ခေါက်သိမ်းပါ"
 
@@ -9438,9 +14413,26 @@ msgstr "အိုဗာဒုတ် (အဖွင့်/အပိတ်)"
 msgid "&Show Clipping (on/off)"
 msgstr "တွဲညှပ်ချက်ကို ပြပါ"
 
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "သက်ရောက်မှု"
+
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr "၀င်းဒိုး"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
 
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
@@ -9467,7 +14459,7 @@ msgstr "ဦးစားပေးချက်များ..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "အိုဒေးစီးတီးကို ပိတ်ပါ"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -9514,7 +14506,8 @@ msgstr "အခြေစိုက်စခန်း"
 msgid "Using:"
 msgstr "သုံးစွဲခြင်း -"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "ပြန်ဖွင့်ချက်"
 
@@ -9534,7 +14527,8 @@ msgstr "ချာနယ်များ -"
 msgid "Latency"
 msgstr "ငုပ်အောင်းနေမှု"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "မီလီစက္ကန့်များ"
 
@@ -9547,6 +14541,15 @@ msgid "&Latency compensation:"
 msgstr "ဖိသိပ်မှုကို ငြိမ်သက်​စေပါ -"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "ဖယ်ရှားထားတဲ့ အသံ အသံလမ်းကြော(များ)"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "၁ (မိုနို)"
 
@@ -9555,17 +14558,37 @@ msgid "2 (Stereo)"
 msgstr "၂ (စတီရီယို)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "ဖိုင်တွဲများ"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "စီမံချက်များကို ဆယ်တင်ပါ"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "ဖိုင်တွဲများ"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "လှော်လှန်ပါ..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -9596,6 +14619,11 @@ msgid "Temporary files directory"
 msgstr "ယာယီ ဖိုင်များ ဖိုင်တွဲ"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "လုပ်ဆောင်ချက်"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory cannot be on a FAT drive."
 msgstr "ယာယီ ဖိုင်များ ဖိုင်တွဲ"
 
@@ -9621,6 +14649,11 @@ msgstr "ဖိုင်များကို သိမ်းဆည်းမဲ�
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "%s ဖိုင်တွဲ မတည်ရှိဘူး။ ၄င်းကို ဖန်တီးမလား?"
 
@@ -9634,8 +14667,14 @@ msgid "Directory %s is not writable"
 msgstr "ဖိုင်တွဲ %s ကို ရေးလို့မရဘူး"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "ယာယီ ဖိုင်တွဲမှာ ပြင်ဆင်မှုများဟာ အိုဒေးစီးတီးကို ပြန်မဖွင့်မှီတိုင်အောင် သက်ရောက်မှု ရှိမှာ မဟုတ်ဘူး"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "ယာယီ ဖိုင်တွဲ အသစ်"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -9645,11 +14684,36 @@ msgstr "ဦးစားပေးချက်များ..."
 msgid "Sorted by Effect Name"
 msgstr "အမည်အလိုက် မျိုးတုစုပါ"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "အမည်အလိုက် မျိုးတုစုပါ"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "အမည်အလိုက် မျိုးတုစုပါ"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "သက်ရောက်မှု"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -9659,21 +14723,140 @@ msgstr "သက်ရောက်မှု"
 msgid "N&yquist"
 msgstr "နိုင်ခွီးစ်ထ်"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "သက်ရောက်မှု"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "သက်ရောက်မှု တပ်ဆင်ချက်များ"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "ယန္တရားငယ် တပ်ဆင်ချက်များ"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
 msgstr "တန်ဆာပလာ"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "တင်သွင်းပါ"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "ဦးစားပေးချက်များ..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "စစ်ထုတ်ကိရိယာ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "ကြိုတင်သတ်မှတ်ချက်များကို တင်သွင်းပါ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "အထက်ကို ရွှေ့ပါ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "အောက်ကို ရွှေ့ပါ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "အထက်ကို ရွှေ့ပါ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "အောက်ကို ရွှေ့ပါ"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "ပယ်ဖျက်ထားတဲ့ စာတန်းတပ် နယ်ပယ်များ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "တည်နေရာ တင်ပို့ပါ -"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "ရွေးချယ်ပါ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "%s ကို ပယ်ဖျက်ဖို့ သင် သေချာသလား။"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "အသံသွင်းနေတယ်"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -9722,6 +14905,11 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-၁၄၅ dB (၂၄ ဘစ် နမူနာများရဲ့ PCM အတိုင်းအတာ)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "လုပ်ဆောင်ချက်"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
 msgstr "အင်တာနက်မှ"
 
@@ -9730,20 +14918,83 @@ msgid "Display"
 msgstr "ပြသပါ"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "ဘာသာစကား -"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "%s ရဲ့ တည်နေရာ -"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "မီတာ/လှိုင်းသဏ္ဍာန် dB အတိုင်းအတာ -"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show e&xtra menus"
 msgstr "&Y-axis တလျှောက် ဂရစ်ကွက် တခုကို ပြသပါ"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "ကြာရှည်တဲ့ လှုပ်ရှားမှုများကို ပြီးစီးမှုအတွက် မြည်သံ"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "ယန္တရားငယ် တပ်ဆင်ချက်များ"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "ပေတံ"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "တင်သွင်းပါ / တင်ပို့ပါ"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "ဦးစားပေးချက်များ..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -9756,6 +15007,10 @@ msgstr "အဆင့်မြင့် ပေါင်းစပ်မှု ရ�
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "စံညွှန်း"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -9773,9 +15028,22 @@ msgstr "အသံ ဖိုင်တခုဆီ အသံကြောမျာ�
 msgid "S&how Metadata Tags editor before export"
 msgstr "အဆင့်ကို တင်ပို့ဖို့ မက်တာဒေတာ တည်းဖြတ်ကိရိယာ အလျင်ကို ပြသပါ"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "အမှတ်အသားများ တင်ပို့မဲ့ ပုံစံ -"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9795,6 +15063,10 @@ msgid "Open a new project to modify keyboard shortcuts."
 msgstr "ကီးဘုတ် ဖြတ်လမ်းများကို ပြုပြင်ဖို့ စီမံချက် အသစ်တခုကို ဖွင့်ပါ။"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "သော့ချက် ချုပ်နှောင်ချက်များ"
 
@@ -9803,8 +15075,35 @@ msgid "View by:"
 msgstr "မြင်ကွင်း"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "အမည်"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "မြင်ကွင်း"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "မြင်ကွင်း"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "မြင်ကွင်း"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
@@ -9813,6 +15112,12 @@ msgstr "သော့ချက် ချုပ်နှောင်ချက်�
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Short cut"
 msgstr "အသံလမ်းကြောတိုများ"
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "ရွေးစရာများ..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -9827,7 +15132,15 @@ msgid "&Defaults"
 msgstr "စံထားချက်များ"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "အိုဒေးစီးတီး ကီးဘုတ် ဖြတ်လမ်းများ ပါရှိတဲ့ XML ဖိုင်တခုကို ရွေးပါ..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9836,8 +15149,21 @@ msgstr "ကီးဘုတ် ဖြတ်လမ်းများကို တ�
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "ဖွင့်ထားတဲ့ %d ကီးဘုတ် ဖြတ်လမ်းများ\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -9850,6 +15176,38 @@ msgstr "ကီးဘုတ် ဖြတ်လမ်းများကို တ�
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "ကီးဘုတ် ဖြတ်လမ်းများကို တင်ပို့မဲ့ ပုံစံ -"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -9887,19 +15245,67 @@ msgstr "FFmpeg စုစည်းခန်း မူအဆင့် -"
 msgid "FFmpeg Library:"
 msgstr "FFmpeg စုစည်းခန်း -"
 
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "ရှာပါ..."
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Dow&nload"
+msgstr "ဆွဲချပါ"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
 msgstr "စုစည်းခန်းများ"
 
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "ကိရိယာများ"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "ဦးစားပေးချက်များ..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "ကြားခံမြင်ကွင်း"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
 msgctxt "MIDI"
 msgid "Interface"
 msgstr "ကြားခံမြင်ကွင်း"
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ ကိန်းပြည့်တခု ဖြစ်ရမယ်"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
 
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
@@ -9911,16 +15317,50 @@ msgid "Preferences for Module"
 msgstr "ဦးစားပေးချက်များ..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "ယာယီ ဖိုင်တွဲမှာ ပြင်ဆင်မှုများဟာ အိုဒေးစီးတီးကို ပြန်မဖွင့်မှီတိုင်အောင် သက်ရောက်မှု ရှိမှာ မဟုတ်ဘူး"
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "ကျွန်ပ်ကို မေးပါ"
 
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "အသံညှိကိရိယာ"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -9962,7 +15402,10 @@ msgstr "ဘယ်-ဒရွတ်ဆွဲပါ"
 msgid "Set Selection Range"
 msgstr "ရွေးချယ်မှု အတိုင်းအတာကို ချမှတ်ပါ"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-ဘယ်-နှိုပ်ပါ"
 
@@ -10049,6 +15492,15 @@ msgstr "ဘယ်-ဒရွတ်ဆွဲပါ"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "အသံကြောများ အကြား အပိုင်းကို အထက်/အောက် ရွေ့လျားပါ"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "ဘယ်-ဒရွတ်ဆွဲပါ"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -10152,9 +15604,34 @@ msgstr "နယ်ပယ် ဖြတ်ယူပြီးနောက် အစ�
 msgid "Seek Time when playing"
 msgstr "ဖွင့်ပြနေချိန်မှာ အချိန်ကို ​ရွေးပါ"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "အိုဒေးစီးတီး ဦးစားပေးချက်များ"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -10163,6 +15640,11 @@ msgstr "ဦးစားပေးချက်များ..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "ဦးစားပေးချက်များ..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -10188,6 +15670,11 @@ msgstr "လက်တွေ့-အချိန် အသွင်ပြောင�
 msgid "Sample Rate Con&verter:"
 msgstr "နမူနာ နှုန်းထား အသွင်ပြောင်းကိရိယာ -"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
 #: src/prefs/QualityPrefs.cpp
 msgid "High-quality Conversion"
 msgstr "အဆင့်မြင့်-အရည်အသွေး အသွင်ပြောင်းမှု"
@@ -10195,6 +15682,11 @@ msgstr "အဆင့်မြင့်-အရည်အသွေး အသွင�
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "နမူနာ နှုန်းထား အသွင်ပြောင်းကိရိယာ -"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -10213,12 +15705,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "အိုဗာဒုတ် -အသစ်တခုကို အသံသွင်းနေတုန်း အခြား အသံကြောများကို ဖွင့်ပြပါ"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "ဆော့ဗ်ဝဲ ဆက်လက်ဖွင့်ပြမှု (အဖွင့်/အပိတ်)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "အသံလမ်းကြော အသစ်"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "တင်သွင်းဖို့ စီးကြောင်း(များ)ကို ရွေးချယ်ပါ"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -10232,6 +15734,11 @@ msgstr "အဆင့် -"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Name newly recorded tracks"
 msgstr "အသံလမ်းကြောများကို ပေါင်းစပ်ခြင်းနဲ့ တင်ဆက်ခြင်း"
+
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
@@ -10254,21 +15761,54 @@ msgid "System &Date"
 msgstr "ရက်စွဲကို စတင်ပါ"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+#, fuzzy
+msgid "System T&ime"
+msgstr "ရက်စွဲကို စတင်ပါ"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "အသံက အသံသွင်းမှုကို သက်၀င်စေတယ်"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "အသံလမ်းကြောကို မှတ်သားပါ"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
+msgstr "ချဲ့ထွင်မှု စံထားချက်"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
 msgstr "ချဲ့ထွင်မှု စံထားချက်"
 
 #. i18n-hint: Grayscale color scheme for spectrograms
@@ -10287,10 +15827,20 @@ msgstr "အစဉ်လိုက်"
 msgid "Frequencies"
 msgstr "ကြိမ်နှုန်း (Hz)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "အသံပေါက် (EAC)"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ အလွန်ဆုံး ၀ Hz ရှိရမယ်"
 
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
@@ -10299,6 +15849,19 @@ msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ အ�
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be less than maximum frequency"
 msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ အများဆုံး ကြိမ်နှုန်းထက် ငယ်ရမယ်"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ အလွန်ဆုံး ၀ Hz ရှိရမယ်"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -10328,6 +15891,24 @@ msgstr "အနည်းဆုံး ကြိမ်နှုန်း (Hz) -"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "အများဆုံး ကြိမ်နှုန်း (Hz) -"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "ရလဒ် ချာနယ်များ - %2d"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "မြှင့်တင်ချက် (dB) -"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -10360,6 +15941,11 @@ msgstr "၃၂၇၆၈ - အကျဉ်းမြောင်းဆုံး �
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "၀င်းဒိုး အမျိုးအစား"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "ယိုယွင်းမှု အကြောင်းရင်း -"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -10407,6 +15993,21 @@ msgid "The minimum frequency must be an integer"
 msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ ကိန်းပြည့်တခု ဖြစ်ရမယ်"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "အများဆုံး ကြိမ်နှုန်းဟာ ကိန်းပြည့်ဖြစ်ရမယ်"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "အများဆုံး ကြိမ်နှုန်းဟာ ကိန်းပြည့်ဖြစ်ရမယ်"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "အများဆုံး ကြိမ်နှုန်းဟာ ကိန်းပြည့်ဖြစ်ရမယ်"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "The minimum amplitude (dB) must be an integer"
 msgstr "အနည်းဆုံး ကျယ်ပြန့်မှု (dB) ဟာ ကိန်းပြည့် ဖြစ်ရမယ်"
 
@@ -10435,13 +16036,14 @@ msgid "Info"
 msgstr "အချက်အလက်"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -10520,8 +16122,24 @@ msgid "Enable &dragging selection edges"
 msgstr "ဘယ်နဲ့ ညာ ရွေးချယ်​မှု အစွန်းများ အတွက် ဒရွတ်ဆွဲမှုကို ဖွင့်ပါ"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "\"အသံကြော ဗဟိုပြုချက် ရွှေ့ပါ\" ဟာ အသံကြောများ တလျှောက် ထပ်ခါ ဝိုင်းရံပေးတယ်"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
@@ -10544,6 +16162,10 @@ msgid "Spectrogram"
 msgstr "စပက်ထရိုဂရမ်များ"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "ပြန်ရေးမှတ်ပါ"
 
@@ -10558,6 +16180,10 @@ msgstr "ရွေးချယ်ချက်ကို ချဲ့ထွင်�
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "ချဲ့ထွင်မှု စံထားချက်"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -10580,6 +16206,16 @@ msgid "50ths of Seconds"
 msgstr "စက္ကန့်များ"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "စက္ကန့်များ"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "စက္ကန့်များ"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "မီလီစက္ကန့်များ"
 
@@ -10587,7 +16223,12 @@ msgstr "မီလီစက္ကန့်များ"
 msgid "Samples"
 msgstr "နမူနာများ"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "ချဲ့ထွင်ပါ"
 
@@ -10596,12 +16237,42 @@ msgid "Preferences for Tracks"
 msgstr "ဦးစားပေးချက်များ..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "စံထားချက် မြင်ကွင်း စနစ် -"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "စံထားချက် နမူနာ အမျိုးအစား -"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "နမူနာများ"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -10632,6 +16303,38 @@ msgstr "သတိပေးချက်များ"
 msgid "Preferences for Warnings"
 msgstr "ဦးစားပေးချက်များ..."
 
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "စီမံချက်ကို သိမ်းဆည်းပါ"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "စတီရီယိုကို မိုနိုအဖြစ် ခွဲခြမ်းပါ"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "စတီရီယိုကို မိုနိုအဖြစ် ခွဲခြမ်းပါ"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
+
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
 msgid "Waveforms"
@@ -10653,16 +16356,24 @@ msgid "Stopped"
 msgstr "ရပ်နားပါ"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "ခေတ္တရပ်နားပါ"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "အစကို ကျော်သွားပါ"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "အဆုံးကို ကျော်သွားပါ"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "ခေတ္တရပ်နားပါ"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "အစပြုဖို့ ရွေးချယ်ခြင်း"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "အဆုံးသတ်ဖို့ ရွေးချယ်ခြင်း"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -10676,20 +16387,24 @@ msgstr "အသံလမ်းကြော အသစ်"
 msgid "Append Record"
 msgstr "ပူးတွဲချက် မှတ်တမ်း"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "အဆုံးသတ်ဖို့ ရွေးချယ်ခြင်း"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "အစပြုဖို့ ရွေးချယ်ခြင်း"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "ခေတ္တရပ်နားပါ"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "ရေးမှတ်ချက် ခလုတ်တန်း"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -10700,6 +16415,11 @@ msgstr "အမြန်နှုန်းကို ပြန်ဖွင့်�
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "အသံ တည်နေရာ -"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -10722,8 +16442,18 @@ msgid "Select Playback Device"
 msgstr "အမြန်နှုန်းကို ပြန်ဖွင့်ပါ"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "အသံတိတ်စေပါ"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "အစမ်းမြင်ကွင်း မရနိုင်ဘူး\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -10747,11 +16477,22 @@ msgstr "ရွေးချယ်ချက် ပြင်ပကို တိဖ�
 msgid "Silence audio selection"
 msgstr "ရွေးချယ်ချက်ကို ငြိမ်သက်စေပါ"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "အသံလမ်းကြောတိုများ"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "ချဲ့ကားပါ"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "ကျုံ့ပါ"
 
@@ -10818,42 +16559,23 @@ msgstr "အသံသွင်းမှု မီတာ"
 msgid "&Playback Meter Toolbar"
 msgstr "မီတာကို ဖွင့်ပြပါ"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "ပြန်ဖွင့်ချက်"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "ပြန်ဖွင့်ချက်"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "ပြန်ဖွင့်ချက်"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "ပေါင်းစပ်ကိရယာ ခလုတ်တန်း"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "ပေတံ"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
@@ -10861,6 +16583,7 @@ msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ခ�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
@@ -10868,9 +16591,24 @@ msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ခ�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "စောင့်ကြည့်မှုကို စတင်ပါ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "စောင့်ကြည့်မှုကို စတင်ပါ"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "ပေတံ"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -10918,9 +16656,24 @@ msgstr "ကူးသွားတဲ့ နေရာ"
 msgid "Length"
 msgstr "အရှည်"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "အလယ်ဗဟို"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -10947,6 +16700,10 @@ msgstr "ဘေ့စ် ကြိမ်နှုန်းများ မြှ�
 msgid "Center Frequency"
 msgstr "အစဉ်လိုက် ကြိမ်နှုန်း"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -10965,8 +16722,8 @@ msgstr "ကိရိယာ ခလုတ်တန်း"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
 
 #: src/toolbars/ToolBar.cpp
@@ -10993,7 +16750,8 @@ msgstr "အချိန် ရွှေ့ပြောင်း ကိရိယ�
 msgid "Zoom Tool"
 msgstr "ချဲ့ထွင် ကိရိယာ"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "ရေးဆွဲ ကိရိယာ"
 
@@ -11069,11 +16827,13 @@ msgstr "တခု (သို့) အမှတ်အသား နယ်သတ်�
 msgid "Drag label boundary."
 msgstr "အမှတ်အသား နယ်သတ်မျဉ်းကို ဒရွတ်ဆွဲပါ"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "မွမ်းမံထားတဲ့ အမှတ်အသား"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "အမှတ်အသား တည်းဖြတ်မှု"
 
@@ -11128,31 +16888,42 @@ msgstr "တည်းဖြတ်ထားတဲ့ အမှတ်အသား�
 msgid "New label"
 msgstr "ပေါင်းထည့်ထားတဲ့ အမှတ်အသား"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "ရှစ်သံတွဲ အထက်"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "ရှစ်သံတွဲ အောက်"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "ဒေါင်လိုက် ချဲ့ကားဖို့ နှိုပ်ပါ၊ ကျုံ့ဖို့ Shift-နှိုပ်ပါ၊ သီးခြား ချဲ့ထွင် နယ်ပယ်တခုကို ဖန်တီးဖို့ ဒရွတ်ဆွဲပါ။"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "ညာ-နှိုပ်ပါ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "ကျုံ့ပါ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-ဘယ်-နှိုပ်ပါ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-ဘယ်-နှိုပ်ပါ"
 
@@ -11175,6 +16946,14 @@ msgid "Stretch"
 msgstr "ယိုယွင်းမှု အကြောင်းရင်း -"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "ပေါင်းစပ်ထားတဲ့ ညှပ်စများ"
 
@@ -11186,7 +16965,8 @@ msgstr "ပေါင်းစပ်ပါ"
 msgid "Expanded Cut Line"
 msgstr "ချဲ့ကားထားတဲ့ ဖြတ်ယူမှု လိုင်း"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "ချဲ့ကားပါ"
 
@@ -11210,6 +16990,11 @@ msgstr "ရွှေ့ထားတဲ့ နမူနာ"
 msgid "Sample Edit"
 msgstr "နမူနာ တည်းဖြတ်မှု"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "အမှတ်ကို ချဲ့ကားပါ"
@@ -11217,6 +17002,16 @@ msgstr "အမှတ်ကို ချဲ့ကားပါ"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "စပက်ထရိုဂရမ်များ"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -11242,7 +17037,8 @@ msgstr "အော်တို ဒတ်ကို ဆောင်ရွတ်န�
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' မှ %s သို့ ပြောင်းလဲမှု"
@@ -11256,7 +17052,60 @@ msgid "Rat&e"
 msgstr "နှုန်းထားကို ချမှတ်ပါ"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -11277,7 +17126,8 @@ msgstr "နှုန်းထား​ ပြောင်းလဲမှု"
 msgid "Set Rate"
 msgstr "နှုန်းထားကို ချမှတ်ပါ"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "မျိုးစုံ"
 
@@ -11370,10 +17220,25 @@ msgid "Right, %dHz"
 msgstr "ညာဖက်၊"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "ညာဖက်"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -11383,6 +17248,15 @@ msgstr "စတီရီယို အသံလမ်းကြောများ�
 msgid "Click and drag to rearrange sub-views"
 msgstr "တချိန်ထဲမှာ အသံကြော တခုကို ရွှေ့ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "တချိန်ထဲမှာ အသံကြော တခုကို ရွှေ့ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "ချဲ့ကားပါ"
@@ -11390,6 +17264,10 @@ msgstr "ချဲ့ကားပါ"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "ချဲ့ထွင်ပါ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -11435,12 +17313,28 @@ msgid "Set Range"
 msgstr "အတိုင်းအတာကို ချမှတ်ပါ"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "ပြသပါ"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "ပေါင်းစပ်ဖြည့်စွတ်ခြင်း -"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
@@ -11460,9 +17354,8 @@ msgstr "လျင်မြန်တဲ့ ဆင့် ဆက်စပ်ဖန�
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "တချိန်ထဲမှာ အသံကြော တခုကို ရွှေ့ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -11513,6 +17406,21 @@ msgstr "ချိန်ညှိထားတဲ့ စာအိတ်။"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "ခလုတ်တန်းများ"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "စောင့်ကြည့်မှုကို စတင်ပါ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "ပေတံ"
@@ -11528,6 +17436,11 @@ msgstr "ဗဟိုပြုထားတဲ့ အသံလမ်းကြေ�
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "အသံလမ်းကြောကို အောက် ရွှေ့ပါ"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "နိုင်ခွီးစ်ထ် လှုံ့ဆော်ချက်..."
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -11584,6 +17497,11 @@ msgstr "အသံကို ရွေးချယ်ဖို့ နှိုပ�
 msgid "Click and drag to select audio"
 msgstr "အသံကို ရွေးချယ်ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "တချိန်ထဲမှာ အသံကြော တခုကို ရွှေ့ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
@@ -11605,6 +17523,10 @@ msgstr "%.2f စက္ကန့်နေရာ %.2f အတွက် ငြိမ
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "%.2f စက္ကန့်နေရာ %.2f အတွက် ငြိမ်သက်တဲ့ ရွေးချယ်မှု အသံလမ်းကြောများ"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -11631,6 +17553,12 @@ msgstr "ညွှန်ကြားချက်"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl-ဘယ်-နှိုပ်"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "လှုပ်ရှားမှုတခုကို ရွေးချယ်ပါ"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -11677,11 +17605,31 @@ msgstr "ဖိနှိုပ်ပါ"
 msgid "Button"
 msgstr "ခလုတ်"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
 #. i18n-hint: "x" suggests a multiplicative factor
 #: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.2fx"
 msgstr "%.1f dB"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" မတည်ရှိဘူး။\n"
+"\n"
+"၄င်းကို သင် ဖန်တီးလိုသလား?"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
@@ -11711,13 +17659,28 @@ msgstr "ဗလာ"
 msgid "Backwards"
 msgstr "နောက်ပြန်ချက်များ"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "ရှေ့ဆက်မှုများ"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "အင်တာနက်ပေါ်မှ အကူအညီ"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "ဖိုင်များ အားလုံး (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -11756,6 +17719,13 @@ msgid "Refresh Rate"
 msgstr "နှုန်းထားကို ချမှတ်ပါ"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "စက္ကန့် [၁-၁၀၀] မှာ မီတာ ပြန်နှိုးချက် နှုန်းထား -"
 
@@ -11768,12 +17738,21 @@ msgid "Meter Style"
 msgstr "မီတာ"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "စစ်ထုတ်ကိရိယာ"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "ကြာမြင့်ချိန်"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "ပျက်စီးမှု အလိုအလျှောက် ဆယ်တင်ရေး"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -11788,9 +17767,26 @@ msgid " Monitoring "
 msgstr "စောင့်ကြည့်မှုကို ရပ်နားပါ"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Please select an action"
@@ -11803,6 +17799,13 @@ msgstr "လှုပ်ရှားမှုတခုကို ရွေးခ�
 msgid "01000,01000 seconds"
 msgstr "01000,01000 စက္ကန့်များ"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + နမူနာများ"
+
 #. i18n-hint: Format string for displaying time in hours, minutes and
 #. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
@@ -11811,6 +17814,12 @@ msgstr "01000,01000 စက္ကန့်များ"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s"
 msgstr "0100 နာရီ 060 မီနစ် 060 စက္ကန့်"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -11875,6 +17884,7 @@ msgstr "0100 နာရီ 060 မိနစ် 060 စက္ကန့်+># န�
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "နမူနာများ"
@@ -12036,6 +18046,15 @@ msgstr "၀၁၀၀၀,၀၁၀၀၀ ဘောင်များ|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -12043,6 +18062,10 @@ msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 နာရီ 060 မိနစ် 060>0100 စက္ကန့်"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -12058,11 +18081,36 @@ msgstr "ရှစ်သံတွဲ အောက်"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 ဘောင်များ|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in semitones and cents
 #: src/widgets/NumericTextCtrl.cpp
 msgid "semitones + cents"
 msgstr "အဆင့်များ-တ၀က်ပါတဲ့ အသံ၀က်များ"
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
 
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
@@ -12070,9 +18118,24 @@ msgstr "အဆင့်များ-တ၀က်ပါတဲ့ အသံ၀က�
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 ဘောင်များ|24"
 
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "အမျိုးအစားကို ပြောင်းဖို့ ညာဖက် ကြွတ်ခလုတ် (သို့) အကြောင်းအရာ သော့ချက်ကို သုံးစွဲပါ"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "စက္ကန့်များ"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -12116,6 +18179,11 @@ msgstr "အတည်ပြုပါ"
 msgid "Unable to write files to directory: %s."
 msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -12134,6 +18202,10 @@ msgid "Don't show this warning again"
 msgstr "ဒီသတိပေးချက်ကို နောက်တခါ မပြနဲ့"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-အဆုံးမရှိ"
 
@@ -12142,13 +18214,31 @@ msgid "-Infinity"
 msgstr "-အဆုံးမရှိ"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "ဗလာ"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "ပူးတွဲချက် မှတ်တမ်း"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "အတိုင်းအတာ တခုကို ချဲ့ကားပါ"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "LOF အမှားအယွင်း"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -12166,11 +18256,20 @@ msgid "Value must not be greater than %s"
 msgstr "စတင်ခြင်းနဲ့ ရပ်တန့်ခြင်းဟာ ၀ ထက် ကြီးရမယ်။"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "ဖန်တီးခဲ့တဲ့ စီမံချက် အသစ်"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "ဖိုင်တွဲများ"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "ဖိုင်တွဲများ"
 
 #: src/xml/XMLFileReader.cpp
@@ -12191,16 +18290,49 @@ msgstr "ဖိုင်ကို မဖွင့်နိုင်ဘူး"
 msgid "Spectral edit multi tool"
 msgstr "ရွေးချယ်မှု"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "စစ်ထုတ်ကိရိယာ"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "ကြိမ်နှုန်း (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "အမှားအယွင်း"
@@ -12228,6 +18360,22 @@ msgstr "စက္ကန့်များပါတဲ့ ကြိမ်နှ�
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ အလွန်ဆုံး ၀ Hz ရှိရမယ်"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "ရွေးချယ်မှု"
@@ -12239,6 +18387,28 @@ msgstr "မှေးမှိန်ပျောက်ကွယ်စေပါ"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "အသုံးချနေတယ်..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -12265,8 +18435,16 @@ msgid "S-Curve Down"
 msgstr "အောက်ကို ရွှေ့ပါ"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "စတင်မှု"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -12275,6 +18453,14 @@ msgstr "တိုးတက်မှု"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "စတင်မှု"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -12287,6 +18473,14 @@ msgstr "အစဉ်လိုက်"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "အစဉ်လိုက်"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -12325,6 +18519,24 @@ msgstr "အောက်ကို ရွှေ့ပါ"
 msgid "Error~%~%"
 msgstr "အမှားအယွင်း"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "ထပ်လုပ်ပါ"
@@ -12332,6 +18544,10 @@ msgstr "ထပ်လုပ်ပါ"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "တွဲညှပ်မှုကို ​ရှာပါ..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -12345,6 +18561,23 @@ msgstr "တွဲညှပ်ခြင်း"
 msgid "Reconstructing clips..."
 msgstr "နှိုပ်ချက်များနဲ့ ပွင့်ထွက်ချက်များကို ဖယ်ရှားခြင်း"
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "အတိုင်းအတာ %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "အသံလမ်းကြောကို မှတ်သားပါ"
@@ -12352,6 +18585,21 @@ msgstr "အသံလမ်းကြောကို မှတ်သားပါ"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "အသံလမ်းကြောကို မှတ်သားပါ"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -12385,6 +18633,19 @@ msgstr "အသံလမ်းကြော အမည်"
 msgid "Fade direction"
 msgstr "ဆူညံသံ လျှော့ချခြင်း"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "နှောင့်နှေးစေပါ"
@@ -12400,6 +18661,19 @@ msgstr "သော့ချက် အမျိုးအစား"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "စတုဂံပုံ"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "ဆူညံသံ လျှော့ချခြင်း (dB) -"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -12425,6 +18699,14 @@ msgstr "အစမ်းမြင်ကွင်း"
 msgid "Number of echoes"
 msgstr "ထပ်လုပ်မဲ့ အကြိမ် အရေအတွက် -"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
@@ -12436,6 +18718,10 @@ msgstr "ညီမျှစေခြင်း"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3 ဖိုင်များ"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -12450,10 +18736,24 @@ msgstr "ထပ်ရေးချက်ကို အတည်ပြုပါ"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "အမျိုအစားဖိုင်ကို မဖွင့်နိုင်ဘူး။"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "အမှားအယွင်း (ဖိုင်ကို ရေးထားတာ မဖြစ်နိုင်ဘူး) - %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "အမှားအယွင်း (ဖိုင်ကို ရေးထားတာ မဖြစ်နိုင်ဘူး) - %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -12484,18 +18784,67 @@ msgstr "အရှည် (စက္ကန့်များ)"
 msgid "Length of label region (seconds)"
 msgstr "အရှည် (စက္ကန့်များ)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "အမှတ်အသား တည်းဖြတ်မှု"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "ဖိသိပ်မှုကို ငြိမ်သက်​စေပါ -"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "သတိပေးချက်များ"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -12505,6 +18854,12 @@ msgstr "အမှတ်အသားများကို ဆက်စပ်ပ�
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "အမှတ်အသားများကို ဆက်စပ်ပါ"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -12523,13 +18878,46 @@ msgstr "ညီမျှစေခြင်းကို လုပ်ဆောင�
 msgid "Dominic Mazzoni"
 msgstr "ဒိုမီနစ် မာဇုံနီ အားဖြင့်"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "ကြိမ်နှုန်း (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "အနည်းဆုံး ကြိမ်နှုန်းဟာ အလွန်ဆုံး ၀ Hz ရှိရမယ်"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -12577,6 +18965,11 @@ msgid "Point after sound"
 msgstr "ပူးတွဲထားတဲ့ စတီရီယို"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "စက္ကန့်များပါတဲ့ အရှည်မှ"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "စက္ကန့်များပါတဲ့ အရှည်မှ"
 
@@ -12584,11 +18977,41 @@ msgstr "စက္ကန့်များပါတဲ့ အရှည်မှ"
 msgid "Maximum leading silence"
 msgstr "တိတ်ဆိတ်မှုကို တိဖြတ်ခြင်း..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "တိတ်ဆိတ်မှုကို တိဖြတ်ခြင်း..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "အမည်ဟာ ဗလာ မဖြစ်ရဘူး"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -12620,8 +19043,25 @@ msgid "Hard Clip"
 msgstr "တွဲညှပ်မှုကို ​ရှာ​ပါ"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "ညာဖက် ချာနယ်"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "အဆင့် -"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -12646,6 +19086,10 @@ msgstr "ရွေးချယ်မှု"
 #: plug-ins/noisegate.ny
 msgid "Gate"
 msgstr "ဂိတ်ပေါက်"
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Stereo Linking"
@@ -12679,6 +19123,44 @@ msgstr "တိုက်ခိုက်/ယိုယွင်းတဲ့ အခ�
 msgid "Decay (ms)"
 msgstr "တိုက်ခိုက်/ယိုယွင်းတဲ့ အချိန်"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "အမည်ဟာ ဗလာ မဖြစ်ရဘူး"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "အသံပေါက် ရွှေ့ပြောင်းကိရိယာ"
@@ -12686,6 +19168,22 @@ msgstr "အသံပေါက် ရွှေ့ပြောင်းကိရ�
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "ချိန်ညှိကိရိယာကို သုံးစွဲနေခြင်း..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -12708,7 +19206,8 @@ msgstr "MP3 ဖိုင်များ"
 msgid "HTML file"
 msgstr "MP3 ဖိုင်များ"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "ဖိုင်များကို အမည်ပေးပါ -"
 
@@ -12725,9 +19224,24 @@ msgid "Disallow"
 msgstr "ခွင့်ပြုမထားချက်"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "ခွင့်ပြုမထားချက်"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "'%s' ကို မဖယ်ရှားနိုင်ဘူး"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -12738,16 +19252,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "တည်နေရာ တင်ပို့ပါ -"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "အသံ ထုတ်လုပ်နေခြင်း"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "စစ်ထုတ်ကိရိယာ"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -12760,6 +19316,10 @@ msgstr "အသံလမ်းကြောကို ဖယ်ရှားပါ"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "မြည်သံ ထုတ်လုပ်နေခြင်း"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -12778,8 +19338,20 @@ msgid "Swing amount"
 msgstr "တွန့်လိမ်ခြင်း"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "ထပ်လုပ်မဲ့ အကြိမ် အရေအတွက် -"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -12802,12 +19374,54 @@ msgid "Beat sound"
 msgstr "ထပ်လုပ်ပါ"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "ဆူညံသံ ဖယ်ရှားခြင်း"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "ဆူညံသံ..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -12818,12 +19432,25 @@ msgid "Generating Risset Drum..."
 msgstr "ဆူညံသံ ထုတ်လုပ်ခြင်း"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "နှောင့်နှေးချိန် (စက္ကန့်များ) -"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "အစဉ်လိုက် ကြိမ်နှုန်း"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "ကြိမ်နှုန်း (Hz)"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -12836,6 +19463,10 @@ msgstr "မတင်ပို့နိုင်ဘူး"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "အသုံးချနေတယ်..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -12854,6 +19485,10 @@ msgid "HTML files"
 msgstr "MP3 ဖိုင်များ"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "နမူနာ တည်းဖြတ်မှု"
 
@@ -12866,8 +19501,29 @@ msgid "Include header information"
 msgstr "တည်ဆောက်မှု အချက်အလက်"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "အားလုံး"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -12882,6 +19538,11 @@ msgstr "\t-help (ဒီသတင်းတို အတွက်)"
 msgid "Errors Only"
 msgstr "အမှားအယွင်း -"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -12894,6 +19555,46 @@ msgstr "ညာဖက် ချာနယ်"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "နမူနာများ"
 
@@ -12901,6 +19602,43 @@ msgstr "နမူနာများ"
 #, lisp-format
 msgid "~a seconds."
 msgstr "စက္ကန့်များ"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -12919,6 +19657,10 @@ msgid "Value (dB)"
 msgstr "အဆင့် -"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "အစဉ်လိုက်"
 
@@ -12935,6 +19677,14 @@ msgid "Right (dB)"
 msgstr "ညာဖက်၊"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "အစဉ်လိုက်"
 
@@ -12945,6 +19695,40 @@ msgstr "ချာနယ် နှစ်ခု (စတီရီယို)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "၁ ချာနယ် (မိုနို)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "အမှားအယွင်း (ဖိုင်ကို ရေးထားတာ မဖြစ်နိုင်ဘူး) - %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -12959,8 +19743,40 @@ msgid "Select file"
 msgstr "MIDI ဖိုင်တခုကို ရွေးပါ..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "အမှားအယွင်း"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -12970,6 +19786,15 @@ msgstr "အမျိုအစားဖိုင်ကို မဖွင့်�
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "ရွေးချယ်မှု"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -12992,8 +19817,16 @@ msgid "Wet level (percent)"
 msgstr "၂-အဆင့်"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "အသုံးချနေတယ်..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -13035,9 +19868,96 @@ msgstr "စီစစ်ပါ"
 msgid "Strength"
 msgstr "စစ်ထုတ်ကိရိယာ"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "အော်တို ဒတ်ကို ဆောင်ရွတ်နေတယ်..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -13071,6 +19991,150 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "ကြိမ်နှုန်း (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "အိုဒေးစီးတီးကို ပိတ်ပါ"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "ချာနယ်"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "ဖိုင် ဖွင့်လှစ်မှု အမှားအယွင်း"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "အိုဒေးစီးတီး %s ခလုတ်တန်း"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "အသံသွင်းနေခြင်း"
+
+#~ msgid "Commit Id:"
+#~ msgstr "ညွှန်ကြားချက် -"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "QuickTime မှတဆင့် တင်သွင်းပါ"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "အမျိုအစားဖိုင်ကို မဖွင့်နိုင်ဘူး။\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "အသံသွင်းနေခြင်း\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "ပြန်ဖွင့်ချက်\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "ပြန်ဖွင့်ချက်\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "ပြန်ဖွင့်ချက်\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "ဂျီစထရီးမား-လိုက်ဖက်တဲ့ ဖိုင်များ"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "ဂျီစထရီးမား အစပြုမှု မအောင်မြင်ဘူး"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "'%s' ကို '%s' အဖြစ် အမည် မပြောင်းနိုင်ဘူး"
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "အညွှန်း[%02x] ကိုဓ[%s], ဘာသာစကား[%s], ဘစ်နှုန်းထား[%s], ချာနယ်များ[%d], ကြာမြင့်ချိန်[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "ဂျီစထရီးမား %s: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "ပြန်ဖွင့်ချက်"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "ပြန်ဖွင့်ချက်"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "ပြန်ဖွင့်ချက်"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "အိုဒေးစီးတီး အကြောင်း..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "အသံ သက်၀င်စေတဲ့ အသံသွင်းမှု (အဖွင့်/အပိတ်)"
+
+#~ msgid "Recording Volume"
+#~ msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#~ msgid "Playback Volume"
+#~ msgstr "ပြန်ဖွင့်ချက်"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "အသံသွင်းခြင်း ပြီးဆုံးမှု"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "ပြန်ဖွင့်ချက်"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "ပြန်ဖွင့်ချက်"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "ပေါင်းစပ်ကိရယာ ခလုတ်တန်း"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "တချိန်ထဲမှာ အသံကြော တခုကို ရွှေ့ဖို့ နှိုပ်ပြီး ဒရွတ်ဆွဲပါ"
+
 #~ msgid "Program build date:"
 #~ msgstr "ပရိုဂရမ် တည်ဆောက်မှု ရက်စွဲ -"
 
@@ -13081,10 +20145,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "အမ"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "စမ်းသပ်ဖိုင်ကို မဖွင့်နိုင်/မဖန်တီးနိုင်ဘူး"
 
 #, fuzzy
 #~ msgid "available"
@@ -13120,9 +20180,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 
 #~ msgid "LAME MP3 Library:"
 #~ msgstr "လမ် MP3 စုစည်းခန်း -"
-
-#~ msgid "&Locate..."
-#~ msgstr "ရှာပါ..."
 
 #~ msgid "&Download"
 #~ msgstr "ဆွဲချပါ"
@@ -13215,9 +20272,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #, fuzzy
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "ယာယီဖိုင်များကို ရှင်းလင်းနေတယ်"
-
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "ယာယီသိမ်းဆည်းခန်း ဖိုင်တွဲများကို ရှင်းလင်းနေတယ်"
 
 #~ msgid "%s-old%d"
 #~ msgstr "%s-အဟောင်း%d"
@@ -13325,9 +20379,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 
 #~ msgid "Projects"
 #~ msgstr "စီမံချက်များ"
-
-#~ msgid "When saving a project that depends on other audio files"
-#~ msgstr "စီမံချက် တခုကို သိမ်းဆည်းတဲ့အခါ အခြား အသံဖိုင်များ အပေါ် မူတည်တယ်"
 
 #, fuzzy
 #~ msgid "Silence Finder"
@@ -13536,10 +20587,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgstr "ရေးဆွဲမှုကို သုံးစွဲဖို့၊ အသံလမ်းကြော ရွေးနိုင်တဲ့ စာရင်းတွဲ စာရင်းမှတ်ထဲမှ 'လှိုင်းသဏ္ဍာန်' ကို ရွေးပါ။"
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "အသံလမ်းကြော ဖယ်ရှားမှု"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "နှိုပ်ချက်များနဲ့ ပွင့်ထွက်ချက်များကို ဖယ်ရှားခြင်း"
 
@@ -13577,18 +20624,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 
 #~ msgid "false"
 #~ msgstr "မှားတယ်"
-
-#, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "အသံ ဖိုင်"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "နောက်ဆုံး သက်ရောက်မှုကို ထပ်လုပ်ပါ"
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "အမျိုးအစား ဖိုင်ကို မသိမ်းဆည်းနိုင်ဘူး။"
 
 #, fuzzy
 #~ msgid "Unable to save MIDI device info"
@@ -13676,10 +20711,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgstr "ချိန်ကြိုးကို တည်းဖြတ်ပါ..."
 
 #, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "ရေးမှတ်ချက် ခလုတ်တန်း"
-
-#, fuzzy
 #~ msgid "&Tools"
 #~ msgstr "ကိရိယာများ"
 
@@ -13751,10 +20782,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "ရေးမှတ်ခြင်း"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "ခလုတ်တန်းများ"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -13938,10 +20965,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgstr "ယိုယွင်း ချိန်"
 
 #, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "အမည်"
-
-#, fuzzy
 #~ msgid "InterpolateLin"
 #~ msgstr "ပေါင်းစပ်ဖြည့်စွတ်ခြင်း -"
 
@@ -13997,10 +21020,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgstr "တုံ့ပြန်ချက် (%) -"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "အရွယ်"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "တုံ့ပြန်ချက် (%) -"
 
@@ -14015,10 +21034,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "တိုးတက်မှု"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "စတီရီယို"
 
 #, fuzzy
 #~ msgid "FilterType"
@@ -14059,10 +21074,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "တိတ်ဆိတ်မှုကို တိဖြတ်ပါ"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "ပြောင်းပြန်လှန်နေခြင်း"
 
 #~ msgid ""
 #~ "The keyboard shortcut '%s' is already assigned to:\n"
@@ -14156,10 +21167,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgstr "အခြေစိုက်စခန်း"
 
 #, fuzzy
-#~ msgid "&Length of preview:"
-#~ msgstr "အစမ်းမြင်ကွင်း အရှည် -"
-
-#, fuzzy
 #~ msgid "(uncheck when recording computer playback)"
 #~ msgstr "(\"စတီရီယို ပေါင်းစပ်မှု\" ကို အသံသွင်းနေစဉ် ပြန်ရုပ်ပါ)"
 
@@ -14244,9 +21251,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgid "Welcome to Audacity "
 #~ msgstr "အိုဒေးစီးတီးမှ ကြိုဆိုပါတယ်"
 
-#~ msgid "Edit Metadata"
-#~ msgstr "မက်တာဒေတာကို တည်းဖြတ်ပါ"
-
 #~ msgid "Disk space remains for recording %d hours and %d minutes."
 #~ msgstr "အသံသွင်းမှု %d နာရီနဲ့ %d မိနစ်အတွက် ကျန်တဲ့ ဓါတ်ပြား နေရာလပ်။"
 
@@ -14265,10 +21269,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #, fuzzy
 #~ msgid "R&ight Channel"
 #~ msgstr "ညာဖက် ချာနယ်"
-
-#, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "မြှင့်တင်ချက် (dB) -"
 
 #, fuzzy
 #~ msgid "&Enable level control"
@@ -14663,9 +21663,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgid "Equalization..."
 #~ msgstr "ညီမျှစေခြင်း..."
 
-#~ msgid "Performing Equalization"
-#~ msgstr "ညီမျှစေခြင်းကို လုပ်ဆောင်နေတယ်"
-
 #~ msgid "Fading In"
 #~ msgstr "ကြည်လင်ထင်ရှားစေခြင်း"
 
@@ -14753,10 +21750,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 #~ msgid "Applying Reverb"
 #~ msgstr "ချိန်ညှိကိရိယာကို သုံးစွဲနေခြင်း..."
 
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "ဖိုင်ကို တင်ပို့ပါ..."
-
 #~ msgid "Silence..."
 #~ msgstr "တိတ်ဆိတ်ပါ..."
 
@@ -14815,9 +21808,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 
 #~ msgid "Note length (seconds)"
 #~ msgstr "အရှည် (စက္ကန့်များ) ကို မှတ်သားပါ"
-
-#~ msgid "Note velocity"
-#~ msgstr "အလျင်ကို မှတ်သားပါ"
 
 #~ msgid "Note key"
 #~ msgstr "သော့ချက်ကို မှတ်သားပါ"
@@ -14884,9 +21874,6 @@ msgstr "ကြိမ်နှုန်း (Hz)"
 
 #~ msgid "Recovering a project will not change any files on disk before you save it."
 #~ msgstr "စီမံချက်တခုကို ဆယ်တင်မှုက ၄င်းကို မသိမ်းဆည်းခင် ဓါတ်ပြားပေါ်က ဖိုင်များကို ပြောင်းလဲစေမှာ မဟုတ်ဘူး။"
-
-#~ msgid "Do Not Recover"
-#~ msgstr "မဆယ်တင်နဲ့"
 
 #~ msgid "Confirm?"
 #~ msgstr "အတည်ပြုသလား။"

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
-"tenacity/tenacity/nb_NO/>\n"
+"Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/tenacity/tenacity/nb_NO/>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,42 +18,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Poedit-Bookmarks: 1429,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Avslutt Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Kanal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Feil ved dekoding av fil"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Feil ved innlasting av metadata"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacitys %s verktøylinje"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Opptak"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -64,6 +27,24 @@ msgstr "Kan ikke fastslå"
 #, c-format
 msgid "%s bytes"
 msgstr "bytes"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -193,7 +174,8 @@ msgid "Script"
 msgstr "Skript"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Utdata"
 
@@ -209,7 +191,12 @@ msgstr "Nyquist-skripter (*.ny)|*.ny|Lisp-skripter (*.lsp)|*.lsp|Alle filer|*"
 msgid "Script was not saved."
 msgstr "Skriptet ble ikke lagret."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Advarsel"
 
@@ -222,15 +209,25 @@ msgid "Find dialog"
 msgstr "Finn dialog"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango Icon Gallery (oppgavelinjeikoner)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "© 2009 av Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "© 2009 av Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Ekstern Audacity-modul som har en enkel IDE for å skrive effekter."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -253,7 +250,8 @@ msgstr "Uten tittel"
 msgid "Nyquist Effect Workbench - "
 msgstr "Arbeidsbenk for Nyquist-effekter - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Ny"
 
@@ -293,7 +291,8 @@ msgstr "Kopier"
 msgid "Copy to clipboard"
 msgstr "Kopier til utklippstavlen"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Klipp ut"
 
@@ -301,7 +300,8 @@ msgstr "Klipp ut"
 msgid "Cut to clipboard"
 msgstr "Klipp ut til utklippstavlen"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Lim inn"
 
@@ -326,7 +326,8 @@ msgstr "Velg alle"
 msgid "Select all text"
 msgstr "Velg all tekst"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Angre"
 
@@ -334,7 +335,8 @@ msgstr "Angre"
 msgid "Undo last change"
 msgstr "Angre forrige endring"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Gjør om"
 
@@ -390,11 +392,19 @@ msgstr "Neste"
 msgid "Go to next S-expr"
 msgstr "Hopp til neste S-uttrykk"
 
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Start"
+msgstr "StartFrekv"
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Start script"
 msgstr "Start skript"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Stopp"
 
@@ -408,15 +418,23 @@ msgstr "Stopp skript"
 msgid "About %s"
 msgstr "Om"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Kompileringsinformasjon"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "På"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Av"
 
@@ -426,8 +444,9 @@ msgid "The Build"
 msgstr "Debugversjon"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Erklærings-ID:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versjon"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -437,22 +456,28 @@ msgstr "Kompileringstype:"
 msgid "Compiler:"
 msgstr "Innpakker:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Installeringsprefiks: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Innstillingsmappe: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Innstillingsmappe: "
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Filformatstøtte"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Flerplattform GUI-bibliotek"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -466,7 +491,6 @@ msgstr "Samplingsfrekvenskonvertering"
 msgid "MP3 Importing"
 msgstr "MP3-importering"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis-importering og -eksportering"
@@ -475,7 +499,6 @@ msgstr "Ogg Vorbis-importering og -eksportering"
 msgid "ID3 tag support"
 msgstr "Støtte for ID3-tagger"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC-importering og -eksportering"
@@ -493,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg import/eksport"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importer via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Funksjoner"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Støtte for tilleggsmoduler"
 
@@ -515,6 +530,10 @@ msgstr "Støtte for endring av tonehøyde og tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Støtte for ekstremt tonefall og tempoendring"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Funksjoner"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -628,6 +647,15 @@ msgstr "nettutvikler"
 msgid "%s, graphics"
 msgstr "grafikk"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -637,6 +665,10 @@ msgstr "Audacity, den frie, åpen-kildede, flerplattforms programvaren for å sp
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Takk til"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -671,6 +703,10 @@ msgid "%s Team Members"
 msgstr "Emeritus-medlemmer"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Bidragsytere"
 
@@ -687,6 +723,7 @@ msgstr "Nettsted og grafikk"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "norsk (bokmål) oversettelse av Imre Kristoffer Eilertsen og Kevin Brubeck Unhammer"
@@ -704,6 +741,22 @@ msgstr "Særlig takk til:"
 #, c-format
 msgid "%s website: "
 msgstr "Audacity sitt nettsted: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Bidragsytere"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -726,6 +779,7 @@ msgstr "Tidslinje"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klikk og dra for å begynne å søke"
@@ -733,6 +787,7 @@ msgstr "Klikk og dra for å begynne å søke"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klikk og dra for å begynne å dra"
@@ -740,6 +795,7 @@ msgstr "Klikk og dra for å begynne å dra"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Klikk og beveg for å gni. Klikk og dra for å lete."
@@ -747,6 +803,7 @@ msgstr "Klikk og beveg for å gni. Klikk og dra for å lete."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Beveg for å lete"
@@ -754,6 +811,7 @@ msgstr "Beveg for å lete"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Beveg for å dra"
@@ -810,7 +868,17 @@ msgstr ""
 "Kan ikke låse området utenfor\n"
 "prosjektets varighet."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Feil"
 
@@ -834,7 +902,8 @@ msgstr ""
 "Dette er et éngangsspørsmål, etter en 'installering' hvor du ønsket å tilbakestille preferansene."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Tilbakestill Audacity-innstillinger"
 
 #: src/AudacityApp.cpp
@@ -847,6 +916,10 @@ msgstr ""
 "Fant ikke fila %s.\n"
 "\n"
 "Den har blitt fjernet fra lista med nylig brukte filer."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -871,19 +944,25 @@ msgstr "&Åpne..."
 msgid "Open &Recent..."
 msgstr "Åpne n&ylig brukt..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Om Audacity..."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "&Preferences..."
+msgstr "&Innstillinger..."
 
 #: src/AudacityApp.cpp src/menus/FileMenus.cpp
 msgid "&File"
 msgstr "&Fil"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity kunne ikke finne et trygt sted å lagre midlertidig filer.\n"
@@ -891,20 +970,23 @@ msgstr ""
 "Vennligst velg en passende filplassering i preferansemenyen."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity kunne ikke finne et sted å lagre midlertidig filer.\n"
 "Vennligst legg inn en passende mappe i innstillinger-dialogboksen."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity vil nå avsluttes. Vennligst kjør Audacity igjen for å benytte den nye midlertidige mappen."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -913,15 +995,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity klarte ikke å låse mappen med midlertidige filer.\n"
 "Denne mappen er kanskje i bruk av en annen kopi av Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Vil du starte Audacity likevel?"
 
 #: src/AudacityApp.cpp
@@ -929,24 +1013,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "Feil ved lukking av midlertidig mappe"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Systemet har oppdaget at en annen kopi av Audacity kjører.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Bruk Ny eller Åpne-kommandoene i den kjørende\n"
 "Audacity-prosessen for å åpne flere prosjekter samtidig.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity kjører allerede"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity prosjektfiler"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -966,7 +1098,8 @@ msgstr "kjør selvdiagnostikk"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "vis Audacity-versjon"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -976,9 +1109,10 @@ msgid "audio or project file name"
 msgstr "lyd- eller prosjekt-filnavn"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -991,24 +1125,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity prosjektfiler"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Melding"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "DarkAudacity-tilpasning"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Hjelp"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Avslutt Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity-logg%s"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1020,9 +1178,14 @@ msgstr "&Lagre..."
 msgid "Cl&ear"
 msgstr "T&øm"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Lukk"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1071,7 +1234,8 @@ msgid "Error Initializing Midi"
 msgstr "Feil ved initialisering av MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity-logg%s"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1087,48 +1251,18 @@ msgstr ""
 msgid "Out of memory!"
 msgstr "Tom for minne!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
 msgstr ""
-"Automatisk justering av inndatanivå stanset. Det var ikke mulig å optimisere mer.\n"
-"Fortsatt for høyt."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automatisk justering av inndatanivå senket lydnivået til %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatisk justering av opptaksnivå stanset. Det var ikke mulig å optimisere mer. Fortsatt for lavt."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automatisk justering av opptaksnivå økte lydnivået til %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr ""
-"Automatisk justering av opptaksnivå stanset. Det totale antallet analyser ble\n"
-"overskredet uten å komme fram til et akseptabelt lydnivå.\n"
-"Fortsatt for høyt."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr ""
-"Automatisk justering av opptaksnivå stanset. Det totale antallet analyser ble\n"
-"overskredet uten å komme fram til et akseptabelt lydnivå.\n"
-"Fortsatt for lavt."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatisk justering av opptaksnivå stanset. %.2f virker som et akseptabelt lydnivå."
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Velg opptaksenhet\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Velg opptaksenhet\n"
 
 #: src/AudioIOBase.cpp
@@ -1171,8 +1305,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Opptaksslutt:\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Opptaksslutt:\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Opptaksslutt:\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Opptaksslutt:\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -1186,42 +1330,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Velg opptaksenhet\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Velg opptaksenhet\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Velg avspillingsenhet\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Klarte ikke å åpne sjangerfil.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Velg avspillingsenhet\n"
+
+#: src/AudioIOBase.cpp
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Datarater\n"
 
 #: src/AudioIOBase.cpp
 #, c-format
-msgid "%d - %s\n"
-msgstr "%s - %s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Simuler opptaksfeil\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Avspillingsvolum\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Opptaksvolum\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Opptaksvolum\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Avspillingsvolum: %s (emulert)\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Avspillingsvolum: %s (emulert)\n"
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1229,8 +1371,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Velg opptaksenhet\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Velg opptaksenhet\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Velg avspillingsenhet\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Velg avspillingsenhet\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -1238,8 +1390,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatisk krasjgjenoppretting"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1251,12 +1404,14 @@ msgid "Recoverable &projects"
 msgstr "Gjenopprettelige prosjekt"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Velg"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Navn"
 
@@ -1267,6 +1422,10 @@ msgstr " valgt"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Ingen er valgt"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1341,6 +1500,11 @@ msgstr "Effekt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menykommando (med parametere)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1487,7 +1651,8 @@ msgstr "Gjen&opprett markering"
 msgid "I&mport..."
 msgstr "I&mporter..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&ksporter..."
 
@@ -1528,7 +1693,8 @@ msgstr "Flytt &opp"
 msgid "Move &Down"
 msgstr "Flytt &ned"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Lagre"
 
@@ -1611,7 +1777,8 @@ msgid "Run"
 msgstr "Kjør"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Lukk"
 
@@ -1755,14 +1922,22 @@ msgid "Benchmark completed successfully.\n"
 msgstr "Benkpresset ble vellykket utført.\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Sluttdato og tidspunkt"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Utgivelsesversjon"
 
 #: src/BuildInfo.h
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Utgivelsesversjon"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1791,6 +1966,18 @@ msgstr "Velg lyden som %s skal bruke (for eksempel, Ctrl + A for å velge alle),
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Ingen lyd er valgt"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1840,10 +2027,24 @@ msgstr "Nåværende prosjekt"
 msgid "Checkpointing %s"
 msgstr "Importerer %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Kunne ikke skrive til filen: %s\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Klarte ikke å lagre prosjektet.\n"
+"Kanskje %s ikke kan skrives til, eller disken er full."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1864,6 +2065,10 @@ msgid ""
 msgstr ""
 "Mislyktes i å registrere:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1961,6 +2166,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopier navn til utklippstavlen"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Manglende filer"
 
@@ -1969,10 +2179,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Hvis du fortsetter, vil prosjektet ikke bli lagret til disk. Er det dette du vil?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1984,7 +2195,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Avhengighetskontroll"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ingen"
 
@@ -1992,7 +2206,7 @@ msgstr "Ingen"
 msgid "Rectangle"
 msgstr "Rektangel"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trekant"
 
@@ -2006,8 +2220,18 @@ msgstr "Rektangulær"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Hamming"
 msgstr "Hamming, ingen"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
@@ -2024,14 +2248,30 @@ msgstr "Blackman, Hann"
 msgid "Welch"
 msgstr "Velkommen!"
 
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg-støtte ikke kompilert"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2054,8 +2294,8 @@ msgid "Locate FFmpeg"
 msgstr "Finn FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity trenger filen %s for å importere og eksportere via FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2068,7 +2308,8 @@ msgstr "Plasseringen til '%s':"
 msgid "To find '%s', click here -->"
 msgstr "For å finne '%s', klikk her →"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Bla gjennom..."
 
@@ -2094,8 +2335,9 @@ msgid "FFmpeg not found"
 msgstr "Fant ikke FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2116,25 +2358,34 @@ msgstr "Ikke vis denne advarselen igjen"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Fant ingen kompatible FFmpeg-bibliotek."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity klarte ikke å åpne filen i %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity klarte ikke å lese fra en fil i %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity lyktes i å lagre en fil i %s, men mislyktes i å gi den det nye navnet %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2172,7 +2423,9 @@ msgstr "Kopier ikke &noe lyd"
 msgid "As&k"
 msgstr "&Spør"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Alle filer|*"
 
@@ -2181,6 +2434,11 @@ msgstr "Alle filer|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Lagrer prosjektdatafiler"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Bibliotek"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -2193,6 +2451,10 @@ msgstr "Gi navn til filer:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3-filer"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2234,6 +2496,14 @@ msgstr "Kubikkrot autosamsvar"
 msgid "Enhanced Autocorrelation"
 msgstr "Forbedret autosamsvar"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spektrum"
+
 #  i18n-hint: This refers to a "window function", used in the
 #  Frequency analyze dialog box.
 #  i18n-hint: This refers to a "window function", used in the
@@ -2254,6 +2524,17 @@ msgstr "Linær frekvens"
 msgid "Log frequency"
 msgstr "Logaritmisk frekvens"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Skroll"
@@ -2261,6 +2542,15 @@ msgstr "Skroll"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Forstørr"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2327,6 +2617,18 @@ msgid "s"
 msgstr "sek"
 
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f sek (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f sek (%d Hz) (%s) = %.3f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
@@ -2341,10 +2643,16 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f sek (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Spektrum"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Eksporter spektral data som:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Kunne ikke skrive til filen: %s"
@@ -2523,6 +2831,11 @@ msgstr "Forkast"
 msgid "&Compact"
 msgstr "&Kommando"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2530,19 +2843,19 @@ msgid "&History..."
 msgstr "&Historie..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Intern feil i %s i %s linje %d.\n"
 "Vennligst informer Audacity-teamet om dette hos https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Intern feil i %s linje %d.\n"
 "Vennligst informer Audacity-teamet om dette hos https://forum.audacityteam.org/."
@@ -2561,7 +2874,9 @@ msgid "Track"
 msgstr "Spor"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Kommentar"
 
@@ -2621,7 +2936,8 @@ msgstr "Skriv inn spornavn"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Kommentarspor"
 
@@ -2632,11 +2948,13 @@ msgstr "En eller flere lagrede merker kunne ikke bli innlest."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Første oppstart av Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Velg språk for Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2646,7 +2964,8 @@ msgstr "Velg språk for Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Det valgte språket, %s (%s), er ikke det samme som systemspråket, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Bekreft"
 
@@ -2664,13 +2983,19 @@ msgstr ""
 "Den gamle fila har blitt lagret som '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Åpner Audacity-prosjekt"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity-karaoke%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Bla gjennom..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2716,17 +3041,28 @@ msgid "Mixing and rendering tracks"
 msgstr "Mikser og rendrer spor"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity miksepult%s"
 
 #  i18n-hint: Title of the Gain slider, used to adjust the volume
 #  i18n-hint: Title of the Gain slider, used to adjust the volume
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Sporvolum"
+
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Velocity"
+msgstr "Notehastighet"
 
 #: src/MixerBoard.cpp
 msgid "Musical Instrument"
@@ -2735,28 +3071,43 @@ msgstr "Musikkinstrument"
 #  i18n-hint: Title of the Pan slider, used to move the sound left or right
 # stereoscopically
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panorering"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Demp"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr " Satt til solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Signalnivåmåler"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Flyttet glidebryter for sporvolum"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Beveget på Velocity-glideren"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Flyttet glidebryter for panorering"
 
@@ -2787,9 +3138,9 @@ msgstr ""
 "Den vil ikke bli lastet inn."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2822,16 +3173,19 @@ msgstr ""
 "\n"
 "Bruk kun moduler fra kilder som du stoler på"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Ja"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nei"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacitys modulinnlaster"
 
 #: src/ModuleManager.cpp
@@ -2853,6 +3207,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Notespor"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2962,7 +3426,8 @@ msgstr "&Velg alle"
 msgid "C&lear All"
 msgstr "T&øm alle"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Aktiver"
 
@@ -3038,6 +3503,21 @@ msgstr ""
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "For å bruke et filter, må alle markerte spor være av samme samplingsfrekvens."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Innspillt lyd"
@@ -3056,10 +3536,11 @@ msgid "Dropouts"
 msgstr "Lydutfall"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3099,11 +3580,11 @@ msgid "Inspecting project file data"
 msgstr "Inspiserer prosjektfildata"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3146,11 +3627,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Advarsel - Manglende forkortede fil(er)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Prosjektsjekken av \"%s\"-mappen oppdaget \n"
@@ -3175,12 +3656,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Advarsel - Manglende forkortnings-oppsummeringsfil(er)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3239,7 +3720,8 @@ msgstr "Advarsel - Enslige blokkfil(er)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Framgang"
 
@@ -3264,6 +3746,11 @@ msgstr "Advarsel: Problemer under automatisk gjenoppretting"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<uten tittel>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Prosjekt"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3304,11 +3791,98 @@ msgid ""
 msgstr "Klarte ikke åpne forvalgsfilen."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"Mislyktes i å registrere:\n"
+"%s"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Lagrer et Audacity-prosjekt"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Kunne ikke starte opp MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kunne ikke starte opp MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kunne ikke starte opp MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kunne ikke starte opp MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kunne ikke starte opp MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kunne ikke starte opp MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Kunne ikke starte opp MP3-strøm"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Kunne ikke starte opp MP3-strøm"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3322,12 +3896,35 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Enslig blokkfil: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Klarte ikke å sette strømmen på pause."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Fant ikke kodeken"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+"Mislyktes i å registrere:\n"
+"%s"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3338,9 +3935,9 @@ msgid "Error Writing to File"
 msgstr "Feil ved skriving til fil"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3351,6 +3948,19 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Å lagre &prosjekter"
 
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "&Om Audacity..."
+
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
@@ -3358,10 +3968,10 @@ msgstr "(Gjenopprettet)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Denne filen ble lagret med Audacity %s. Du bruker Audacity %s.\n"
 "Du kan måtte trenge å oppgradere til en nyere versjon for å åpne denne filen."
@@ -3369,6 +3979,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Kan ikke åpne prosjektfile"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3383,6 +3997,10 @@ msgid "Unable to parse project information."
 msgstr "Klarte ikke åpne forvalgsfilen."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Å lagre &prosjekter"
 
@@ -3391,12 +4009,35 @@ msgid "Error Saving Project"
 msgstr "Feil ved lagring av prosjekt"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Å lagre et &tomt prosjekt"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3404,8 +4045,24 @@ msgstr ""
 "Heldigvis kan de følgende prosjektene automatisk gjenopprettes:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Noen prosjekter ble ikke lagret skikkelig siste gang Audacity ble kjørt.\n"
+"Heldigvis kan de følgende prosjektene automatisk gjenopprettes:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Prosjektet ble gjenopprettet"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Mappe for midlertidige filer"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3435,6 +4092,17 @@ msgstr "Advarsel - Tomt prosjekt"
 msgid "Insufficient Disk Space"
 msgstr "Diskplass"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3454,8 +4122,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%s: Lagre prosjektet \"%s\" som..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Lagre prosjekt' er for Audacity-prosjekter, og ikke lydfiler.\n"
@@ -3532,11 +4201,12 @@ msgid "Error Opening Project"
 msgstr "Feil ved åpning av prosjekt"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Du prøver å opne en automatisk lagret sikkerhetskopi.\n"
 "Dette kan føre til omfattende tap av data.\n"
@@ -3569,6 +4239,12 @@ msgid "Error Opening File or Project"
 msgstr "Feil ved åpning av fil eller prosjekt"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Prosjektet ble gjenopprettet"
 
@@ -3594,12 +4270,33 @@ msgid "Error Importing"
 msgstr "Feil ved importering"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Bestem prosjekt"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Kan ikke åpne prosjektfile"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Kommando"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3610,8 +4307,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatisk lagring aktivert:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Velkommen til Audacity versjon %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3669,6 +4366,12 @@ msgstr[1] "%d minutter"
 msgid "%s and %s."
 msgstr "%s og %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3683,6 +4386,21 @@ msgstr "Vannrett skrollelinje"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Vertikal skrollelinje"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -3699,6 +4417,18 @@ msgstr "Høy kvalitet"
 #: src/Resample.cpp
 msgid "Best Quality (Slowest)"
 msgstr "Beste kvalitet (Tregest)"
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "16-bit PCM"
 
 #. i18n-hint: Audio data bit depth (precision): 32-bit floating point
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
@@ -3793,7 +4523,8 @@ msgstr "Alle preferanser"
 msgid "SelectionBar"
 msgstr "Markering"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spekterutvalg"
 
@@ -3801,42 +4532,56 @@ msgstr "Spekterutvalg"
 msgid "Timer"
 msgstr "Tid:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Verktøy"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "&Kontroll"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mikser"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Lydnivå"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Avspillingsmåler"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Opptaksmåler"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Rediger"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Enhet"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Avspill med gitt hastighet"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Gni"
 
@@ -3851,7 +4596,10 @@ msgstr "Linjal"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Spor"
 
@@ -3936,6 +4684,10 @@ msgstr "Utdata-forhåndsvisning"
 msgid "&Settings"
 msgstr "&Valg"
 
+#: src/ShuttleGui.cpp
+msgid "Debu&g"
+msgstr ""
+
 #: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
 msgid "Off"
 msgstr "Av"
@@ -3957,7 +4709,8 @@ msgid "Activation level (dB):"
 msgstr "Aktiveringsnivå (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Velkommen til Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4084,10 +4837,25 @@ msgstr "Feil ved lagring av markeringsfil"
 msgid "Unsuitable"
 msgstr "Modulen er uegnet"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Mappe for midlertidige filer"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity klarte ikke skrive til fila:\n"
@@ -4107,9 +4875,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4118,9 +4886,9 @@ msgstr ""
 "for skriving."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity klarte ikke skrive bilder til fil:\n"
@@ -4137,9 +4905,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4149,9 +4917,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4160,8 +4928,9 @@ msgstr ""
 "Har den kanskje dårlig png-format?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity klarte ikke lese standardtemaet sitt.\n"
@@ -4199,9 +4968,9 @@ msgstr ""
 "var allerede tilstede. Vil du overskrive dem?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity klarte ikke lagre fila:\n"
@@ -4240,7 +5009,11 @@ msgstr "Tilpasset"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Varighet"
 
@@ -4251,7 +5024,8 @@ msgid "Time Track"
 msgstr "Tidsspor"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity nedtellingsopptak"
 
 #: src/TimerRecordDialog.cpp
@@ -4325,7 +5099,8 @@ msgstr "Nåværende prosjekt"
 msgid "Recording start:"
 msgstr "Opptaksstart:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Varighet:"
 
@@ -4346,7 +5121,8 @@ msgid "Action after Timer Recording:"
 msgstr "Handling etter tidsinnstilt opptak:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Framgang for Audacity nedtellingsopptak"
 
 #: src/TimerRecordDialog.cpp
@@ -4442,6 +5218,7 @@ msgstr "099 dager 024 t 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Startdato og tidspunkt"
@@ -4486,7 +5263,8 @@ msgstr "Vil du aktivere automatisk &eksportering?"
 msgid "Export Project As:"
 msgstr "Eksporter prosjekt som:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Innstillinger"
 
@@ -4499,7 +5277,8 @@ msgid "Do nothing"
 msgstr "Ikke gjør noe"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Avslutt Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4523,7 +5302,8 @@ msgid "Scheduled to stop at:"
 msgstr "Planlagt å stoppes klokken:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacitys nedtellingsopptak - Venter på å starte"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4549,8 +5329,13 @@ msgid "Recording Exported:"
 msgstr "Opptaket er eksportert:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacitys nedtellingsopptak - Venter"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -4671,6 +5456,10 @@ msgstr "Flytt spor opp"
 msgid "Move Track Down"
 msgstr "Flytt spor ned"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4737,6 +5526,20 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Anvender %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Bunkekommando"
@@ -4751,16 +5554,33 @@ msgstr "%s er ikke et parameter som er akseptert av %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Ugyldig verdi for parameteret '%s': burde være %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Kommando"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repeter %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4773,6 +5593,10 @@ msgstr "Terskel:"
 #: src/commands/CompareAudioCommand.h
 msgid "Compares a range on two tracks."
 msgstr "Sammenligner en rekkevidde på to spor."
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
 
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
@@ -4790,6 +5614,11 @@ msgstr "Utfører demohandlingen."
 msgid "Drag"
 msgstr "Dra"
 
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Panel"
+msgstr "Sporpanel"
+
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
 msgstr "Program"
@@ -4801,6 +5630,11 @@ msgstr "Spor 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Spor 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -4854,7 +5688,8 @@ msgstr "Klippinger"
 msgid "Envelopes"
 msgstr "Inngjerdinger"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Kommentarer"
 
@@ -4862,9 +5697,30 @@ msgstr "Kommentarer"
 msgid "Boxes"
 msgstr "Bokser"
 
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
 msgstr "Raskt"
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Typer:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Nåværende prosjekt"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -4890,9 +5746,22 @@ msgstr "Kommentarer"
 msgid "Command:"
 msgstr "Kommando:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Gir deg hjelp med en kommando."
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Import2"
+msgstr "Importer"
 
 #: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
 msgid "File Name:"
@@ -4919,12 +5788,17 @@ msgstr "Eksporter til en fil."
 msgid "Builtin Commands"
 msgstr "Innebygde kommandoer"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity-teamet"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Sørger for innebygde effekter i Audacity"
 
 #: src/commands/LoadCommands.cpp
@@ -4975,11 +5849,22 @@ msgstr "Lagrer et prosjekt."
 msgid "Saves a copy of current project."
 msgstr "Lagrer et prosjekt."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Hent innstilling"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Navn:"
 
@@ -5031,7 +5916,8 @@ msgstr "Fullskjerm"
 msgid "Toolbars"
 msgstr "Verktøylinjer"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effekter"
 
@@ -5171,7 +6057,8 @@ msgstr "Velg"
 msgid "Add"
 msgstr "Legg til"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Fjern"
 
@@ -5231,6 +6118,11 @@ msgstr "Hos:"
 msgid "Color:"
 msgstr "Farge:"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
+#, fuzzy
+msgid "Start:"
+msgstr "Starttid:"
+
 #: src/commands/SetClipCommand.h
 msgid "Sets various values for a clip."
 msgstr "Bestemmer diverse verdier for et klipp."
@@ -5252,7 +6144,8 @@ msgid "Edited Envelope"
 msgstr "Bestem inngjerding"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Omhyllingskurve"
 
@@ -5295,6 +6188,14 @@ msgstr "Frekvens:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Gi ny størrelse:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5346,7 +6247,10 @@ msgstr "Panorer:"
 msgid "Set Track Visuals"
 msgstr "Bestem sporets visualiteter"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineær"
 
@@ -5389,6 +6293,12 @@ msgstr "Bruk spektruminnstillinger"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Spekterutvalg"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5444,12 +6354,18 @@ msgstr "Du valgte et spor som ikke inneholder lyd. Autodukk kan bare behandle ly
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Autodukk trenger et kontrollspor som må plasseres under de valgte sporene."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Duck-mengde:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekunder"
 
@@ -5473,7 +6389,8 @@ msgstr "Indre uttoningslengde:"
 msgid "Inner &fade up length:"
 msgstr "Indre inntoningslengde:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Terskel:"
 
@@ -5492,6 +6409,21 @@ msgstr "Enkel tonekontrolleffekt"
 #: src/effects/BassTreble.cpp
 msgid "Tone controls"
 msgstr "Tonekontrollere"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass (dB):"
+msgstr "&Volum (dB):"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Ba&ss (dB):"
+msgstr "&Volum (dB):"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "BassBoost"
 
 #: src/effects/BassTreble.cpp
 msgid "&Treble (dB):"
@@ -5588,6 +6520,10 @@ msgid "from (Hz)"
 msgstr "fra (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "til (Hz)"
 
@@ -5595,17 +6531,23 @@ msgstr "til (Hz)"
 msgid "t&o"
 msgstr "til"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Prosentverdi:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Prosentvis endring"
 
 #: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
 msgid "&Use high quality stretching (slow)"
 msgstr "Bruk høykvalitets strekking (treg)"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -5621,7 +6563,9 @@ msgstr "8"
 #  unimportant, not relevant).
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "(ingen)"
 
@@ -5649,6 +6593,7 @@ msgstr "Standard vinyl-RPM:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Fra RPM"
@@ -5661,6 +6606,7 @@ msgstr "fra"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Til RPM"
@@ -5803,6 +6749,12 @@ msgstr "Komprimering"
 msgid "Compresses the dynamic range of audio"
 msgstr "Komprimer lydens dynamiske rekkevidde"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -5811,6 +6763,20 @@ msgstr "%.2f sek"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f sek"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f sek"
 
 #: src/effects/Compressor.cpp
@@ -5928,7 +6894,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Kontrastanalyse, for å måle RMS-volumforskjeller mellom to merkede lydsekvenser."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Slutt"
 
@@ -5988,6 +6955,18 @@ msgstr "&Forskjell:"
 msgid "&Help"
 msgstr "&Hjelp"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "null"
@@ -5995,6 +6974,13 @@ msgstr "null"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "kunne ikke fastslå"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "RMS med %.2f dB i gjennomsnitt"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6048,6 +7034,12 @@ msgstr "Nåværende forskjell"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Målt forgunnsnivå"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6117,6 +7109,12 @@ msgstr "Suksesskriterium 1.4.7 i WCAG 2.0: Ikke bestått"
 msgid "Data gathered"
 msgstr "Data hentet inn"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Kontrastanalyse (WCAG 2-samsvar)"
@@ -6182,6 +7180,10 @@ msgstr "Mykklipp -12dB, 80% utjevningsforsterkning"
 #: src/effects/Distortion.cpp
 msgid "Fuzz Box"
 msgstr "Frynseboks"
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Blues drive sustain"
@@ -6250,6 +7252,16 @@ msgstr "Perkusjonsbegrenser"
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
 msgstr "Øvre terskel"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Parametre"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Parametre"
 
 #: src/effects/Distortion.cpp
 msgid "Number of repeats"
@@ -6368,6 +7380,12 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "Lager dobbel-tone flerfrekvenstoner (DTMF) slik som de som lages av tastaturet på telefoner"
 
 #: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "DTMF-sekvens:"
 
@@ -6375,7 +7393,9 @@ msgstr "DTMF-sekvens:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitude (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Varighet:"
 
@@ -6396,6 +7416,12 @@ msgstr "%.1f sek"
 msgid "Tone duration:"
 msgstr "Tonevarighet:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
+
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Stillhetsvarighet:"
@@ -6414,7 +7440,8 @@ msgstr "Ekko"
 msgid "Repeats the selected audio again and again"
 msgstr "Repeterer den markerte lyden om og om igjen"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Den ønskede verdien overgår minnekapasiteten."
 
@@ -6438,7 +7465,8 @@ msgstr "Forvalg"
 msgid "Export Effect Parameters"
 msgstr "R&ediger parametre"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Kunne ikke åpne filen: \"%s\""
@@ -6475,6 +7503,15 @@ msgstr "Klargjør forhåndsvisning"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Forhåndsviser"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 # "Anvende" or "Legge til"? (not all marked fuzzy)
 #: src/effects/EffectManager.cpp
@@ -6694,6 +7731,11 @@ msgid "Options..."
 msgstr "Valg..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Typer:"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Navn: %s"
@@ -6754,6 +7796,11 @@ msgstr "Stopp avspilling (P)"
 msgid "Play"
 msgstr "Spill av"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
@@ -6779,12 +7826,32 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "Justerer volumnivåene til spesielle frekvenser"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "BassBoost"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "BassBoost"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -6819,8 +7886,35 @@ msgid "Effect Unavailable"
 msgstr "Effekten er utilgjengelig"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Maks dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
 
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
@@ -6901,8 +7995,16 @@ msgid "D&efault"
 msgstr "Stan&dard"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &Sammenknyttet"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7147,7 +8249,8 @@ msgid "Builtin Effects"
 msgstr "Innebygde effekter"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Sørger for innebygde effekter i Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7157,6 +8260,14 @@ msgstr "Ukjent navn på innebygd effekt"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normaliser støymengden til"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Sets the loudness of one or more tracks"
@@ -7186,8 +8297,20 @@ msgid "Loudness LUFS"
 msgstr "Støynivå-LUFS"
 
 #: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Normaliser stereokanalene uavhengig"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -7225,6 +8348,11 @@ msgid "&Noise type:"
 msgstr "Støytype:"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Median"
+msgstr "Middels"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Second greatest"
 msgstr "Nest største"
 
@@ -7245,7 +8373,17 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (standard)"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "Blackman, Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, ingen"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, ingen"
 
 #: src/effects/NoiseReduction.cpp
@@ -7345,8 +8483,9 @@ msgid "Step 1"
 msgstr "Steg 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Marker noen sekunder med bare støy slik at Audacity\n"
@@ -7398,13 +8537,63 @@ msgstr "Vindus&typer"
 msgid "Window si&ze:"
 msgstr "&Størrelse på vindu"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (standard)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "T&rinn per vindu"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7520,12 +8709,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Normaliser stereokanalene uavhengig"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Strekk"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch er bare for en ekstrem tidsstrekk- eller \"stase\"-effekt"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Strekkfaktor:"
@@ -7575,6 +8770,11 @@ msgstr ""
 "\n"
 "Prøv med å forlenge lydutvalget til minst %.1f sekunder,\n"
 "eller reduser 'Tidsresolusjon'-mengden til mindre enn %.1f sekunder."
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Phaser"
+msgstr "Fase"
 
 #: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
@@ -7803,6 +9003,11 @@ msgstr "Eksporterer den markerte lyden"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS-tid / Tonefall-strekking"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -7961,6 +9166,11 @@ msgstr "Bruk standarder"
 msgid "Restore Defaults"
 msgstr "Gjenopprett standardverdier"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8052,6 +9262,11 @@ msgid "Chirp"
 msgstr "Kvitter"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Tone"
+msgstr "Lav tone"
+
+#: src/effects/ToneGen.cpp
 msgid "Generates an ascending or descending tone of one of four types"
 msgstr "Genererer en økende eller synkende tone av enten en av fire typer"
 
@@ -8115,6 +9330,10 @@ msgstr "Oppdag stillhet"
 msgid "Tr&uncate to:"
 msgstr "Kort ned til:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Komprimer til:"
@@ -8128,7 +9347,8 @@ msgid "VST Effects"
 msgstr "VST-effekter"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Legger til muligheten for å bruke VST-effekter i Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8140,7 +9360,8 @@ msgstr "Søker gjennom VST-skall"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registrering %d av %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Kunne ikke laste inn biblioteket"
 
@@ -8152,15 +9373,25 @@ msgstr "VST-effektinnstillinger"
 msgid "Buffer Size"
 msgstr "Bufferstørrelse"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Buffertid (8 til 1048576 samplinger):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Latenskompensasjon"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Aktiver &kompensering"
 
@@ -8186,11 +9417,17 @@ msgid "Save VST Preset As:"
 msgstr "Lagre VST-innstillinger som:"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Åpne VST-program"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "Åpne VST-program"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity prosjektfiler"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8217,7 +9454,8 @@ msgstr "Feil ved innlasting av VST-innstillinger"
 msgid "Unable to load presets file."
 msgstr "Klarte ikke å åpne innstillingsfil."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Effektinnstillinger"
 
@@ -8233,6 +9471,16 @@ msgstr "Klarte ikke åpne forvalgsfilen."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Denne parameterfilen ble lagret fra %s. Vil du fortsette?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8264,7 +9512,8 @@ msgid "Audio Unit Effects"
 msgstr "Lydenhetseffekter"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Sørger for støtte for lydenhetseffekter i Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8280,12 +9529,25 @@ msgid "Audio Unit Effect Options"
 msgstr "Innstillinger for lydenhetseffekter"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Grensesnitt"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Velg &grensesnitt"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Full"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
@@ -8379,6 +9641,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Kunne ikke hente strømbeskrivelsen"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Klarte ikke åpne forvalgsfilen."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Samplingsfrekvenskonvertering"
 
@@ -8389,6 +9656,21 @@ msgstr ""
 "Mislyktes i å registrere:\n"
 "%s"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Kunne ikke hente strømbeskrivelsen"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Kunne ikke hente strømbeskrivelsen"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Klarte ikke åpne forvalgsfilen."
+
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
 #: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
@@ -8397,6 +9679,7 @@ msgstr "Lydenhet"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADPSA-effekter"
@@ -8406,16 +9689,23 @@ msgid "Provides LADSPA Effects"
 msgstr "Sørger for LADSPA-effekter"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity bruker ikke lenger vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "LADSPA-effektinnstillinger"
 
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s om:"
@@ -8426,6 +9716,7 @@ msgstr "Effektutdata"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "LADPSA"
@@ -8438,6 +9729,10 @@ msgstr "LV2-effektinnstillinger"
 #, c-format
 msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Buffertid (8 til 1048576 samplinger):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -8457,12 +9752,24 @@ msgstr "%d kurver eksportert til %s\n"
 msgid "%s requires unsupported option %s\n"
 msgstr "%d kurver eksportert til %s\n"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "Tonegenerator"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-effekter"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Sørger for LV2-effektstøtte i Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8470,7 +9777,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist-effekter"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Sørger for Nyquist-effektstøtte i Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8485,6 +9793,12 @@ msgstr "&Nyquist-arbeider"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Misformet Nyquist-tilleggstoppområde"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -8691,7 +10005,8 @@ msgstr "Velg en fil"
 msgid "Save file as"
 msgstr "Lagre filen som"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "uten tittel"
 
@@ -8700,7 +10015,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-effekter"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Sørger for Vamp-effektstøtte i Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -8718,6 +10034,18 @@ msgstr "Beklager, klarte ikke starte opp Vamp-tillegget."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Innstillinger for tillegg"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+#, fuzzy
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -8876,15 +10204,28 @@ msgid "Command Output"
 msgstr "Utdata fra kommando"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
 "Du har valgt et filnavn med en filendelse som ikke ble gjenkjent.\n"
 "Vil du fortsette?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "\"%s\"-modulen funnet."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Klarte ikke å åpne innstillingsfil."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -8931,6 +10272,14 @@ msgid ""
 msgstr ""
 "FFmpeg fant ikke lydkodek 0x%x.\n"
 "Støtte for denne kodeken er nok ikke kompilert inn."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -8996,7 +10345,8 @@ msgstr "Eksporterer lyden som %s"
 msgid "Invalid sample rate"
 msgstr "Ugyldig samplingsfrekvens"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Gi ny datafrekvens"
 
@@ -9028,7 +10378,8 @@ msgstr "Datarater"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kb/s"
@@ -9048,6 +10399,43 @@ msgid "%.2f kbps"
 msgstr "%.2f kb/s"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
 msgstr "1"
 
@@ -9060,6 +10448,10 @@ msgid "Constrained"
 msgstr "Konstant"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Lyd..."
 
@@ -9068,8 +10460,44 @@ msgid "Low Delay"
 msgstr "Forsinkelse"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Middels"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -9140,8 +10568,17 @@ msgid "Replace preset '%s'?"
 msgstr "Overskriv forhåndsinnstillingen '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Hoved"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9251,6 +10688,10 @@ msgstr "Språk:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bitreservoar"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9384,6 +10825,11 @@ msgstr ""
 "0 - standard\n"
 "min - 1\n"
 "maks - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9543,6 +10989,17 @@ msgstr "Ingen kommentarer å eksportere."
 msgid "Select xml file to export presets into"
 msgstr "Velg XML-fila som forhåndsinnstillingene skal eksporteres til"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Klarte ikke å gjette formatet"
@@ -9553,7 +11010,22 @@ msgid "Failed to find the codec"
 msgstr "Fant ikke kodeken"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "16 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "24 bit"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
+msgstr "0 (raskest)"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "8 (best)"
 msgstr "0 (raskest)"
 
 #: src/export/ExportFLAC.cpp
@@ -9633,8 +11105,23 @@ msgid "145-185 kbps"
 msgstr "Middels, 145-185 kb/s"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "Standard, 170-210 kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "Middels, 145-185 kb/s"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
 msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
+msgstr "Middels, 145-185 kb/s"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -9666,6 +11153,12 @@ msgstr "Sinnssyk"
 msgid "Extreme"
 msgstr "Ekstrem"
 
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Standard"
+msgstr "Standard"
+
 #: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "Middels"
@@ -9685,6 +11178,11 @@ msgstr "Konstant"
 #: src/export/ExportMP3.cpp
 msgid "Joint Stereo"
 msgstr "Kombinert stereo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Gjør til stereo"
 
 #: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
@@ -9709,8 +11207,8 @@ msgid "Locate LAME"
 msgstr "Finn LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity trenger fila %s for å lage MP3-er."
 
 #: src/export/ExportMP3.cpp
@@ -9741,14 +11239,35 @@ msgid "Where is %s?"
 msgstr "Hvor finnes filen %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Du lenker til lame_enc.dll v%d.%d. Denne utgaven er ikke kompatibel med Audacity\n"
 "%d.%d.%d.\n"
 "Vennligst last ned den nyeste utgaven av MP3-biblioteket LAME."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Lagrer prosjektdatafiler"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -9996,6 +11515,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Klarer ikke å bestemme QuickTime-rendringskvalitet"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Klarte ikke å åpne innstillingsfil."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Klarte ikke å åpne innstillingsfil."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Klarte ikke å åpne innstillingsfil."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Klarte ikke å åpne innstillingsfil."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Klarte ikke å åpne innstillingsfil."
 
@@ -10006,6 +11545,10 @@ msgstr "Eksporterer markert lyd som Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Eksporterer lyden som Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -10024,8 +11567,28 @@ msgid "Other uncompressed files"
 msgstr "Andre ukomprimerte filer"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Feil ved importering"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -10053,11 +11616,11 @@ msgid "All supported files"
 msgstr "Alle filer|*|Alle støttede filer|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\"\n"
@@ -10066,11 +11629,11 @@ msgstr ""
 "kan redigere den ved å klikke Fil > Importer > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\"\n"
 "er en MIDI-fil, ikke en lydfil. \n"
@@ -10082,18 +11645,18 @@ msgid "Select stream(s) to import"
 msgstr "Velg strøm(mer) å importere"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Denne versjonen av Audacity ble ikke kompilert med støtte for %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "«%s» er et spor på en lyd-CD. \n"
 "Audacity kan ikke åpne lyd-CD-er direkte. \n"
@@ -10102,10 +11665,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "«%s» er en spillelistefil. \n"
@@ -10114,10 +11677,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» er en Windows Media Audio-fil. \n"
@@ -10126,10 +11689,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» er en Advanced Audio Coding-fil. \n"
@@ -10138,12 +11701,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "«%s» er en kryptert lydfil. \n"
@@ -10154,10 +11717,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» er en RealPlayer media-fil. \n"
@@ -10166,12 +11729,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "«%s» er en note-basert fil, ikke en lydfil.\n"
 "Audacity kan ikke åpne denne filtypen.\n"
@@ -10179,10 +11742,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10193,10 +11756,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» er en Wavpack-lydfil.\n"
@@ -10205,10 +11768,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» er en Dolby Digital-lydfil.\n"
@@ -10217,10 +11780,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» er en Ogg Speex-lydfil.\n"
@@ -10229,10 +11792,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "«%s» er en videofil.\n"
@@ -10246,20 +11809,31 @@ msgstr "\"%s\"-modulen funnet."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity gjenkjente ikke filtypen til '%s'.\n"
 "Prøv å installer FFmpeg. For ukomprimerte filer, prøv også med Fil → Importer → Rå data."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "tester"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10268,6 +11842,11 @@ msgstr ""
 "Importererne som visstnok støtter slike filer er:\n"
 "%s,\n"
 "men ingen av dem gjenkjente dette filformatet."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Lagrer prosjektdatafiler"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10284,8 +11863,57 @@ msgid "Import Project"
 msgstr "Importer forhåndsinnstillinger"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Intern feil i koordineringsprosessen."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Ugyldig samplingsfrekvens"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10293,16 +11921,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Kunne ikke finne prosjektdatamappen: «%s»"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Prosjektstart"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Ugyldig samplingsfrekvens"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Ugyldig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10332,40 +12018,6 @@ msgstr "Indeks[%02x] Kodek[%s], Språk[%s], Bitrate[%s], Kanaler[%d], Varighet[%
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC-filer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-kompatible filer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Klarte ikke å legge til en dekoder til pipeføringen"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer-importerer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Klarte ikke å sette strømmen på pause."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indeks[%02x] Kodek[%s], Språk[%s], Bitrate[%s], Kanaler[%d], Varighet[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Filen inneholder ikke noen lydstrømmer."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Klarte ikke å importere filen, tilstandsendringen mislyktes."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer-feil: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10427,6 +12079,14 @@ msgstr "Klarte ikke å åpne filen %s."
 msgid "MP3 files"
 msgstr "MP3-filer"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis-filer"
@@ -10461,8 +12121,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF og andre ukomprimerte filtyper"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) flytende 32-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -10473,12 +12227,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-bit flyttall"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-bit flyttall"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) flytende 32-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bit"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -10489,12 +12287,20 @@ msgid "24 bit DWVW"
 msgstr "24 bit"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -10546,6 +12352,18 @@ msgstr "Importer rå data"
 msgid "No endianness"
 msgstr "Ingen endianness"
 
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Big-endian"
+msgstr ""
+
 #  i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #  know the correct technical word.
 #  i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
@@ -10583,6 +12401,11 @@ msgid "Start offset:"
 msgstr "Standard startpunkt:"
 
 #: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "bytes"
+msgstr "bytes"
+
+#: src/import/ImportRaw.cpp
 msgid "Amount to import:"
 msgstr "Mengde å importere:"
 
@@ -10594,6 +12417,10 @@ msgstr "Datapunktrate:"
 #: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
 msgid "&Import"
 msgstr "&Importer"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -10615,12 +12442,17 @@ msgstr "%s høyre"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
 msgid_plural "%s %d of %d clips %s"
 msgstr[0] "%s %d av %d klipp %s"
 msgstr[1] "%s %d av %d klipp %s"
+
+#: src/menus/ClipMenus.cpp
+msgid "start"
+msgstr ""
 
 #: src/menus/ClipMenus.cpp
 msgid "end"
@@ -10634,6 +12466,7 @@ msgstr "slutt"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -10660,7 +12493,8 @@ msgstr "Tidsforskjøv klippene mot høyre"
 msgid "Time shifted clips to the left"
 msgstr "Tidsforskjøv klippene mot venstre"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Tidsforskyvning"
 
@@ -10798,7 +12632,8 @@ msgstr "Trim valgte lydspor fra %.2f sekunder til %.2f sekunder"
 msgid "Trim Audio"
 msgstr "Trim lyd"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Del opp"
 
@@ -10924,34 +12759,6 @@ msgid "Ext&ra"
 msgstr "Ekst&ra"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mik&ser"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Jus&ter avspillingsvolum ..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Øk avspillingsvolum"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Senk avspillingsvolum"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Just&er opptaksvolum ..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Ø&k opptaksvolum"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "S&enk opptaksvolum"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "En&het"
 
@@ -10987,6 +12794,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Eksporterer markert lyd"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Merk tekst"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -11036,6 +12849,11 @@ msgstr "Importer kommentarer"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Velg en MIDI-fil"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Alle filer|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -11119,6 +12937,11 @@ msgid "&Labels..."
 msgstr "&Kommentarer..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Eksporter MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Rådata..."
 
@@ -11135,6 +12958,10 @@ msgstr "Skriv &ut..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "A&vslutt"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -11203,8 +13030,9 @@ msgid "&Getting Started"
 msgstr "&Kom i gang"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity sin &bruksanvisning"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Bruksanvisning ..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -11230,11 +13058,8 @@ msgstr "&MIDI-enhetsinformasjon ..."
 msgid "Show &Log..."
 msgstr "Vis &logg..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Om Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Lagt til kommentar"
 
@@ -11434,6 +13259,10 @@ msgstr "Gå bakover gjennom aktive vinduer"
 #: src/menus/NavigationMenus.cpp
 msgid "Move Forward Through Active Windows"
 msgstr "Gå fremover gjennom aktive vinduer"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -11702,6 +13531,11 @@ msgid "Select Sync-Locked"
 msgstr "Velg synk-låste"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "R&egion"
+msgstr "Avspill &region"
+
+#: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
 msgstr "&Venstregrense til gitt avspillingsposisjon"
 
@@ -11921,6 +13755,7 @@ msgstr "Markør langt ho&pp høyre"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Sø&k"
@@ -12132,18 +13967,21 @@ msgid "Created new label track"
 msgstr "Lagte nytt kommentarspor"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Denne versjonen av Audcity støtter kun ett tidsspor for hvert prosjektvindu."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Lagte nytt tidsspor"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Ny samplingsfrekvens (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Verdien du skrev inn er ugyldig"
 
@@ -12400,7 +14238,9 @@ msgstr "Spiller av"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Opptak"
 
@@ -12458,6 +14298,13 @@ msgstr "Vennligst velg minst %d kanaler."
 msgid "Please select a time within a clip."
 msgstr "Vennligst velg et tidspunkt innenfor et klipp."
 
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Tra&nsport"
+msgstr "&Kontroll"
+
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
 msgstr "Spi&ll av"
@@ -12474,6 +14321,11 @@ msgstr "Spill av / stopp og &plasser markør"
 #: src/menus/TransportMenus.cpp
 msgid "&Loop Play"
 msgstr "&Spill av i løkke"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Pauset"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
@@ -12539,10 +14391,6 @@ msgstr "Overdubb (av/på)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Spill gjennom med programvare (av/på)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Automatisk justering av inndatanivå (av/på)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -12762,7 +14610,7 @@ msgstr "Innstillinger: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Avslutt Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -12809,7 +14657,8 @@ msgstr "&Vert:"
 msgid "Using:"
 msgstr "Bruker:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Avspilling"
 
@@ -12829,7 +14678,8 @@ msgstr "Kan&aler:"
 msgid "Latency"
 msgstr "Latens"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "millisekunder"
 
@@ -12849,8 +14699,19 @@ msgstr "Ingen lydgrensesnitt"
 msgid "No devices found"
 msgstr "Ingen enheter funnet"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 kanal (mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 kanaler (stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Mapper"
 
@@ -12863,8 +14724,22 @@ msgid "Default directories"
 msgstr "Mapper"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Bla gjennom..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -12943,7 +14818,8 @@ msgid "Directory %s is not writable"
 msgstr "Mappen %s er ikke skrivbar"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Endringer til den midlertidige mappen trer først i kraft når Audacity startes på nytt"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -12976,9 +14852,16 @@ msgstr "Sortert etter type"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "LADPSA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -12993,6 +14876,12 @@ msgstr "Nyquist"
 #: src/prefs/EffectsPrefs.cpp
 msgid "&Vamp"
 msgstr "Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -13015,11 +14904,13 @@ msgid "Plugin Options"
 msgstr "Innstillinger for plug-ins"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Sjekk for oppdaterte plug-ins når Audacity starter opp"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Søk på nytt etter plug-ins hver gang Audacity startes opp"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13199,13 +15090,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Be&hold merker hvis utvalget smettes til et merke"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "S&lå sammen systemets og Audacity sine temaer"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Bruk stort sett Venstre-til-Høyre-oppsett for Høyre-til-Venstre-språk"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13220,9 +15116,18 @@ msgstr "Vis gni-linjal"
 msgid "Language \"%s\" is unknown"
 msgstr "Språket \"%s\" er ukjent"
 
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Importer / Eksporter"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Innstillinger: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -13268,6 +15173,10 @@ msgstr "Eksporter kommentarer som:"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "Eksporterte Allegro-filer (.gro) lagrer tid som:"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13354,7 +15263,15 @@ msgid "&Defaults"
 msgstr "Stan&darder"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Velg en XML-fil som inneholder Audacity tastatursnarveier..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13363,8 +15280,21 @@ msgstr "Feil ved importering av tastatursnarveier"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Lastet inn %d tastatursnarveier\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -13385,6 +15315,15 @@ msgstr "Du kan ikke tilegne en knapp til denne funksjonen"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "Du må velge en knapp før du kan tilegne den en snarvei"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -13455,12 +15394,17 @@ msgid "Dow&nload"
 msgstr "Last& ned"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity har automatisk oppdaget gyldige FFmpeg-bibliotek.\n"
 "Vil du fremdeles lete etter dem manuelt?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -13497,6 +15441,10 @@ msgstr "MIDI-synthesizerl&atens (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "MIDI-synthesizerlatensen må være en integer"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -13507,8 +15455,9 @@ msgid "Preferences for Module"
 msgstr "Innstillinger: "
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Disse er eksperimentelle moduler. Aktiver dem kun hvis du har lest\n"
@@ -13516,12 +15465,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "'Spør' betyr at Audacity vil spørre deg om du vil laste inn modulen ved hver oppstart."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "'Mislyktes' betyr at Audacity mener at modulen er ødelagt og ikke ønsker å kjøre den."
 
 #. i18n-hint preserve the leading spaces
@@ -13530,7 +15481,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "'Ny' betyr at valget ikke har blitt tatt ennå."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Endringer i disse innstillingene trer først i kraft når Audacity startes på nytt."
 
 #: src/prefs/ModulePrefs.cpp
@@ -13548,6 +15500,10 @@ msgstr "Ingen moduler ble funnet"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Moduler"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -13589,7 +15545,10 @@ msgstr "Venstreklikk+dra"
 msgid "Set Selection Range"
 msgstr "Sett markeringsområde"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Skift+venstreklikk"
 
@@ -13678,6 +15637,15 @@ msgstr "-Venstreklikk+dra"
 msgid "Move clip up/down between tracks"
 msgstr "Flytt klipp opp/ned mellom spor"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Venstreklikk+dra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 # juster? endre? forandre? gjør om? still? (not all marked fuzzy)
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -13709,6 +15677,11 @@ msgstr "Endre flere datapunkter"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Endre kun ETT datapunkt"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Multiverktøy"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -13800,7 +15773,8 @@ msgid "Always scrub un&pinned"
 msgstr "Alltid gni lø&snede"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity-innstillinger"
 
 #: src/prefs/PrefsDialog.cpp
@@ -13814,6 +15788,11 @@ msgstr "Innstillinger: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Innstillinger: "
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -13856,6 +15835,14 @@ msgstr "Datafrekvenskonver&terer:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Ut&jevning:"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -13925,39 +15912,6 @@ msgid "System T&ime"
 msgstr "System&tid"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatisk justering av opptaksnivå"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Aktiver automatisk justering av opptaksnivå."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Ønsket makslyd:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Innen:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Analysetid:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "millisekunder (varigheten til én analyse)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Antall konsekutive analyser:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 betyr uendelig"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Slå-og-rull-opptak"
 
@@ -13973,6 +15927,16 @@ msgstr "Kryss&ton:"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Mel"
 msgstr "Mel-skala"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14107,6 +16071,10 @@ msgid "1024 - default"
 msgstr "1024 - standard"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - minst båndbredde"
 
@@ -14200,13 +16168,19 @@ msgid "Preferences for Theme"
 msgstr "Innstillinger: "
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Info"
+msgstr "Hent info"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14390,7 +16364,8 @@ msgstr "Samplinger"
 msgid "4 Pixels per Sample"
 msgstr "4 piksler per sampling"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Maks forstørring"
 
@@ -14520,6 +16495,20 @@ msgid "Skip to End"
 msgstr "Gå til slutt"
 
 #: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Pause"
+msgstr "Pauset"
+
+# "Home" something else on Norwegian keyboards?
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Markering til start"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Markering til slutt"
+
+#: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
 msgstr "Spill av i løkke"
 
@@ -14531,21 +16520,17 @@ msgstr "Ta opp nytt spor"
 msgid "Append Record"
 msgstr "Føy til opptak"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Markering til slutt"
-
-# "Home" something else on Norwegian keyboards?
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Markering til start"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pauset"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s om:"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -14625,11 +16610,17 @@ msgstr "Demp markert lyd"
 msgid "Sync-Lock Tracks"
 msgstr "Synk-lås spor"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zoom inn"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zoom ut"
 
@@ -14696,43 +16687,6 @@ msgstr "Verktøylinje for opptaksmåler"
 msgid "&Playback Meter Toolbar"
 msgstr "Verktøylinje for avspillingsmåler"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Opptaksvolum"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Avspillingsvolum"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Opptaksvolum: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Opptaksvolum (Utilgjengelig; bruk systemmikseren.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Avspillingsvolum: %s (emulert)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Avspillingsvolum: %s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Avspillingsvolum (Utilgjengelig; bruk systemmikseren.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Mik&serverktøylinje"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Let"
@@ -14748,6 +16702,7 @@ msgstr "Gniing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Stopp gniing"
@@ -14755,6 +16710,7 @@ msgstr "Stopp gniing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Begynn å gni"
@@ -14762,6 +16718,7 @@ msgstr "Begynn å gni"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Stop søkingen"
@@ -14769,6 +16726,7 @@ msgstr "Stop søkingen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Start søking"
@@ -14823,7 +16781,9 @@ msgstr "Smett på"
 msgid "Length"
 msgstr "Lengde"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Midtstilt"
 
@@ -14887,8 +16847,8 @@ msgstr "&Enhetsverktøylinje"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacitys %s verktøylinje"
 
 #: src/toolbars/ToolBar.cpp
@@ -14915,7 +16875,8 @@ msgstr "Tidsforskyvningsverktøy"
 msgid "Zoom Tool"
 msgstr "Zoomverktøy"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Tegneverktøy"
 
@@ -14991,11 +16952,13 @@ msgstr "Dra en eller flere merkegrenser."
 msgid "Drag label boundary."
 msgstr "Dra merkegrense."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Endret kommentar"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "&Rediger kommentar"
 
@@ -15050,31 +17013,42 @@ msgstr "Redigerte kommentarer"
 msgid "New label"
 msgstr "Nytt merke"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Opp en oktav"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Ned en oktav"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klikk for å zoome inn loddrett. Skift-klikk for å zoome ut. Dra for å velge et område å zoome."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Høyreklikk for å se menyen."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Tilbakestill forstørring"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Skift+venstreklikk"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr ""
 "Zoom inn\n"
@@ -15118,7 +17092,8 @@ msgstr "Sammenføy"
 msgid "Expanded Cut Line"
 msgstr "Utvidet utklippslinjen"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Utvid"
 
@@ -15141,6 +17116,11 @@ msgstr "Flyttet utvalg"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Datapunktredigering"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15167,6 +17147,11 @@ msgid "S&pectrogram Settings..."
 msgstr "S&pektrograminnstillinger ..."
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Formatendring"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Endrer tempo"
 
@@ -15182,7 +17167,8 @@ msgstr "Behandler: %s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Endret «%s» til %s"
@@ -15194,6 +17180,54 @@ msgstr "Formatendring"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Frek&vens"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15213,7 +17247,8 @@ msgstr "Endret rate"
 msgid "Set Rate"
 msgstr "Sett rate"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Multi"
 
@@ -15232,6 +17267,11 @@ msgstr "Del opp stereospor"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Del stereo til mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -15282,6 +17322,16 @@ msgid "Split to Mono"
 msgstr "Del opp til mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Venstre, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Venstre, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Venstre, %dHz"
@@ -15292,19 +17342,22 @@ msgid "Right, %dHz"
 msgstr "Høyre, %dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% venstre"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% høyre"
@@ -15316,6 +17369,15 @@ msgstr "Klikk og dra for å justere, dobbeltklikk for å tilbakestille"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "Klikk og dra for å flytte et spor i tid"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Klikk og dra for å flytte et spor i tid"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -15336,6 +17398,11 @@ msgstr "Bølgeform"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "&Bølgefarge"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Musikkinstrument"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -15409,9 +17476,8 @@ msgstr "Logaritmisk interpolering"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klikk og dra for å flytte et spor i tid"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15462,6 +17528,7 @@ msgstr "Justert omhyllingskurve."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Gni"
@@ -15473,6 +17540,7 @@ msgstr "Leter"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Gni-&linjal"
@@ -15709,9 +17777,19 @@ msgstr "Tom"
 msgid "Backwards"
 msgstr "Tilbake"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Fram"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -15924,6 +18002,7 @@ msgstr "0100 t 060 m 060 s+># datapunkter"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "datapunkter"
@@ -16008,6 +18087,16 @@ msgstr "0100 t 060 m 060 s+>030 frames| .999000999"
 msgid "NTSC frames"
 msgstr "NTSC-bilderate"
 
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000,01000 frames|29.97002997"
+msgstr "01000 01000 bilderate|24"
+
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at PAL TV frame rate (used for European TV)
 #: src/widgets/NumericTextCtrl.cpp
@@ -16078,6 +18167,15 @@ msgstr "01000 01000 bilderate|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000<0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -16085,6 +18183,10 @@ msgstr "0100000<0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0,001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -16150,6 +18252,11 @@ msgstr "(Bruk kontekstmenyen for å endre format.)"
 msgid "centiseconds"
 msgstr "centisekunder"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Pågått i:"
@@ -16191,6 +18298,11 @@ msgstr "Bekreft lukking"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Klarte ikke åpne forvalgsfilen."
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -16295,15 +18407,27 @@ msgstr "Klarte ikke å åpne filen"
 msgid "Spectral edit multi tool"
 msgstr "Spekterredigerings-multiverktøy"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrerer ..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Lansert under vilkårene til GNU General Public License versjon 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aVennligst velg frekvenser."
@@ -16330,7 +18454,8 @@ msgstr ""
 "                      Prøv å øke lavfrekvensbindingen~%~\n"
 "                      eller reduser 'Bredde'-filteret."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Feil.~%"
@@ -16391,6 +18516,25 @@ msgstr "Studiostil-utfasing"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Benytter utfasing ..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Lagre som &standardverdier"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Lansert under vilkårene til GNU General Public License versjon 2"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16536,6 +18680,11 @@ msgstr "Slagoppdager"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Oppdager slag ..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Audacity-logg%s"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -16690,6 +18839,10 @@ msgid "Allow duration to change"
 msgstr "Tillat at varigheten kan endres"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Gjenta siste effekt"
 
@@ -16700,6 +18853,10 @@ msgstr "Tonekontroll (EQ)"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3-filer"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -16713,6 +18870,12 @@ msgstr "Bekreft overskriving"
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Feil.~%Klarte ikke å åpne filen"
+
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Feil.~%\"~a\" kunne ikke bli lagret."
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
@@ -16846,13 +19009,39 @@ msgstr "Høypassfilter"
 msgid "Performing High-Pass Filter..."
 msgstr "Utfører høypassfilter ..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Dominic Mazzoni"
+msgstr "Støyfjerning av Dominic Mazzoni"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvens (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Avrulling (dB per oktav)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -16873,10 +19062,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Merk sammenslåing"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Lansert under vilkårene til GNU General Public License versjon 2"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -16919,12 +19104,37 @@ msgid "Point after sound"
 msgstr "Kombinert stereo"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "~aOmrådelengde = ~a sekunder."
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "~aOmrådelengde = ~a sekunder."
 
 #: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Oppdager stillhet..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Oppdager stillhet..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -16937,6 +19147,11 @@ msgstr "Utvalget må være mer enn %d samplinger."
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "Ingen lyder ble funnet. Prøv å redusere stillhets~%nivået og minimumsstillhetsvarigheten."
 
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
 #: plug-ins/limiter.ny
 msgid "Limiter"
 msgstr "Begrenser"
@@ -16944,6 +19159,11 @@ msgstr "Begrenser"
 #: plug-ins/limiter.ny
 msgid "Limiting..."
 msgstr "Begrenser ..."
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Type"
+msgstr "Typer:"
 
 #: plug-ins/limiter.ny
 msgid "Soft Limit"
@@ -16982,6 +19202,10 @@ msgstr ""
 msgid "Limit to (dB)"
 msgstr "Begrens til (dB):"
 
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
 msgstr "Benytt oppveiingsforsterking"
@@ -17001,6 +19225,10 @@ msgstr "Støytype:"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Markering"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -17037,6 +19265,44 @@ msgstr "Kompresserings-/forfalnings-tid"
 #: plug-ins/noisegate.ny
 msgid "Decay (ms)"
 msgstr "Kompresserings-/forfalnings-tid"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Utvalget må være mer enn %d samplinger."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
 
 #: plug-ins/notch.ny
 msgid "Notch Filter"
@@ -17086,7 +19352,8 @@ msgstr "MP3-filer"
 msgid "HTML file"
 msgstr "MP3-filer"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Gi navn til filer:"
 
@@ -17103,9 +19370,24 @@ msgid "Disallow"
 msgstr "Ikke tillatt"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Ikke tillatt"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Klarte ikke å fjerne %s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -17122,6 +19404,20 @@ msgstr "Feil.~%\"~a\" kunne ikke bli lagret."
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Ubrukte filtre:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Velg en fil"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Pluck"
@@ -17166,6 +19462,10 @@ msgstr "Rytmespor"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Genererer rytme ..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -17256,6 +19556,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI-tonen til et sterkt slag"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI-tonen til et svakt slag"
 
@@ -17276,6 +19580,10 @@ msgid "Generating Risset Drum..."
 msgstr "Genererer Risset-tromme ..."
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Forsinkelsestid (sekunder)"
 
@@ -17290,6 +19598,11 @@ msgstr "Bredden til støybåndet (Hz)"
 #: plug-ins/rissetdrum.ny
 msgid "Amount of noise in mix (percent)"
 msgstr "Støymengde i miksen (prosent)"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amplitude (0 - 1)"
+msgstr "Amplitude (0-1):"
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
@@ -17372,6 +19685,11 @@ msgstr "Vis meldinger"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Kun feil"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -17637,6 +19955,15 @@ msgstr "Feil.~%Klarte ikke å åpne filen"
 msgid "Spectral Delete"
 msgstr "Spekterutvalg"
 
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Anvender tremolo ..."
@@ -17664,6 +19991,10 @@ msgstr "Vokal-reduksjon og -isolering"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Benytter handlingen ..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -17814,6 +20145,10 @@ msgid "Processing Vocoder..."
 msgstr "Behandler vokal-koder ..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "Distanse: (1 til 120, standard = 20)"
 
@@ -17854,6 +20189,213 @@ msgstr "Hyppigheten til radarnåler (Hz)"
 msgid "Error.~%Stereo track required."
 msgstr "Feil.~%Stereospor er påkrevd."
 
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Avslutt Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Kanal"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Feil ved dekoding av fil"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Feil ved innlasting av metadata"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacitys %s verktøylinje"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Opptak"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Erklærings-ID:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Flerplattform GUI-bibliotek"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importer via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr ""
+#~ "Automatisk justering av inndatanivå stanset. Det var ikke mulig å optimisere mer.\n"
+#~ "Fortsatt for høyt."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automatisk justering av inndatanivå senket lydnivået til %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatisk justering av opptaksnivå stanset. Det var ikke mulig å optimisere mer. Fortsatt for lavt."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automatisk justering av opptaksnivå økte lydnivået til %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr ""
+#~ "Automatisk justering av opptaksnivå stanset. Det totale antallet analyser ble\n"
+#~ "overskredet uten å komme fram til et akseptabelt lydnivå.\n"
+#~ "Fortsatt for høyt."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr ""
+#~ "Automatisk justering av opptaksnivå stanset. Det totale antallet analyser ble\n"
+#~ "overskredet uten å komme fram til et akseptabelt lydnivå.\n"
+#~ "Fortsatt for lavt."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatisk justering av opptaksnivå stanset. %.2f virker som et akseptabelt lydnivå."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Klarte ikke å åpne sjangerfil.\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "%s - %s\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Simuler opptaksfeil\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Avspillingsvolum\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Opptaksvolum\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Opptaksvolum\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Avspillingsvolum: %s (emulert)\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Avspillingsvolum: %s (emulert)\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Sluttdato og tidspunkt"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-kompatible filer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Klarte ikke å legge til en dekoder til pipeføringen"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer-importerer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Klarte ikke å sette strømmen på pause."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indeks[%02x] Kodek[%s], Språk[%s], Bitrate[%s], Kanaler[%d], Varighet[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Filen inneholder ikke noen lydstrømmer."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Klarte ikke å importere filen, tilstandsendringen mislyktes."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer-feil: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mik&ser"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Jus&ter avspillingsvolum ..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Øk avspillingsvolum"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Senk avspillingsvolum"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Just&er opptaksvolum ..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Ø&k opptaksvolum"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "S&enk opptaksvolum"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity sin &bruksanvisning"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Om Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Automatisk justering av inndatanivå (av/på)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatisk justering av opptaksnivå"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Aktiver automatisk justering av opptaksnivå."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Ønsket makslyd:"
+
+#~ msgid "Within:"
+#~ msgstr "Innen:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Analysetid:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "millisekunder (varigheten til én analyse)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Antall konsekutive analyser:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 betyr uendelig"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Opptaksvolum"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Avspillingsvolum"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Opptaksvolum: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Opptaksvolum (Utilgjengelig; bruk systemmikseren.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Avspillingsvolum: %s (emulert)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Avspillingsvolum: %s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Avspillingsvolum (Utilgjengelig; bruk systemmikseren.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Mik&serverktøylinje"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klikk og dra for å flytte et spor i tid"
+
 #~ msgid "Program build date:"
 #~ msgstr "Dato programmet ble kompilert: "
 
@@ -17875,10 +20417,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 #, fuzzy
 #~ msgid "Unknown error"
 #~ msgstr "Ukjent"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Klarte ikke åpne forvalgsfilen."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -19159,10 +21697,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 #~ msgstr "Start til &markeringsslutt"
 
 #, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
-
-#, fuzzy
 #~ msgid "Show start time and end time"
 #~ msgstr "Startdato og tidspunkt"
 
@@ -19289,9 +21823,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 #~ msgid "Freq"
 #~ msgstr "Frekvens"
 
-#~ msgid "Phase"
-#~ msgstr "Fase"
-
 #~ msgid "Depth"
 #~ msgstr "Dybde"
 
@@ -19307,9 +21838,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 # What's "Hf" a shortening of here?
 #~ msgid "HfDamping"
 #~ msgstr "HfDemping"
-
-#~ msgid "ToneLow"
-#~ msgstr "Lav tone"
 
 #~ msgid "ToneHigh"
 #~ msgstr "Høy tone"
@@ -19366,9 +21894,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 #~ msgid "PitchPercentChangeEnd"
 #~ msgstr "Sluttpunkt for toneprosentendring"
 
-#~ msgid "StartFreq"
-#~ msgstr "StartFrekv"
-
 #~ msgid "EndFreq"
 #~ msgstr "SluttFrekv"
 
@@ -19386,9 +21911,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 
 #~ msgid "Offset"
 #~ msgstr "Forsinkelse"
-
-#~ msgid "Version"
-#~ msgstr "Versjon"
 
 #~ msgid "C&ategory:"
 #~ msgstr "K&ategori"
@@ -19435,9 +21957,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 #~ msgid "Move Sele&ction when Aligning"
 #~ msgstr "Flytt utvalg ved koordinering"
 
-#~ msgid "&Mono"
-#~ msgstr "Mono"
-
 #~ msgid "&Left Channel"
 #~ msgstr "Venstre kanal"
 
@@ -19452,9 +21971,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "For å tegne, velg «Bølgeform» i nedtrekksmenyen til sporet."
-
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "RMS med %.2f dB i gjennomsnitt"
 
 #~ msgid "Average RMS = %.2f dB."
 #~ msgstr "Gjennomsnittlig RMS = %.2f dB."
@@ -20178,9 +22694,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 #~ msgid "Chirp Generator"
 #~ msgstr "Kvittergenerator"
 
-#~ msgid "Tone Generator"
-#~ msgstr "Tonegenerator"
-
 #~ msgid "Truncate Silence..."
 #~ msgstr "Fjern stillhet..."
 
@@ -20209,9 +22722,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 
 #~ msgid "Note length (seconds)"
 #~ msgstr "Notelengde (sekund)"
-
-#~ msgid "Note velocity"
-#~ msgstr "Notehastighet"
 
 #~ msgid "Note key"
 #~ msgstr "Toneart"
@@ -20554,9 +23064,6 @@ msgstr "Feil.~%Stereospor er påkrevd."
 
 #~ msgid "Attempt to run Noise Removal without a noise profile.\n"
 #~ msgstr "Prøv å kjøre støyfjerning uten en støyprofil.\n"
-
-#~ msgid "Noise Removal by Dominic Mazzoni"
-#~ msgstr "Støyfjerning av Dominic Mazzoni"
 
 #~ msgid "Sorry, this effect cannot be performed on stereo tracks where the individual channels of the track do not match."
 #~ msgstr "Beklager, denne effekten kan ikke utføres på stereospor hvor de enkelte sporkanalene ikke passer sammen."

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -16,11 +16,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-05 05:22+0000\n"
 "Last-Translator: Edgar <Edgar@anotherfoxguy.com>\n"
-"Language-Team: Dutch <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"nl/>\n"
+"Language-Team: Dutch <https://hosted.weblate.org/projects/tenacity/tenacity/nl/>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,80 +27,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Tenacity bijwerken"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "Overslaan"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "Update installeren"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Wijzigingslog"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Meer informatie op GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Fout bij controleren op updates"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Kon niet verbinden met de updateserver van Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Bijwerkingsgegevens zijn beschadigd."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Fout bij downloaden van update."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Kan de Tenacity-downloadkoppeling niet openen."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s is beschikbaar!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Opname"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Niet in staat om te bepalen"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr "%s bytes"
 
 #. i18n-hint: Abbreviation for Kilo bytes
 #: libraries/lib-strings/Internat.cpp
 #, c-format
 msgid "%s KB"
 msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -223,8 +174,13 @@ msgstr "Stoppen\tF6"
 msgid "&About"
 msgstr "Over"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script"
+msgstr "Script"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Uitvoer"
 
@@ -240,7 +196,12 @@ msgstr "Nyquist-scripts (*.ny)|*.ny|Lisp-scripts (*.lsp)|*.lsp|Alle bestanden|*"
 msgid "Script was not saved."
 msgstr "Script werd niet opgeslagen."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Waarschuwing"
 
@@ -253,18 +214,25 @@ msgid "Find dialog"
 msgstr "Zoekvenster"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr "Harvey Lubin (logotype)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango Icon Gallery (werkbalkpictogrammen)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 door Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
-msgstr ""
-"Externe Tenacity-module die een simpele IDE voorziet voor het schrijven van "
-"effecten."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr "Externe Tenacity-module die een simpele IDE voorziet voor het schrijven van effecten."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -286,7 +254,8 @@ msgstr "Naamloos"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist-effectenwerkbank - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nieuw"
 
@@ -326,7 +295,8 @@ msgstr "Kopiëren"
 msgid "Copy to clipboard"
 msgstr "Kopiëren naar klembord"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Knippen"
 
@@ -334,7 +304,8 @@ msgstr "Knippen"
 msgid "Cut to clipboard"
 msgstr "Knippen naar klembord"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Plakken"
 
@@ -359,7 +330,8 @@ msgstr "Alles selecteren"
 msgid "Select all text"
 msgstr "Alle tekst selecteren"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Ongedaan maken"
 
@@ -367,7 +339,8 @@ msgstr "Ongedaan maken"
 msgid "Undo last change"
 msgstr "Laatste wijziging ongedaan maken"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Opnieuw uitvoeren"
 
@@ -424,7 +397,8 @@ msgid "Go to next S-expr"
 msgstr "Ga naar volgende S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Begin"
 
@@ -432,7 +406,8 @@ msgstr "Begin"
 msgid "Start script"
 msgstr "Script starten"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Stoppen"
 
@@ -446,15 +421,23 @@ msgstr "Script stoppen"
 msgid "About %s"
 msgstr "Over %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "OK"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Programma-informatie"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Uitgeschakeld"
 
@@ -464,8 +447,9 @@ msgid "The Build"
 msgstr "De build"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Commit-id:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versie: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -475,22 +459,28 @@ msgstr "Bouwtype:"
 msgid "Compiler:"
 msgstr "Compileerder:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Installatie-prefix:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Instellingenmap:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Instellingenmap:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Bestandsindelingen"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Cross-platform GUI-bibliotheek"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -504,7 +494,6 @@ msgstr "Samplerate omzetten"
 msgid "MP3 Importing"
 msgstr "MP3 importeren"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis importeren en exporteren"
@@ -513,7 +502,6 @@ msgstr "Ogg Vorbis importeren en exporteren"
 msgid "ID3 tag support"
 msgstr "ID3-tag ondersteuning"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC importeren en exporteren"
@@ -531,14 +519,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importeren/exporteren via FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importeren via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Functies"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Plugin-ondersteuning"
 
@@ -553,6 +533,10 @@ msgstr "Ondersteuning voor toonhoogte- en tempowijzigingen"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Ondersteuning voor extreme toonhoogte- en tempowijzigingen"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Functies"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -645,6 +629,12 @@ msgstr "%s, Audacity-componist"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, tester"
+msgstr "%s, Audacity technicus"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, Audacity Nyquist plugins"
 
@@ -665,16 +655,22 @@ msgstr "%s, Audacity grafiek"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (met inbegrip van %s, %s, %s, %s en %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Gratis, open source, cross-platform software voor het opnemen en bewerken "
-"van geluiden."
+msgstr "Gratis, open source, cross-platform software voor het opnemen en bewerken van geluiden."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Met dank aan"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "N.B. De namen zijn gesorteerd in alfabetische volgorde, niet in volgorde van belangrijkheid."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -707,6 +703,10 @@ msgid "%s Team Members"
 msgstr "%s Teamleden"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr "Audacity emeritus:"
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Audacity medewerkers"
 
@@ -719,6 +719,7 @@ msgstr "Audacity Website en Graphics"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Nederlandse vertaling door Thomas De Rocker, Leo Clijsen en Tino Meinen"
@@ -736,6 +737,22 @@ msgstr "Audacity. Speciale dank:"
 #, c-format
 msgid "%s website: "
 msgstr "%s-website: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s medewerkers"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Het Audacity%s handelsmerk wordt binnen deze software alleen gebruikt voor beschrijvende en informatieve doeleinden."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity wordt niet geproduceerd of onderschreven door MuseCY SM Ltd. of Dominic M Mazzoni."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -758,6 +775,7 @@ msgstr "Tijdlijn"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klikken of slepen om te beginnen met zoeken"
@@ -765,6 +783,7 @@ msgstr "Klikken of slepen om te beginnen met zoeken"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klikken of slepen om te beginnen met scrubben"
@@ -772,6 +791,7 @@ msgstr "Klikken of slepen om te beginnen met scrubben"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Klikken en bewegen om te scrubben. Klikken en slepen om te zoeken."
@@ -779,6 +799,7 @@ msgstr "Klikken en bewegen om te scrubben. Klikken en slepen om te zoeken."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Bewegen om te zoeken"
@@ -786,6 +807,7 @@ msgstr "Bewegen om te zoeken"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Bewegen om te scrubben"
@@ -842,7 +864,17 @@ msgstr ""
 "Kan gebied voorbij einde van project\n"
 "niet vergrendelen."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Fout"
 
@@ -866,7 +898,8 @@ msgstr ""
 "Dit is een eenmalige vraag, na een 'installatie' waar u vroeg om de voorkeuren te herstellen."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Tenacity-voorkeuren opnieuw instellen"
 
 #: src/AudacityApp.cpp
@@ -882,9 +915,8 @@ msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
-msgstr ""
-"De SQLite-bibliotheek is niet geïnitialiseerd. Tenacity kan niet doorgaan."
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr "De SQLite-bibliotheek is niet geïnitialiseerd. Tenacity kan niet doorgaan."
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -908,7 +940,7 @@ msgstr "Openen…"
 msgid "Open &Recent..."
 msgstr "Recent openen..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "Over Tenacity…"
 
@@ -921,35 +953,34 @@ msgid "&File"
 msgstr "Bestand"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
-"Tenacity kon geen veilige plaats vinden om tijdelijke bestanden op te slaan."
-"\n"
-"Tenacity heeft een plaats nodig waar programma's voor automatisch opschonen "
-"de tijdelijke bestanden niet verwijderen. \n"
+"Tenacity kon geen veilige plaats vinden om tijdelijke bestanden op te slaan.\n"
+"Tenacity heeft een plaats nodig waar programma's voor automatisch opschonen de tijdelijke bestanden niet verwijderen. \n"
 "Geef een passende map op in het voorkeuren-venster."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity kon geen plek vinden om tijdelijke bestanden op te slaan.\n"
 "Selecteer hiervoor een geschikte map in het voorkeuren-dialoogvenster."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"Tenacity zal nu worden afgesloten. Start Tenacity opnieuw om de nieuwe "
-"tijdelijke map te gebruiken."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "Tenacity zal nu worden afgesloten. Start Tenacity opnieuw om de nieuwe tijdelijke map te gebruiken."
 
 #: src/AudacityApp.cpp
 #, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -958,15 +989,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity kon de map met tijdelijke bestanden niet vergrendelen.\n"
 "Deze map is mogelijk in gebruik door een andere kopie van Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Wilt u Tenacity toch opstarten?"
 
 #: src/AudacityApp.cpp
@@ -974,19 +1007,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Fout bij vergrendelen van tijdelijke map"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Er is ontdekt dat er al een kopie van Tenacity is opgestart.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Gebruik de opdrachten Nieuw of Open in het momenteel lopende Tenacity\n"
 "proces om meerdere projecten tegelijk te openen.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity is al opgestart"
 
 #: src/AudacityApp.cpp
@@ -1002,7 +1038,8 @@ msgstr ""
 "en een herstart kan nodig zijn."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Tenacity opstartfout"
 
 #: src/AudacityApp.cpp
@@ -1042,8 +1079,9 @@ msgstr ""
 "en een herstart kan nodig zijn."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1075,7 +1113,8 @@ msgstr "diagnosetesten uitvoeren"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Tenacity-versie weergeven"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1085,9 +1124,10 @@ msgid "audio or project file name"
 msgstr "bestandsnaam van audio of project"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1100,16 +1140,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tenacity projectbestanden"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Bericht"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Tenacity-configuratiefout"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1119,25 +1161,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Het volgende configuratiebestand kon niet worden geopend:\n"
 "\n"
 "\t%s\n"
 "\n"
-"Dit kan vele oorzaken hebben, maar de meest waarschijnlijke zijn dat de "
-"schijf vol is of dat u geen schrijfrechten heeft voor het bestand. Meer "
-"informatie kan worden verkregen door op de helpknop hieronder te klikken.\n"
+"Dit kan vele oorzaken hebben, maar de meest waarschijnlijke zijn dat de schijf vol is of dat u geen schrijfrechten heeft voor het bestand. Meer informatie kan worden verkregen door op de helpknop hieronder te klikken.\n"
 "\n"
-"U kunt proberen het probleem te verhelpen en vervolgens op \"opnieuw "
-"proberen\" klikken om verder te gaan.\n"
+"U kunt proberen het probleem te verhelpen en vervolgens op \"opnieuw proberen\" klikken om verder te gaan.\n"
 "\n"
-"Als u ervoor kiest om Tenacity af te sluiten, kan uw project in een "
-"onopgeslagen toestand achterblijven, die zal worden hersteld wanneer u het "
-"de volgende keer opent."
+"Als u ervoor kiest om Tenacity af te sluiten, kan uw project in een onopgeslagen toestand achterblijven, die zal worden hersteld wanneer u het de volgende keer opent."
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
+msgid "Help"
+msgstr "Helpen"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Tenacity afsluiten"
 
 #: src/AudacityFileConfig.cpp
@@ -1145,7 +1189,8 @@ msgid "&Retry"
 msgstr "Opnieuw proberen"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacity-log"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1157,9 +1202,14 @@ msgstr "Opslaan…"
 msgid "Cl&ear"
 msgstr "Wissen"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "Sluiten"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1208,7 +1258,8 @@ msgid "Error Initializing Midi"
 msgstr "Fout bij initialiseren van midi"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity-audio"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1223,37 +1274,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Te weinig geheugen!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automatische opnameniveau-wijziging gestopt. Onmogelijk om het nog meer te optimaliseren. Nog steeds te hoog."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automatische opnameniveau-wijziging verlaagde het volume naar %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatische opnameniveau-wijziging gestopt. Onmogelijk om het nog meer te optimaliseren. Nog steeds te laag."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automatische opnameniveau-wijziging verhoogde het volume naar %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automatische opnameniveau-wijziging gestopt. Het totale aantal analyses werd overschreden zonder een acceptabel volume te vinden. Nog steeds te hoog."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automatische opnameniveau-wijziging gestopt. Het totale aantal analyses werd overschreden zonder een acceptabel volume te vinden. Nog steeds te laag."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatische opnameniveau-wijziging gestopt. %.2f lijkt een acceptabele waarde te zijn."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1352,43 +1372,6 @@ msgstr "Geen afspeelapparaat gevonden voor '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Kan gemeenschappelijke samplerates niet controleren zonder beide apparaten.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "%d ontvangen bij openen van apparaten\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Niet in staat om Portmixer te openen\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Beschikbare mixers:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Beschikbare opnamebronnen:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Beschikbare afspeelvolumes:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Opnamevolume is geëmuleerd\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Opnamevolume is ingebouwd\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Afspeelvolume is geëmuleerd\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Afspeelvolume is ingebouwd\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1431,28 +1414,29 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatisch herstel na crash"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
-"De volgende projecten zijn niet correct opgeslagen tijdens de laatste "
-"Tenacity-sessie en kunnen automatisch hersteld worden.\n"
+"De volgende projecten zijn niet correct opgeslagen tijdens de laatste Tenacity-sessie en kunnen automatisch hersteld worden.\n"
 "\n"
-"Sla na het herstel de projecten op om er zeker van te zijn dat de "
-"wijzigingen op schijf worden geschreven."
+"Sla na het herstel de projecten op om er zeker van te zijn dat de wijzigingen op schijf worden geschreven."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "Herstelbare projecten"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Selecteren"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Naam"
 
@@ -1532,8 +1516,18 @@ msgid "Export Macro"
 msgstr "Macro exporteren"
 
 #: src/BatchCommands.cpp
+#, fuzzy
+msgid "Effect"
+msgstr "Effecten"
+
+#: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menu-opdracht (met parameters)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1603,6 +1597,11 @@ msgstr "Macro's beheren"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Macro selecteren"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+msgid "Macro"
+msgstr "Makro"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
@@ -1674,7 +1673,8 @@ msgstr "Herstellen"
 msgid "I&mport..."
 msgstr "Importeren…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "Exporteren…"
 
@@ -1682,9 +1682,19 @@ msgstr "Exporteren…"
 msgid "Edit Steps"
 msgstr "Stappen bewerken"
 
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr "Numer"
+
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "Opdracht  "
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#, fuzzy
+msgid "Parameters"
+msgstr "Parameters"
 
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp
 msgid "&Insert"
@@ -1706,7 +1716,8 @@ msgstr "Naar boven"
 msgid "Move &Down"
 msgstr "Naar beneden"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "Opslaan"
 
@@ -1789,9 +1800,17 @@ msgid "Run"
 msgstr "Starten"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Sluiten"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "Benchmarken"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1929,10 +1948,6 @@ msgid "No revision identifier was provided"
 msgstr "Er is geen revisie-identificatiecode opgegeven"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Onbekende datum en tijd"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Debug-build (debugniveau %d)"
@@ -1987,8 +2002,7 @@ msgid ""
 msgstr ""
 "Selecteer de te gebruiken audio voor %s.\n"
 "\n"
-"1. Selecteer audio die ruis vertegenwoordigt en gebruik %s om uw "
-"'ruisprofiel' te krijgen.\n"
+"1. Selecteer audio die ruis vertegenwoordigt en gebruik %s om uw 'ruisprofiel' te krijgen.\n"
 "\n"
 "2. Als je ruisprofiel hebt, selecteer je de audio die je wilt veranderen\n"
 "en gebruik %s om die audio te wijzigen."
@@ -2016,6 +2030,11 @@ msgid ""
 msgstr ""
 "U moet eerst wat audio selecteren om deze handeling uit te voeren\n"
 "(selecteren van andere soorten tracks zal niet werken.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2178,6 +2197,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Namen naar klembord kopiëren"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Ontbrekend"
 
@@ -2186,15 +2210,15 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Wanneer u doorgaat zal uw project niet op de schijf worden opgeslagen. Is dat wat u wilt?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
-"Uw project is op zichzelf staand; het is niet afhankelijk van externe "
-"audiobestanden. \n"
+"Uw project is op zichzelf staand; het is niet afhankelijk van externe audiobestanden. \n"
 "\n"
 "Sommige oudere Tenacity projecten zijn niet op zichzelf staand, en zorg \n"
 "is nodig om hun externe afhankelijkheden op de juiste plaats te houden.\n"
@@ -2204,7 +2228,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Afhankelijkheidscontrole"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Geen"
 
@@ -2212,7 +2239,7 @@ msgstr "Geen"
 msgid "Rectangle"
 msgstr "Rechthoek"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Driehoek"
 
@@ -2223,6 +2250,40 @@ msgstr "Flexibel"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Rechthoekig"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, geen"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Blackman"
+msgstr "Blackmann, Hann"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+#, fuzzy
+msgid "Blackman-Harris"
+msgstr "Blackmann, Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Welkom!"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2244,9 +2305,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg-ondersteuning niet gecompileerd in"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2268,11 +2330,9 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg opzoeken"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"Tenacity heeft het bestand '%s' nodig om audio te importeren en exporteren "
-"via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "Tenacity heeft het bestand '%s' nodig om audio te importeren en exporteren via FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2284,7 +2344,8 @@ msgstr "Locatie van '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Klik hier om '%s' terug te vinden -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Bladeren…"
 
@@ -2310,8 +2371,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg niet gevonden"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2320,8 +2382,7 @@ msgstr ""
 "Tenacity probeerde FFmpeg te gebruiken om een geluidsbestand te importeren,\n"
 "maar de bibliotheken konden niet worden gevonden.\n"
 "\n"
-"Als U de FFmpeg-importeerfunctie wilt gebruiken, ga dan naar Bewerken > "
-"Voorkeuren > Bibliotheken\n"
+"Als U de FFmpeg-importeerfunctie wilt gebruiken, ga dan naar Bewerken > Voorkeuren > Bibliotheken\n"
 "om de FFmpeg-bibliotheken te downloaden of lokaliseren."
 
 #: src/FFmpeg.cpp
@@ -2342,26 +2403,24 @@ msgid "Only libavformat.so"
 msgstr "Alleen libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity kon een bestand in %s niet openen."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity kon een bestand in %s niet lezen."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
-msgstr ""
-"Tenacity kon een bestand schrijven naar %s maar kon het niet hernoemen naar "
-"%s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr "Tenacity kon een bestand schrijven naar %s maar kon het niet hernoemen naar %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2399,7 +2458,9 @@ msgstr "Geen audio kopiëren"
 msgid "As&k"
 msgstr "Vragen"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Alle bestanden"
 
@@ -2425,6 +2486,10 @@ msgstr "Tekstbestanden"
 msgid "XML files"
 msgstr "XML-bestanden"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
@@ -2449,6 +2514,11 @@ msgstr "De map %s heeft geen schrijfrechten"
 msgid "Frequency Analysis"
 msgstr "Frequentieanalyse"
 
+#: src/FreqWindow.cpp src/prefs/SpectrumPrefs.h
+#, fuzzy
+msgid "Spectrum"
+msgstr "Spectraal"
+
 #: src/FreqWindow.cpp
 msgid "Standard Autocorrelation"
 msgstr "Standaard autocorrelatie"
@@ -2460,6 +2530,13 @@ msgstr "Derdemachtswortel autocorrelatie"
 #: src/FreqWindow.cpp
 msgid "Enhanced Autocorrelation"
 msgstr "Verhoogde autocorrelatie"
+
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+msgid "Cepstrum"
+msgstr ""
 
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
@@ -2477,6 +2554,17 @@ msgstr "Lineair"
 msgid "Log frequency"
 msgstr "Logaritmisch"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Scrollen"
@@ -2485,6 +2573,15 @@ msgstr "Scrollen"
 msgid "Zoom"
 msgstr "Zoomen"
 
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
 msgstr "Horizontaal scroll"
@@ -2492,6 +2589,11 @@ msgstr "Horizontaal scroll"
 #: src/FreqWindow.cpp
 msgid "Zoom Horizontal"
 msgstr "Horizontaal zoomen"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cursor:"
+msgstr "Cursor"
 
 #: src/FreqWindow.cpp
 msgid "Peak:"
@@ -2532,19 +2634,53 @@ msgstr "Om het spectrum te tekenen moeten alle tracks dezelfde samplerate hebben
 #: src/FreqWindow.cpp
 #, c-format
 msgid "Too much audio was selected. Only the first %.1f seconds of audio will be analyzed."
-msgstr ""
-"Er was teveel audio geselecteerd. Alleen de eerste %.1f seconden audio "
-"worden geanalyseerd."
+msgstr "Er was teveel audio geselecteerd. Alleen de eerste %.1f seconden audio worden geanalyseerd."
 
 #: src/FreqWindow.cpp
 msgid "Not enough data selected."
 msgstr "Niet genoeg data geselecteerd."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr "%.4f seconde (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr "%.4f seconde (%d Hz) (%s) = %f"
+
+#: src/FreqWindow.cpp
+msgid "spectrum.txt"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Spectrale gegevens exporteren als:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Kon niet naar bestand schrijven: %s"
@@ -2621,13 +2757,11 @@ msgstr "Geen lokale hulp"
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
-msgstr ""
-"<br><br>De versie van Tenacity die u gebruikt is een <b>alfa-testversie</b>."
+msgstr "<br><br>De versie van Tenacity die u gebruikt is een <b>alfa-testversie</b>."
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
-msgstr ""
-"<br><br>De versie van Tenacity die u gebruikt is een <b>bèta-testversie</b>."
+msgstr "<br><br>De versie van Tenacity die u gebruikt is een <b>bèta-testversie</b>."
 
 #: src/HelpText.cpp
 msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
@@ -2669,11 +2803,7 @@ msgstr "Audacity kan onbeschermde bestanden in verschillende andere formaten imp
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"U kunt ook onze hulp lezen over het importeren van [[https://manual."
-"audacityteam.org/man/playing_and_recording.html#midi|midi-bestanden]] en "
-"tracks van [[https://manual.audacityteam.org/man/faq_opening_and_saving_files"
-".html#fromcd| audio-cd's]]."
+msgstr "U kunt ook onze hulp lezen over het importeren van [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|midi-bestanden]] en tracks van [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio-cd's]]."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
@@ -2740,19 +2870,19 @@ msgid "&History..."
 msgstr "Geschiedenis…"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Interne fout in %s op %s regel %d.\n"
 "Breng het Tenacity-team op de hoogte via https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Interne fout in %s op %s regel %d.\n"
 "Informeer het Tenacity-team op https://tenacityaudio.org/."
@@ -2764,6 +2894,20 @@ msgstr "Interne fout"
 #: src/LabelDialog.cpp
 msgid "Edit Labels"
 msgstr "Labels bewerken"
+
+#. i18n-hint: (noun).  A track contains waves, audio etc.
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Track"
+msgstr "Track"
+
+#. i18n-hint: (noun)
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#, fuzzy
+msgid "Label"
+msgstr "Labels"
 
 #. i18n-hint: (noun) of a label
 #: src/LabelDialog.cpp src/TimerRecordDialog.cpp
@@ -2821,7 +2965,8 @@ msgstr "Naam van track invoeren"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Label-track"
 
@@ -2832,11 +2977,13 @@ msgstr "Een of meerdere opgeslagen labels konden niet gelezen worden."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Tenacity eerste keer opgestart"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Kies de taal die Tenacity moet gebruiken:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2846,7 +2993,8 @@ msgstr "Kies de taal die Tenacity moet gebruiken:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "De taal die u gekozen heeft, %s (%s), is niet dezelfde als de taal van het systeem, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Bevestigen"
 
@@ -2864,8 +3012,14 @@ msgstr ""
 "Het oude bestand is opgeslagen als ‘%s’"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Tenacity-project wordt geopend"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Vasthoudendheid. Speciale dank:"
 
 #: src/LyricsWindow.cpp
 msgid "&Karaoke..."
@@ -2915,19 +3069,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Tracks mixen en renderen"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tenacity mengpaneel%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Versterking"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Snelheid"
 
@@ -2936,28 +3094,43 @@ msgid "Musical Instrument"
 msgstr "Muziekinstrument"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balans"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Dempen"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr " Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Signaalniveaumeter"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Hoofdvolumeschuif verplaatst"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Snelheidsschuif verplaatst"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Balansschuif verplaatst"
 
@@ -2992,9 +3165,9 @@ msgstr ""
 "Ze wordt niet geladen."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3028,16 +3201,19 @@ msgstr ""
 "\n"
 "Gebruik alleen modules van betrouwbare bronnen"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Ja"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nee"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity module-lader"
 
 #: src/ModuleManager.cpp
@@ -3060,6 +3236,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Notentrack"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3095,6 +3381,11 @@ msgstr[1] "Deze plug-ins inschakelen?\n"
 #: src/PluginManager.cpp
 msgid "Enable new plug-ins"
 msgstr "Nieuwe plugins inschakelen"
+
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Nyquist-scripts"
 
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
@@ -3165,7 +3456,8 @@ msgstr "Alles selecteren"
 msgid "C&lear All"
 msgstr "Alles wissen"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Inschakelen"
 
@@ -3245,13 +3537,13 @@ msgid "Mismatched Sampling Rates"
 msgstr "Samplerates komen niet overeen"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
-"Er zijn te weinig sporen geselecteerd voor opname met deze "
-"bemonsteringsfrequentie.\n"
+"Er zijn te weinig sporen geselecteerd voor opname met deze bemonsteringsfrequentie.\n"
 "(Tenacity vereist twee kanalen met dezelfde samplefrequentie voor\n"
 "elk stereospoor)"
 
@@ -3277,15 +3569,15 @@ msgid "Dropouts"
 msgstr "Uitval"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
-"Opgenomen audio is verloren gegaan op de gelabelde plaatsen. Mogelijke "
-"redenen:\n"
+"Opgenomen audio is verloren gegaan op de gelabelde plaatsen. Mogelijke redenen:\n"
 "\n"
 "Andere toepassingen strijden met Tenacity voor processortijd\n"
 "\n"
@@ -3310,10 +3602,7 @@ msgstr "Sluit het project onmiddelijk zonder wijzigingen"
 
 #: src/ProjectFSCK.cpp
 msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
-msgstr ""
-"Doorgaan met reparaties die in log genoteerd staat, en controleren op meer "
-"fouten. Dit zal het project in zijn huidige staat opslaan, tenzij u \"het "
-"project direct sluiten\" kiest bij verdere foutmeldingen."
+msgstr "Doorgaan met reparaties die in log genoteerd staat, en controleren op meer fouten. Dit zal het project in zijn huidige staat opslaan, tenzij u \"het project direct sluiten\" kiest bij verdere foutmeldingen."
 
 #: src/ProjectFSCK.cpp
 msgid "Warning - Problems Reading Sequence Tags"
@@ -3324,11 +3613,11 @@ msgid "Inspecting project file data"
 msgstr "Data van projectbestand wordt geïnspecteerd"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3371,11 +3660,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Waarschuwing - Ontbrekend(e) ge-aliast(e) bestand(en)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "De projectcontrole van map \"%s\" \n"
@@ -3400,12 +3689,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Waarschuwing - Ontbrekend(e) alias-overzichtbestand(en)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3463,7 +3752,8 @@ msgstr "Waarschuwing - Verdwaalde blokbestanden"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Voortgang"
 
@@ -3488,6 +3778,11 @@ msgstr "Waarschuwing: problemen bij automatisch herstel"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<naamloos>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Einde project"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3557,12 +3852,14 @@ msgstr ""
 "(niet in staat om de vereiste tijdelijke bestanden aan te maken)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Dit is geen Tenacity-projectbestand"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3694,9 +3991,9 @@ msgid "Error Writing to File"
 msgstr "Fout bij schrijven naar bestand"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3708,6 +4005,19 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Project comprimeren"
 
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Snelheid"
+
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
 msgid "(Recovered)"
@@ -3715,14 +4025,13 @@ msgstr "(Hersteld)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Dit bestand is opgeslagen met Tenacity %s.\n"
-"U maakt echter gebruik van Tenacity versie %s. U moet upgraden naar een "
-"nieuwere versie om dit bestand te kunnen openen."
+"U maakt echter gebruik van Tenacity versie %s. U moet upgraden naar een nieuwere versie om dit bestand te kunnen openen."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
@@ -3791,8 +4100,9 @@ msgid "Backing up project"
 msgstr "Reservekopie maken van project"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3801,8 +4111,9 @@ msgstr ""
 "Het is hersteld naar de laatste momentopname."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3881,14 +4192,13 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%s Project \"%s\" opslaan als..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
-"'Project opslaan' dient voor een Tenacity-project, niet voor een "
-"audiobestand.\n"
-"Voor een audiobestand dat opent in andere toepassingen, gebruikt u "
-"'exporteren'.\n"
+"'Project opslaan' dient voor een Tenacity-project, niet voor een audiobestand.\n"
+"Voor een audiobestand dat opent in andere toepassingen, gebruikt u 'exporteren'.\n"
 
 #. i18n-hint: In each case, %s is the name
 #. of the file being overwritten.
@@ -3961,11 +4271,12 @@ msgid "Error Opening Project"
 msgstr "Fout bij openen project"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "U probeert een automatisch gegenereerd back-upbestand te openen.\n"
 "Dit kan resulteren in zwaar verlies van gegevens.\n"
@@ -4074,8 +4385,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatische database-back-up mislukt."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Welkom bij Tenacity versie %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4187,6 +4498,24 @@ msgstr "Hoge kwaliteit"
 msgid "Best Quality (Slowest)"
 msgstr "Beste kwaliteit (traagste)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit DPCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "8-bit DPCM"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "32-bit float"
+msgstr "32-bit float"
+
 #: src/SampleFormat.cpp
 msgid "Unknown format"
 msgstr "Onbekend formaat"
@@ -4275,41 +4604,67 @@ msgstr "Alle voorkeuren"
 msgid "SelectionBar"
 msgstr "Selectiebalk"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spectrale selectie"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Timer"
+msgstr "Tijd"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Gereedschap"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Afspelen"
 
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Mixer"
+msgstr "Mengpaneel"
+
+#. i18n-hint: Noun (the meter is used for playback or record level monitoring)
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter"
+msgstr "Afspeelvolume"
+
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Afspeelvolume"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Opnamevolume"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Bewerken"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Apparaat"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Afspelen-met-snelheid"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Scrubben"
 
@@ -4320,6 +4675,17 @@ msgstr "Track-paneel"
 #: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
 msgid "Ruler"
 msgstr "Liniaal"
+
+#. i18n-hint: "Tracks" include audio recordings but also other collections of
+#. * data associated with a time line, such as sequences of labels, and musical
+#. * notes
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
+#, fuzzy
+msgid "Tracks"
+msgstr "Tracks"
 
 #: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
 msgid "First Track"
@@ -4427,7 +4793,8 @@ msgid "Activation level (dB):"
 msgstr "Inschakelingsniveau (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Welkom bij Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4458,6 +4825,11 @@ msgstr "Track-nummer"
 msgid "Year"
 msgstr "Jaar"
 
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genre"
+msgstr "Genres bewerken"
+
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Opmerkingen"
@@ -4481,6 +4853,11 @@ msgstr "Toevoegen"
 #: src/Tags.cpp
 msgid "&Remove"
 msgstr "Verwijderen"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genres"
+msgstr "Genres bewerken"
 
 #: src/Tags.cpp
 msgid "E&dit..."
@@ -4566,9 +4943,9 @@ msgstr ""
 "Klip op de help-knop voor tips over geschikte stations."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity kon bestand niet schrijven:\n"
@@ -4588,9 +4965,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4599,9 +4976,9 @@ msgstr ""
 "niet openen voor schrijven."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity kon geen beelden schrijven naar bestand:\n"
@@ -4618,9 +4995,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4630,9 +5007,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4641,8 +5018,9 @@ msgstr ""
 "niet inladen. Wellicht een foutief png-format?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity kon het standaardthema niet lezen.\n"
@@ -4680,9 +5058,9 @@ msgstr ""
 "waren al aanwezig. Overschrijven?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity kon bestand niet opslaan:\n"
@@ -4721,7 +5099,11 @@ msgstr "Aangepast"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Tijdsduur"
 
@@ -4732,7 +5114,8 @@ msgid "Time Track"
 msgstr "Tijd-track"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Tenacity timeropname"
 
 #: src/TimerRecordDialog.cpp
@@ -4806,7 +5189,8 @@ msgstr "Huidig project"
 msgid "Recording start:"
 msgstr "Opname-begin:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Tijdsduur:"
 
@@ -4827,7 +5211,8 @@ msgid "Action after Timer Recording:"
 msgstr "Actie na timer-opnemen:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Voortgang van Tenacity timeropname"
 
 #: src/TimerRecordDialog.cpp
@@ -4908,6 +5293,12 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Timer-opnemen"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 dagen 024 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -4918,6 +5309,7 @@ msgstr "099 dagen 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Begindatum en -tijd"
@@ -4962,7 +5354,8 @@ msgstr "Automatisch exporteren inschakelen?"
 msgid "Export Project As:"
 msgstr "Project exporteren als:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opties"
 
@@ -4975,7 +5368,8 @@ msgid "Do nothing"
 msgstr "Niets doen"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Tenacity afsluiten"
 
 #: src/TimerRecordDialog.cpp
@@ -4999,7 +5393,8 @@ msgid "Scheduled to stop at:"
 msgstr "Gepland stoppen om:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Tenacity timeropname - Wachten op begin opname"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5025,8 +5420,14 @@ msgid "Recording Exported:"
 msgstr "Opname geëxporteerd:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Tenacity timer-opnemen - wachten"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, %d Hz"
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5036,6 +5437,13 @@ msgstr "(Esc om te annuleren)"
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
 msgstr "Track-weergave"
+
+#. i18n-hint: The %d is replaced by the number of the track.
+#. i18n-hint: compose a name identifying an unnamed track by number
+#: src/TrackPanelAx.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "Track %d"
+msgstr "Einde track"
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this track is muted. (The mute button is on.)
@@ -5210,6 +5618,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s toepassen..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "(%d): %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "MISLUKT"
@@ -5228,13 +5646,15 @@ msgstr "%s is geen parameter die aanvaard wordt door %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Ongeldige waarde voor parameter \"%s\" moet %s zijn"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Opdracht"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Herhalen %s"
@@ -5269,6 +5689,10 @@ msgid "Compares a range on two tracks."
 msgstr "Vergelijkt een bereik op twee tracks."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Delay-tijd (seconden):"
 
@@ -5291,6 +5715,21 @@ msgstr "Venster"
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
 msgstr "Toepassing"
+
+#: src/commands/DragCommand.cpp
+#, fuzzy
+msgid "Track 0"
+msgstr "Track"
+
+#: src/commands/DragCommand.cpp
+#, fuzzy
+msgid "Track 1"
+msgstr "Track"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5336,13 +5775,50 @@ msgstr "Menu's"
 msgid "Preferences"
 msgstr "Voorkeuren"
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Clip instellen"
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Envelopes"
+msgstr "Verloop"
+
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Labels"
+msgstr "Labels"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Boxen"
 
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
 msgstr "Kort"
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "EQ-type:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Formaat"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -5351,6 +5827,11 @@ msgstr "Haalt informatie op in JSON-formaat."
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "Track-info ophalen"
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "EQ-type:"
 
 #: src/commands/GetTrackInfoCommand.h
 msgid "Gets track values as JSON."
@@ -5363,6 +5844,10 @@ msgstr "Opmerking"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Opdracht:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5400,12 +5885,17 @@ msgstr "Exporteert naar een bestand."
 msgid "Builtin Commands"
 msgstr "Ingebouwde opdrachten"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Het Tenacity-team"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Voorziet ingebouwde opdrachten in Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5468,7 +5958,10 @@ msgstr "Wist de inhoud van de log."
 msgid "Get Preference"
 msgstr "Voorkeur ophalen"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Naam:"
 
@@ -5493,6 +5986,11 @@ msgid "Sets the value of a single preference."
 msgstr "Stelt de waarde in van een enkele voorkeur."
 
 #: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "Screenshot..."
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Window"
 msgstr "Venster"
 
@@ -5512,9 +6010,15 @@ msgstr "Volledig scherm"
 msgid "Toolbars"
 msgstr "Werkbalken"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effecten"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Scriptables I"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -5595,6 +6099,11 @@ msgstr "Tijd selecteren"
 msgid "Project Start"
 msgstr "Begin project"
 
+#: src/commands/SelectCommand.cpp src/commands/SetProjectCommand.cpp
+#, fuzzy
+msgid "Project"
+msgstr "Project"
+
 #: src/commands/SelectCommand.cpp
 msgid "Project End"
 msgstr "Einde project"
@@ -5644,7 +6153,8 @@ msgstr "Instellen"
 msgid "Add"
 msgstr "Toevoegen"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Verwijderen"
 
@@ -5729,7 +6239,8 @@ msgid "Edited Envelope"
 msgstr "Envelope bewerkt"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Verloop"
 
@@ -5774,6 +6285,14 @@ msgid "Resize:"
 msgstr "Grootte wijzigen:"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Breedte:"
 
@@ -5810,6 +6329,11 @@ msgid "Set Track Audio"
 msgstr "Track-audio instellen"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Gain:"
+msgstr "Versterking"
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Pan:"
 msgstr "Balans:"
 
@@ -5817,7 +6341,10 @@ msgstr "Balans:"
 msgid "Set Track Visuals"
 msgstr "Track-visuals instellen"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineair"
 
@@ -5830,12 +6357,22 @@ msgid "Times 2"
 msgstr "Tweemaal"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "HalfWave"
+msgstr "Halve golf"
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
 msgstr "Weergave:"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
 msgstr "Schaal:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "Zoomen"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
@@ -5922,7 +6459,9 @@ msgid "Duck &amount:"
 msgstr "Hoeveelheid demping:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "seconden"
 
@@ -5946,7 +6485,8 @@ msgstr "Binnenste fade-down-lengte:"
 msgid "Inner &fade up length:"
 msgstr "Binnenste fade-up-lengte:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Drempelwaarde:"
 
@@ -5967,12 +6507,27 @@ msgid "Tone controls"
 msgstr "Toonregeling"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass (dB):"
+msgstr "Bass (dB):"
+
+#: src/effects/BassTreble.cpp
 msgid "Ba&ss (dB):"
 msgstr "Bass (dB):"
 
 #: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass"
+msgstr "Bassen afsnijden"
+
+#: src/effects/BassTreble.cpp
 msgid "&Treble (dB):"
 msgstr "Treble (dB):"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Treble afsnijden"
 
 #: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
@@ -6072,11 +6627,13 @@ msgstr "naar (Hz)"
 msgid "t&o"
 msgstr "naar"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Percentage verandering:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Percentage verandering"
 
@@ -6084,9 +6641,23 @@ msgstr "Percentage verandering"
 msgid "&Use high quality stretching (slow)"
 msgstr "Hoge kwaliteit uitrekken gebruiken (traag)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n/b"
 
@@ -6114,6 +6685,7 @@ msgstr "Standaard RPM vinyl:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Van rpm"
@@ -6126,6 +6698,7 @@ msgstr "van"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "naar rpm"
@@ -6261,8 +6834,19 @@ msgid "Max Spike Width"
 msgstr "Maximum piekbreedte"
 
 #: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Compressie"
+
+#: src/effects/Compressor.cpp
 msgid "Compresses the dynamic range of audio"
 msgstr "Comprimeert het dynamisch bereik van audio"
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -6273,6 +6857,20 @@ msgstr "%.2f seconden"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f seconden"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6389,9 +6987,15 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Contrast-analyzer, om RMS-volumeverschillen tussen twee geluidsselecties te meten."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Einde"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "Volume (dB):"
 
 #: src/effects/Contrast.cpp
 msgid "&Foreground:"
@@ -6445,6 +7049,18 @@ msgstr "Verschil:"
 msgid "&Help"
 msgstr "Help"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nul"
@@ -6452,6 +7068,13 @@ msgstr "nul"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "onbepaald"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6505,6 +7128,12 @@ msgstr "Huidig verschil"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Gemeten voorgrondniveau"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f seconden"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6574,9 +7203,20 @@ msgstr "Slaagcriteria 1.4.7 voor WCAG 2.0: mislukt"
 msgid "Data gathered"
 msgstr "Data verzameld"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Contrast-analyse (WCAG 2-compatibiliteit)"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Hoog contrast"
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -6611,6 +7251,11 @@ msgid "Expand and Compress"
 msgstr "Expanderen en comprimeren"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Leveller"
+msgstr "Niveau"
+
+#: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Rectifier-vervorming"
 
@@ -6619,8 +7264,26 @@ msgid "Hard Limiter 1413"
 msgstr "Hard limiter 1413"
 
 #: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Fuzz Box"
 msgstr "Fuzz box"
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Light Crunch Overdrive"
@@ -6687,6 +7350,16 @@ msgid "Upper Threshold"
 msgstr "Bovenste drempel"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Parameters"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Parameters"
+
+#: src/effects/Distortion.cpp
 msgid "Number of repeats"
 msgstr "Aantal herhalingen"
 
@@ -6717,6 +7390,10 @@ msgstr "Parameter-bediending"
 #: src/effects/Distortion.cpp
 msgid "Clipping level"
 msgstr "Clipping-niveau"
+
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Make-up Gain"
@@ -6814,7 +7491,9 @@ msgstr "DTMF-sequentie:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitude (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Tijdsduur:"
 
@@ -6827,18 +7506,40 @@ msgid "Duty cycle:"
 msgstr "Bedrijfscyclus:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f seconden"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Tijdsduur geluidstonen:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Tijdsduur stilte:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
+
+#: src/effects/Echo.cpp
+msgid "Echo"
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Blijft de geselecteerde audio herhalen"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Gevraagde waarde overschrijdt geheugencapaciteit."
 
@@ -6862,7 +7563,8 @@ msgstr "Voorinstellingen"
 msgid "Export Effect Parameters"
 msgstr "Effect-parameters exporteren"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Kon bestand \"%s\" niet openen"
@@ -6899,6 +7601,15 @@ msgstr "Voorbeeld voorbereiden"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Voorbeeld"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7116,6 +7827,11 @@ msgid "Options..."
 msgstr "Opties…"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Naam: %s"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Naam: %s"
@@ -7176,6 +7892,11 @@ msgstr "Afspelen stoppen"
 msgid "Play"
 msgstr "Afspelen"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
@@ -7221,6 +7942,10 @@ msgid "Low rolloff for speech"
 msgstr "Lage roloff voor spraak"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefoon"
 
@@ -7255,6 +7980,43 @@ msgstr "Samplerate van track is te laag voor dit effect."
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Effect niet beschikbaar"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7583,7 +8345,8 @@ msgid "Builtin Effects"
 msgstr "Ingebouwde effecten"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Voorziet ingebouwde effecten in Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7593,6 +8356,10 @@ msgstr "Onbekende naam van ingebouwd effect"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "waargenomen loudness"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7619,6 +8386,19 @@ msgstr "Verwerken: %s"
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Normaliseren"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7693,6 +8473,11 @@ msgstr "Blackmann, Hann"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, geen"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, geen"
 
 #: src/effects/NoiseReduction.cpp
@@ -7792,12 +8577,12 @@ msgid "Step 1"
 msgstr "Stap 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
-"Selecteer een aantal seconden met alleen ruis zodat Tenacity weet wat "
-"gefilterd moet worden.\n"
+"Selecteer een aantal seconden met alleen ruis zodat Tenacity weet wat gefilterd moet worden.\n"
 "Klik daarna op ‘Ruisprofiel verkrijgen’:"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
@@ -7846,13 +8631,62 @@ msgstr "Venstertypes:"
 msgid "Window si&ze:"
 msgstr "Venstergrootte:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (standaard)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Stappen per venster:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7968,12 +8802,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Stereokanalen onafhankelijk normaliseren"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Uitrekken"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch is alleen voor een extreme tijdrek of \"stasis\"-effect"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Uitrekfactor:"
@@ -8025,6 +8865,10 @@ msgstr ""
 "of de 'tijdresolutie' te verminderen naar minder dan %.1f seconden."
 
 #: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
 msgstr "Combineert signalen waarvan de fase verschoven is met het originele signaal"
 
@@ -8039,6 +8883,10 @@ msgstr "Stappen"
 #: src/effects/Phaser.cpp
 msgid "&Dry/Wet:"
 msgstr "Dry/Wet:"
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
@@ -8247,6 +9095,30 @@ msgstr "Keert de geselecteerde audio om"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS tijd/toonhoogte uitrekken"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Highpass"
+msgstr "Hoog:"
+
 #: src/effects/ScienFilter.cpp
 msgid "Classic Filters"
 msgstr "Klassieke filters"
@@ -8280,6 +9152,11 @@ msgstr "Passband rimpel (dB)"
 #: src/effects/ScienFilter.cpp
 msgid "&Subtype:"
 msgstr "Subtype:"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Cutoff (Hz)"
+msgstr "naar (Hz)"
 
 #: src/effects/ScienFilter.cpp
 msgid "C&utoff:"
@@ -8380,6 +9257,11 @@ msgstr "Standaardwaarden"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Standaardinstellingen herstellen"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8539,6 +9421,10 @@ msgstr "Stilte detecteren"
 msgid "Tr&uncate to:"
 msgstr "Afkappen tot:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Compresseren naar:"
@@ -8552,7 +9438,8 @@ msgid "VST Effects"
 msgstr "VST-effecten"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Voegt de mogelijkheid toe om VST-effecten te gebruiken in Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8564,7 +9451,8 @@ msgstr "VST-shell scannen"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "%d van %d registreren: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Kon de bibliotheek niet laden"
 
@@ -8584,20 +9472,17 @@ msgstr "De buffergrootte regelt het aantal samples dat bij elke iteratie naar he
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Buffergrootte (8 tot 1048576 samples):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Vertragingscompensatie"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
-msgstr ""
-"Als onderdeel van hun verwerking moeten sommige VST-effecten het terugsturen "
-"van audio naar Tenacity vertragen. Wanneer u deze vertraging niet "
-"compenseert, zult u merken dat er kleine stiltes in het geluid zijn "
-"aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, "
-"maar het kan zijn dat het niet voor alle VST-effecten werkt."
+msgstr "Als onderdeel van hun verwerking moeten sommige VST-effecten het terugsturen van audio naar Tenacity vertragen. Wanneer u deze vertraging niet compenseert, zult u merken dat er kleine stiltes in het geluid zijn aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, maar het kan zijn dat het niet voor alle VST-effecten werkt."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Compensatie inschakelen"
 
@@ -8631,7 +9516,8 @@ msgid "Standard VST program file"
 msgstr "Standaard VST-programmabestand"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Tenacity VST-voorinstellingbestand"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8658,7 +9544,8 @@ msgstr "Fout bij laden van VST-voorinstellingen"
 msgid "Unable to load presets file."
 msgstr "Niet in staat om voorinstelling-bestand te laden."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Effect-instellingen"
 
@@ -8674,6 +9561,17 @@ msgstr "Niet in staat om voorinstelling-bestand te lezen."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Het parameterbestand werd opgeslagen vanuit %s. Doorgaan?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+#, fuzzy
+msgid "VST"
+msgstr "VST"
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8705,7 +9603,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio Unit-effecten"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Voorziet ondersteuning voor Audio Unit Effects in Tenacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8721,13 +9620,9 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio Unit-effectopties"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
-msgstr ""
-"Als onderdeel van hun verwerking moeten sommige Audio-Unit-effecten het "
-"terugsturen van audio naar Tenacity vertragen. Wanneer u deze vertraging "
-"niet compenseert, zult u merken dat er kleine stiltes in het geluid zijn "
-"aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, "
-"maar het kan zijn dat het niet voor alle Audio-Unit-effecten werkt."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr "Als onderdeel van hun verwerking moeten sommige Audio-Unit-effecten het terugsturen van audio naar Tenacity vertragen. Wanneer u deze vertraging niet compenseert, zult u merken dat er kleine stiltes in het geluid zijn aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, maar het kan zijn dat het niet voor alle Audio-Unit-effecten werkt."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -8862,8 +9757,16 @@ msgstr "Aanmaken van property-lijst voor voorinstelling mislukt"
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "Instellen van class info voor voorinstelling \"%s\" mislukt"
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Audio Unit-effecten"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA-effecten"
@@ -8873,7 +9776,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Voorziet LADSPA-effecten"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity gebruikt niet langer vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -8881,17 +9785,30 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA-effect-opties"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
-msgstr ""
-"Als onderdeel van hun verwerking moeten sommige LADSPA-effecten het "
-"terugsturen van audio naar Tenacity vertragen. Wanneer u deze vertraging "
-"niet compenseert, zult u merken dat er kleine stiltes in het geluid zijn "
-"aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, "
-"maar het kan zijn dat het niet voor alle LADSPA-effecten werkt."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr "Als onderdeel van hun verwerking moeten sommige LADSPA-effecten het terugsturen van audio naar Tenacity vertragen. Wanneer u deze vertraging niet compenseert, zult u merken dat er kleine stiltes in het geluid zijn aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, maar het kan zijn dat het niet voor alle LADSPA-effecten werkt."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s over:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Effect-outvoer"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8903,13 +9820,9 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Buffergrootte (8 tot %d samples):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
-msgstr ""
-"Als onderdeel van hun verwerking moeten sommige LV2-effecten het terugsturen "
-"van audio naar Tenacity vertragen. Wanneer u deze vertraging niet "
-"compenseert, zult u merken dat er kleine stiltes in het geluid zijn "
-"aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, "
-"maar het kan zijn dat het niet voor alle LV2-effecten werkt."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr "Als onderdeel van hun verwerking moeten sommige LV2-effecten het terugsturen van audio naar Tenacity vertragen. Wanneer u deze vertraging niet compenseert, zult u merken dat er kleine stiltes in het geluid zijn aangebracht. Het inschakelen van deze optie zorgt voor deze compensatie, maar het kan zijn dat het niet voor alle LV2-effecten werkt."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -8929,12 +9842,25 @@ msgstr "%s heeft niet-ondersteunde functie %s nodig\n"
 msgid "%s requires unsupported option %s\n"
 msgstr "%s heeft niet-ondersteunde optie %s nodig\n"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "Genereren"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+#, fuzzy
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-effecten"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Voorziet ondersteuning voor LV2-effecten in Tenacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8942,7 +9868,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist-effecten"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Voorziet ondersteuning voor Nyquist-effecten in Tenacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9027,6 +9954,10 @@ msgstr "';type tool'-effecten kunnen geen labels teruggeven van Nyquist\n"
 #, c-format
 msgid "nyx_error returned from %s.\n"
 msgstr "nyx_error teruggekregen van%s.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "plug-in"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist returned a list."
@@ -9166,7 +10097,8 @@ msgstr "Bestand selecteren"
 msgid "Save file as"
 msgstr "Bestand opslaan als"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "naamloos"
 
@@ -9175,7 +10107,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-effecten"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Voorziet ondersteuning voor Vamp-effecten in Tenacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9197,6 +10130,13 @@ msgstr "Plugin-instellingen"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programma"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+#, fuzzy
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9275,6 +10215,18 @@ msgstr "Formaat-opties"
 #, c-format
 msgid "Channel: %2d"
 msgstr "Kanaal: %2d"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -9485,7 +10437,8 @@ msgstr "Audio exporteren als %s"
 msgid "Invalid sample rate"
 msgstr "Ongeldige samplerate"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Resampelen"
 
@@ -9504,8 +10457,7 @@ msgid ""
 "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the current output file format. "
 msgstr ""
-"De combinatie van de samplefrequentie (%d) en bitsnelheid (%d kbps) van het "
-"project wordt niet\n"
+"De combinatie van de samplefrequentie (%d) en bitsnelheid (%d kbps) van het project wordt niet\n"
 "ondersteund door het huidige uitvoerbestandsformaat. "
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
@@ -9516,6 +10468,14 @@ msgstr "U kunt een van de onderstaande samplerates kiezen."
 msgid "Sample Rates"
 msgstr "Samplerates"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Bitrate:"
@@ -9523,6 +10483,48 @@ msgstr "Bitrate:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Kwaliteit (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f seconden"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9533,12 +10535,50 @@ msgid "Constrained"
 msgstr "Beperkt"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Audio"
+msgstr "Audio..."
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Kleine vertraging"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
 msgstr "Smalband"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mediumband"
+msgstr "Gemiddeld"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Wideband"
@@ -9617,6 +10657,19 @@ msgid "Replace preset '%s'?"
 msgstr "Voorinstelling '%s' vervangen?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "Hoofdmix"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
 msgstr "M4A (AAC)-bestanden (FFmpeg)"
 
@@ -9645,6 +10698,21 @@ msgid "Estimate"
 msgstr "Schatting"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Niveau"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Niveau"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Niveau"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Full search"
 msgstr "Volledig doorzoeken"
 
@@ -9671,6 +10739,12 @@ msgstr "Voorinstellingen importeren"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Export Presets"
 msgstr "Voorinstellingen exporteren"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Huidige codec:"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
@@ -9705,6 +10779,10 @@ msgstr "Taal:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bit-reservoir"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9822,6 +10900,11 @@ msgstr ""
 "max - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Naam:"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "LPC coefficients precision\n"
 "Optional\n"
@@ -9834,6 +10917,11 @@ msgstr ""
 "0 - standaard\n"
 "min - 1\n"
 "max - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Gebruik LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10090,6 +11178,40 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (beste kwaliteit)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Extreem, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "Standaard, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (kleinere bestanden)"
 
@@ -10106,6 +11228,10 @@ msgstr "Extreem, 220-260 kbps"
 msgid "Standard, 170-210 kbps"
 msgstr "Standaard, 170-210 kbps"
 
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
 msgid "Insane"
@@ -10115,7 +11241,8 @@ msgstr "Waanzinnig"
 msgid "Extreme"
 msgstr "Extreem"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standaard"
 
@@ -10132,8 +11259,18 @@ msgid "Average"
 msgstr "Gemiddeld"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Constant"
+msgstr "Constante gain"
+
+#: src/export/ExportMP3.cpp
 msgid "Joint Stereo"
 msgstr "Stereo samengevoegd"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Stereo maken"
 
 #: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
@@ -10158,8 +11295,8 @@ msgid "Locate LAME"
 msgstr "LAME opzoeken"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity heeft het bestand %s nodig om MP3S aan te kunnen maken."
 
 #: src/export/ExportMP3.cpp
@@ -10187,13 +11324,12 @@ msgid "Where is %s?"
 msgstr "Waar is %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
-"U linkt naar lame_enc.dll versie %d.%d. Deze versie is niet compatibel met "
-"Tenacity %d.%d.%d.\n"
+"U linkt naar lame_enc.dll versie %d.%d. Deze versie is niet compatibel met Tenacity %d.%d.%d.\n"
 "Download de laatste versie van 'LAME voor Tenacity'."
 
 #: src/export/ExportMP3.cpp
@@ -10281,8 +11417,7 @@ msgid ""
 "The project sample rate (%d) is not supported by the MP3\n"
 "file format. "
 msgstr ""
-"De samplefrequentie van het project (%d) wordt niet ondersteund door het "
-"MP3\n"
+"De samplefrequentie van het project (%d) wordt niet ondersteund door het MP3\n"
 "bestandsformaat. "
 
 #: src/export/ExportMP3.cpp
@@ -10291,8 +11426,7 @@ msgid ""
 "The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
 "supported by the MP3 file format. "
 msgstr ""
-"De combinatie van de samplefrequentie (%d) en de bitsnelheid (%d kbps) van "
-"het project wordt niet\n"
+"De combinatie van de samplefrequentie (%d) en de bitsnelheid (%d kbps) van het project wordt niet\n"
 "ondersteund door het MP3-bestandsformaat. "
 
 #: src/export/ExportMP3.cpp
@@ -10498,6 +11632,18 @@ msgstr "De geselecteerde audio wordt als Ogg Vorbis geëxporteerd"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Audio exporteren als Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "Header:"
+msgstr ""
+
 #: src/export/ExportPCM.cpp src/import/ImportRaw.cpp
 msgid "Encoding:"
 msgstr "Codering:"
@@ -10507,9 +11653,10 @@ msgid "Other uncompressed files"
 msgstr "Andere bestanden zonder compressie"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "U probeerde een WAV-bestand te exporteren dat groter zou zijn dan 4 GB.\n"
 "Tenacity kan dit niet, dus het exporteren is gestopt."
@@ -10519,8 +11666,9 @@ msgid "Error Exporting"
 msgstr "Fout bij exporteren"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Uw geëxporteerde WAV-bestand is ingekort omdat Tenacity geen WAV\n"
@@ -10560,25 +11708,24 @@ msgid "All supported files"
 msgstr "Alle ondersteunde bestanden"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "‘%s’ \n"
 "is een MIDI-bestand, geen audiobestand. \n"
-"Tenacity kan dit type bestand niet afspelen of bewerken, maar u kunt het wel "
-"\n"
+"Tenacity kan dit type bestand niet afspelen of bewerken, maar u kunt het wel \n"
 "bewerken via Bestand > Importeren > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "is geen audiobestand. \n"
@@ -10589,19 +11736,18 @@ msgid "Select stream(s) to import"
 msgstr "Selecteer te importeren stream(s)"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
-msgstr ""
-"In deze versie van Tenacity is ondersteuning voor %s niet meegecompileerd."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
+msgstr "In deze versie van Tenacity is ondersteuning voor %s niet meegecompileerd."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "‘%s’ is een audio-cd bestand.\n"
 "Tenacity kan audio-cd's niet rechtstreeks openen.\n"
@@ -10610,24 +11756,22 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" is een afspeellijstbestand. \n"
-"Tenacity kan dit bestand niet openen omdat het alleen links naar andere "
-"bestanden bevat. \n"
-"U kunt het misschien openen in een teksteditor en de eigenlijke "
-"audiobestanden downloaden."
+"Tenacity kan dit bestand niet openen omdat het alleen links naar andere bestanden bevat. \n"
+"U kunt het misschien openen in een teksteditor en de eigenlijke audiobestanden downloaden."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "‘%s’ is een Windows Media audio-bestand.\n"
@@ -10636,41 +11780,38 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is een Advanced Audio Coding bestand.\n"
-"Zonder de optionele FFmpeg-bibliotheek kan Tenacity dit type bestand niet "
-"openen.\n"
-"Anders moet u het omzetten naar een ondersteund audioformaat zoals WAV of "
-"AIFF."
+"Zonder de optionele FFmpeg-bibliotheek kan Tenacity dit type bestand niet openen.\n"
+"Anders moet u het omzetten naar een ondersteund audioformaat zoals WAV of AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" is een gecodeerd audiobestand. \n"
 "Deze zijn meestal afkomstig van een online muziekwinkel. \n"
 "Tenacity kan dit type bestand niet openen vanwege de encryptie. \n"
-"Probeer het bestand in Tenacity op te nemen, of brand het op een audio-CD en "
-"\n"
+"Probeer het bestand in Tenacity op te nemen, of brand het op een audio-CD en \n"
 "de CD-track uitpakken naar een ondersteund audioformaat zoals WAV of AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "‘%s’ is een RealPlayer media-bestand.\n"
@@ -10679,12 +11820,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" is een op noten gebaseerd bestand, geen geluidsbestand. \n"
 "Tenacity kan dit type bestand niet openen. \n"
@@ -10693,28 +11834,26 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is een Musepack geluidsbestand. \n"
 "Tenacity kan dit type bestand niet openen. \n"
-"Als u denkt dat het een MP3-bestand is, herbenoem het met de uitgang \".mp3\""
-" \n"
-"en probeer het opnieuw te importeren. Anders moet u het omzetten in een "
-"ondersteund audioformaat\n"
+"Als u denkt dat het een MP3-bestand is, herbenoem het met de uitgang \".mp3\" \n"
+"en probeer het opnieuw te importeren. Anders moet u het omzetten in een ondersteund audioformaat\n"
 "zoals WAV of AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is een Wavpack geluidsbestand. \n"
@@ -10723,10 +11862,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is een Dolby Digital geluidsbestand. \n"
@@ -10735,10 +11874,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is een Ogg Speex geluidsbestand. \n"
@@ -10747,10 +11886,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" is een videobestand. \n"
@@ -10764,16 +11903,15 @@ msgstr "Bestand \"%s\" niet gevonden."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Tenacity herkende het type bestand van '%s' niet.\n"
 "\n"
-"%sProbeer ook Bestand > Importeren > Raw-data voor niet-gecomprimeerde "
-"bestanden."
+"%sProbeer ook Bestand > Importeren > Raw-data voor niet-gecomprimeerde bestanden."
 
 #: src/import/Import.cpp
 msgid ""
@@ -10783,11 +11921,16 @@ msgstr ""
 "Probeer FFmpeg te installeren.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, Audacity technicus"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10817,20 +11960,18 @@ msgid "Import Project"
 msgstr "Project importeren"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
-"Dit project is opgeslagen door Tenacity versie 1.0 of eerder. Het formaat "
-"is\n"
-"gewijzigd en deze versie van Tenacity is niet in staat om het project te "
-"importeren.\n"
+"Dit project is opgeslagen door Tenacity versie 1.0 of eerder. Het formaat is\n"
+"gewijzigd en deze versie van Tenacity is niet in staat om het project te importeren.\n"
 "\n"
-"Gebruik een versie van Tenacity vóór v3.0.0 om het project te upgraden, "
-"waarna\n"
+"Gebruik een versie van Tenacity vóór v3.0.0 om het project te upgraden, waarna\n"
 "u het kunt importeren met deze versie van Tenacity."
 
 #: src/import/ImportAUP.cpp
@@ -10876,10 +12017,9 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Kon de map met projectdata niet vinden: ‘%s’"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
-msgstr ""
-"Er zijn MIDI-tracks gevonden in het projectbestand, maar deze versie van "
-"Tenacity heeft geen MIDI-ondersteuning. Track wordt gebypasst."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr "Er zijn MIDI-tracks gevonden in het projectbestand, maar deze versie van Tenacity heeft geen MIDI-ondersteuning. Track wordt gebypasst."
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
@@ -10983,40 +12123,6 @@ msgstr "Index[%02x] Codec[%s], Taal[%s], Bitfrequentie[%s], Kanalen[%d], Duur[%d
 msgid "FLAC files"
 msgstr "Flac-bestanden"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-compatibele bestanden"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Niet in staat om decoder aan pijplijn toe te voegen"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer-importer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Niet in staat om streamstatus in pauze te zetten."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index[%02d], type[%s], kanalen[%d], frequentie[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Bestand bevat geen audiostreams."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Niet in staat om bestand te importeren, statuswijziging mislukt."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer-fout: 1%s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Bestandenlijst in gewone tekst"
@@ -11119,12 +12225,97 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "Wav, Aiff, en andere types zonder compressie"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG-containerformaat)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (zonder header)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11155,6 +12346,34 @@ msgid "64 bit float"
 msgstr "64-bit float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12-bit DWVW"
 
@@ -11167,12 +12386,20 @@ msgid "24 bit DWVW"
 msgstr "24-bit DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bit DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8-bit DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11307,6 +12534,7 @@ msgstr "%s rechts"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11330,6 +12558,7 @@ msgstr "einde"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11356,7 +12585,8 @@ msgstr "Tijdverplaatste clips naar rechts"
 msgid "Time shifted clips to the left"
 msgstr "Tijdverplaatste clips naar links"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Tijd verschuiven"
 
@@ -11494,7 +12724,8 @@ msgstr "Geselecteerde audiotracks trimmen van %.2f seconden naar %.2f seconden"
 msgid "Trim Audio"
 msgstr "Audio trimmen"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Splitsen"
 
@@ -11619,34 +12850,6 @@ msgid "Ext&ra"
 msgstr "Extra"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mixer"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Afspeelvolume wijzigen..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Afspeelvolume verhogen"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Afspeelvolume verlagen"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Opnamevolume wijzigen..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Opnamevolume verhogen"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Opnamevolume verlagen"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "Apparaat"
 
@@ -11682,6 +12885,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Geselecteerde audio exporteren"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Labeltekst"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -11907,8 +13116,9 @@ msgid "&Getting Started"
 msgstr "Ermee beginnen"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audactiy-handleiding"
+#, fuzzy
+msgid "&Manual"
+msgstr "Handleiding..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -11934,11 +13144,8 @@ msgstr "MIDI-apparaatinfo..."
 msgid "Show &Log..."
 msgstr "Log weergeven..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Over Tenacity…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Label toegevoegd"
 
@@ -12188,6 +13395,11 @@ msgid "Uncategorized"
 msgstr "Ongesorteerd"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Nieuw…"
+
+#: src/menus/PluginMenus.cpp
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -12338,6 +13550,11 @@ msgstr "Meer info..."
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
 msgstr "Bericht..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Help..."
+msgstr "Helpen"
 
 #: src/menus/PluginMenus.cpp
 msgid "Open Project..."
@@ -12620,6 +13837,7 @@ msgstr "Cursor grote sprong rechts"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Zoeken"
@@ -12831,20 +14049,21 @@ msgid "Created new label track"
 msgstr "Nieuwe labeltrack aangemaakt"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
-msgstr ""
-"Deze versie van Tenacity staat slechts een tijd-track toe voor elk "
-"projectvenster."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr "Deze versie van Tenacity staat slechts een tijd-track toe voor elk projectvenster."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Nieuwe tijd-track aangemaakt"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nieuwe samplerate (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "De ingevoerde waarde is ongeldig"
 
@@ -13101,7 +14320,9 @@ msgstr "Afspelen"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Opnemen"
 
@@ -13250,10 +14471,6 @@ msgstr "Overdub (aan/uit)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Softwarematig playthrough (aan/uit)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Automatische opnameniveau-wijziging (aan/uit)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13468,7 +14685,8 @@ msgid "Preferences for Application"
 msgstr "Voorkeuren voor toepassing"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Tenacity bijwerken"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13499,6 +14717,13 @@ msgstr "Apparaten"
 msgid "Preferences for Device"
 msgstr "Voorkeuren voor apparaat"
 
+#. i18n-hint Software interface to audio devices
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgctxt "device"
+msgid "Interface"
+msgstr "Gebruikersinterface"
+
 #. i18n-hint: (noun)
 #: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
 msgid "&Host:"
@@ -13508,7 +14733,8 @@ msgstr "Host:"
 msgid "Using:"
 msgstr "met:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Afspelen"
 
@@ -13528,7 +14754,8 @@ msgstr "Kanalen:"
 msgid "Latency"
 msgstr "Tijdsvertraging (Latency)"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milliseconden"
 
@@ -13548,8 +14775,19 @@ msgstr "Geen audio-interfaces"
 msgid "No devices found"
 msgstr "Geen apparaten gevonden"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 kanaal (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 kanalen (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Mappen"
 
@@ -13657,10 +14895,9 @@ msgid "Directory %s is not writable"
 msgstr "De map %s is niet beschrijfbaar"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
-msgstr ""
-"Wijziging van de tijdelijke map zal pas van kracht zijn nadat Tenacity "
-"herstart is"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr "Wijziging van de tijdelijke map zal pas van kracht zijn nadat Tenacity herstart is"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -13692,6 +14929,7 @@ msgstr "Gegroepeerd op type"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "LADSPA"
@@ -13743,11 +14981,13 @@ msgid "Plugin Options"
 msgstr "Plugin-opties"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Op bijgewerkte plugins controleren wanneer Tenacity start"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Plugins opnieuw scannen bij volgende keer dat Tenacity opstart"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13779,6 +15019,11 @@ msgstr "Regels om importfilters te kiezen"
 #: src/prefs/ExtImportPrefs.cpp
 msgid "File extensions"
 msgstr "Bestandsextensies"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Bestandstype:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Importer order"
@@ -13814,11 +15059,7 @@ msgstr "Ongebruikte filters:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"Er bevinden zich spatietekens (spaties, regeleindes, tabs of linefeeds) in "
-"een van de items. Ze zullen waarschijnlijk de patroonvergelijking "
-"doorbreken. Tenzij u weet wat u doet, is het aanbevolen om spaties weg te "
-"knippen. Wilt u dat Tenacity de spaties voor u wegknipt?"
+msgstr "Er bevinden zich spatietekens (spaties, regeleindes, tabs of linefeeds) in een van de items. Ze zullen waarschijnlijk de patroonvergelijking doorbreken. Tenzij u weet wat u doet, is het aanbevolen om spaties weg te knippen. Wilt u dat Tenacity de spaties voor u wegknipt?"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -13835,6 +15076,13 @@ msgstr "Bevestiging om regel te wissen"
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
 msgstr "Uitgebreid importeren"
+
+#. i18n-hint: refers to Audacity's user interface settings
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgctxt "GUI"
+msgid "Interface"
+msgstr "Gebruikersinterface"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Preferences for GUI"
@@ -13921,7 +15169,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Labels behouden als selectie aan een label plakt"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Systeem- en Tenacity-thema laten overgaan"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -13945,6 +15194,10 @@ msgstr "Scrub-liniaal weergeven"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "Taal \"%s\" is onbekend"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14095,9 +15348,9 @@ msgstr ""
 "   *   \"%s\"  (omdat de sneltoets '%s' gebruikt wordt door \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
-msgstr ""
-"Een XML-bestand selecteren dat de sneltoets-configuratie voor Tenacity bevat."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
+msgstr "Een XML-bestand selecteren dat de sneltoets-configuratie voor Tenacity bevat."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Importing Keyboard Shortcuts"
@@ -14229,8 +15482,9 @@ msgid "Dow&nload"
 msgstr "Downloaden"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity heeft automatisch geldige FFmpeg-bibliotheken gedetecteerd.\n"
@@ -14257,6 +15511,13 @@ msgstr "Voorkeuren voor MidiIO"
 msgid "No MIDI interfaces"
 msgstr "Geen MIDI-interfaces"
 
+#. i18n-hint Software interface to MIDI
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgctxt "MIDI"
+msgid "Interface"
+msgstr "Gebruikersinterface"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Using: PortMidi"
 msgstr "In gebruik: PortMidi"
@@ -14269,32 +15530,39 @@ msgstr "MIDI Synth-vertraging (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "De MIDI-synthesizervertraging moet een geheel getal zijn"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "Voorkeuren voor module"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
-"Dit zijn experimentele modules. Schakel ze alleen in als u de Tenacity-"
-"handleiding gelezen heeft\n"
+"Dit zijn experimentele modules. Schakel ze alleen in als u de Tenacity-handleiding gelezen heeft\n"
 "en weet wat u aan het doen bent."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
-msgstr ""
-"  'Vragen' betekent dat Tenacity zal vragen of u de modules wilt laden elke "
-"keer als het opstart."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr "  'Vragen' betekent dat Tenacity zal vragen of u de modules wilt laden elke keer als het opstart."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr ""
-"  'Mislukt' betekent dat Tenacity denk dat de module defect is en weigert ze "
-"te starten."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr "  'Mislukt' betekent dat Tenacity denk dat de module defect is en weigert ze te starten."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -14302,10 +15570,9 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Nieuw' betekent dat er nog geen keuze gemaakt werd."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
-msgstr ""
-"Wijzigingen aan deze instellingen hebben alleen effect wanneer Tenacity "
-"opstart."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "Wijzigingen aan deze instellingen hebben alleen effect wanneer Tenacity opstart."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -14318,6 +15585,14 @@ msgstr "Mislukt"
 #: src/prefs/ModulePrefs.cpp
 msgid "No modules were found"
 msgstr "Geen modules gevonden"
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14359,7 +15634,10 @@ msgstr "Links-slepen"
 msgid "Set Selection Range"
 msgstr "Selectie maken"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-linksklikken"
 
@@ -14447,6 +15725,15 @@ msgstr "-links-slepen"
 msgid "Move clip up/down between tracks"
 msgstr "Clip naar andere track verplaatsen"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-links-slepen"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14475,6 +15762,11 @@ msgstr "Meerdere samples wijzigen"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Slechts één sample wijzigen"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Multitool"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14566,7 +15858,8 @@ msgid "Always scrub un&pinned"
 msgstr "Altijd niet-vastgezet scrubben"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Tenacity voorkeuren"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14580,6 +15873,11 @@ msgstr "Voorkeuren:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Voorkeuren voor kwaliteit"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14622,6 +15920,14 @@ msgstr "Samplerate converter:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Dither:"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14691,39 +15997,6 @@ msgid "System T&ime"
 msgstr "Systeemtijd"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatische opnameniveau-wijziging"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Automatische opnameniveau-wijziging inschakelen."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Doelpiek:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Tussen:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Analysetijd:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milliseconden (tijd van een analyse)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Aantal opeenvolgende analyses:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 betekent oneindig"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Punch and Roll opnemen"
 
@@ -14734,6 +16007,21 @@ msgstr "Pre-roll:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Crossfaden:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14767,6 +16055,11 @@ msgstr "Omgekeerde grijswaarden"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Frequenties"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -14861,6 +16154,10 @@ msgstr "8 - breedband"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - standaard"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -14960,28 +16257,26 @@ msgid "Info"
 msgstr "Informatie"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
 msgstr ""
 "Het gebruik van thema's is experimenteel.\n"
 "\n"
-"Om het uit te proberen klikt u op \"Thema-cache opslaan\" waarna u met een "
-"beeldbewerkingsprogramma zoals ‘The Gimp’ de\n"
+"Om het uit te proberen klikt u op \"Thema-cache opslaan\" waarna u met een beeldbewerkingsprogramma zoals ‘The Gimp’ de\n"
 "afbeeldingen en kleuren in ImageCacheVxx.png kunt bewerken.\n"
 "\n"
-"Klik op \"Thema-cache laden\" om de gewijzigde afbeeldingen weer in Tenacity "
-"te laden.\n"
+"Klik op \"Thema-cache laden\" om de gewijzigde afbeeldingen weer in Tenacity te laden.\n"
 "\n"
-"(Momenteel worden alleen de afspeelwerkbalk en de kleuren van de golfvorm "
-"beïnvloed, ondanks\n"
+"(Momenteel worden alleen de afspeelwerkbalk en de kleuren van de golfvorm beïnvloed, ondanks\n"
 "het feit dat het afbeeldingenbestand ook andere pictogrammen weergeeft.)"
 
 #: src/prefs/ThemePrefs.cpp
@@ -15032,6 +16327,11 @@ msgid "Simple"
 msgstr "Eenvoudig"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Multi-track"
+msgstr "Track selecteren"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "&Select all audio, if selection required"
 msgstr "Alle audio selecteren als selectie vereist is"
 
@@ -15079,6 +16379,11 @@ msgstr "Logaritmisch (dB)"
 #: src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.h
 msgid "Waveform"
 msgstr "Golfvorm"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Spectrogram"
+msgstr "Spectrogrammen"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Connect dots"
@@ -15137,10 +16442,16 @@ msgid "MilliSeconds"
 msgstr "Milliseconden"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Samples"
+msgstr "Eenvoudig"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "4 Pixels per Sample"
 msgstr "4 pixels per sample"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Maximale zoom"
 
@@ -15262,16 +16573,24 @@ msgid "Stopped"
 msgstr "Gestopt"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pauzeren"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Naar begin springen"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Naar einde springen"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pauzeren"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Tot begin selecteren"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Tot einde selecteren"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15285,20 +16604,17 @@ msgstr "Nieuwe track opnemen"
 msgid "Append Record"
 msgstr "Aansluitend opnemen"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Tot einde selecteren"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Tot begin selecteren"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s gepauzeerd."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15378,11 +16694,17 @@ msgstr "Audioselectie dempen"
 msgid "Sync-Lock Tracks"
 msgstr "Tracks sync-vergrendelen"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Inzoomen"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Uitzoomen"
 
@@ -15449,43 +16771,6 @@ msgstr "Opnamemeterwerkbalk"
 msgid "&Playback Meter Toolbar"
 msgstr "Afspeelmeterwerkbalk"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Opnamevolume"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Afspeelvolume"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Opnamevolume: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Opnamevolume (niet beschikbaar; gebruik systeemmixer)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Afspeelvolume: %.2f (geëmuleerd)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Afspeelvolume %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Afspeelvolume (niet beschikbaar; gebruik systeemmixer)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Mixer-werkbalk"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Zoeken"
@@ -15501,6 +16786,7 @@ msgstr "Scrubben"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Scrubben stoppen"
@@ -15508,6 +16794,7 @@ msgstr "Scrubben stoppen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Scrubben starten"
@@ -15515,6 +16802,7 @@ msgstr "Scrubben starten"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Zoeken stoppen"
@@ -15522,6 +16810,7 @@ msgstr "Zoeken stoppen"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Zoeken starten"
@@ -15576,7 +16865,9 @@ msgstr "Vangen (snap-to)"
 msgid "Length"
 msgstr "Lengte"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centrum"
 
@@ -15640,13 +16931,18 @@ msgstr "Tijd-werkbalk"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Tenacity %s-werkbalk"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Klikken en slepen om grootte van de werkbalk aan te passen"
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Gereedschap"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -15664,7 +16960,8 @@ msgstr "Tijd verschuiven"
 msgid "Zoom Tool"
 msgstr "Zoomen"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Tekenen"
 
@@ -15740,11 +17037,13 @@ msgstr "Een of meer labelgrenzen verslepen."
 msgid "Drag label boundary."
 msgstr "Labelgrens verslepen."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Label aangepast"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Label bewerken"
 
@@ -15799,31 +17098,42 @@ msgstr "Bewerkte labels"
 msgid "New label"
 msgstr "Nieuw label"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Octaaf naar boven"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Octaaf naar beneden"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klikken om verticaal in te zoomen. Shift-klikken om uit te zoomen. Slepen om op een bepaald gebied te zoomen."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Rechtsklikken voor menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zoom herstellen"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-rechtsklikken"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Links-klikken/links-slepen"
 
@@ -15865,7 +17175,8 @@ msgstr "Samenvoegen"
 msgid "Expanded Cut Line"
 msgstr "Snijlijn uitgebreid"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Uitvouwen"
 
@@ -15888,6 +17199,11 @@ msgstr "Samples verplaatst"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Sample bewerken"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15933,7 +17249,8 @@ msgstr "Verwerken...   %i %%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "‘%s’ gewijzigd in %s"
@@ -15945,6 +17262,54 @@ msgstr "Formatwijziging"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Ratio"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15964,7 +17329,8 @@ msgstr "Snelheidsverandering"
 msgid "Set Rate"
 msgstr "Frequentie instellen"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Multi-weergave"
 
@@ -15983,6 +17349,10 @@ msgstr "Stereotrack splitsen"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Van stereo naar mono splitsen"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16052,14 +17422,23 @@ msgstr "Left, %d Hz"
 msgid "Right, %dHz"
 msgstr "Right, %d Hz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% links"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% rechts"
@@ -16081,6 +17460,16 @@ msgid "Close sub-view"
 msgstr "Subweergave sluiten"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Inzoomen"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Zoomen"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
 msgstr "Halve golf"
 
@@ -16091,6 +17480,11 @@ msgstr "Golfvorm"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Golfkleur"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Muziekinstrument"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -16164,8 +17558,8 @@ msgstr "Logaritmische interpolatie"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klikken en slepen om een track in tijd te verplaatsen, of klik om te selecteren"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16216,6 +17610,7 @@ msgstr "Verloop aangepast."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Scrubben"
@@ -16227,6 +17622,7 @@ msgstr "Zoeken"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Scrub-liniaal"
@@ -16410,6 +17806,24 @@ msgstr "Klikken"
 msgid "Button"
 msgstr "Knop"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16443,13 +17857,28 @@ msgstr "Leeg"
 msgid "Backwards"
 msgstr "Achterwaarts"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Voorwaarts"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Hulp op het internet"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Menu's"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -16570,6 +17999,28 @@ msgstr "Selecteer een actie"
 msgid "01000,01000 seconds"
 msgstr "01000 01000 seconden"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 h 060 m 060<0100 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -16613,6 +18064,13 @@ msgstr "hh:mm:ss + milliseconden"
 msgid "0100 h 060 m 060>01000 s"
 msgstr "0100 h 060 m 060<01000 s"
 
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + samples"
+msgstr "hh:mm:ss + milliseconden"
+
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes, 's' to the abbreviation for seconds and
@@ -16623,6 +18081,15 @@ msgstr "0100 h 060 m 060<01000 s"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s+># samples"
 msgstr "0100 h 060 m 060 s + <# samples"
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "Resampelen"
 
 #. i18n-hint: Format string for displaying time in samples (lots of samples).
 #. * Change the ',' to the 1000s separator for your locale, and translate
@@ -16679,6 +18146,14 @@ msgstr "hh:mm:ss + NTSC drop-frames"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s+>30 frames|N"
 msgstr "0100 h 060 m 060 s + <30 frames|N"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr "hh:mm:ss + NTSC drop-frames"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
@@ -16774,6 +18249,15 @@ msgstr "01000 01000 frames|75"
 msgid "010,01000>0100 Hz"
 msgstr "010 01000<0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -16781,6 +18265,10 @@ msgstr "010 01000<0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0.001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -16821,6 +18309,12 @@ msgstr "1000 semitonen <0100 centiemen|17.312340491"
 msgid "hundredths of cents"
 msgstr "honderdsten van centiemen"
 
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
@@ -16839,6 +18333,11 @@ msgstr "(Gebruik het contextmenu om het formaat te wijzigen)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "centiseconden"
+
+#: src/widgets/PopupMenuTable.h
+#, fuzzy, c-format
+msgid "%s (%s)"
+msgstr "(%s)"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -16901,6 +18400,10 @@ msgstr "Voorkeuren > Mappen"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Deze melding niet meer weergeven"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -16984,15 +18487,27 @@ msgstr "Kon XML niet verwerken"
 msgid "Spectral edit multi tool"
 msgstr "Multitool spectrale bewerking"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filteren..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Vrijgegeven onder de voorwaarden van de GNU General Public LIcense versie 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aSelecteer frequenties."
@@ -17019,7 +18534,8 @@ msgstr ""
 "                      Probeer de lage frequentie te verhogen~%~\n"
 "                      of de filter-'breedte' te verminderen."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Fout.~%"
@@ -17027,6 +18543,11 @@ msgstr "Fout.~%"
 #: plug-ins/SpectralEditParametricEQ.ny
 msgid "Spectral edit parametric EQ"
 msgstr "Spectrale bewerking parametrische EQ"
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Gain (dB)"
+msgstr "Volume (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
@@ -17051,8 +18572,7 @@ msgid ""
 "                        be greater than ~a Hz"
 msgstr ""
 "~aFrequentieselectie is te hoog voor de track-samplerate.~%~\n"
-"                        Voor de huidige track kan de hoge frequentie-"
-"instelling  ~%~\n"
+"                        Voor de huidige track kan de hoge frequentie-instelling  ~%~\n"
 "                        niet groter zijn dan ~a Hz"
 
 #: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
@@ -17077,6 +18597,25 @@ msgstr "Studio-fadeout"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Fade toepassen..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Standaard instellen"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Vrijgegeven onder de voorwaarden van de GNU General Public LIcense versie 2 of later."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17222,6 +18761,11 @@ msgid "Finding beats..."
 msgstr "Beats zoeken..."
 
 #: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Tenacity-log"
+
+#: plug-ins/beat.ny
 msgid "Threshold Percentage"
 msgstr "Drempel-percentage"
 
@@ -17316,6 +18860,11 @@ msgstr "Alternerend in/uit"
 #, lisp-format
 msgid "Error.~%Select 2 (or more) tracks to crossfade."
 msgstr "Fout.~%Selecteer 2 (of meer) tracks om te crossfaden."
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay"
+msgstr "Kleine vertraging"
 
 #: plug-ins/delay.ny
 msgid "Applying Delay Effect..."
@@ -17500,6 +19049,11 @@ msgid "Message on completion"
 msgstr "Bericht bij voltooiing"
 
 #: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Details"
+msgstr "Details"
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "Alleen waarschuwingen"
 
@@ -17536,13 +19090,38 @@ msgstr "Highpass-filter"
 msgid "Performing High-Pass Filter..."
 msgstr "Highpass-filter uitvoeren..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequentie (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB per octaaf)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17563,10 +19142,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Geluiden labelen"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Vrijgegeven onder de voorwaarden van de GNU General Public LIcense versie 2 of later."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17637,8 +19212,7 @@ msgstr "~a h ~a m ~a s"
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Too many silences detected.~%Only the first 10000 labels added."
-msgstr ""
-"Te veel stiltes gedetecteerd. ~%Alleen de eerste 10000 labels toegevoegd."
+msgstr "Te veel stiltes gedetecteerd. ~%Alleen de eerste 10000 labels toegevoegd."
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -17657,8 +19231,18 @@ msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one
 msgstr "Het labelen van gebieden tussen geluiden~%vereist ten minste twee geluiden.~%Er is slechts een geluid gedetecteerd."
 
 #: plug-ins/limiter.ny
+#, fuzzy
+msgid "Limiter"
+msgstr "dB-limiet"
+
+#: plug-ins/limiter.ny
 msgid "Limiting..."
 msgstr "Limiteren..."
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Type"
+msgstr "EQ-type:"
 
 #: plug-ins/limiter.ny
 msgid "Soft Limit"
@@ -17722,6 +19306,10 @@ msgid "Select Function"
 msgstr "Functie selecteren"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
 msgstr "Ruisniveau analyseren"
 
@@ -17748,6 +19336,16 @@ msgstr "Frequenties gaten boven (kHz)"
 #: plug-ins/noisegate.ny
 msgid "Level reduction (dB)"
 msgstr "Niveaureductie (dB)"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Attack (ms)"
+msgstr "Attack-tijd"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Decay (ms)"
+msgstr "Decay (seconden)"
 
 #: plug-ins/noisegate.ny
 #, lisp-format
@@ -17836,6 +19434,11 @@ msgid "Select file(s) to install"
 msgstr "Bestand(en) selecteren om te installeren"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Plug-in"
+msgstr "Plugin-ondersteuning"
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Lisp file"
 msgstr "Lisp-bestand"
 
@@ -17843,7 +19446,8 @@ msgstr "Lisp-bestand"
 msgid "HTML file"
 msgstr "HTML-bestand"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Tekstbestand"
 
@@ -17920,6 +19524,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI-waarden voor C-noten: 36, 48, 60 [middelste C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Tokkel-MIDI-toonhoogte"
 
@@ -17948,6 +19556,10 @@ msgid "Generating Rhythm..."
 msgstr "Ritme genereren..."
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 beats/minuut"
 
@@ -17964,12 +19576,20 @@ msgid "Swing amount"
 msgstr "Hoeveelheid swing"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
 msgstr "'Aantal balken' op nul instellen om de 'ritme-track duur' in te schakelen."
 
 #: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Aantal balken"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -18028,6 +19648,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI-toonhoogte van sterke beat"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI-toonhoogte van zwakke beat"
 
@@ -18040,8 +19664,17 @@ msgstr ""
 "Ritmespoorduur' in op groter dan nul."
 
 #: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Risset Drum"
+msgstr "Risset Drum genereren..."
+
+#: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Risset Drum genereren..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18058,6 +19691,11 @@ msgstr "Breedte van ruisband (Hz)"
 #: plug-ins/rissetdrum.ny
 msgid "Amount of noise in mix (percent)"
 msgstr "Hoeveelheid ruis in mix (procent)"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amplitude (0 - 1)"
+msgstr "Amplitude (0-1):"
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
@@ -18141,6 +19779,11 @@ msgstr "Berichten weergeven"
 msgid "Errors Only"
 msgstr "Alleen fouten"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -18197,6 +19840,11 @@ msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
 msgstr "Links: ~a lin, ~a dB | Rechts: ~a lin, ~a dB."
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~a samples."
+msgstr "Samples weergeven:"
+
+#: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "~a seconds."
 msgstr "~a seconden."
@@ -18241,6 +19889,11 @@ msgstr "Links: ~a lin, ~a dB | Rechts: ~a lineair, &nbsp;&nbsp;~a dB."
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
 msgstr "sample-data"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample #"
+msgstr "Sample bewerken"
 
 #: plug-ins/sample-data-export.ny
 msgid "Value (linear)"
@@ -18399,6 +20052,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Fout.~%Track-samplerate lager dan 100 Hz wordt niet ondersteund."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Tremolo toepassen..."
 
@@ -18425,6 +20082,10 @@ msgstr "Stem-reductie en -isolatie"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Handeling toepassen..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18548,8 +20209,7 @@ msgid ""
 msgstr ""
 " - Hoewel de Track stereo is het veld duidelijk extra breed.\n"
 "                Dit kan vreemde effecten veroorzaken.\n"
-"                Vooral wanneer het door slechts één luidspreker wordt "
-"afgespeeld."
+"                Vooral wanneer het door slechts één luidspreker wordt afgespeeld."
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -18568,8 +20228,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Deze plug-in werkt alleen met stereotracks."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Vocoder verwerken..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18611,6 +20279,229 @@ msgstr "Frequentie van radar-needles (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Fout.~%Stereotrack vereist."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Tenacity bijwerken"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "Overslaan"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "Update installeren"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Wijzigingslog"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Meer informatie op GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Fout bij controleren op updates"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Kon niet verbinden met de updateserver van Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Bijwerkingsgegevens zijn beschadigd."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Fout bij downloaden van update."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Kan de Tenacity-downloadkoppeling niet openen."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s is beschikbaar!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Opname"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Commit-id:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Cross-platform GUI-bibliotheek"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importeren via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automatische opnameniveau-wijziging gestopt. Onmogelijk om het nog meer te optimaliseren. Nog steeds te hoog."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automatische opnameniveau-wijziging verlaagde het volume naar %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatische opnameniveau-wijziging gestopt. Onmogelijk om het nog meer te optimaliseren. Nog steeds te laag."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automatische opnameniveau-wijziging verhoogde het volume naar %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automatische opnameniveau-wijziging gestopt. Het totale aantal analyses werd overschreden zonder een acceptabel volume te vinden. Nog steeds te hoog."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automatische opnameniveau-wijziging gestopt. Het totale aantal analyses werd overschreden zonder een acceptabel volume te vinden. Nog steeds te laag."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatische opnameniveau-wijziging gestopt. %.2f lijkt een acceptabele waarde te zijn."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "%d ontvangen bij openen van apparaten\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Niet in staat om Portmixer te openen\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Beschikbare mixers:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Beschikbare opnamebronnen:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Beschikbare afspeelvolumes:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Opnamevolume is geëmuleerd\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Opnamevolume is ingebouwd\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Afspeelvolume is geëmuleerd\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Afspeelvolume is ingebouwd\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Onbekende datum en tijd"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-compatibele bestanden"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Niet in staat om decoder aan pijplijn toe te voegen"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer-importer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Niet in staat om streamstatus in pauze te zetten."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index[%02d], type[%s], kanalen[%d], frequentie[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Bestand bevat geen audiostreams."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Niet in staat om bestand te importeren, statuswijziging mislukt."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer-fout: 1%s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mixer"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Afspeelvolume wijzigen..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Afspeelvolume verhogen"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Afspeelvolume verlagen"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Opnamevolume wijzigen..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Opnamevolume verhogen"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Opnamevolume verlagen"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audactiy-handleiding"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Over Tenacity…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Automatische opnameniveau-wijziging (aan/uit)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatische opnameniveau-wijziging"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Automatische opnameniveau-wijziging inschakelen."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Doelpiek:"
+
+#~ msgid "Within:"
+#~ msgstr "Tussen:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Analysetijd:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milliseconden (tijd van een analyse)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Aantal opeenvolgende analyses:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 betekent oneindig"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Opnamevolume"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Afspeelvolume"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Opnamevolume: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Opnamevolume (niet beschikbaar; gebruik systeemmixer)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Afspeelvolume: %.2f (geëmuleerd)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Afspeelvolume %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Afspeelvolume (niet beschikbaar; gebruik systeemmixer)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Mixer-werkbalk"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klikken en slepen om een track in tijd te verplaatsen, of klik om te selecteren"
 
 #~ msgid "Program build date:"
 #~ msgstr "Bouwdatum programma:"
@@ -18698,129 +20589,6 @@ msgstr "Fout.~%Stereotrack vereist."
 #~ msgid "Gra&yscale"
 #~ msgstr "Grijswaarden"
 
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "OK"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland lucius"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Harvey Lubin (logo)"
-msgstr "Harvey Lubin (logotype)"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Script"
-msgstr "Script"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
 #, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s bytes"
-msgstr "%s bytes"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%.4f sec (%d Hz) (%s) = %f"
-msgstr "%.4f seconde (%d Hz) (%s) = %f"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#. i18n-hint: This is the number of the command in the list
-#: src/BatchProcessDialog.cpp
-msgid "Num"
-msgstr "Numer"
-
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
-msgid "Help"
-msgstr "Helpen"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity wordt niet geproduceerd of onderschreven door MuseCY SM Ltd. of "
-"Dominic M Mazzoni."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Het Audacity%s handelsmerk wordt binnen deze software alleen gebruikt voor "
-"beschrijvende en informatieve doeleinden."
-
-#: src/AboutDialog.cpp
-msgid "Emeritus:"
-msgstr "Audacity emeritus:"
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s, tester"
-msgstr "%s, Audacity technicus"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#. i18n-hint: This is the heading for a column in the edit macros dialog
-#: src/BatchProcessDialog.cpp
-msgid "Macro"
-msgstr "Makro"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s medewerkers"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"N.B. De namen zijn gesorteerd in alfabetische volgorde, niet in volgorde van "
-"belangrijkheid."
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"

--- a/locale/oc.po
+++ b/locale/oc.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:22+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Occitan <https://hosted.weblate.org/projects/tenacity/tenacity/oc/>\n"
@@ -14,39 +14,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "&A prepaus de \"Audacity\"..."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Passar"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Canal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Error de dubèrtura de fichièr"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Error de dubèrtura de fichièr"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Enregistrament"
+#: libraries/lib-strings/Internat.cpp
+msgid "Unable to determine"
+msgstr ""
 
 #: libraries/lib-strings/Internat.cpp
 #, c-format
@@ -88,6 +58,20 @@ msgid "2nd Experimental Command"
 msgstr "Mercejaments particulièrs :"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Nyquist Workbench..."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Undo\tCtrl+Z"
+msgstr "&Copiar\tCtrl+C"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Copiar\tCtrl+C"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Cu&t\tCtrl+X"
 msgstr "Co&par\tCtrl+X"
 
@@ -96,43 +80,184 @@ msgid "&Copy\tCtrl+C"
 msgstr "&Copiar\tCtrl+C"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Paste\tCtrl+V"
+msgstr "Co&par\tCtrl+X"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Cle&ar\tCtrl+L"
 msgstr "Escaf&ar\tCtrl+L"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Select A&ll\tCtrl+A"
+msgstr "Seleccionar tot"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Find...\tCtrl+F"
 msgstr "&Cercar...\tCtrl+F"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Go to"
 msgstr "&Anar a"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Select &Font..."
+msgstr "Seleccionar..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Split &Vertically"
+msgstr "Afichar totas las pistas"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Split &Horizontally"
+msgstr "Orizontal"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show S&cript"
+msgstr "Arrestar lo script"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show &Output"
+msgstr "Sortida"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "Barra d'aisinas"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Stop\tF6"
+msgstr "Arrestar"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&About"
 msgstr "A &prepaus"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Arrestar lo script"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Sortida"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+msgid "Load Nyquist script"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Avertiment"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Save Nyquist script"
+msgstr "Lançar lo script"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 per Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 per Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Nyquist Effect Workbench"
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "No matches found"
+msgstr "Cap de periferic pas trobat\n"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
 msgstr "Sens nom"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Nyquist Effect Workbench - "
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Novèl"
 
@@ -153,6 +278,11 @@ msgid "Save"
 msgstr "Enregistrar"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Save script"
+msgstr "Enregistrar lo script coma..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Save As"
 msgstr "Enregistrar jos"
 
@@ -168,7 +298,8 @@ msgstr "Copiar"
 msgid "Copy to clipboard"
 msgstr "Copiar al quicha-papièrs"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Copar"
 
@@ -176,7 +307,8 @@ msgstr "Copar"
 msgid "Cut to clipboard"
 msgstr "Copar cap al pòrtapapièr"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Empegar"
 
@@ -201,12 +333,33 @@ msgstr "Seleccionar tot"
 msgid "Select all text"
 msgstr "Seleccionar tot lo tèxte"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Restablir"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Undo last change"
+msgstr "Cambiament de format"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&Tornar far"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Redo previous change"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find"
+msgstr "Recercar"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find text"
 msgstr "Recercar"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -214,15 +367,44 @@ msgid "Match"
 msgstr "Correspond"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to top S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Precedent"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to previous S-expr"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Seguent"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Aviar"
 
@@ -230,7 +412,8 @@ msgstr "Aviar"
 msgid "Start script"
 msgstr "Lançar lo script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Arrestar"
 
@@ -244,17 +427,71 @@ msgstr "Arrestar lo script"
 msgid "About %s"
 msgstr "A prepaus de %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "OK"
+msgstr "&D'acòrdi"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informacions de generacion"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Activat"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Desactivat"
+
+#. i18n-hint: Information about when audacity was compiled follows
+#: src/AboutDialog.cpp
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Inversion"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr "Tipe de fichièr :"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Config folder:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "Repertòri :"
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -266,6 +503,48 @@ msgid "MP3 Importing"
 msgstr "Importacion MP3"
 
 #: src/AboutDialog.cpp
+msgid "Ogg Vorbis Import and Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "FLAC import and export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "Exportar"
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "FFmpeg Import/Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "Totes los fichièrs preses en carga"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Features"
 msgstr "Foncionalitats"
 
@@ -273,9 +552,145 @@ msgstr "Foncionalitats"
 msgid "GPL License"
 msgstr "Licéncia GPL"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, lead Tenacity developer"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, Tenacity developer"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, Tenacity contributor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, co-founder and developer"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, developer"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, developer and support"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, documentation and support"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, documentation and support, French"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, composer"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, tester"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, Nyquist plug-ins"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, web developer"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "<h3>"
 msgstr "&Find...\tCtrl+F"
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Credits"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "DarkTenacity Customisation"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s Contributors"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -286,6 +701,41 @@ msgstr "Mercejaments particulièrs :"
 msgid "Libraries"
 msgstr "Bibliotècas"
 
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s includes code from the following projects:"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s Team Members"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Contributors"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
+
+#. i18n-hint: The translation of "translator_credits" will appear
+#. *  in the credits in the About Audacity window.  Use this to add
+#. *  your own name(s) to the credits.
+#. *
+#. *  For example:  "English translation by Dominic Mazzoni."
+#.
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "translator_credits"
+msgstr "Traductors"
+
 #: src/AboutDialog.cpp
 msgid "Translators"
 msgstr "Traductors"
@@ -294,13 +744,193 @@ msgstr "Traductors"
 msgid "Special thanks:"
 msgstr "Mercejaments particulièrs :"
 
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s website: "
+msgstr ""
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr ""
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Click and drag to adjust, double-click to reset"
+msgstr "Clicar-rossegar per calar temporalament una pista"
+
+#. i18n-hint: This text is a tooltip on the icon (of a pin) representing
+#. the temporal position in the audio.
+#: src/AdornedRulerPanel.cpp
+msgid "Record/Play head"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Ora"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Click or drag to begin Seek"
+msgstr "Clicar-rossegar per modificar los escandilhs."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Click or drag to begin Scrub"
+msgstr "Clicar-rossegar per seleccionar l'audiò."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Move to Seek"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Move to Scrub"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Move to Scrub. Drag to Seek."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Quick-Play disabled"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Quick-Play enabled"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Timeline Options"
+msgstr "Opcions generalas"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Enable dragging selection"
+msgstr "Fa venir la seleccion muda"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Pinned Play Head"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Error"
+msgstr "ErrorError.~%"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid "Failed to remove %s"
+msgstr ""
+
 #: src/AudacityApp.cpp
 msgid "Failed!"
 msgstr "Fracàs !"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Restablir las preferéncias d'Audacity"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -321,7 +951,7 @@ msgstr "&Dubrir..."
 msgid "Open &Recent..."
 msgstr "Recentament dobèrts..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&A prepaus de \"Audacity\"..."
@@ -335,36 +965,196 @@ msgid "&File"
 msgstr "&Fichièr"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity pòt pas trapar de plaça per estocar los fichièrs temporaris.\n"
 "Dintratz, se vos plai, un repertòri apropriat dins la boita de dialòg de las preferéncias."
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid ""
+"Tenacity could not find a place to store temporary files.\n"
+"Please enter an appropriate directory in the preferences dialog."
+msgstr ""
+"Audacity pòt pas trapar de plaça per estocar los fichièrs temporaris.\n"
+"Dintratz, se vos plai, un repertòri apropriat dins la boita de dialòg de las preferéncias."
+
+#: src/AudacityApp.cpp
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Running two copies of Tenacity simultaneously may cause\n"
+"data loss or cause your system to crash.\n"
+"\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Volètz totjorn lançar Audacity ?"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/AudacityApp.cpp
+msgid "The system has detected that another copy of Tenacity is running.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Use the New or Open commands in the currently running Tenacity\n"
+"process to open multiple projects simultaneously.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity es ja dubèrt"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
+msgstr "Audacity es a se lançar..."
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
+
+#. i18n-hint: This displays a list of available options
+#: src/AudacityApp.cpp
+msgid "this help message"
+msgstr ""
+
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+msgid "run self diagnostics"
+msgstr ""
+
+#. i18n-hint: This displays the Audacity version
+#: src/AudacityApp.cpp
+msgid "display Tenacity version"
+msgstr ""
+
+#. i18n-hint: This is a list of one or more files that Audacity
+#. *           should open upon startup
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "audio or project file name"
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Audacity project (.aup3) files are not currently \n"
+"associated with Tenacity. \n"
+"\n"
+"Associate them, so they open on double-click?"
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Audacity Project Files"
 msgstr "Fichièr projècte Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Messatge"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+msgid "Tenacity Configuration Error"
+msgstr ""
+
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Ajuda"
+
+#: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Quit Tenacity"
+msgstr "&A prepaus de \"Audacity\"..."
 
 #: src/AudacityFileConfig.cpp
 msgid "&Retry"
 msgstr "&Tornar ensajar"
+
+#: src/AudacityLogger.cpp
+msgid "Tenacity Log"
+msgstr ""
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
@@ -375,9 +1165,33 @@ msgstr "&Enregistrar..."
 msgid "Cl&ear"
 msgstr "&Escafar"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Barrar"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+msgid "Save log to:"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy, c-format
+msgid "Couldn't save log to file: %s"
+msgstr "Impossible d'enregistrar lo fichièr : "
+
+#: src/AudioIO.cpp
+msgid "Could not find any audio devices.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid ""
+"You will not be able to play or record audio.\n"
+"\n"
+msgstr ""
 
 #: src/AudioIO.cpp
 #, c-format
@@ -389,12 +1203,57 @@ msgid "Error Initializing Audio"
 msgstr "Error d'initialisacion audio"
 
 #: src/AudioIO.cpp
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "Error d'initialisacion audio"
+
+#: src/AudioIO.cpp
+msgid "Tenacity Audio"
+msgstr ""
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
+
+#: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Memòria insufisenta !"
 
 #: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Default recording device number: %d\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Default playback device number: %d\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
 msgid "No devices found\n"
 msgstr "Cap de periferic pas trobat\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Device info unavailable for: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -416,32 +1275,173 @@ msgstr "Nom d'òste : %s\n"
 msgid "Recording channels: %d\n"
 msgstr "Canal d'enregistrament : %d\n"
 
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Playback channels: %d\n"
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Recording Latency: %g\n"
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Recording Latency: %g\n"
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "High Playback Latency: %g\n"
+msgstr ""
+
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 msgid "Supported Rates:\n"
 msgstr "Taus preses en cargar :\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Fonts d'enregistrament disponiblas :\n"
+#, c-format
+msgid "Selected recording device: %d - %s\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Cap de periferic pas trobat\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Selected playback device: %d - %s\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Cap de periferic pas trobat\n"
+
+#: src/AudioIOBase.cpp
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Taus preses en cargar :\n"
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Selected MIDI recording device: %d - %s\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Selected MIDI playback device: %d - %s\n"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "No MIDI playback device found for '%s'.\n"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Automatic Crash Recovery"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
+"\n"
+"After recovery, save the projects to ensure changes are written to disk."
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Recoverable &projects"
+msgstr ""
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Seleccion"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nom"
+
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Discard Selected"
+msgstr "&Enregistrar lo projècte"
+
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Recover Selected"
+msgstr "Seleccionat"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "&Skip"
 msgstr "&Passar"
 
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "No projects selected"
+msgstr "Pas pro de donadas seleccionadas"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
+
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
 msgstr "Seleccionar una comanda"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Command"
+msgstr "Comanda"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Edit Parameters"
+msgstr "Paramètres"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Use Preset"
+msgstr "Enregistrar la preseleccion"
+
+#: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Parameters"
+msgstr "Paramètres"
 
 #: src/BatchCommandDialog.cpp
 msgid "&Details"
@@ -456,8 +1456,81 @@ msgid "MP3 Conversion"
 msgstr "Conversion MP3"
 
 #: src/BatchCommands.cpp
+#, fuzzy
+msgid "Fade Ends"
+msgstr "Fondre en dubèrtura"
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Import Macro"
+msgstr "Importar MIDI"
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Export Macro"
+msgstr "Exportar"
+
+#: src/BatchCommands.cpp
 msgid "Effect"
 msgstr "Efèit"
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (With Parameters)"
+msgstr ""
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+msgid "Menu Command (No Parameters)"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Your batch command of %s was not recognized."
+msgstr ""
+
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+msgid "Applied Macro"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Apply Macro"
+msgstr "Aplicar %s"
+
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Applied Macro '%s'"
+msgstr "Efièch·aplicat·: %s"
+
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Apply '%s'"
+msgstr "Aplicar %s"
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid ""
+"Apply %s with parameter(s)\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Test Mode"
@@ -469,8 +1542,69 @@ msgid "Apply %s"
 msgstr "Aplicar %s"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
+#. i18n-hint: A macro is a sequence of commands that can be applied
+#. * to one or more audio files.
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Select Macro"
+msgstr "Seleccion"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+msgid "Macro"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Apply Macro to:"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Apply macro to project"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "&Project"
+msgstr "Projècte"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to files..."
+msgstr "Aplicacion de \"Phaser\""
+
+#: src/BatchProcessDialog.cpp
 msgid "&Files..."
 msgstr "&Fichièrs..."
+
+#. i18n-hint: The Expand button makes the dialog bigger, with more in it
+#: src/BatchProcessDialog.cpp
+msgid "&Expand"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "No macro selected"
+msgstr "Pas pro de donadas seleccionadas"
+
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Applying '%s' to current project"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Please save and close the current project first."
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Select file(s) for batch processing..."
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Applying..."
@@ -484,9 +1618,39 @@ msgstr "Fichièr"
 msgid "&Cancel"
 msgstr "&Anullar"
 
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Remo&ve"
+msgstr "Suprimir"
+
 #: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
 msgid "&Rename..."
 msgstr "&Tornar nomenar..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "Importar..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "Exportar..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Edit Steps"
+msgstr "Modificar las etiquetas"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -496,6 +1660,10 @@ msgstr "Comanda "
 msgid "Parameters"
 msgstr "Paramètres"
 
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp
+msgid "&Insert"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "&Edit..."
 msgstr "&Edicion..."
@@ -504,31 +1672,404 @@ msgstr "&Edicion..."
 msgid "De&lete"
 msgstr "&Suprimir"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+msgid "Move &Up"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+msgid "Move &Down"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Enregistrar"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
+
+#. i18n-hint: This is the last item in a list.
+#: src/BatchProcessDialog.cpp
+msgid "- END -"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "%s changed"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Do you want to save the changes?"
 msgstr "Volètz enregistrar las modificacions ?"
+
+#: src/BatchProcessDialog.cpp
+msgid "Enter name of new macro"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Name of new macro"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Name must not be blank"
+msgstr ""
+
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Names may not contain '%c' and '%c'"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of a file.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Are you sure you want to delete %s?"
+msgstr ""
+
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Benchmark"
+msgstr "&Lançar Tèst de performanças..."
+
+#: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of Edits:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Run"
 msgstr "Executar"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Barrar"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "&Lançar Tèst de performanças..."
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Export Benchmark Data as:"
+msgstr "Exportar las donadas espectralas jos :"
+
+#: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Preparacion...\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Performing %d edits...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Paste: %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Reading data again...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"You must first select some audio for '%s' to act on.\n"
+"\n"
+"Ctrl + A selects all audio."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
 #, fuzzy
-msgid "Unknown date and time"
-msgstr "Format desconegut"
+msgid "No Audio Selected"
+msgstr "Seleccionat"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Failed to set safe mode on primary connection to %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Failed to set safe mode on checkpoint connection to %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, fuzzy
+msgid "Checkpointing project"
+msgstr "Enregistrament del projècte"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Checkpointing %s"
+msgstr ""
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Could not write to %s.\n"
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Failed to create savepoint:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Failed to release savepoint:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Removing Dependencies"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copying audio data into project..."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Project Depends on Other Audio Files"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Project Dependencies"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Audio File"
@@ -539,12 +2080,30 @@ msgid "Disk Space"
 msgstr "Espaci disc"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "Seleccionar un fichièr"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "Anullar enregistrament"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Enregistrar la còpia"
+
+#: src/Dependencies.cpp
 msgid "Do Not Copy"
 msgstr "Copiar pas"
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Whenever a project depends on other files:"
+msgstr ""
 
 #. i18n-hint: One of the choices of what you want Audacity to do when
 #. * Audacity finds a project depends on another file.
@@ -552,15 +2111,58 @@ msgstr "Copiar pas"
 msgid "Ask me"
 msgstr "Me demandar"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "Seleccionar un fichièr"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "&Copiar cap al quichapapièrs"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Mancant"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dependencies.cpp
+msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Dependency Check"
+msgstr ""
+
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Pas cap"
 
@@ -568,29 +2170,214 @@ msgstr "Pas cap"
 msgid "Rectangle"
 msgstr "Rectangular"
 
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Triangle"
+msgstr ""
+
 #: src/Dither.cpp
 msgid "Shaped"
 msgstr "Onda"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFT.cpp
+#, fuzzy
+msgid "Rectangular"
+msgstr "Rectangular"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Benvenguda !"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Emplaçament"
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "To find '%s', click here -->"
+msgstr ""
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Percórrer..."
+
+#: src/FFmpeg.cpp
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr ""
 
 #. i18n-hint: (verb)
 #: src/FFmpeg.cpp src/export/ExportMP3.cpp
 msgid "Download"
 msgstr "Telecargament"
 
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "Suprimir « %s » ?"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "Mostrar pas mai aquel avertiment"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
+"Perhaps %s is not writable or the disk is full.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
 #  i18n-hint: You do not need to translate "LOF"
 #: src/FileException.h
 msgid "File Error"
 msgstr "Error de fichièr"
 
+#. i18n-hint: %s will be the error message from the libsndfile software library
+#: src/FileFormats.cpp
+#, c-format
+msgid "Error (file may not have been written): %s"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy all audio into project (safest)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
 #: src/FileFormats.cpp
 msgid "As&k"
 msgstr "Deman&dar"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Totes los fichièrs"
 
@@ -601,6 +2388,15 @@ msgid "AUP3 project files"
 msgstr "Fichièr projècte AUP3"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamic Libraries"
+msgstr "Bibliotècas"
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "Fichièrs tèxte"
 
@@ -608,12 +2404,24 @@ msgstr "Fichièrs tèxte"
 msgid "XML files"
 msgstr "Fichièrs XML"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "%s fichièrs"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -627,6 +2435,11 @@ msgstr "Analisi de frequéncias"
 #: src/FreqWindow.cpp src/prefs/SpectrumPrefs.h
 msgid "Spectrum"
 msgstr "Espèctre"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Standard Autocorrelation"
+msgstr "Autocorrelacion Avançada"
 
 #: src/FreqWindow.cpp
 msgid "Cuberoot Autocorrelation"
@@ -646,9 +2459,51 @@ msgstr "Autocorrelacion Avançada"
 msgid "Cepstrum"
 msgstr "Cepstre"
 
+#. i18n-hint: This refers to a "window function",
+#. * such as Hann or Rectangular, used in the
+#. * Frequency analyze dialog box.
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%s window"
+msgstr "Fenèstra"
+
 #: src/FreqWindow.cpp
 msgid "Linear frequency"
 msgstr "Frequéncia linearia"
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Log frequency"
+msgstr "Frequéncia bassa"
+
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoom avant"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -665,20 +2520,98 @@ msgid "Cursor:"
 msgstr "Cursor :"
 
 #: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "&Algorithm:"
+msgstr "Algoritme"
+
+#: src/FreqWindow.cpp
 msgid "&Size:"
 msgstr "&Talha : "
+
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Export..."
+msgstr "Exportar..."
 
 #: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "&Foncion :"
 
 #: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "&Replot..."
+msgstr "&Importar..."
+
+#: src/FreqWindow.cpp
+msgid "To plot the spectrum, all selected tracks must be the same sample rate."
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, c-format
+msgid "Too much audio was selected. Only the first %.1f seconds of audio will be analyzed."
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "Not enough data selected."
 msgstr "Pas pro de donadas seleccionadas"
+
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Espèctre"
 
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Exportar las donadas espectralas jos :"
+
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
+#, fuzzy, c-format
+msgid "Couldn't write to file: %s"
+msgstr "Impossible de dubrir lo fichièr : "
 
 #: src/FreqWindow.cpp
 msgid "Frequency (Hz)\tLevel (dB)"
@@ -688,17 +2621,138 @@ msgstr "Frequéncia (Hz)\tNivèl (dB)"
 msgid "Lag (seconds)\tFrequency (Hz)\tLevel"
 msgstr "Desencalatge (segondas)\tFrequéncia (Hz)\tNivèl"
 
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Plot Spectrum..."
+msgstr "Espèctre"
+
 #: src/HelpText.cpp
 msgid "Welcome!"
 msgstr "Benvenguda !"
 
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "Lectura"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording Audio"
+msgstr "Audio gravat"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Recording - Choosing the Recording Device"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Recording - Choosing the Recording Source"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Recording - Setting the Recording Level"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Fichièr àudio"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Dubertura d'un projècte Audacity"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
 msgid "Burn to CD"
 msgstr "Gravar sul CD"
 
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
 #: src/HistoryWindow.cpp
 msgid "History"
+msgstr "Istoric"
+
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Manage History"
 msgstr "Istoric"
 
 #: src/HistoryWindow.cpp src/effects/TruncSilence.cpp plug-ins/vocalrediso.ny
@@ -710,14 +2764,59 @@ msgid "Used Space"
 msgstr "Espaci utilizat"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
+msgid "&Undo levels available"
+msgstr ""
+
+#: src/HistoryWindow.cpp
+msgid "&Levels to discard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/HistoryWindow.cpp
+#, fuzzy
+msgid "&Discard"
+msgstr "I&gnorar"
+
+#: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "I&gnorar"
+
+#: src/HistoryWindow.cpp
+msgid "&Compact"
+msgstr ""
+
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Istoric..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -733,7 +2832,9 @@ msgid "Track"
 msgstr "Pista"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Marcador"
 
@@ -761,23 +2862,78 @@ msgstr "Frequéncia nauta"
 msgid "New..."
 msgstr "Novèl..."
 
+#: src/LabelDialog.cpp
+msgid "Press F2 or double click to edit cell contents."
+msgstr ""
+
+#: src/LabelDialog.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Select a text file containing labels"
+msgstr "Causir un fichièr XML que conten d'acorchas clavièr..."
+
+#: src/LabelDialog.cpp src/ProjectFileManager.cpp src/menus/FileMenus.cpp
+#, fuzzy, c-format
+msgid "Could not open file: %s"
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/LabelDialog.cpp
+msgid "No labels to export."
+msgstr ""
+
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Export Labels As:"
 msgstr "Exportar los marcadors jos :"
 
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "New Label Track"
+msgstr "Novèla pista"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Enter track name"
+msgstr "Cambiar lo nom de la pista en : "
+
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "Poliça de la pista de marcadors"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Primièr desmarratge d'Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Causir la lenga qu'Audiacity utilizarà :"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirmar"
+
+#: src/Legacy.cpp
+msgid "Error Converting Legacy Project File"
+msgstr ""
 
 #: src/Legacy.cpp
 #, c-format
@@ -789,8 +2945,19 @@ msgstr ""
 "L'ancian fichièr es estat salvegardat jos '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Dubertura d'un projècte Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Mercejaments particulièrs :"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "&Enregistrar..."
 
 #: src/Menus.cpp
 #, c-format
@@ -810,59 +2977,309 @@ msgstr "&Tornar far %s"
 msgid "&Redo"
 msgstr "&Tornar far"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "Desactivat"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
 msgstr "Mescla"
 
+#: src/Mix.cpp src/menus/TrackMenus.cpp
+msgid "Mix and Render"
+msgstr ""
+
+#: src/Mix.cpp
+msgid "Mixing and rendering tracks"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr ""
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Ganh"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocitat"
 
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panoramic"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Mut"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Solò"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Cursor de nivèl desplaçat"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Cursor de nivèl desplaçat"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Cursor de panoramic desplaçat"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/MixerBoard.cpp
+msgid "&Mixer Board..."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"Unable to load the \"%s\" module.\n"
+"\n"
+"Error: %s"
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid "Module Unsuitable"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Òc"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Pas cap"
+
+#: src/ModuleManager.cpp
+msgid "Tenacity Module Loader"
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Pista de nòta"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, fuzzy, c-format
+msgid "Overwrite the plug-in file %s?"
+msgstr "Espotir los fichièrs existissents"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, c-format
+msgid ""
+"Failed to register:\n"
+"%s"
+msgstr ""
 
 #. i18n-hint A plug-in is an optional added program for a sound
 #. effect, or generator, or analyzer
@@ -872,6 +3289,29 @@ msgid "Enable this plug-in?\n"
 msgid_plural "Enable these plug-ins?\n"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/PluginManager.cpp
+msgid "Enable new plug-ins"
+msgstr ""
+
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Manage Plug-ins"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Afichar"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -885,8 +3325,20 @@ msgstr "&Tot selectionar"
 
 #. i18n-hint: Radio button to show just the currently disabled effects
 #: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show disabled"
+msgstr "(desactivat)"
+
+#. i18n-hint: Radio button to show just the currently disabled effects
+#: src/PluginRegistrationDialog.cpp
 msgid "D&isabled"
 msgstr "Des&activat"
+
+#. i18n-hint: Radio button to show just the currently enabled effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show enabled"
+msgstr "Afichar tot"
 
 #. i18n-hint: Radio button to show just the currently enabled effects
 #: src/PluginRegistrationDialog.cpp
@@ -898,6 +3350,11 @@ msgstr "&Activat"
 msgid "Show new"
 msgstr "Afichar los novèls"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "State"
 msgstr "Estat"
@@ -906,7 +3363,18 @@ msgstr "Estat"
 msgid "Path"
 msgstr "Camin"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "&Select All"
+msgstr "Seleccionar tot"
+
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "C&lear All"
+msgstr "Escafar"
+
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Activar"
 
@@ -914,9 +3382,75 @@ msgstr "&Activar"
 msgid "&Disable"
 msgstr "&Desactivar"
 
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Enabling effects or commands:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Enabling effect or command:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Effect or Command at %s failed to register:\n"
+"%s"
+msgstr ""
+
+#: src/Printing.cpp
+msgid "There was a problem printing."
+msgstr ""
+
 #: src/Printing.cpp
 msgid "Print"
 msgstr "Estampar"
+
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+#, c-format
+msgid "Actual Rate: %d"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/effects/Effect.cpp
+#, fuzzy
+msgid ""
+"Error opening sound device.\n"
+"Try changing the audio host, playback device and the project sample rate."
+msgstr "Error a la dubèrtura del periferic son. Verificatz los reglatges del periferic e l'escandalhatge del projècte"
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
 
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
@@ -926,27 +3460,517 @@ msgstr "Audio gravat"
 msgid "Record"
 msgstr "Enregistrar"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no further changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progression"
+
+#: src/ProjectFSCK.cpp
+msgid "Cleaning up unused directories in project data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
 
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<senstítol >"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projècte"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to open the project's database"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to open database file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to discard connection"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Failed to restore connection"
+msgstr "Frequéncia d'escandalhatge :"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to execute a project file command:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to prepare project file command:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Unable to initialize the project file"
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+msgid "Unable to work with the blockfiles"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to attach destination database"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to bind SQL parameter"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Copying Project"
+msgstr "Enregistrament del projècte"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Error Writing to File"
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write file %s.\n"
+"Perhaps disk is full or not writable.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Compacting project"
+msgstr "Enregistrament del projècte"
+
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Velocitat"
+
+#. i18n-hint: E.g this is recovered audio that had been lost.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "(Recovered)"
+msgstr "Enregistrar"
+
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to bind to blob"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to decode project document"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Unable to parse project information."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Enregistrament del projècte"
 
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Enregistrament del projècte"
+
 #: src/ProjectFileIO.cpp
 msgid "Syncing"
 msgstr "Sincronizacion"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "Enregistrament del projècte"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Project Recovered"
+msgstr "Suprimir la (las) pista(s)"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "Enregistrament del projècte"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Insufficient Disk Space"
+msgstr "Espaci disc"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -954,13 +3978,98 @@ msgid "Saved %s"
 msgstr "%s enregistrat"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy, c-format
+msgid "%sSave Project \"%s\" As..."
+msgstr "Enregistrar lo projècte &jos..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
+
+#. i18n-hint: Heading: A warning that a project is about to be overwritten.
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Overwrite Project Warning"
+msgstr "Espotir los fichièrs existissents"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy, c-format
+msgid "%sSave Copy of Project \"%s\" As..."
+msgstr "Enregistrar lo projècte &jos..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Copy of Project"
+msgstr "Enregistrament del projècte"
+
+#: src/ProjectFileManager.cpp
 msgid "Can't open new empty project"
 msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error opening a new empty project"
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/ProjectFileManager.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Select one or more files"
+msgstr "Seleccionar un fichièr"
 
 #: src/ProjectFileManager.cpp
 #, c-format
 msgid "%s is already open in another window."
 msgstr "%s est déjà ouvert dans une autre fenêtre."
+
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
@@ -972,6 +4081,33 @@ msgstr "Error de dubèrtura de fichièr"
 
 #: src/ProjectFileManager.cpp
 #, c-format
+msgid ""
+"File may be invalid or corrupted: \n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Project was recovered"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Recover"
+msgstr "Enregistrar"
+
+#: src/ProjectFileManager.cpp
+#, c-format
 msgid "Imported '%s'"
 msgstr "« %s » importat"
 
@@ -980,17 +4116,80 @@ msgid "Import"
 msgstr "Importar"
 
 #: src/ProjectFileManager.cpp
+msgid "Failed to import project"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Error Importing"
 msgstr "Error d'importacion"
+
+#: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact Project"
+msgstr "&Enregistrar lo projècte"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compacted project file"
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/ProjectFileManager.cpp
+msgid "Compact"
+msgstr ""
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
 msgstr "Novèl projècte creat"
 
+#: src/ProjectHistory.cpp
+msgid "Automatic database backup failed."
+msgstr ""
+
+#: src/ProjectManager.cpp
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
+msgstr "La benvenguda a Audacity version %s"
+
+#. i18n-hint: The first %s numbers the project, the second %s is the project name.
+#: src/ProjectManager.cpp
+#, fuzzy, c-format
+msgid "%sSave changes to %s?"
+msgstr "« %s » cambiat en %s"
+
+#: src/ProjectManager.cpp
+msgid "Save project before closing?"
+msgstr ""
+
+#: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
 #: src/ProjectManager.cpp
 #, c-format
-msgid "Welcome to Audacity version %s"
-msgstr "La benvenguda a Audacity version %s"
+msgid "Disk space remaining for recording: %s"
+msgstr ""
 
 #: src/ProjectManager.cpp
 msgid "Less than 1 minute"
@@ -1010,6 +4209,53 @@ msgid_plural "%d minutes"
 msgstr[0] "%d minuta"
 msgstr[1] "%d minutas"
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
+#. i18n-hint: This is an experimental feature where the main panel in
+#. Audacity is put on a notebook tab, and this is the name on that tab.
+#. Other tabs in that notebook may have instruments, patch panels etc.
+#: src/ProjectWindow.cpp
+msgid "Main Mix"
+msgstr ""
+
+#: src/ProjectWindow.cpp
+#, fuzzy
+msgid "Horizontal Scrollbar"
+msgstr "Orizontal"
+
+#: src/ProjectWindow.cpp
+msgid "Vertical Scrollbar"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+msgid "Low Quality (Fastest)"
+msgstr ""
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Qualitat mejana"
@@ -1018,69 +4264,329 @@ msgstr "Qualitat mejana"
 msgid "High Quality"
 msgstr "Nauta qualitat"
 
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+msgid "16-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+msgid "24-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
 #: src/SampleFormat.cpp
 msgid "Unknown format"
 msgstr "Format desconegut"
 
 #: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
 msgid "Choose location to save files"
 msgstr "Causir un luòc per salvagardar los fichièrs"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "Enregistrar la preseleccion"
 
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Causir..."
 
 #: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Resize Small"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Resize Large"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "White Bkgnd"
+msgstr "Blanc"
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture Full Window"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture Window Plus"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Screen"
+msgstr "Plen ecran"
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture part of a project window"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "&Barra d'aisinas"
+
+#: src/Screenshot.cpp
 msgid "All Effects"
 msgstr "Totes los efèits"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Scriptables"
+msgstr "Totes los fichièrs"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Preferences"
+msgstr "Preferéncias"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Seleccion"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Spectral Selection"
+msgstr "Definir un punt de seleccion"
 
 #: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
 msgid "Timer"
 msgstr "Minutador"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Aisinas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Transpòrt"
 
+#: src/Screenshot.cpp
+msgid "Mixer"
+msgstr ""
+
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Mètre"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Play Meter"
+msgstr "Mètre"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Record Meter"
+msgstr "Enregistrar"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Editacion"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Periferic"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play-at-Speed"
+msgstr "Velocitat de lectura"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Scrub"
+msgstr ""
+
+#: src/Screenshot.cpp src/TrackPanel.cpp
+#, fuzzy
+msgid "Track Panel"
+msgstr "Pista 0"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
 
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Pistas"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "Pista de nòta"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "Suprimir· la pista"
 
 #: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
 msgid "Scale"
 msgstr "Escala"
+
+#: src/Screenshot.cpp
+msgid "One Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "Pista de nòta"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "Bolegar la pista"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "Totas las pistas"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "Causir un luòc per salvagardar los fichièrs exportats"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "Messatge"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
 msgstr "&Apercebut"
 
 #: src/ShuttleGui.cpp
+#, fuzzy
+msgid "Dry Previe&w"
+msgstr "&Apercebut"
+
+#: src/ShuttleGui.cpp
 msgid "&Settings"
 msgstr "&Paramètres"
+
+#: src/ShuttleGui.cpp
+msgid "Debu&g"
+msgstr ""
 
 #: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
 msgid "Off"
 msgstr "Desactivat"
+
+#: src/Snap.cpp
+msgid "Nearest"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+msgid "Sound Activated Record"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+msgid "Activation level (dB):"
+msgstr ""
+
+#: src/SplashDialog.cpp
+#, fuzzy
+msgid "Welcome to Tenacity!"
+msgstr "La benvenguda a Audacity version %s"
+
+#: src/SplashDialog.cpp
+#, fuzzy
+msgid "Don't show this again at start up"
+msgstr "Mostrar pas mai aquel avertiment"
+
+#: src/SqliteSampleBlock.cpp
+#, fuzzy
+msgid "Connection to project file is null"
+msgstr "Impossible de dubrir lo fichièr projècte"
 
 #: src/Tags.cpp
 msgid "Artist Name"
@@ -1095,12 +4601,25 @@ msgid "Album Title"
 msgstr "Títol de l'album"
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Track Number"
+msgstr "Pista 0"
+
+#: src/Tags.cpp
 msgid "Year"
 msgstr "Annada"
+
+#: src/Tags.cpp
+msgid "Genre"
+msgstr ""
 
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
 msgstr "Comentaris"
+
+#: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Tag"
@@ -1111,12 +4630,204 @@ msgid "Value"
 msgstr "Valor"
 
 #: src/Tags.cpp
+msgid "&Add"
+msgstr ""
+
+#: src/Tags.cpp
 msgid "&Remove"
 msgstr "&Suprimir "
 
 #: src/Tags.cpp
+msgid "Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&Edicion..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "Seleccionar..."
+
+#: src/Tags.cpp
 msgid "Template"
 msgstr "Modèl"
+
+#: src/Tags.cpp
+msgid "&Load..."
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "Restaurar las valors per defaut"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Don't show this when exporting audio"
+msgstr "Mostrar pas mai aquel avertiment"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Edit Genres"
+msgstr "Modificar las etiquetas"
+
+#: src/Tags.cpp
+msgid "Unable to save genre file."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Reset Genres"
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Are you sure you want to reset the genre list to defaults?"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to open genre file."
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/Tags.cpp
+msgid "Load Metadata As:"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/Tags.cpp
+msgid "Save Metadata As:"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid "Unsuitable"
+msgstr "Activar"
+
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
+"  %s."
+msgstr "Impossible de dubrir lo fichièr : "
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
+"  %s\n"
+"for writing."
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not write images to file:\n"
+"  %s."
+msgstr ""
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not create directory:\n"
+"  %s"
+msgstr "Impossible d'enregistrar lo fichièr : "
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not save file:\n"
+"  %s"
+msgstr "Impossible de dubrir lo fichièr : "
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+#, fuzzy
+msgid "Classic"
+msgstr "Classic"
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
@@ -1145,34 +4856,329 @@ msgstr "Personalizat"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Durada"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "Novèla pista"
+
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Save Timer Recording As"
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Error Saving Timer Recording Project"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "Durada"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Error in Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export path is invalid."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Error in Automatic Export"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Timer Recording Disk Space Warning"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Current Project"
+msgstr "Novèl projècte creat"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Recording start:"
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Durada :"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Recording end:"
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export enabled:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Action after Timer Recording:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record Progress"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording stopped."
+msgstr "Enregistrament\n"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording completed."
+msgstr "Enregistrament\n"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Recording saved: %s"
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Recording exported: %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Timer Recording"
+msgstr "Enregistrament"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint a format string for days, hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: This string is used to configure the controls for times when the recording is
+#. * started and stopped. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
+#. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date and Time"
+msgstr "Data iniciala"
 
 #: src/TimerRecordDialog.cpp
 msgid "Start Date"
 msgstr "Data iniciala"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date and Time"
+msgstr "Format desconegut"
+
+#: src/TimerRecordDialog.cpp
 msgid "End Date"
 msgstr "Data finala"
+
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Enable &Automatic Save?"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Save Project As:"
+msgstr "Enregistrar lo projècte &jos..."
 
 #: src/TimerRecordDialog.cpp src/menus/PluginMenus.cpp
 msgid "Select..."
 msgstr "Seleccionar..."
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp
+msgid "Automatic Export"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Enable Automatic &Export?"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Export Project As:"
+msgstr "Exportar los marcadors jos :"
+
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcions"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "After Recording completes:"
+msgstr "Enregistrament\n"
+
+#: src/TimerRecordDialog.cpp
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
+msgstr "&A prepaus de \"Audacity\"..."
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Recording duration:"
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp
+msgid "Scheduled to stop at:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr ""
+
+#. i18n-hint: "in" means after a duration of time,
+#. which is shown below this string
+#: src/TimerRecordDialog.cpp
+msgid "Recording will commence in:"
+msgstr ""
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Recording Saved:"
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Recording Exported:"
+msgstr "Enregistrament"
+
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting"
+msgstr ""
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
 msgid "(Esc to cancel)"
 msgstr "(Esc per anullar)"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Pista"
 
 #. i18n-hint: The %d is replaced by the number of the track.
 #. i18n-hint: compose a name identifying an unnamed track by number
@@ -1182,10 +5188,51 @@ msgid "Track %d"
 msgstr "Pista %d"
 
 #. i18n-hint: This is for screen reader software and indicates that
+#. this track is muted. (The mute button is on.)
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Muted"
+msgstr "Mut"
+
+#. i18n-hint: This is for screen reader software and indicates that
 #. this track is soloed. (The Solo button is on.)
 #: src/TrackPanelAx.cpp
 msgid " Soloed"
 msgstr "Solò"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is selected.
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Selected"
+msgstr "Seleccionat"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Mute On"
+msgstr "Mut"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Solo On"
+msgstr "Solò"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "Seleccion"
+
+#: src/TrackPanelResizeHandle.cpp
+msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
+msgstr ""
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to resize the track."
@@ -1204,20 +5251,195 @@ msgstr "Suprimir· la pista"
 msgid "Removed track '%s.'"
 msgstr "« %s » pista suprimida"
 
+#: src/TrackUtilities.cpp
+#, fuzzy
+msgid "Track Remove"
+msgstr "Suprimir"
+
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' to Top"
+msgstr "« %s » cambiat en %s"
+
+#: src/TrackUtilities.cpp
+#, fuzzy
+msgid "Move Track to Top"
+msgstr "Bolegar la pista"
+
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, c-format
+msgid "Moved '%s' to Bottom"
+msgstr ""
+
+#: src/TrackUtilities.cpp
+#, fuzzy
+msgid "Move Track to Bottom"
+msgstr "Bolegar la pista"
+
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' Up"
+msgstr "« %s » importat"
+
+#: src/TrackUtilities.cpp
+#, c-format
+msgid "Moved '%s' Down"
+msgstr ""
+
+#. i18n-hint: Past tense of 'to move', as in 'moved audio track up'.
+#: src/TrackUtilities.cpp
+#, fuzzy
+msgid "Move Track Up"
+msgstr "Bolegar la pista"
+
+#: src/TrackUtilities.cpp
+#, fuzzy
+msgid "Move Track Down"
+msgstr "Bolegar la pista"
+
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
+#. i18n-hint: Voice key is an experimental/incomplete feature that
+#. is used to navigate in vocal recordings, to move forwards and
+#. backwards by words.  So 'key' is being used in the sense of an index.
+#. This error message means that you've selected too short
+#. a region of audio to be able to use this feature.
+#: src/VoiceKey.cpp
+msgid "Selection is too small to use voice key."
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Results\n"
+msgstr ""
+
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Complete"
+msgstr ""
+
+#: src/WaveClip.cpp
+msgid "Resampling failed."
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to paste the selection"
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to expand the cut line"
+msgstr ""
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, fuzzy, c-format
+msgid "Applying %s..."
+msgstr "Aplicacion..."
+
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Comanda"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Comanda"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Répéter %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
+
+#: src/commands/CompareAudioCommand.cpp
+#, fuzzy
+msgid "Compare Audio"
+msgstr "Audio gravat"
+
+#: src/commands/CompareAudioCommand.cpp
+#, fuzzy
+msgid "Threshold:"
+msgstr "Sulhet"
+
+#: src/commands/CompareAudioCommand.h
+msgid "Compares a range on two tracks."
+msgstr ""
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
 
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
@@ -1226,6 +5448,15 @@ msgstr "Durada de la sosta (segondas) :"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Factor de decreissença :"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+#, fuzzy
+msgid "Drag"
+msgstr "Limpar a esquèrra"
 
 #: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
 msgid "Panel"
@@ -1243,6 +5474,45 @@ msgstr "Pista 0"
 msgid "Track 1"
 msgstr "Pista 1"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+#, fuzzy
+msgid "Window Name:"
+msgstr "Fenèstra"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Get Info"
+msgstr "Informacion"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Commands"
 msgstr "Comandas"
@@ -1255,7 +5525,17 @@ msgstr "Menús"
 msgid "Preferences"
 msgstr "Preferéncias"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+msgid "Clips"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Envelopes"
+msgstr "Aisina de nivèl (envolopa)"
+
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Marcadors"
 
@@ -1263,13 +5543,46 @@ msgstr "Marcadors"
 msgid "Boxes"
 msgstr "Bóstias"
 
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Tipe :"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Format :"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Get Track Info"
+msgstr "Novèla pista"
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "Tipe :"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
 
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
@@ -1279,21 +5592,143 @@ msgstr "Comentari"
 msgid "Command:"
 msgstr "Comanda:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Import2"
+msgstr "Importar"
+
 #: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
 msgid "File Name:"
 msgstr "Nom de fichièr :"
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Export2"
+msgstr "Exportar"
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Number of Channels:"
+msgstr "Canal esquèrra"
+
+#: src/commands/ImportExportCommands.h
+msgid "Imports from a file."
+msgstr ""
+
+#: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Exports to a file."
+msgstr "Expòrt Multiple"
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Builtin Commands"
+msgstr "Comanda"
+
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+msgid "The Tenacity Team"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Format desconegut"
 
 #: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Text:"
 msgstr "Tèxte :"
 
+#: src/commands/MessageCommand.h
+msgid "Echos a message."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "Open Project2"
+msgstr "Projècte"
+
+#: src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "Add to History"
+msgstr "&Istoric..."
+
+#: src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "Save Project2"
+msgstr "&Enregistrar lo projècte"
+
 #: src/commands/OpenSaveCommands.cpp
 msgid "Save Copy"
 msgstr "Enregistrar la còpia"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "Save Log"
+msgstr "Enregistrar la còpia"
+
+#: src/commands/OpenSaveCommands.cpp
+#, fuzzy
+msgid "Clear Log"
+msgstr "Escafar"
+
+#: src/commands/OpenSaveCommands.h
+#, fuzzy
+msgid "Opens a project."
+msgstr "Dubertura d'un projècte Audacity"
+
+#: src/commands/OpenSaveCommands.h
+#, fuzzy
+msgid "Saves a project."
+msgstr "&Enregistrar lo projècte"
+
+#: src/commands/OpenSaveCommands.h
+#, fuzzy
+msgid "Saves a copy of current project."
+msgstr "Enregistrar lo projècte &jos..."
+
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
+#: src/commands/PreferenceCommands.cpp
+#, fuzzy
+msgid "Get Preference"
+msgstr "Preferéncias"
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nom :"
+
+#: src/commands/PreferenceCommands.cpp
+#, fuzzy
+msgid "Set Preference"
+msgstr "Preferéncias"
 
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
@@ -1302,6 +5737,14 @@ msgstr "Valor :"
 #: src/commands/PreferenceCommands.cpp
 msgid "Reload"
 msgstr "Tornar cargar"
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -1312,15 +5755,71 @@ msgid "Window"
 msgstr "Fenèstra"
 
 #: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Full Window"
+msgstr "Fenèstra"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Window Plus"
+msgstr "Fenèstra"
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Fullscreen"
 msgstr "Plen ecran"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Toolbars"
+msgstr "&Barra d'aisinas"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efèits"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Scriptables"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Selectionbar"
+msgstr "Seleccion"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Trackpanel"
+msgstr "Pista"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "First Two Tracks"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "First Three Tracks"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "First Four Tracks"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Tracks Plus"
+msgstr "Pistas"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "First Track Plus"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "All Tracks"
+msgstr "Totas las pistas"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "All Tracks Plus"
 msgstr "Totas las pistas"
 
 #: src/commands/ScreenshotCommand.cpp
@@ -1334,20 +5833,91 @@ msgid "White"
 msgstr "Blanc"
 
 #: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Path:"
+msgstr "Camin"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Rèireplan :"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy, c-format
+msgid "Error trying to save file: %s"
+msgstr "Causir un luòc per salvagardar los fichièrs"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "Captura d'ecran"
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
 msgstr "Seleccionar una ora"
 
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Project Start"
+msgstr "Projècte"
+
 #: src/commands/SelectCommand.cpp src/commands/SetProjectCommand.cpp
 msgid "Project"
 msgstr "Projècte"
 
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Project End"
+msgstr "Projècte"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Selection Start"
+msgstr "Seleccion"
+
 #: src/commands/SelectCommand.cpp src/toolbars/SelectionBar.cpp
 msgid "Selection"
 msgstr "Seleccion"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Selection End"
+msgstr "Seleccion"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Start Time:"
+msgstr "Ora iniciala"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "End Time:"
+msgstr "Ora finala"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Select Frequencies"
+msgstr "Seleccionar una ora"
+
+#: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Select Tracks"
+msgstr "Totas las pistas"
 
 #. i18n-hint verb, imperative
 #: src/commands/SelectCommand.cpp
@@ -1358,17 +5928,89 @@ msgstr "Definir"
 msgid "Add"
 msgstr "Apondre"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Suprimir"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "First Track:"
+msgstr "Pista de nòta"
+
+#: src/commands/SelectCommand.cpp
+#, fuzzy
+msgid "Track Count:"
+msgstr "Poliça de la pista de marcadors"
 
 #: src/commands/SelectCommand.cpp
 msgid "Mode:"
 msgstr "Mòde :"
 
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a time range."
+msgstr "Seleccionar un fichièr"
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Frequéncia linearia"
+
+#: src/commands/SelectCommand.h
+msgid "Selects a range of tracks."
+msgstr ""
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects Audio."
+msgstr "Seleccion"
+
+#: src/commands/SetClipCommand.cpp
+msgid "Set Clip"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Color 0"
+msgstr "Color :"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Color 1"
+msgstr "Color :"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Color 2"
+msgstr "Color :"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Color 3"
+msgstr "Color :"
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Color:"
 msgstr "Color :"
+
+#: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
+#, fuzzy
+msgid "Start:"
+msgstr "Aviar"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
+
+#: src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Set Envelope"
+msgstr "Aisina de nivèl (envolopa)"
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Time:"
@@ -1383,13 +6025,27 @@ msgid "Edited Envelope"
 msgstr "Envolopa ajustada."
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Aisina de nivèl (envolopa)"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
 msgstr "Definir l'etiqueta"
+
+#: src/commands/SetLabelCommand.cpp
+#, fuzzy
+msgid "Label Index"
+msgstr "Edicion de marcador"
+
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
@@ -1398,6 +6054,25 @@ msgstr "Seleccionat"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Modificar las etiquetas"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+#, fuzzy
+msgid "Set Project"
+msgstr "&Enregistrar lo projècte"
+
+#: src/commands/SetProjectCommand.cpp
+#, fuzzy
+msgid "Rate:"
+msgstr "Debit :"
+
+#: src/commands/SetProjectCommand.cpp
+#, fuzzy
+msgid "Resize:"
+msgstr "&Talha : "
 
 #: src/commands/SetProjectCommand.cpp
 msgid "X:"
@@ -1411,13 +6086,75 @@ msgstr "Y :"
 msgid "Width:"
 msgstr "Largor :"
 
+#: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Height:"
+msgstr "Clar"
+
+#: src/commands/SetProjectCommand.h
+msgid "Sets various values for a project."
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Track Index:"
+msgstr "Pista %d"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Channel Index:"
+msgstr "Canals :"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Set Track Status"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Unnamed"
 msgstr "Sens nom"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Focused"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Set Track Audio"
+msgstr "Pista %d"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Gain:"
+msgstr "Ganh"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Set Track Visuals"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineariá"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Reset"
+msgstr "Prereglatges"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Ora"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -1427,30 +6164,211 @@ msgstr "Afichatge :"
 msgid "Scale:"
 msgstr "Escala :"
 
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "Zoom avant"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "VZoom Top:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "VZoom Bottom:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Use Spectral Prefs"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Spectral Select"
+msgstr "Definir un punt de seleccion"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Set Track"
+msgstr "Novèla pista"
+
+#: src/commands/SetTrackInfoCommand.h
+msgid "Sets various values for a track."
+msgstr ""
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Amplificacion"
 
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "&Amplification (dB):"
+msgstr "Aplicacion :"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
+msgstr "Aplicacion"
+
+#: src/effects/Amplify.cpp
+msgid "&New Peak Amplitude (dB):"
+msgstr ""
+
+#: src/effects/Amplify.cpp
+msgid "Allo&w clipping"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Duck &amount:"
+msgstr ""
+
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segondas"
+
+#: src/effects/AutoDuck.cpp
+msgid "Ma&ximum pause:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "&Threshold:"
+msgstr "Sulhet"
+
+#: src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "Preview not available"
+msgstr "disponible"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+msgid "Simple tone control effect"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+msgid "Tone controls"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass (dB):"
+msgstr "Amplificacion (dB) :"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Ba&ss (dB):"
+msgstr "Amplificacion (dB) :"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass"
 msgstr "Bassa"
 
 #: src/effects/BassTreble.cpp
+msgid "&Treble (dB):"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+msgid "Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+msgid "&Volume (dB):"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Nivèl"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "Cambiar la nautor"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "Changes the pitch of a track without changing its tempo"
+msgstr "Cambiar la nautor sens cambiar lo tempò"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Nauta qualitat"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Cambiar la nautor sens cambiar lo tempò"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
+
+#. i18n-hint: (noun) Musical pitch.
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "Pitch"
+msgstr "Nautor (EAC)"
 
 #. i18n-hint: changing musical pitch "from" one value "to" another
 #: src/effects/ChangePitch.cpp
@@ -1458,17 +6376,164 @@ msgctxt "change pitch"
 msgid "from"
 msgstr "de"
 
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgctxt "change pitch"
+msgid "&from"
+msgstr "de"
+
+#: src/effects/ChangePitch.cpp
+msgid "from Octave"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgctxt "change pitch"
+msgid "to"
+msgstr "Arrestar"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgctxt "change pitch"
+msgid "&to"
+msgstr "&Anar a"
+
+#: src/effects/ChangePitch.cpp
+msgid "to Octave"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "Semitones (half-steps)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "&Semitones (half-steps):"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Frequency"
 msgstr "Frequéncia"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "from (Hz)"
+msgstr "de"
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
+msgid "t&o"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent C&hange:"
+msgstr "Percentatge de modificacion :"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "Percentatge de modificacion :"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
 msgstr "Cambiar la velocitat"
 
 #: src/effects/ChangeSpeed.cpp
+msgid "Changes the speed of a track, also changing its pitch"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
 msgid "Change Speed, affecting both Tempo and Pitch"
 msgstr "Cambiar la velocitat en modificar tempò e nautor"
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "&Speed Multiplier:"
+msgstr "Expòrt Multiple"
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgctxt "change speed"
+msgid "&from"
+msgstr "de"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgctxt "change speed"
+msgid "&to"
+msgstr "&Anar a"
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "Selection Length"
+msgstr "Seleccion"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "C&urrent Length:"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "Current length of selection."
+msgstr "Escafar la seleccion"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -1476,13 +6541,63 @@ msgctxt "change speed"
 msgid "from"
 msgstr "de"
 
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "&New Length:"
+msgstr "Longor"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgctxt "change speed"
+msgid "to"
+msgstr "Arrestar"
+
 #: src/effects/ChangeTempo.cpp
 msgid "Change Tempo"
 msgstr "Cambiar lo tempò"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Changes the tempo of a selection without changing its pitch"
+msgstr "Cambiar lo tempò sens modificar la nautor"
+
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "Nauta qualitat"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "Cambiar lo tempò sens modificar la nautor"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgctxt "change tempo"
+msgid "&from"
+msgstr "de"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgctxt "change tempo"
+msgid "&to"
+msgstr "&Anar a"
 
 #: src/effects/ChangeTempo.cpp
 msgid "Length (seconds)"
@@ -1494,9 +6609,142 @@ msgctxt "change tempo"
 msgid "from"
 msgstr "de"
 
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "t&o"
+msgstr ""
+
+#: src/effects/ChangeTempo.cpp
+#, fuzzy, c-format
+msgid "Length in seconds from %s, to"
+msgstr "Durada (segondas)"
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Supression dels clics..."
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, c-format
+msgid "Selection must be larger than %d samples."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
 #: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
 msgid "Threshold"
 msgstr "Sulhet"
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Compressor..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.2f secs"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+msgid "&Noise Floor:"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "Bruch"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Ratio:"
+msgstr "Durada :"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
+msgstr "Durada"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Attack Time:"
+msgstr "Atac :"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Atac :"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "R&elease Time:"
+msgstr "Data de sortida"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
@@ -1505,18 +6753,269 @@ msgstr "Sulhet"
 msgid "Release Time"
 msgstr "Data de sortida"
 
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Threshold %d dB"
+msgstr "Sulhet"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Attack Time %.2f secs"
+msgstr "Atac :"
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Release Time %.1f secs"
+msgstr "Data de sortida"
+
+#: src/effects/Contrast.cpp
+msgid "You can only measure one track at a time."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Please select an audio track."
+msgstr "Novèla·pista audiò creada"
+
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Fin"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Foreground:"
+msgstr "Rèireplan :"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Measure selection"
+msgstr "Escafar la seleccion"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Background:"
+msgstr "Rèireplan :"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background start time"
+msgstr "Rèireplan"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "Rèireplan"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Mea&sure selection"
+msgstr "Escafar la seleccion"
 
 #: src/effects/Contrast.cpp
 msgid "Result"
 msgstr "Resultat"
 
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "Prereglatges"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "Preferéncias"
+
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&Ajuda"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "indeterminate"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr "Preferéncias"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Exportar los marcadors jos :"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "Renomenar « %s »"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Foreground"
+msgstr "Rèireplan"
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "Background"
@@ -1526,6 +7025,165 @@ msgstr "Rèireplan"
 msgid "Results"
 msgstr "Resultats"
 
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Contraste elevat"
+
+#: src/effects/Distortion.cpp
+msgid "Hard Clipping"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Soft Clipping"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Expand and Compress"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Leveller"
+msgstr "Nivèl"
+
+#: src/effects/Distortion.cpp
+msgid "Rectifier Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Limiter 1413"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Upper Threshold"
+msgstr "Sulhet"
+
 #: src/effects/Distortion.cpp
 msgid "Parameter 1"
 msgstr "Paramètre 1"
@@ -1534,18 +7192,269 @@ msgstr "Paramètre 1"
 msgid "Parameter 2"
 msgstr "Paramètre 2"
 
+#: src/effects/Distortion.cpp
+msgid "Number of repeats"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion"
+msgstr "Durada"
+
+#: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Distortion type:"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Threshold controls"
+msgstr "Sulhet"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter controls"
+msgstr "Paramètres"
+
+#: src/effects/Distortion.cpp
+msgid "Clipping level"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Clipping threshold"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Distortion amount"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Output level"
+msgstr "Vistmètre de sortida"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Repeat processing"
+msgstr "Répéter %s"
+
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "dB Limit"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Wet level"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Residual level"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "DTMF &sequence:"
+msgstr "Frequéncia (Hz) :"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
+#, fuzzy
+msgid "&Amplitude (0-1):"
+msgstr "Amplitud (0 a 1)"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "&Duration:"
+msgstr "Durada :"
+
+#: src/effects/DtmfGen.cpp
+msgid "&Tone/silence ratio:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Tone duration:"
+msgstr "Durada :"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Silence duration:"
+msgstr "Silenci"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "Echo"
 msgstr "Ecò"
+
+#: src/effects/Echo.cpp
+#, fuzzy
+msgid "Repeats the selected audio again and again"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
+#: src/effects/Echo.cpp
+#, fuzzy
+msgid "&Delay time (seconds):"
+msgstr "Durada de la sosta (segondas) :"
+
+#: src/effects/Echo.cpp
+#, fuzzy
+msgid "D&ecay factor:"
+msgstr "Factor de decreissença :"
+
+#: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "Prereglatges"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp
+msgid "Export Effect Parameters"
+msgstr ""
+
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+msgid "Error Saving Effect Presets"
+msgstr ""
+
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#, fuzzy, c-format
+msgid "Error writing to file: \"%s\""
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/effects/Effect.cpp
+msgid "Import Effect Parameters"
+msgstr ""
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is not a valid presets file.\n"
+msgstr ""
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Preparing preview"
+msgstr "Preparacion...\n"
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Previewing"
+msgstr "&Apercebut"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -1553,20 +7462,205 @@ msgid "Applied effect: %s"
 msgstr "Efièch·aplicat·: %s"
 
 #: src/effects/EffectManager.cpp
+#, fuzzy, c-format
+msgid "Applied command: %s"
+msgstr "Efièch·aplicat·: %s"
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Select Preset"
+msgstr "Enregistrar la preseleccion"
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "&Preset:"
+msgstr "Prereglatges :"
+
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "User Presets"
+msgstr "Prereglatges"
+
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "Paramètres d'usina"
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Current Settings"
+msgstr "Reglatges de l'efièch"
+
+#: src/effects/EffectManager.cpp
 msgid "Factory Defaults"
 msgstr "Paramètres d'usina"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Effect failed to initialize"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Effects Rack"
+msgstr "Efèits"
 
 #: src/effects/EffectUI.cpp
 msgid "&Apply"
 msgstr "&Aplicar"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Latency: 0"
+msgstr "Laténcia"
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Active State"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Move Up"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Move effect up in the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Move Down"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Move effect down in the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Favorite"
 msgstr "Favorit"
 
 #: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Remove effect from the rack"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Name of the effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Latency: %4d"
+msgstr "Laténcia"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Some Command"
+msgstr "Seleccionar una comanda"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "&Manage"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Start and stop playback"
+msgstr ""
+
+#. i18n-hint: The access key "&P" should be the same in
+#. "Stop &Playback" and "Start &Playback"
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start &Playback"
+msgstr "Lectura"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Preview effect"
+msgstr "&Apercebut"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Preview effect"
+msgstr "&Apercebut"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Retorn"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Retorn"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip forward"
+msgstr "Enrèire a la començança"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Forward"
+msgstr "Enrèire a la començança"
+
+#: src/effects/EffectUI.cpp
 msgid "Enable"
 msgstr "Activar"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Save Preset..."
+msgstr "Enregistrar la preseleccion"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "Enregistrar la preseleccion"
 
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
@@ -1590,38 +7684,370 @@ msgid "Type: %s"
 msgstr "Tipe : %s"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Name: %s"
+msgstr "Nom :"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Version: %s"
+msgstr "Version : %s"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Version : %s"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Description: %s"
 msgstr "Version : %s"
 
 #: src/effects/EffectUI.cpp
 msgid "About"
 msgstr "A prepaus"
 
+#: src/effects/EffectUI.cpp
+#, c-format
+msgid "Are you sure you want to delete \"%s\"?"
+msgstr ""
+
 #: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
 msgid "Save Preset"
 msgstr "Enregistrar la preseleccion"
 
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Preset name:"
+msgstr "Prereglatges :"
+
+#: src/effects/EffectUI.cpp
+msgid "You must specify a name"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid ""
+"Preset already exists.\n"
+"\n"
+"Replace?"
+msgstr ""
+
+#. i18n-hint: The access key "&P" should be the same in
+#. "Stop &Playback" and "Start &Playback"
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Stop &Playback"
+msgstr "Lectura"
+
 #: src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp
 msgid "Play"
 msgstr "Legir"
+
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
 
 #: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Equalization"
 msgstr "Egalisacion"
+
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Filter Curve EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Bass Boost"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "Bassa"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Treble Boost"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Treble Cut"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "To apply Equalization, all selected tracks must have the same sample rate."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Track sample rate is too low for this effect."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Effect Unavailable"
+msgstr "disponible"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "Tipe :"
+
+#: src/effects/Equalization.cpp
+msgid "Draw Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Draw"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Interpolation type"
+msgstr "Interpolacion rapida"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Frequéncia linearia"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Frequéncia linearia"
+
+#: src/effects/Equalization.cpp
+msgid "Length of &Filter:"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Centrat"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Seleccion"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Select Curve"
+msgstr "Seleccionat"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Inversar"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Show grid lines"
+msgstr "Afichar los novèls"
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Processing: "
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "D&efaut"
 
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "&Bench"
+msgstr ""
+
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
 msgid "unnamed"
 msgstr "sens nom"
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Error de dubèrtura de fichièr"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Egalisacion en cors"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Manage Curves List"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Manage Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Nom..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Nom..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Escafar"
+
+#: src/effects/Equalization.cpp
+msgid "&Get More..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "De&faults"
+msgstr "Valors per defaut"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -1638,9 +8064,92 @@ msgid "Rename '%s'"
 msgstr "Renomenar « %s »"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Cambiament de nom"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "Overwrite existing curve '%s'?"
+msgstr "Espotir los fichièrs existissents"
+
+#: src/effects/Equalization.cpp
+msgid "Curve exists"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Can't delete 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Suprimir « %s » ?"
+
+#: src/effects/Equalization.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Deletion"
+msgstr "Escafar la seleccion"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "Delete %d items?"
+msgstr "Suprimir « %s » ?"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Causir un luòc per salvagardar los fichièrs"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Exportar los ma&rcadors..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cannot Export 'unnamed'"
+msgstr "Impossible d'exportar l'audiò vers %s"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d curves exported to %s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "No curves exported"
+msgstr ""
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -1650,14 +8159,121 @@ msgstr "Fondre en dubèrtura"
 msgid "Fade Out"
 msgstr "Fondre en barradura"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-in to the selected audio"
+msgstr "Clicar-rossegar per seleccionar l'audiò."
+
+#: src/effects/Fade.cpp
+msgid "Applies a linear fade-out to the selected audio"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "Find Clipping"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Cursor Drecha"
+
+#: src/effects/FindClipping.cpp
+msgid "&Start threshold (samples):"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "St&op threshold (samples):"
+msgstr ""
+
+#: src/effects/Generator.cpp
+msgid "There is not enough room available to generate the audio"
+msgstr ""
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Inversar"
+
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Totes los efèits"
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "perceived loudness"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+#, fuzzy
+msgid "Normalizing Loudness...\n"
+msgstr "Normalizar......"
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 #, c-format
 msgid "Analyzing: %s"
 msgstr "Analisi en cors : %s"
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "Version : %s"
+
+#: src/effects/Loudness.cpp
+#, fuzzy
+msgid "&Normalize"
+msgstr "Normalizar"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -1672,65 +8288,932 @@ msgctxt "noise"
 msgid "Pink"
 msgstr "Ròse"
 
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
 #: src/effects/Noise.cpp
 msgid "Noise"
 msgstr "Bruch"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
+#, fuzzy
+msgid "&Noise type:"
+msgstr "Tipe de fichièr :"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Median"
 msgstr "Mediana"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Second greatest"
+msgstr "Segondas"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Hann, Hann (per defaut)"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (per defaut)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Reduccion de bruit"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "All noise profile data must have the same sample rate."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Selected noise profile is too short."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Noise reduction (dB):"
+msgstr "Resolucion de bruch"
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Noise reduction"
 msgstr "Resolucion de bruch"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Sensitivity:"
+msgstr "Sensibilitat"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Sensitivity"
 msgstr "Sensibilitat"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Attac&k time (secs):"
+msgstr "Durada de la sosta (segondas) :"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Attack time"
+msgstr "Atac :"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "R&elease time (secs):"
+msgstr "Durada de la sosta (segondas) :"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Release time"
+msgstr "Data de sortida"
+
+#: src/effects/NoiseReduction.cpp
+msgid "&Frequency smoothing (bands):"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Analisi de frequéncias"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "Sensibilitat"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Old Sensitivity"
+msgstr "Sensibilitat"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Step 1"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid ""
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
+"then click Get Noise Profile:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Get Noise Profile"
+msgstr "Creacion d'un perfil de bruch"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "Step 2"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "Bruch"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "&Isolate"
+msgstr ""
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+msgid "Resid&ue"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "Paramètres avançats"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Window types:"
+msgstr "Fenèstra"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Window si&ze:"
+msgstr "Fenèstra"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "2048 (default)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "4 (default)"
+msgstr "Hann, Hann (per defaut)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Eliminacion del bruch"
 
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to remove noise.\n"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise re&duction (dB):"
+msgstr "Resolucion de bruch"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "Sensibilitat"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Fr&equency smoothing (Hz):"
+msgstr "Frequéncia (Hz)"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "Durada de la sosta (segondas) :"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Atac :"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "Suprimir"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Normalizar"
+
+#: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Removing DC offset and Normalizing...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset...\n"
+msgstr "Supression· del bruch"
+
+#: src/effects/Normalize.cpp
+msgid "Normalizing without removing DC offset...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Normalize peak amplitude to   "
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Peak amplitude dB"
+msgstr "Amplitud (0 a 1)"
+
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Estirat"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
+#. i18n-hint: This is how many times longer the sound will be, e.g. applying
+#. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
+#. * will give an (approximately) 10 second sound
+#.
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "&Stretch Factor:"
+msgstr "Factor de decreissença :"
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "&Time Resolution (seconds):"
+msgstr "Durada de la sosta (segondas) :"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Faser"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "&Stages:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Stages"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO Freq&uency (Hz):"
+msgstr "Frequéncia (Hz)"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "Frequéncia LFO (Hz) :"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO Sta&rt Phase (deg.):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO start phase in degrees"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Pregondor :"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Feedbac&k (%):"
+msgstr "Enrèire (%) :"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "&Output gain (dB):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Output gain (dB)"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid "Repair"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Repetir"
 
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+msgid "&Number of repeats to add:"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+msgid "Current selection length: dd:hh:mm:ss"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+msgid "New selection length: dd:hh:mm:ss"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+#, c-format
+msgid "Current selection length: %s"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+#, fuzzy, c-format
+msgid "New selection length: %s"
+msgstr "Definir un punt de seleccion"
+
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Suprimir la (las) pista(s)"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Medium Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Reverb"
+msgstr "Reverberacion"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Talha"
+
+#: src/effects/Reverb.cpp
+msgid "&Pre-delay (ms):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Rever&berance (%):"
+msgstr "Enrèire (%) :"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Da&mping (%):"
+msgstr "Pregondor (%) :"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Tone &High (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Ganh"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Ganh"
+
+#: src/effects/Reverb.cpp
+msgid "Stereo Wid&th (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy, c-format
+msgid "Reverb: %s"
 msgstr "Reverberacion"
 
 #: src/effects/Reverse.cpp
 msgid "Reverse"
 msgstr "Inversar lo sens"
 
+#: src/effects/Reverse.cpp
+msgid "Reverses the selected audio"
+msgstr ""
+
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Classic Filters"
+msgstr ""
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "To apply a filter, all selected tracks must have the same sample rate."
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Tipe de fichièr :"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Align MIDI to Audio"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Periòde"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Periòde"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size:"
+msgstr "Fenèstra"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size"
+msgstr "Fenèstra"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Silence Threshold:"
+msgstr "Eliminacion del bruch"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Silence Threshold"
+msgstr "Eliminacion del bruch"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Presmooth Time:"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Presmooth Time"
+msgstr ""
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time:"
+msgstr "Ora finala"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time"
+msgstr "Ora finala"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time:"
+msgstr "Alisar l'escandilh"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time"
+msgstr "Alisar l'escandilh"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Use Defaults"
+msgstr "Valors per defaut"
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Restaurar las valors per defaut"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
+#. i18n-hint: noun
+#: src/effects/Silence.cpp
+#, fuzzy
+msgctxt "generator"
+msgid "Silence"
+msgstr "Detectar silenci"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
+#: src/effects/StereoToMono.cpp
+#, fuzzy
+msgid "Stereo To Mono"
+msgstr "Esterèo"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
+
+#: src/effects/StereoToMono.cpp
+#, fuzzy
+msgid "Resampling left channel"
+msgstr "Canal de drecha"
+
+#: src/effects/StereoToMono.cpp
+#, fuzzy
+msgid "Resampling right channel"
+msgstr "Canal de drecha"
+
+#: src/effects/StereoToMono.cpp
+msgid "Mixing down to mono"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Sliding Stretch"
+msgstr "Estirat"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
 
 #: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
 msgid "Logarithmic"
@@ -1748,24 +9231,585 @@ msgstr "Carrat"
 msgid "Sawtooth"
 msgstr "Dents de raissa"
 
+#: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "&Waveform:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "&Frequency (Hz):"
+msgstr "Frequéncia (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Frequéncia (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "Frequéncia (Hz)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Amplitud (0 a 1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Amplitud (0 a 1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "I&nterpolation:"
+msgstr "Interpolacion rapida"
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Detected Silence"
+msgstr "Detectar silenci"
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Detectar silenci"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Detectar silenci"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "C&ompress to:"
+msgstr "Compression :"
+
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "Efèits"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "Could not load the library"
+msgstr "Impossible de dubrir la librariá d'encodatge MP3 !"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effect Options"
+msgstr "Opcions d'efèit"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Buffer Size"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Latency Compensation"
+msgstr "Combinason de clau"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &compensation"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Save VST Preset As:"
+msgstr "Enregistrar la preseleccion"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Standard VST bank file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Standard VST program file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Tenacity VST preset file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Error Saving VST Presets"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Prereglatges :"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST preset files"
+msgstr "Fichièrs tèxte"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Error Loading VST Presets"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unable to load presets file."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Reglatges de l'efièch"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unable to allocate memory when loading presets file."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unable to read presets file."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Dept&h (%):"
+msgstr "Pregondor :"
 
 #: src/effects/Wahwah.cpp
 msgid "Reso&nance:"
 msgstr "Resonància:"
 
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Resonància:"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah Frequency Offse&t (%):"
+msgstr "Frequéncia (Hz)"
+
+#: src/effects/Wahwah.cpp
+msgid "Wah frequency offset in percent"
+msgstr ""
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Totes los efèits"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Could not find component"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Could not initialize component"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effect Options"
+msgstr "Opcions d'efèit"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "User Interface"
+msgstr "Interfàcia"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Select &interface"
+msgstr "Seleccionar una ora"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Full"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Generic"
+msgstr "&Congrear"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Import Audio Unit Presets"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "Prereglatges"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
 msgstr "Emplaçament"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Couldn't open \"%s\""
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Unable to read the preset from \"%s\""
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Failed to encode preset from \"%s\""
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Unable to store preset in config file"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid ""
+"Could not import \"%s\" preset\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Export Audio Unit Preset As %s:"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Standard Audio Unit preset file"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid ""
+"Could not export \"%s\" preset\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Export Audio Unit Presets"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Import Audio Unit Preset As %s:"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to set preset name"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to retrieve preset content"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to convert property list to XML data"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Frequéncia d'escandalhatge :"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Failed to write XML preset to \"%s\""
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to convert preset to internal format"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Failed to create property list for preset"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr ""
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Fichièr àudio"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "LADSPA Effects"
+msgstr "Totes los efèits"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Provides LADSPA Effects"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "LADSPA Effect Options"
+msgstr "Opcions d'efèit"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Effect Output"
+msgstr "Opcions d'efèit"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "LV2 Effect Settings"
+msgstr "Reglatges de l'efièch"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Congrear"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
+#: src/effects/lv2/LoadLV2.cpp
+#, fuzzy
+msgid "LV2 Effects"
+msgstr "Efèits"
+
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/nyquist/LoadNyquist.cpp
+#, fuzzy
+msgid "Nyquist Effects"
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#. i18n-hint: It is acceptable to translate this the same as for "Nyquist Prompt"
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist Worker"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Ill-formed Nyquist plug-in header"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Audio selection required."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist Error"
 msgstr "Aplicacion d'efièch \"Nyquist\"..."
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -1773,32 +9817,355 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Desolat, l'efièch pòt pas èsser realizat que las pistas estereofonicas an de canals individuals que correspondon pas."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Debug Output: "
+msgstr "Sortida"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "Enregistrament\n"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "plug-in"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned a list."
+msgstr "Nyquist revirèt tròp de canals audio.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "Nyquist returned the value: %f"
+msgstr "Nyquist revirèt tròp de canals audio.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "Nyquist returned the value: %d"
+msgstr "Nyquist revirèt tròp de canals audio.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist returned too many audio channels.\n"
 msgstr "Nyquist revirèt tròp de canals audio.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned one audio channel as an array.\n"
+msgstr "Nyquist revirèt tròp de canals audio.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned an empty array.\n"
+msgstr "Nyquist revirèt tròp de canals audio.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned nil audio.\n"
+msgstr "Nyquist revirèt tròp de canals audio.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "This version of Audacity does not support Nyquist plug-in version %ld"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Could not open file"
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
+#. i18n-hint: refers to programming "languages"
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Could not determine language"
+msgstr "Impossible de dubrir lo fichièr : "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr ""
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Intrar una comanda Nyquist :"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid "&Load"
+msgstr ""
+
+#. i18n-hint: Nyquist is the name of a programming language
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist scripts"
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#. i18n-hint: Lisp is the name of a programming language
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Lisp scripts"
+msgstr "Arrestar lo script"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be loaded"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid ""
+"Value range:\n"
+"%s to %s"
+msgstr "« %s » cambiat en %s"
+
+#  i18n-hint: You do not need to translate "LOF"
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Value Error"
+msgstr "Error de fichièr"
+
 #: src/effects/nyquist/Nyquist.cpp plug-ins/sample-data-export.ny
 msgid "Select a file"
 msgstr "Seleccionar un fichièr"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Save file as"
+msgstr "TornarRenommar lo fichièr :"
+
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "sens títol"
+
+#: src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "Vamp Effects"
+msgstr "Efèits"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "Desolat, l'efièch pòt pas èsser realizat que las pistas estereofonicas an de canals individuals que correspondon pas."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "&Paramètres"
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "No format specific options"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Export Audio"
+msgstr "Expòrt Multiple"
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp src/menus/EditMenus.cpp
+msgid "Edit Metadata Tags"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "Etiquetas exportadas"
 
 #: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid "Are you sure you want to export the file as \"%s\"?\n"
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
 msgstr "Desolat, los noms de mai de 256 caractèrs son pas suportats."
+
+#: src/export/Export.cpp
+#, c-format
+msgid "A file named \"%s\" already exists. Replace?"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one mono file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one stereo file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down to one exported file according to the encoder settings."
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Advanced Mixing Options"
+msgstr "Paramètres avançats"
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Format Options"
+msgstr "Opcions generalas"
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Channel: %2d"
+msgstr "Canals :"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Output Channels: %2d"
+msgstr "%d Canals"
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "Panèl"
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"Unable to export.\n"
+"Error %s"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Show output"
+msgstr ""
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Comanda"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "(external program)"
+msgstr "Error intèrna"
 
 #: src/export/ExportCL.cpp src/export/ExportPCM.cpp
 #, c-format
@@ -1814,28 +10181,465 @@ msgid "Exporting the selected audio using command-line encoder"
 msgstr "Exportacion·de·la·seleccion· audio en utilizant un encodaire a linha de comanda"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Exporting the audio using command-line encoder"
+msgstr "Exportacion·de·la·seleccion· audio en utilizant un encodaire a linha de comanda"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "Comanda "
+
+#: src/export/ExportCL.cpp
 msgid "&OK"
 msgstr "&D'acòrdi"
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#  i18n-hint: You do not need to translate "LOF"
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg Error"
+msgstr "Error de fichièr"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio as %s"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Frequéncia d'escandalhatge :"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
+msgid "Resample"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "Frequéncia d'escandalhatge :"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Debit :"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Quality (kbps):"
+msgstr "Qualitat :"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "On"
+msgstr "Dubrir"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Constrained"
+msgstr "Constanta"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Àudio"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Low Delay"
+msgstr "Retard"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mediumband"
+msgstr "Mediana"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Fullband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression"
+msgstr "Compression :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame Duration:"
+msgstr "Durada :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Vbr Mode:"
+msgstr "Mòde :"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "Aplicacion :"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Current Format:"
+msgstr "Format :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Current Codec:"
+msgstr "Codec :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Error Saving FFmpeg Presets"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Espotir los fichièrs existissents"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Confirm Overwrite"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select format before saving a profile"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Lo repertòri %s existís pas. Lo volètz crear ?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Replace preset '%s'?"
+msgstr "Suprimir « %s » ?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "G"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Main"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Custom FFmpeg Export"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Nivèl"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Nivèl"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Nivèl"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Full search"
 msgstr "Recèrca completa"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Log search"
+msgstr "Recèrca completa"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Preset:"
 msgstr "Prereglatges :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Enregistrar la preseleccion"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Prereglatges"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Prereglatges"
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -1843,32 +10647,451 @@ msgid "Codec:"
 msgstr "Codec :"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Show All Codecs"
+msgstr "Afichar tot"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "General Options"
 msgstr "Opcions generalas"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Lenga :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "Qualitat :"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Frequéncia d'escandalhatge :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Profile:"
 msgstr "Perfil :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Opcions"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Compression:"
 msgstr "Compression :"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Frame:"
 msgstr "Quadre :"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Seleccionar fins a la fin"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Debit :"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Packet Size:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "Suprimir « %s » ?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "No presets to export"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file to export presets into"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Failed to guess format"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Failed to find the codec"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "0 (fastest)"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "8 (best)"
+msgstr ""
 
 #: src/export/ExportFLAC.cpp
 msgid "Level:"
 msgstr "Nivèl :"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Bit depth:"
+msgstr "Debit :"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "FLAC Files"
+msgstr "Totes los fichièrs"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Impossible d'exportar l'audiò vers %s"
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the selected audio as FLAC"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the audio as FLAC"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy
+msgid "MP2 Files"
+msgstr "Fichièrs XML"
+
+#: src/export/ExportMP2.cpp
+msgid "Cannot export MP2 with this sample rate and bit rate"
+msgstr ""
+
+#: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
+msgid "Unable to open target file for writing"
+msgstr ""
+
+#: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %ld kbps"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio at %ld kbps"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Medium"
+msgstr "Mediana"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "disponible"
 
 #: src/export/ExportMP3.cpp
 msgid "Average"
@@ -1879,8 +11102,18 @@ msgid "Constant"
 msgstr "Constanta"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "Esterèo"
+
+#: src/export/ExportMP3.cpp
 msgid "Stereo"
 msgstr "Esterèo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "Debit :"
 
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
@@ -1888,20 +11121,195 @@ msgid "Quality"
 msgstr "Qualitat"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "Canals :"
+
+#: src/export/ExportMP3.cpp
+msgid "Force export to mono"
+msgstr ""
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Tenacity needs the file %s to create MP3s."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr "Emplaçament"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "To find %s, click here -->"
+msgstr ""
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+msgid "To get a free copy of LAME, click here -->"
+msgstr ""
+
+#. i18n-hint: It's asking for the location of a file, for
+#. * example, "Where is lame_enc.dll?" - you could translate
+#. * "Where would I find the file %s" instead if you want.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Where is %s?"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Fichièr projècte AUP3"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "Fichièrs XML"
+
+#: src/export/ExportMP3.cpp
 msgid "Could not open MP3 encoding library!"
+msgstr "Impossible de dubrir la librariá d'encodatge MP3 !"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Could not initialize MP3 encoding library!"
 msgstr "Impossible de dubrir la librariá d'encodatge MP3 !"
 
 #: src/export/ExportMP3.cpp
 msgid "Not a valid or supported MP3 encoding library!"
 msgstr "La librariá d'encodatge MP3 es pas valida o pas suportada !"
 
+#: src/export/ExportMP3.cpp
+msgid "Unable to initialize MP3 stream"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio with %s preset"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Exporting the audio with VBR quality %s"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio at %d Kbps"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
 msgstr "Expòrt Multiple"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Cannot Export Multiple"
+msgstr "Expòrt Multiple"
+
+#: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export files to:"
+msgstr "Format d'expòrt :"
+
+#: src/export/ExportMultiple.cpp
 msgid "Folder:"
 msgstr "Repertòri :"
+
+#: src/export/ExportMultiple.cpp
+msgid "Create"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Options:"
+msgstr "Opcions"
+
+#: src/export/ExportMultiple.cpp
+msgid "Split files based on:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Include audio before first label"
@@ -1912,11 +11320,34 @@ msgid "First file name:"
 msgstr "Primièr nom de fichièr :"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Primièr nom de fichièr :"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "TornarRenommar lo fichièr :"
 
 #: src/export/ExportMultiple.cpp
+msgid "Using Label/Track Name"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Numbering before Label/Track Name"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Prefix de nom de fichièr :"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "Prefix de nom de fichièr :"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "Prefix de nom de fichièr :"
 
 #: src/export/ExportMultiple.cpp
@@ -1924,12 +11355,122 @@ msgid "Overwrite existing files"
 msgstr "Espotir los fichièrs existissents"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Choose a location to save the exported files"
 msgstr "Causir un luòc per salvagardar los fichièrs exportats"
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Continue to export remaining files?"
+msgstr ""
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Save As..."
+msgstr "Enregistrar jos"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis Files"
+msgstr "Es pas un fichièr Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - rate or quality problem"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem with metadata"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem initialising"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem creating stream"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem with packets"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+msgid "Unable to export - problem with file"
+msgstr ""
 
 #: src/export/ExportOGG.cpp
 msgid "Exporting the selected audio as Ogg Vorbis"
 msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Exporting the audio as Ogg Vorbis"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Header:"
@@ -1940,17 +11481,411 @@ msgid "Encoding:"
 msgstr "Encodatge :"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "Causir un fichièr audio pas comprimit..."
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Error Exporting"
+msgstr "Error d'importacion"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
 msgstr "Impossible d'exportar l'audiò dins aquel format."
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "All supported files"
+msgstr "Totes los fichièrs preses en carga"
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid "Select stream(s) to import"
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "This version of Tenacity was not compiled with %s support."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Fichièr projècte AUP3"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid ""
+"Couldn't import the project:\n"
+"\n"
+"%s"
+msgstr "Impossible de trapar lo repertòri de donadas del projècte : \"%s\""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Import Project"
+msgstr "Projècte"
+
+#: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Impossible de trapar lo repertòri de donadas del projècte : \"%s\""
 
+#: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Project Import"
+msgstr "Projècte"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Failed to open %s"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Failed to seek to position %lld in %s"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Unable to read %lld samples from %s"
+msgstr ""
+
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "Totes los fichièrs"
+
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Lista dels fichièrs en format tèxt"
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+#, fuzzy
+msgid "Invalid window offset in LOF file."
+msgstr "Durada invalida dins lo fichièr LOF."
 
 #  i18n-hint: You do not need to translate "LOF"
 #. i18n-hint: You do not need to translate "LOF"
@@ -1963,6 +11898,16 @@ msgstr "Error de LOF"
 msgid "Invalid duration in LOF file."
 msgstr "Durada invalida dins lo fichièr LOF."
 
+#: src/import/ImportLOF.cpp
+msgid "MIDI tracks cannot be offset individually, only audio files can be."
+msgstr ""
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+#, fuzzy
+msgid "Invalid track offset in LOF file."
+msgstr "Durada invalida dins lo fichièr LOF."
+
 #: src/import/ImportMIDI.cpp
 #, c-format
 msgid "Imported MIDI from '%s'"
@@ -1971,6 +11916,44 @@ msgstr "Midi importat dempuei '%s'"
 #: src/import/ImportMIDI.cpp
 msgid "Import MIDI"
 msgstr "Importar MIDI"
+
+#: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s: Filename too short."
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s: Incorrect filetype."
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s."
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "Fichièrs XML"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis files"
+msgstr "Es pas un fichièr Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -1981,12 +11964,237 @@ msgid "Not an Ogg Vorbis file"
 msgstr "Es pas un fichièr Ogg Vorbis"
 
 #: src/import/ImportOGG.cpp
+msgid "Vorbis version mismatch"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
 msgid "Invalid Vorbis bitstream header"
 msgstr "Encap Vorbis bitstream invalid"
 
 #: src/import/ImportOGG.cpp
 msgid "Internal logic fault"
 msgstr "Error de logica intèrna"
+
+#: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 16 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 24 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "Importacion MP3"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "Fichièrs tèxte"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to start QuickTime extraction"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to retrieve stream description"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get fill buffer"
+msgstr ""
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "Importar de donadas brutas (Raw)"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -2032,8 +12240,18 @@ msgid "%d Channels"
 msgstr "%d Canals"
 
 #: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
 msgid "Channels:"
 msgstr "Canals :"
+
+#. i18n-hint: (noun)
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Start offset:"
+msgstr "Lançar lo script"
 
 #: src/import/ImportRaw.cpp
 msgid "bytes"
@@ -2048,11 +12266,26 @@ msgstr "Tròç a importar :"
 msgid "Sample rate:"
 msgstr "Frequéncia d'escandalhatge :"
 
+#: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Import"
+msgstr "Importar"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s left"
 msgstr "%s demorant"
+
+#. i18n-hint: given the name of a track, specify its right channel
+#: src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s right"
+msgstr "Clar"
 
 #. i18n-hint:
 #. First %s is replaced with the noun "start" or "end"
@@ -2062,12 +12295,18 @@ msgstr "%s demorant"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
 msgid_plural "%s %d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "start"
+msgstr "Aviar"
 
 #: src/menus/ClipMenus.cpp
 msgid "end"
@@ -2081,6 +12320,7 @@ msgstr "fin"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -2098,6 +12338,82 @@ msgid "%d of %d clip %s"
 msgid_plural "%d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Time shifted clips to the right"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Time shifted clips to the left"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
+msgid "Time-Shift"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Previo&us Clip"
+msgstr "Precedent"
+
+#: src/menus/ClipMenus.cpp
+msgid "Select Previous Clip"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "N&ext Clip"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Select Next Clip"
+msgstr "Seleccionar tot lo tèxte"
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Cursor to Prev Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Ne&xt Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Cursor to Next Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Time Shift &Left"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Time Shift &Right"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasted text from the clipboard"
+msgstr "Empegar dins del pòrtapapièr"
 
 #: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
 msgid "Pasted from the clipboard"
@@ -2121,6 +12437,14 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Escafar de  %.2f segondas a %.2f"
 
 #: src/menus/EditMenus.cpp
+msgid "Pasting one type of track into another is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Copying stereo audio into a mono track is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
 msgid "Duplicated"
 msgstr "Duplicar"
 
@@ -2129,17 +12453,82 @@ msgid "Duplicate"
 msgstr "Duplicar"
 
 #: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split-cut to the clipboard"
+msgstr "Copar cap al pòrtapapièr"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Cut"
+msgstr "Devesir"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Split-deleted %.2f seconds at t=%.2f"
+msgstr "Escafar de  %.2f segondas a %.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Delete"
+msgstr "Escafar"
+
+#: src/menus/EditMenus.cpp
 #, c-format
 msgid "Silenced selected tracks for %.2f seconds at %.2f"
 msgstr "Pistas seleccionadas tornadas mudas de %.2f segondas a %.2f"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#. i18n-hint: verb
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgctxt "command"
+msgid "Silence"
+msgstr "Detectar silenci"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
+msgstr "Pistas seleccionadas tornadas mudas de %.2f segondas a %.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "Àudio"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Devesir"
 
 #: src/menus/EditMenus.cpp
+msgid "Split to new track"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split New"
+msgstr "Devesir"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Joined %.2f seconds at t=%.2f"
+msgstr "Escafar de  %.2f segondas a %.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Escafar de  %.2f segondas a %.2f"
+
+#: src/menus/EditMenus.cpp
 msgid "Detach"
 msgstr "Destacar"
+
+#: src/menus/EditMenus.cpp
+msgid "Metadata Tags"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "&Edit"
@@ -2164,9 +12553,165 @@ msgstr "&Copiar"
 msgid "&Paste"
 msgstr "&Empegar"
 
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Duplic&ate"
+msgstr "Duplicar"
+
+#: src/menus/EditMenus.cpp
+msgid "R&emove Special"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut
+#: src/menus/EditMenus.cpp
+msgid "Spl&it Cut"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of DELETE
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split D&elete"
+msgstr "Escafar"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "Silenci"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Tri&m Audio"
+msgstr "Àudio"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/EditMenus.cpp
+msgid "Sp&lit"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Ne&w"
+msgstr "Devesir"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+msgid "&Join"
+msgstr ""
+
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "Detectar silenci"
+
+#: src/menus/EditMenus.cpp
+msgid "&Metadata..."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "&Preferéncias..."
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "&Delete Key"
+msgstr "&Escafar"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Delete Key&2"
+msgstr "Escafar"
+
+#: src/menus/ExtraMenus.cpp
+msgid "Ext&ra"
+msgstr ""
+
+#: src/menus/ExtraMenus.cpp
+#, fuzzy
+msgid "De&vice"
+msgstr "Periferic"
+
+#: src/menus/ExtraMenus.cpp
+msgid "Change &Recording Device..."
+msgstr ""
+
+#: src/menus/ExtraMenus.cpp
+#, fuzzy
+msgid "Change &Playback Device..."
+msgstr "Cambiament la nautor..."
+
+#: src/menus/ExtraMenus.cpp
+#, fuzzy
+msgid "Change Audio &Host..."
+msgstr "Cambiament la nautor..."
+
+#: src/menus/ExtraMenus.cpp
+#, fuzzy
+msgid "Change Recording Cha&nnels..."
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export Selected Audio"
+msgstr "Exportacion·de·la·seleccion· audio en Ogg Vorbis"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Marcadors"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "There are no label tracks to export."
+msgstr "Novèla·pista de marcadors creada"
+
+#: src/menus/FileMenus.cpp
+msgid "Please select only one Note Track at a time."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+msgid "Please select a Note Track."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "Importar MIDI"
+
 #: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "Fichièr MIDI"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Allegro file"
+msgstr "Totes los fichièrs"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "Importar MIDI"
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -2178,6 +12723,41 @@ msgid "Import Labels"
 msgstr "Importar los m&arcadors"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Select a MIDI file"
+msgstr "Seleccionar un fichièr"
+
+#: src/menus/FileMenus.cpp
+msgid "MIDI and Allegro files"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI files"
+msgstr "Fichièr MIDI"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Allegro files"
+msgstr "Totes los fichièrs"
+
+#: src/menus/FileMenus.cpp
+msgid "&Dangerous Reset..."
+msgstr ""
+
+#. i18n-hint: This is the name of the menu item on Mac OS X only
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Open Recent"
+msgstr "Recentament dobèrts..."
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "Fichièrs tèxte"
+
+#: src/menus/FileMenus.cpp
 msgid "&Save Project"
 msgstr "&Enregistrar lo projècte"
 
@@ -2186,12 +12766,36 @@ msgid "Save Project &As..."
 msgstr "Enregistrar lo projècte &jos..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Backup Project..."
+msgstr "Enregistrar lo projècte &jos..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Export"
+msgstr "Exportar"
+
+#: src/menus/FileMenus.cpp
 msgid "Export as MP&3"
 msgstr "Exportar coma MP&3"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export as &WAV"
+msgstr "Exportar los marcadors jos :"
+
+#: src/menus/FileMenus.cpp
 msgid "Export as &OGG"
 msgstr "Exportar coma &OGG"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Export Audio..."
+msgstr "Exportar..."
+
+#: src/menus/FileMenus.cpp
+msgid "Expo&rt Selected Audio..."
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export &Labels..."
@@ -2202,13 +12806,51 @@ msgid "Export &Multiple..."
 msgstr "Expòrt &Multiple..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MI&DI..."
+msgstr "Exportar..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "Àudio"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Labels..."
+msgstr "Marcadors"
+
+#: src/menus/FileMenus.cpp
+msgid "&MIDI..."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+msgid "&Raw Data..."
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Pa&ge Setup..."
 msgstr "Mesa en pagina..."
 
 #. i18n-hint: (verb) It's item on a menu.
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Print..."
+msgstr "Estampar"
+
+#. i18n-hint: (verb) It's item on a menu.
+#: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Quitar"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export as FLAC"
+msgstr "Exportar los marcadors jos :"
 
 #: src/menus/HelpMenus.cpp
 #, c-format
@@ -2216,49 +12858,576 @@ msgid "Save %s"
 msgstr "Enregistrar %s"
 
 #: src/menus/HelpMenus.cpp
+#, c-format
+msgid "Unable to save %s"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Do you have these problems?"
+msgstr "Volètz enregistrar las modificacions ?"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Fix"
+msgstr "Mescla"
+
+#: src/menus/HelpMenus.cpp
+msgid "Quick Fixes"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "Pas res a far"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&A prepaus de \"Audacity\"..."
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Clocks on the Tracks"
+msgstr "Pista de nòta"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Can't select precisely"
+msgstr "Impossible de dubrir lo fichièr projècte"
+
+#: src/menus/HelpMenus.cpp
+msgid "Recording stops and starts"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Quick Fix..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Getting Started"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Quick Help..."
+msgstr "Ajuda..."
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Diagnostics"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Marcador apondut"
+
+#: src/menus/LabelMenus.cpp
+msgid "Paste Text to New Label"
+msgstr ""
+
+#. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
+#. regions.
+#: src/menus/LabelMenus.cpp
+msgid "Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Cut Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just deleted the labeled audio regions
+#: src/menus/LabelMenus.cpp
+msgid "Deleted labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Delete Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just split cut the labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut on the labels
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just done a special kind of DELETE on
+#. the labeled audio regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Deleted labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of DELETE on labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Delete Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Silenced labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Silence Labeled Audio"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+msgid "Copied labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Copy Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) past tense.  Audacity has just split the labeled
+#. audio (a point or a region)
+#: src/menus/LabelMenus.cpp
+msgid "Split labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Split Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+msgid "Joined labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Join Labeled Audio"
+msgstr ""
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+msgid "Detached labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Detach Labeled Audio"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Labels"
+msgstr "Marcadors"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Edit Labels..."
+msgstr "Modificar las etiquetas"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Add Label at &Selection"
+msgstr "&Seleccion"
+
+#: src/menus/LabelMenus.cpp
+msgid "Add Label at &Playback Position"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+msgid "Paste Te&xt to New Label"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "La&beled Audio"
+msgstr "Audio gravat"
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
 msgid "&Cut"
 msgstr "&Copar"
 
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Cut"
+msgstr "Edicion de marcador"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Delete"
+msgstr "Escafar"
+
+#. i18n-hint: (verb) A special way to cut out a piece of audio
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "&Split Cut"
+msgstr "Devesir"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split Cut"
+msgstr "Edicion de marcador"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Sp&lit Delete"
+msgstr "&Escafar"
+
+#: src/menus/LabelMenus.cpp
+msgid "Label Split Delete"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "Silenci"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Silence"
+msgstr "Detectar silenci"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+msgid "Co&py"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Copy"
+msgstr "Enregistrar la còpia"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Spli&t"
+msgstr "Devesir"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Split"
+msgstr "Edicion de marcador"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Join"
+msgstr "Edicion de marcador"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move F&orward from Toolbars to Tracks"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to &Previous Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to &Next Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to &First Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to &Last Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to P&revious and Select"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to N&ext and Select"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "&Toggle Focused Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Toggle Focuse&d Track"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Novèl..."
+
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
 msgstr "Desconegudas"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy, c-format
+msgid "&Repeat %s"
+msgstr "Répéter %s"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy, c-format
+msgid "Plug-in %d to %d"
+msgstr "Moduls de %i a %i"
 
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "&Congrear"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+msgid "Repeat Last Generator"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Effe&ct"
 msgstr "Efiè&ch"
+
+#: src/menus/PluginMenus.cpp
+msgid "Repeat Last Effect"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&Analisi"
 
 #: src/menus/PluginMenus.cpp
+msgid "Repeat Last Analyzer"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools"
+msgstr "Aisinas"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Tool"
+msgstr "Répéter %s"
+
+#: src/menus/PluginMenus.cpp
+msgid "&Macros..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Apply Macro"
+msgstr "&Aplicar"
+
+#: src/menus/PluginMenus.cpp
+msgid "Palette..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+msgid "Reset &Configuration"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Screenshot..."
+msgstr "Captura d'ecran"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Run Benchmark..."
 msgstr "&Lançar Tèst de performanças..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Simulate Recording Errors"
+msgstr "Enregistrament"
+
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+msgid "Script&ables I"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Select Time..."
+msgstr "Seleccionar una ora"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Select Frequencies..."
+msgstr "&Preferéncias..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Select Tracks..."
+msgstr "Seleccionar..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Set Track Status..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Cambiar lo nom de la pista en : "
+
+#: src/menus/PluginMenus.cpp
+msgid "Set Track Visuals..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Preference..."
+msgstr "&Preferéncias..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Preference..."
+msgstr "&Preferéncias..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Clip..."
+msgstr "Ajuda..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Envelope..."
+msgstr "Aisina de nivèl (envolopa)"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Label..."
+msgstr "Definir l'etiqueta"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Project..."
+msgstr "Enregistrar lo projècte &jos..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+msgid "Scripta&bles II"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track..."
+msgstr "Novèla pista"
+
+#: src/menus/PluginMenus.cpp
+msgid "Get Info..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Message..."
+msgstr "Messatge"
 
 #: src/menus/PluginMenus.cpp
 msgid "Help..."
 msgstr "Ajuda..."
 
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Open Project..."
+msgstr "Recentament dobèrts..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Save Project..."
+msgstr "Enregistrar lo projècte &jos..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Move Mouse..."
+msgstr "Causir..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Compare Audio..."
+msgstr "Audio gravat"
+
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+msgid "Screenshot (short format)..."
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Definir un punt de seleccion"
+
 #: src/menus/SelectMenus.cpp
 msgid "Position"
 msgstr "Posicion"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Definir un punt de seleccion"
 
 #. i18n-hint: (verb) It's an item on a menu.
 #: src/menus/SelectMenus.cpp
@@ -2266,12 +13435,502 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&None"
+msgstr "Pas cap"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select None"
+msgstr "Seleccion"
+
+#: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Tracks"
+msgstr "Pistas"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "Totas las pistas"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Seleccionat"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "&Left at Playback Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Selection Left at Play Position"
+msgstr "Definir un punt de seleccion"
+
+#: src/menus/SelectMenus.cpp
+msgid "&Right at Playback Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Selection Right at Play Position"
+msgstr "Definir un punt de seleccion"
+
+#: src/menus/SelectMenus.cpp
+msgid "Track &Start to Cursor"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Select Track Start to Cursor"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor to Track &End"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Cursor to Track End"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/SelectMenus.cpp
+msgid "Track Start to En&d"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Track Start to End"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "S&tore Selection"
+msgstr "&Seleccion"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Retrieve Selectio&n"
+msgstr "Escafar la seleccion"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "S&pectral"
+msgstr "Espèctre"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "To&ggle Spectral Selection"
+msgstr "Definir un punt de seleccion"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Next &Higher Peak Frequency"
+msgstr "Frequéncia nauta"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Next &Lower Peak Frequency"
+msgstr "Frequéncia bassa"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Select Cursor to Stored"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Store Cursor Pos&ition"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "At &Zero Crossings"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Zero Crossing"
+msgstr "Seleccion"
+
+#: src/menus/SelectMenus.cpp
 msgid "&Selection"
 msgstr "&Seleccion"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Off"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Nearest"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection to &Start"
+msgstr "Enrèire a la començança"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection to En&d"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Extend &Left"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Extend &Right"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set (or Extend) Le&ft Selection"
+msgstr "Ampliar la seleccion"
+
+#: src/menus/SelectMenus.cpp
+msgid "Set (or Extend) Rig&ht Selection"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Contract L&eft"
+msgstr "Definir un punt de seleccion"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Contract R&ight"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Cursor to"
+msgstr "Cursor :"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Star&t"
+msgstr "Seleccion"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Selection Start"
+msgstr "&Zoom de la seleccion"
+
+#: src/menus/SelectMenus.cpp src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Selection En&d"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Selection End"
+msgstr "&Zoom de la seleccion"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start"
+msgstr "Pista 0"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor to Track Start"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &End"
+msgstr "Pista %d"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor to Track End"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Project Start"
+msgstr "Projècte"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor to Project Start"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Project E&nd"
+msgstr "Projècte"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor to Project End"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Cursor"
+msgstr "Cursor :"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Left"
+msgstr "Cursor :"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Right"
+msgstr "Cursor :"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Sh&ort Jump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Shor&t Jump Right"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long J&ump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long Ju&mp Right"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "&Toolbars"
 msgstr "&Barra d'aisinas"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "Reset Toolb&ars"
+msgstr "&Barra d'aisinas"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr "Pista(s) audiò suprimidas(s)"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+msgid "Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr ""
+
+#. i18n-hint: One or more audio tracks have been panned
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Panned audio track(s)"
+msgstr "Pista(s) audiò suprimidas(s)"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan Track"
+msgstr "Pista"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Zero"
+msgstr "Data iniciala"
+
+#: src/menus/TrackMenus.cpp
+msgid "Start to &Cursor/Selection Start"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to Selection &End"
+msgstr "Definir un punt de seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "End to Cu&rsor/Selection Start"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "End to Selection En&d"
+msgstr "Ampliar la seleccion"
+
+#. i18n-hint: In this and similar messages describing editing actions,
+#. the starting or ending points of tracks are re-"aligned" to other
+#. times, and the time selection may be "moved" too.  The first
+#. noun -- "start" in this example -- is the object of a verb (not of
+#. an implied preposition "from").
+#: src/menus/TrackMenus.cpp
+msgid "Aligned/Moved start to zero"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to zero"
+msgstr "Cursor alinhat"
+
+#. i18n-hint: This and similar messages give shorter descriptions of
+#. the aligning and moving editing actions
+#: src/menus/TrackMenus.cpp
+msgid "Align/Move Start"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align Start"
+msgstr "Aviar"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to cursor/selection start"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to cursor/selection start"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to selection end"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to selection end"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to cursor/selection start"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to cursor/selection start"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+msgid "Align/Move End"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align End"
+msgstr "Alinhat"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to selection end"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to selection end"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TrackMenus.cpp
+msgid "Aligned/Moved end to end"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to end"
+msgstr "Seleccionar fins a la fin"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move End to End"
+msgstr "Anar a la fin"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align End to End"
+msgstr "Anar a la fin"
+
+#: src/menus/TrackMenus.cpp
+msgid "Aligned/Moved together"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned together"
+msgstr "Cursor alinhat"
+
+#: src/menus/TrackMenus.cpp
+msgid "Align/Move Together"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align Together"
+msgstr "Alinhar amb lo &Zèro"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronize MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted gain"
+msgstr "Envolopa ajustada."
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted Pan"
+msgstr "Envolopa ajustada."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
@@ -2290,12 +13949,295 @@ msgid "Created new label track"
 msgstr "Novèla·pista de marcadors creada"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Novèla·pista de temps creada"
 
 #: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Frequéncia d'escandalhatge :"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "The entered value is invalid"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Resampling track %d"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resampled audio track(s)"
+msgstr "Pista(s) audiò suprimidas(s)"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "Suprimir· la pista"
+
+#: src/menus/TrackMenus.cpp
+msgid "Please select at least one audio track and one MIDI track."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by time"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Time"
+msgstr "Ora iniciala"
+
+#: src/menus/TrackMenus.cpp
+msgid "Tracks sorted by name"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Name"
+msgstr "Nom de l'artista"
+
+#: src/menus/TrackMenus.cpp
+msgid "Can't delete track with active audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&Novèl"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mono Track"
+msgstr "Bolegar la pista"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Stereo Track"
+msgstr "Pista de nòta"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Label Track"
+msgstr "Poliça de la pista de marcadors"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Time Track"
+msgstr "Novèla pista"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix Stereo Down to &Mono"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x and Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Mix and Render to Ne&w Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Resample..."
+msgstr "&Tornar nomenar..."
+
+#: src/menus/TrackMenus.cpp
 msgid "Remo&ve Tracks"
 msgstr "Suprimir la (las) pista(s)"
+
+#: src/menus/TrackMenus.cpp
+msgid "M&ute/Unmute"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "Totas las pistas"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Unmute All Tracks"
+msgstr "Totas las pistas"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mut&e Tracks"
+msgstr "Pista de nòta"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "U&nmute Tracks"
+msgstr "Pista de nòta"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Left"
+msgstr "Esquèrra"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan Left"
+msgstr "Esquèrra"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Right"
+msgstr "Drecha"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan Right"
+msgstr "Drecha"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Center"
+msgstr "Centrat"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan Center"
+msgstr "Centrat"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "Totas las pistas"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align End to End"
+msgstr "Anar a la fin"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align &Together"
+msgstr "Alinhar amb lo &Zèro"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Move Selection with Tracks (on/off)"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Move Sele&ction and Tracks"
+msgstr "Reglar la seleccion"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "S&ort Tracks"
+msgstr "Pista de nòta"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "By &Start Time"
+msgstr "Ora iniciala"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "By &Name"
+msgstr "Nom"
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Track"
+msgstr "Pista"
+
+#: src/menus/TrackMenus.cpp
+msgid "Change P&an on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Pan &Left on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Pan &Right on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Change Gai&n on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Increase Gain on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Decrease Gain on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Op&en Menu on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "M&ute/Unmute Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Solo/Unsolo Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Close Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Move Focused Track U&p"
+msgstr "Bolegar la pista"
+
+#: src/menus/TrackMenus.cpp
+msgid "Move Focused Track Do&wn"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Move Focused Track to T&op"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Move Focused Track to &Bottom"
+msgstr ""
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
@@ -2307,17 +14249,361 @@ msgstr "Lectura"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Enregistrament"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track"
+msgstr "Novèla·pista de marcadors creada"
+
+#: src/menus/TransportMenus.cpp
+msgid "no label track at or below focused track"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no labels in label track"
+msgstr "Novèla·pista de marcadors creada"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Please select in a mono track."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Please select in a stereo track or two mono tracks."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "Please select at least %d channels."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Please select a time within a clip."
+msgstr ""
+
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Tra&nsport"
+msgstr "Transpòrt"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&aying"
+msgstr "Lectura"
+
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Loop Play"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Pausa"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Recording"
+msgstr "Enregistrament"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "Enregistrar"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Append Record"
+msgstr "Enregistrar"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Record &New Track"
+msgstr "Suprimir la (las) pista(s)"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Enregistrament"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "R&escan Audio Devices"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Transport &Options"
+msgstr "Aisina·de·seleccion"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "Transpòrt"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay"
+msgstr ""
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play &One Second"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play to &Selection"
+msgstr "&Zoom de la seleccion"
+
+#: src/menus/TransportMenus.cpp
+msgid "Play &Before Selection Start"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play Af&ter Selection Start"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play Be&fore Selection End"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play Aft&er Selection End"
+msgstr "Escafar la seleccion"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play Before a&nd After Selection Start"
+msgstr "Fin·alinhada·amb la començança de la seleccion"
+
+#: src/menus/TransportMenus.cpp
+msgid "Play Before an&d After Selection End"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview"
+msgstr "&Apercebut"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Play-at-Speed"
+msgstr "Velocitat de lectura"
+
+#. i18n-hint: 'Normal Play-at-Speed' doesn't loop or cut preview.
+#: src/menus/TransportMenus.cpp
+msgid "Normal Pl&ay-at-Speed"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play-at-Speed"
+msgstr "Velocitat de lectura"
+
+#: src/menus/TransportMenus.cpp
+msgid "Play C&ut Preview-at-Speed"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Ad&just Playback Speed..."
+msgstr "Velocitat de lectura"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Increase Playback Speed"
+msgstr "Velocitat de lectura"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Decrease Playback Speed"
+msgstr "Velocitat de lectura"
+
+#: src/menus/TransportMenus.cpp
+msgid "Move to Pre&vious Label"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Move to Ne&xt Label"
+msgstr ""
 
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Afichatge"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "Zoom avant"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Zoom &In"
+msgstr "Zoom avant"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Zoom &Normal"
+msgstr "Orizontal"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Zoom &Out"
+msgstr "Zoom arrièr"
+
 #: src/menus/ViewMenus.cpp
 msgid "&Zoom to Selection"
 msgstr "&Zoom de la seleccion"
+
+#: src/menus/ViewMenus.cpp
+msgid "Zoom &Toggle"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Advanced &Vertical Zooming"
+msgstr "Paramètres avançats"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "T&rack Size"
+msgstr "Títol de la pista"
+
+#: src/menus/ViewMenus.cpp
+msgid "&Fit to Width"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Fit to &Height"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Collapse All Tracks"
+msgstr "Totas las pistas"
+
+#: src/menus/ViewMenus.cpp
+msgid "E&xpand Collapsed Tracks"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Sk&ip to"
+msgstr "Anar a la fin"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Selection Sta&rt"
+msgstr "Seleccion"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Skip to Selection Start"
+msgstr "Enrèire a la començança"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Skip to Selection End"
+msgstr "Definir un punt de seleccion"
+
+#: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "&Show Clipping (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+msgid "Show Effects Rack"
+msgstr ""
+
+#: src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Window"
+msgstr "Fenèstra"
 
 #. i18n-hint: Standard Macintosh Window menu item:  Make (the current
 #. * window) shrink to an icon on the dock
@@ -2325,13 +14611,38 @@ msgstr "&Zoom de la seleccion"
 msgid "&Minimize"
 msgstr "&Reduire"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+msgid "Decoding Waveform"
+msgstr ""
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
+
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
 msgstr "Preferéncias d'Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "&A prepaus de \"Audacity\"..."
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -2339,9 +14650,32 @@ msgstr "&A prepaus de \"Audacity\"..."
 msgid "&Check for Updates"
 msgstr "Error de dubèrtura de fichièr"
 
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+#, fuzzy
+msgid "Batch"
+msgstr "Correspond"
+
+#: src/prefs/BatchPrefs.cpp
+#, fuzzy
+msgid "Preferences for Batch"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Behaviors"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Devices"
 msgstr "Periferics"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Preferences for Device"
+msgstr "Preferéncias d'Audacity"
 
 #. i18n-hint Software interface to audio devices
 #: src/prefs/DevicePrefs.cpp
@@ -2354,22 +14688,150 @@ msgstr "Interfàcia"
 msgid "&Host:"
 msgstr "&Òste:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Using:"
+msgstr "Mancant"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Lectura"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "&Device:"
+msgstr "Periferic"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "De&vice:"
+msgstr "Periferic"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Cha&nnels:"
+msgstr "Canals :"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Latency"
 msgstr "Laténcia"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "milliseconds"
+msgstr "segondas"
+
+#: src/prefs/DevicePrefs.cpp
+msgid "&Buffer length:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+msgid "&Latency compensation:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Pista(s) audiò suprimidas(s)"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No devices found"
+msgstr "Cap de periferic pas trobat\n"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Canal (Mono)"
 
 #: src/prefs/DevicePrefs.cpp
 msgid "2 (Stereo)"
 msgstr "2 (Estereofonic)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Repertòris"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Default directories"
+msgstr "Repertòris"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Browse..."
+msgstr "Percórrer..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "B&rowse..."
+msgstr "Percórrer..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Import:"
+msgstr "Importar"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Br&owse..."
+msgstr "Percórrer..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Export:"
+msgstr "Exportar"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Bro&wse..."
+msgstr "Percórrer..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "&Macro output:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "Novèl Repertòri Temporari"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Emplaçament"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Brow&se..."
+msgstr "Percórrer..."
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "&Free Space:"
@@ -2378,6 +14840,20 @@ msgstr "&Espaci liure :"
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location to place the temporary directory"
 msgstr "Causir un luòc per plaçar lo repertòri temporari"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Choose a location"
+msgstr "Causir un luòc per salvagardar los fichièrs"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -2394,12 +14870,195 @@ msgid "Directory %s is not writable"
 msgstr "Lo repertòri %s es protegit en escritura."
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Los cambiaments de dorsièr temporari prendràn efièch sonque aprèp aveire demarat Audacity tornamai "
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Novèl Repertòri Temporari"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Preferences for Effects"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Publisher and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Type and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr ""
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "Totes los efèits"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Opcions d'efèit"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Plugin Options"
+msgstr "Opcions"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Instruction Set"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Extended Import"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ExtImport"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Tipe de fichièr :"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Importar"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Move rule &up"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Move rule &down"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Move f&ilter up"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Move &filter down"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "De&lete selected rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "TornarRenommar lo fichièr :"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Seleccionat"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Do you really want to delete selected rule?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Definir un punt de seleccion"
+
+#: src/prefs/ExtImportPrefs.h
+#, fuzzy
+msgid "Ext Import"
+msgstr "Importar"
 
 #. i18n-hint: refers to Audacity's user interface settings
 #: src/prefs/GUIPrefs.cpp
@@ -2408,12 +15067,32 @@ msgid "Interface"
 msgstr "Interfàcia"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Preferences for GUI"
+msgstr "Preferéncias"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-36 dB (shallow range for high-amplitude editing)"
 msgstr "-36 dB (per edicion d'amplitud bèla)"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (amplitud PCM en escandalhatge 8 bits)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (amplitud PCM en escandalhatge 16 bits)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-72 dB (PCM range of 12 bit samples)"
+msgstr "-96 dB (amplitud PCM en escandalhatge 16 bits)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-84 dB (PCM range of 14 bit samples)"
+msgstr "-145 dB (amplitud PCM en escandalhatge 24 bits)"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "-96 dB (PCM range of 16 bit samples)"
@@ -2427,14 +15106,222 @@ msgstr "-120 dB (limit aproximativa de l'audicion umana)"
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (amplitud PCM en escandalhatge 24 bits)"
 
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Emplaçament"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
 #: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
 msgid "Display"
 msgstr "Afichatge"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Lenga :"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Location of &Manual:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Meter dB &range:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show e&xtra menus"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show Timeline Tooltips"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+msgid "Show Scrub Ruler"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "Importar de donadas brutas (Raw)"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Mix down to Stereo or Mono"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Use Advanced Mixing Options"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Seconds"
+msgstr "Segondas"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Beats"
+msgstr "Repetir"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Exported Label Style:"
+msgstr "Exportar los marcadors jos :"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Keyboard"
 msgstr "Clavièr"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Preferences for KeyConfig"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Key Bindings"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by:"
+msgstr "&Afichatge"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Name"
+msgstr "Nom"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by name"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Bindings"
+msgstr "Avertiments"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Paramètres"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -2444,14 +15331,45 @@ msgstr "Bremba-te : Picar Cmd+Q per sortir. Totas las autras claus son validas."
 msgid "&Import..."
 msgstr "&Importar..."
 
+#: src/prefs/KeyConfigPrefs.cpp src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "&Defaults"
+msgstr "Valors per defaut"
+
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Causir un fichièr XML que conten d'acorchas clavièr..."
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Error Importing Keyboard Shortcuts"
+msgstr "Cargament de los acorchis clavièr"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Cargament %d de las acorchas clavièr\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -2461,9 +15379,96 @@ msgstr "Cargament de los acorchis clavièr"
 msgid "Export Keyboard Shortcuts As:"
 msgstr "Exportar las acorchas clavièr jos :"
 
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Error Exporting Keyboard Shortcuts"
+msgstr "Exportar las acorchas clavièr jos :"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.h
+msgid "Key Config"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Preferences for Library"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
 #: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "Version de la libraria MP3 :"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "Version de la libraria MP3 :"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "Bibliotèca"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Loca&te..."
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Dow&nload"
+msgstr "Telecargament"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.cpp
 msgid "Success"
@@ -2473,16 +15478,79 @@ msgstr "Succès"
 msgid "Library"
 msgstr "Bibliotèca"
 
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "Periferics"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "Preferences for MidiIO"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Interfàcia"
+
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
 msgctxt "MIDI"
 msgid "Interface"
 msgstr "Interfàcia"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
 msgstr "Moduls"
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Preferences for Module"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/ModulePrefs.cpp
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "Los cambiaments de dorsièr temporari prendràn efièch sonque aprèp aveire demarat Audacity tornamai "
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -2492,13 +15560,27 @@ msgstr "Demandar"
 msgid "Failed"
 msgstr "Fracàs"
 
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "No modules were found"
+msgstr "Cap de periferic pas trobat\n"
+
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modul"
 
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
+
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
 msgstr "Mirga"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Preferences for Mouse"
+msgstr "Preferéncias d'Audacity"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Mouse Bindings (default values, not configurable)"
@@ -2507,6 +15589,11 @@ msgstr "Mirga (reglatges per defaut, pas modificables)"
 #: src/prefs/MousePrefs.cpp
 msgid "Tool"
 msgstr "Aisina"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Command Action"
+msgstr "Comanda "
 
 #: src/prefs/MousePrefs.cpp
 msgid "Buttons"
@@ -2528,7 +15615,10 @@ msgstr "Limpar a esquèrra"
 msgid "Set Selection Range"
 msgstr "Reglar la seleccion"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Maj + Clic esquèrra"
 
@@ -2537,12 +15627,100 @@ msgid "Extend Selection Range"
 msgstr "Ampliar la seleccion"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Alt + Clic esquèrra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Select Clip or Entire Track"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Change scrub speed"
+msgstr "Cambiar la velocitat"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom in on Point"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom in on a Range"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "same as right-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Right-Click"
 msgstr "Clic de drecha"
 
 #: src/prefs/MousePrefs.cpp
+msgid "Zoom out one step"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Right-Drag"
 msgstr "Limpar a drecha"
+
+#: src/prefs/MousePrefs.cpp
+msgid "same as left-drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Limpar a esquèrra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom out on a Range"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Clic d'esquèrra"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom default"
+msgstr "Zoom arrièr"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clip left/right or between tracks"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Left-Drag"
+msgstr "Ctrl + rossegar a esquèrra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "-Left-Drag"
+msgstr "Limpar a esquèrra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clip up/down between tracks"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Limpar a esquèrra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -2574,25 +15752,296 @@ msgid "Change ONE Sample only"
 msgstr "Cambiar un sol escandilh :"
 
 #: src/prefs/MousePrefs.cpp
+msgid "Multi"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "same as select tool"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "same as zoom tool"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Any"
 msgstr "Totes"
 
+#: src/prefs/MousePrefs.cpp
+msgid "Scroll tracks up or down"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Shift-Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Scroll waveform"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "-Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Zoom waveform in or out"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "-Shift-Wheel-Rotate"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Vertical Scale Waveform (dB) range"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Preferences for Playback"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Effects Preview"
+msgstr "Efèits"
+
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "&Length:"
+msgstr "Longor"
+
+#. i18n-hint: (noun) this is a preview of the cut
+#: src/prefs/PlaybackPrefs.cpp
+#, fuzzy
+msgid "Cut Preview"
+msgstr "&Apercebut"
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferéncias d'Audacity"
 
 #: src/prefs/PrefsDialog.cpp
 msgid "Category"
 msgstr "Categoria"
 
+#: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
+#, fuzzy
+msgid "Preferences:"
+msgstr "Preferéncias"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Preferences for Quality"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Autre..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "Edicion d'escandilh"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Default Sample &Rate:"
+msgstr "Causir un format d'escandilh"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Default Sample &Format:"
+msgstr "Causir un format d'escandilh"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Frequéncia d'escandalhatge :"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Con&verter:"
+msgstr "Frequéncia d'escandalhatge :"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Interpolacion de qualitat nauta"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sample Rate Conver&ter:"
+msgstr "Frequéncia d'escandalhatge :"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Preferences for Recording"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Record on a new track"
+msgstr ""
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Enregistrament"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Le&vel (dB):"
+msgstr "Amplificacion (dB) :"
+
+#. i18n-hint: start of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Name newly recorded tracks"
+msgstr "Novèla·pista audio stereo creada"
+
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Custom Track &Name"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Custom name text"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Recorded_Audio"
+msgstr "Audio gravat"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "&Track Number"
+msgstr "Pista 0"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "System &Date"
+msgstr "Sistèma"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "System T&ime"
+msgstr "Sistèma"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Punch and Roll Recording"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Cross&fade:"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Period"
 msgstr "Periòde"
+
+#. i18n-hint: New color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (default)"
+msgstr "Classic"
 
 #. i18n-hint: Classic color scheme(from theme) for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -2600,22 +16049,220 @@ msgctxt "spectrum prefs"
 msgid "Color (classic)"
 msgstr "Classic"
 
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr ""
+
+#. i18n-hint: Inverse grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgctxt "spectrum prefs"
+msgid "Inverse grayscale"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Frequencies"
+msgstr "Frequéncia"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Nautor (EAC)"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Minimum frequency must be at least 0 Hz"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The range must be at least 1 dB"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Spectrogram Settings"
+msgstr "Espectrograms"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrograms"
 msgstr "Espectrograms"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Preferences for Spectrum"
+msgstr "Preferéncias d'Audacity"
+
+#. i18n-hint: use is a verb
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "&Use Preferences"
+msgstr "Preferéncias"
+
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "S&cale:"
+msgstr "Escala :"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Mi&n Frequency (Hz):"
+msgstr "Frequéncia (Hz)"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Ma&x Frequency (Hz):"
+msgstr "Frequéncia (Hz)"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Colors"
+msgstr "Color :"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Amplificacion (dB) :"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Amplificacion (dB) :"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
 msgstr "Algoritme"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "A&lgorithm:"
+msgstr "Algoritme"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &size:"
+msgstr "Fenèstra"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "1024 - default"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr "Fenèstra"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Zero padding factor:"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Ena&ble Spectral Selection"
+msgstr "Definir un punt de seleccion"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Minimum Amplitude (dB):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
 msgstr "Paramètres globals"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Ena&ble spectral selection"
+msgstr "Fa venir la seleccion muda"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The maximum frequency must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The minimum frequency must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The gain must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The range must be a positive integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The frequency gain must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The maximum number of notes must be an integer"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr ""
 
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
@@ -2626,8 +16273,159 @@ msgid "Theme"
 msgstr "Tèma"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Preferences for Theme"
+msgstr "Preferéncias"
+
+#: src/prefs/ThemePrefs.cpp
 msgid "Info"
 msgstr "Informacion"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Save Files"
+msgstr "Enregistrar jos"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Load Files"
+msgstr "Fichièrs XML"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+msgid "Tracks Behaviors"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "Simplificat"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Multi-track"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Select all audio, if selection required"
+msgstr ""
+
+#. i18n-hint: Cut-lines are lines that can expand to show the cut audio.
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable cut &lines"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Enable &dragging selection edges"
+msgstr "Fa venir la seleccion muda"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Advanced &vertical zooming"
+msgstr "Paramètres avançats"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Boton"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Logarithmic (dB)"
+msgstr "Logaritmic"
+
+#: src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.h
+msgid "Waveform"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Spectrogram"
+msgstr "Espectrograms"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
+msgid "Fit to Width"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Zoom to Selection"
+msgstr "&Zoom de la seleccion"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Zoom Default"
+msgstr "Valors per defaut"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Minutes"
@@ -2637,14 +16435,171 @@ msgstr "Minutas"
 msgid "Seconds"
 msgstr "Segondas"
 
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "5ths of Seconds"
+msgstr "Segondas"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "10ths of Seconds"
+msgstr "Segondas"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "20ths of Seconds"
+msgstr "Segondas"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "50ths of Seconds"
+msgstr "Segondas"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "100ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "500ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "MilliSeconds"
+msgstr "Segondas"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Samples"
+msgstr "Edicion d'escandilh"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+msgid "Max Zoom"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preferences for Tracks"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "&Pinned Recording/Playback head"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Default &view mode:"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Default Waveform scale:"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "Afichatge :"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Default audio track &name:"
+msgstr "Novèla·pista audiò creada"
+
 #. i18n-hint: The default name for an audio track.
 #: src/prefs/TracksPrefs.cpp
 msgid "Audio Track"
 msgstr "Pista audiò"
 
+#: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
+msgid "Zoom Toggle"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preset 1:"
+msgstr "Prereglatges :"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preset 2:"
+msgstr "Prereglatges :"
+
 #: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
 msgid "Warnings"
 msgstr "Avertiments"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Preferences for Warnings"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "Enregistrament del projècte"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "Enregistrament del projècte"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down to &mono during export"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down to &stereo during export"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
+
+#. i18n-hint: A waveform is a visual representation of vibration
+#: src/prefs/WaveformPrefs.cpp
+msgid "Waveforms"
+msgstr ""
+
+#: src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "Preferences for Waveforms"
+msgstr "Preferéncias d'Audacity"
+
+#: src/prefs/WaveformPrefs.cpp
+msgid "Waveform dB &range:"
+msgstr ""
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
@@ -2654,10 +16609,6 @@ msgid "Stopped"
 msgstr "Arrestada"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Enrèire a la començança"
 
@@ -2665,33 +16616,413 @@ msgstr "Enrèire a la començança"
 msgid "Skip to End"
 msgstr "Anar a la fin"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Select to Start"
+msgstr "Enrèire a la començança"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Select to End"
+msgstr "Seleccionar fins a la fin"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Loop Play"
+msgstr "Legir"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Record New Track"
+msgstr "Novèla pista"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Append Record"
+msgstr "Enregistrar"
+
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. is playing or recording or stopped, and whether it is paused.
+#: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy, c-format
+msgid "%s Paused."
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Aisina·de·seleccion"
+
+#. i18n-hint: (noun) It's the device used for playback.
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Playback Device"
+msgstr "Velocitat de lectura"
+
+#. i18n-hint: (noun) It's the device used for recording.
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Recording Device"
+msgstr "Enregistrament"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "Àudio"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Recording Channels"
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "1 (Mono) Recording Channel"
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "2 (Stereo) Recording Channels"
+msgstr "Canal d'enregistrament : %d\n"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Recording Device"
+msgstr "Enregistrament"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Playback Device"
+msgstr "Lectura"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Seleccionar fins a la fin"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Recording Channels"
+msgstr "Seleccion"
+
+#: src/toolbars/DeviceToolBar.cpp
+msgid "Device information is not available."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that manages devices
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "&Device Toolbar"
+msgstr "&Barra d'aisinas"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Cut selection"
+msgstr "Escafar la seleccion"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Copy selection"
+msgstr "Escafar la seleccion"
+
+#: src/toolbars/EditToolBar.cpp
+msgid "Trim audio outside selection"
+msgstr ""
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Silence audio selection"
+msgstr "Escafar la seleccion"
+
+#: src/toolbars/EditToolBar.cpp
+msgid "Sync-Lock Tracks"
+msgstr ""
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zoom avant"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zoom arrièr"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Fit selection to width"
+msgstr "Definir un punt de seleccion"
+
+#: src/toolbars/EditToolBar.cpp
+msgid "Fit project to width"
+msgstr ""
+
+#: src/toolbars/EditToolBar.cpp
+msgid "Open Effects Rack"
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar for editing
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "&Edit Toolbar"
+msgstr "&Barra d'aisinas"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "Enregistrament"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Recording Meter"
+msgstr "Enregistrament"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Playback Meter"
+msgstr "Velocitat de lectura"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "Enregistrar"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Play"
+msgstr "Mètre"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Playback Level"
+msgstr "Velocitat de lectura"
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Recording Level"
+msgstr "Enregistrament"
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the recording level meters
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "&Recording Meter Toolbar"
+msgstr "Enregistrament"
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the playback level meter
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "&Playback Meter Toolbar"
+msgstr "Enregistrament"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
+
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Scrub Ruler"
+msgstr ""
+
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+msgid "Scrubbing"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Scrubbing"
+msgstr "Arrestar lo script"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Start Scrubbing"
+msgstr "Lançar lo script"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Stop Seeking"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Start Seeking"
+msgstr "Ora iniciala"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Hide Scrub Ruler"
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that enables Scrub or Seek playback and Scrub Ruler
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scru&b Toolbar"
+msgstr "&Barra d'aisinas"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Project Rate (Hz)"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap-To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
+#, fuzzy
+msgid "Audio Position"
+msgstr "Posicion"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Start and End of Selection"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Start and Length of Selection"
+msgstr "Alinhar amb la &fin de la seleccion"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Length and End of Selection"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Length and Center of Selection"
+msgstr ""
 
 #: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
 msgid "Show"
 msgstr "Afichar"
 
 #: src/toolbars/SelectionBar.cpp
+msgid "Snap To"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
 msgid "Length"
 msgstr "Longor"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centrat"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
+
+#. i18n-hint: each string is replaced by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated)
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Selection %s. %s won't change."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for selecting a time range of audio
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "&Selection Toolbar"
+msgstr "Aisina·de·seleccion"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Center frequency and Width"
+msgstr "Frequéncia linearia"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Low and High Frequencies"
+msgstr "Frequéncia nauta"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Center Frequency"
+msgstr "Frequéncia linearia"
 
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Bandwidth"
 msgstr "Benda passanta"
 
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for selecting a frequency range of audio
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Spe&ctral Selection Toolbar"
+msgstr "Definir un punt de seleccion"
+
 #: src/toolbars/TimeToolBar.cpp
 msgid "Time"
 msgstr "Ora"
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for viewing actual time of the cursor
+#: src/toolbars/TimeToolBar.cpp
+#, fuzzy
+msgid "&Time Toolbar"
+msgstr "&Barra d'aisinas"
+
+#. i18n-hint: %s will be replaced by the name of the kind of toolbar.
+#: src/toolbars/ToolBar.cpp
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
+msgstr "Aisina·de·seleccion"
+
+#: src/toolbars/ToolBar.cpp
+#, fuzzy
+msgid "Click and drag to resize toolbar"
+msgstr "Clicar-rossegar per tornar dimensionar la pista."
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Aisina"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -2701,21 +17032,115 @@ msgstr "Aisina·de·seleccion"
 msgid "Envelope Tool"
 msgstr "Aisina·de·nivèl·(envolopa)"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+msgid "Time Shift Tool"
+msgstr ""
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Zoom Tool"
+msgstr "Orizontal"
+
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Aisina·de·dessenh·d'ondas"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Multi-Tool"
+msgstr "Mòde multi aisinas"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "Aisina·de·seleccion"
+
+#. i18n-hint: Clicking this menu item shows a toolbar
+#. that has some tools in it
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools Toolbar"
+msgstr "&Barra d'aisinas"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Selection Tool"
+msgstr "Aisina·de·seleccion"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Envelope Tool"
+msgstr "Aisina·de·nivèl·(envolopa)"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Draw Tool"
+msgstr "Aisina·de·dessenh·d'ondas"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Zoom Tool"
+msgstr "Orizontal"
+
+#: src/toolbars/ToolsToolBar.cpp
+msgid "&Time Shift Tool"
+msgstr ""
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Multi Tool"
+msgstr "Mòde multi aisinas"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Previous Tool"
+msgstr "Precedent"
+
+#: src/toolbars/ToolsToolBar.cpp
+msgid "&Next Tool"
+msgstr ""
+
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Play at selected speed"
+msgstr "Velocitat de lectura"
 
 #: src/toolbars/TranscriptionToolBar.cpp
 msgid "Playback Speed"
 msgstr "Velocitat de lectura"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+msgid "Looped-Play-at-Speed"
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for transcription (currently just vary play speed)
+#: src/toolbars/TranscriptionToolBar.cpp
+msgid "Pla&y-at-Speed Toolbar"
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Marcador modificat"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Edicion de marcador"
+
+#: src/tracks/labeltrack/ui/LabelTextHandle.cpp
+msgid "Click to edit label text"
+msgstr ""
 
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "&Font..."
@@ -2726,13 +17151,103 @@ msgstr "&Poliça..."
 msgid "Label Track Font"
 msgstr "Poliça de la pista de marcadors"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#. i18n-hint: (noun) The name of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+msgid "Face name"
+msgstr ""
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+msgid "Face size"
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Cu&t Label text"
+msgstr "Seleccionar tot lo tèxte"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+msgid "&Copy Label text"
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "&Delete Label"
+msgstr "Definir l'etiqueta"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "&Edit Label..."
+msgstr "Modificar las etiquetas"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Deleted Label"
+msgstr "Definir l'etiqueta"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Edited labels"
+msgstr "Modificar las etiquetas"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "New label"
+msgstr "Marcador apondut"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+msgid "Up &Octave"
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+msgid "Down Octa&ve"
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#, fuzzy
+msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
+msgstr "Clic per zoom vertical, Maj+clic per zoom en arrièr, rossegar per ajustar lo zoom a una zòna"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#, fuzzy
+msgid "Right-click for menu."
+msgstr "Clic de drecha"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom Reset"
+msgstr "Zoom arrièr"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Maj + Clic esquèrra"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Maj + Clic esquèrra"
+
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+#, fuzzy
+msgid "Click and drag to stretch selected region."
+msgstr "Clicar-rossegar per seleccionar l'audiò."
+
+#. i18n-hint: (noun) The track that is used for MIDI notes which can be
+#. dragged to change their duration.
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+#, fuzzy
+msgid "Stretch Note Track"
+msgstr "Pista de nòta"
 
 #. i18n-hint: In the history list, indicates a MIDI note has
 #. been dragged to change its duration (stretch it). Using either past
@@ -2742,17 +17257,106 @@ msgstr "Maj + Clic esquèrra"
 msgid "Stretch"
 msgstr "Estirat"
 
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merged Clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Expand"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Removed Cut Line"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Click and drag to edit the samples"
 msgstr "Clicar-rossegar per modificar los escandilhs."
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#, fuzzy
+msgid "Moved Samples"
+msgstr "Cursor de panoramic desplaçat"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Edicion d'escandilh"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "Zoom arrièr"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy
+msgid "&Spectrogram"
+msgstr "Espectrograms"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy
+msgid "S&pectrogram Settings..."
+msgstr "Espectrograms"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Format :"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Changing sample format"
+msgstr "Modificar l'escandilh"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Processing...   0%%"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Processing...   %i%%"
+msgstr ""
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "« %s » cambiat en %s"
@@ -2760,6 +17364,58 @@ msgstr "« %s » cambiat en %s"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Format Change"
 msgstr "Cambiament de format"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Rat&e"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -2778,6 +17434,34 @@ msgstr "Cambiament de taus"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Set Rate"
 msgstr "Reglar lo taus"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+msgid "&Multi-view"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Ma&ke Stereo Track"
+msgstr "Fa venir estereofonic"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Swap Stereo &Channels"
+msgstr "Intervertir canals"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Spl&it Stereo Track"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Split Stereo to Mo&no"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -2801,9 +17485,123 @@ msgstr "« %s » transformada en pista estereò"
 msgid "Make Stereo"
 msgstr "Fa venir estereofonic"
 
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Swapped Channels in '%s'"
+msgstr "Intervertir canals"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Swap Channels"
 msgstr "Intervertir canals"
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Split stereo track '%s'"
+msgstr "« %s » pista suprimida"
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Split Stereo to Mono '%s'"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Split to Mono"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Esterèo"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Mono, %dHz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
+msgid "Left, %dHz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Right, %dHz"
+msgstr "Drecha"
+
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Right"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
+msgstr "Clicar-rossegar per calar temporalament una pista"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Click and drag to rearrange sub-views"
+msgstr "Clicar-rossegar per calar temporalament una pista"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Rearrange sub-views"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Zoom avant"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Zoom avant"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+msgid "Wa&veform"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "&Wave Color"
+msgstr "Enregistrar la còpia"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "WaveColor Change"
+msgstr "Cambiament de taus"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Change lower speed limit (%) to:"
@@ -2831,11 +17629,86 @@ msgstr "Passar la seleccion de  '%ld' a '%ld'"
 msgid "Set Range"
 msgstr "Reglar l'espandida"
 
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Display"
+msgstr "Afichatge"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Interpolation"
+msgstr "Interpolacion rapida"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "&Linear scale"
+msgstr "Lineariá"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Logaritmic"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "&Range..."
+msgstr "&Tornar nomenar..."
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Logarithmic &Interpolation"
+msgstr "Interpolacion rapida"
+
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
+
+#: src/tracks/ui/CommonTrackControls.cpp
 #, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Clicar-rossegar per calar temporalament una pista"
+msgid "&Name..."
+msgstr "&Tornar nomenar..."
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track &Up"
+msgstr "Bolegar la pista"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track &Down"
+msgstr "Bolegar la pista"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track to &Top"
+msgstr "Bolegar la pista"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track to &Bottom"
+msgstr "Bolegar la pista"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Set Track Name"
+msgstr "Novèla pista"
 
 #: src/tracks/ui/CommonTrackControls.cpp
 #, c-format
@@ -2847,6 +17720,11 @@ msgid "Name Change"
 msgstr "Cambiament de nom"
 
 #: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Click and drag to warp playback time"
+msgstr "Clicar-rossegar per calar temporalament una pista"
+
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Click and drag to edit the amplitude envelope"
 msgstr "Clicas rossegar per modificar los volums (envolopa)."
 
@@ -2854,6 +17732,52 @@ msgstr "Clicas rossegar per modificar los volums (envolopa)."
 #: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Adjusted envelope."
 msgstr "Envolopa ajustada."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+msgid "&Scrub"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Seeking"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scrub &Ruler"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Playing at Speed"
+msgstr "Velocitat de lectura"
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Move mouse pointer to Seek"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Move mouse pointer to Scrub"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scru&bbing"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Retorn"
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scrub For&wards"
+msgstr ""
 
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to move left selection boundary."
@@ -2864,16 +17788,133 @@ msgid "Click and drag to move right selection boundary."
 msgstr "Clicar-rossegar per bolegar a drecha los limits de la seleccion."
 
 #: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move bottom selection frequency."
+msgstr "Clicar e rossegar per bolegar a esquèrra los limits de la seleccion."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move top selection frequency."
+msgstr "Clicar e rossegar per bolegar a esquèrra los limits de la seleccion."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move center selection frequency to a spectral peak."
+msgstr "Clicar e rossegar per bolegar a esquèrra los limits de la seleccion."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move center selection frequency."
+msgstr "Clicar e rossegar per bolegar a esquèrra los limits de la seleccion."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to adjust frequency bandwidth."
+msgstr "Clicar-rossegar per seleccionar l'audiò."
+
+#. i18n-hint: These are the names of a menu and a command in that menu
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Edit, Preferences..."
+msgstr "&Preferéncias..."
+
+#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy, c-format
+msgid "Multi-Tool Mode: %s for Mouse and Keyboard Preferences."
+msgstr "Mòde·multi-aisinas : Ctrl+P per Preferéncias mirga e clavièr"
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to set frequency bandwidth."
+msgstr "Clicar-rossegar per seleccionar l'audiò."
+
+#: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to select audio"
 msgstr "Clicar-rossegar per seleccionar l'audiò."
+
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Clicar-rossegar per calar temporalament una pista"
 
+#: src/tracks/ui/TimeShiftHandle.cpp
+msgid "Could not shift between tracks"
+msgstr ""
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+msgid "Moved clips to another track"
+msgstr ""
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy, c-format
+msgid "Time shifted tracks/clips right %.02f seconds"
+msgstr "Pistas seleccionadas tornadas mudas de %.2f segondas a %.2f"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy, c-format
+msgid "Time shifted tracks/clips left %.02f seconds"
+msgstr "Pistas seleccionadas tornadas mudas de %.2f segondas a %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Command+Click to deselect"
+msgstr ""
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+#, fuzzy
+msgid "Select track"
+msgstr "Seleccion"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Ctrl+Click to deselect"
+msgstr ""
+
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Open menu..."
 msgstr "Dubrir lo menú..."
+
+#. i18n-hint: Command names a modifier key on Macintosh keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Command+Click"
+msgstr "Comanda"
+
+#. i18n-hint: Ctrl names a modifier key on Windows or Linux keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Ctrl+Click"
+msgstr "Clic"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr ""
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, c-format
+msgid "%s to select or deselect track."
+msgstr ""
+
+#. i18n-hint: will substitute name of track for %s
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' up"
+msgstr "« %s » importat"
+
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, c-format
+msgid "Moved '%s' down"
+msgstr ""
 
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Move Track"
@@ -2895,6 +17936,11 @@ msgstr "Esquèrra=Zoom abans, Drecha=Zoom arrièr, Mitan=Normal"
 msgid "(disabled)"
 msgstr "(desactivat)"
 
+#: src/widgets/AButton.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "Press"
+msgstr "Prereglatges"
+
 #: src/widgets/AButton.cpp
 msgid "Button"
 msgstr "Boton"
@@ -2911,6 +17957,21 @@ msgstr "G"
 msgid "R"
 msgstr "D"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+msgid "Please choose an existing file."
+msgstr ""
+
 #: src/widgets/FileDialog/mac/FileDialogPrivate.mm
 msgid "File type:"
 msgstr "Tipe de fichièr :"
@@ -2918,6 +17979,14 @@ msgstr "Tipe de fichièr :"
 #: src/widgets/FileHistory.cpp
 msgid "&Clear"
 msgstr "Es&cafar"
+
+#. i18n-hint: A 'Grabber' is a region you can click and drag on
+#. It's used to drag a track around (when in multi-tool mode) rather
+#. than requiring that you use the drag tool.  It's shown as a series
+#. of horizontal bumps
+#: src/widgets/Grabber.cpp
+msgid "Grabber"
+msgstr ""
 
 #: src/widgets/Grid.cpp
 msgid "Empty"
@@ -2927,29 +17996,541 @@ msgstr "Void"
 msgid "Backwards"
 msgstr "Retorn"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Forwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
+
 #: src/widgets/KeyView.cpp
 msgid "Menu"
 msgstr "Menú"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click to Start Monitoring"
+msgstr "Enrèire a la començança"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click for Monitoring"
+msgstr "Enrèire a la començança"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click to Start"
+msgstr "Enrèire a la començança"
 
 #: src/widgets/Meter.cpp
 msgid "Click"
 msgstr "Clic"
 
 #: src/widgets/Meter.cpp
+msgid "Stop Monitoring"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Start Monitoring"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Recording Meter Options"
+msgstr "Enregistrament"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Playback Meter Options"
+msgstr "Lectura"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Reglar lo taus"
+
+#: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Style"
+msgstr "Mètre"
+
+#: src/widgets/Meter.cpp
 msgid "Gradient"
 msgstr "Degradat"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Type"
+msgstr "Mètre"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Orientacion"
 
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+msgid "Automatic"
+msgstr ""
+
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
 msgstr "Orizontal"
 
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "Afichar totas las pistas"
+
+#: src/widgets/Meter.cpp
+msgid " Monitoring "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Escafar la seleccion"
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + hundredths"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>0100 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + milliseconds"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>01000 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + samples"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+># samples"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+msgid "samples"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames (lots of
+#. * frames) at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at PAL
+#. * TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in octaves
+#: src/widgets/NumericTextCtrl.cpp
+msgid "octaves"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "segondas"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Data de sortida"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Remaining Time:"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Cancel"
 msgstr "Anullar"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to cancel?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Confirm Cancel"
+msgstr "Confirmar"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to stop?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Confirm Stop"
+msgstr "Confirmar"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Are you sure you wish to close?"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Confirm Close"
+msgstr "Confirmar"
+
+#. i18n-hint: %s is replaced with a directory path.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#, c-format
+msgid "Unable to write files to directory: %s."
+msgstr ""
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -2967,35 +18548,1068 @@ msgid "Don't show this warning again"
 msgstr "Mostrar pas mai aquel avertiment"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "Infinit"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: src/widgets/numformatter.cpp
+#, fuzzy
+msgid "-Infinity"
+msgstr "Infinit"
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Empty value"
+msgstr "Void"
+
+#: src/widgets/valnum.cpp
+msgid "Malformed number"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Not in range %d to %d"
+msgstr "Pas res a far"
+
+#: src/widgets/valnum.cpp
+msgid "Value overflow"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value not in range: %s to %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be less than %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be greater than %s"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Select a directory"
+msgstr "Seleccionar un fichièr"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Directory Dialog"
+msgstr "Repertòris"
+
+#: src/widgets/wxPanelWrapper.h
+msgid "File Dialog"
+msgstr ""
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "Error : %s"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Could not load file: \"%s\""
+msgstr "Impossible de dubrir lo fichièr : \"%s\""
+
+#: src/xml/XMLFileReader.cpp
+msgid "Could not parse XML"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, fuzzy
+msgid "Spectral edit multi tool"
+msgstr "Definir un punt de seleccion"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Filtering..."
+msgstr "Preparacion...\n"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid "~aPlease select frequencies."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "ErrorError.~%"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+msgid "Spectral edit parametric EQ"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Gain (dB)"
+msgstr "Ganh"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aCenter frequency must be above 0 Hz."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditShelves.ny
+msgid "Spectral edit shelves"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, fuzzy
+msgid "Studio Fade Out"
+msgstr "Fondre en barradura"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Applying Fade..."
+msgstr "Aplicacion..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Fade Type"
+msgstr "Fondre en dubèrtura"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Fade Up"
+msgstr "Fondre en dubèrtura"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Fade Down"
+msgstr "Fondre en dubèrtura"
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve Up"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve Down"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Start/End as"
+msgstr "Data iniciala"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "dB Gain"
+msgstr "Ganh"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Start (or end)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "None Selected"
+msgstr "Seleccionat"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Linear In"
+msgstr "Lineariá"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Linear Out"
+msgstr "Lineariá"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Logarithmic In"
+msgstr "Logaritmic"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Logarithmic Out"
+msgstr "Logaritmic"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Rounded In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Rounded Out"
+msgstr "Fondre en barradura"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Cosine In"
+msgstr "Cosinus"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Cosine Out"
+msgstr "Cosinus"
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy, lisp-format
+msgid "Error~%~%"
+msgstr "Error"
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Beat Finder"
+msgstr "Silenci"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Finding beats..."
+msgstr "Congrear de silence"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Primièr desmarratge d'Audacity"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Threshold Percentage"
+msgstr "Percentatge de modificacion :"
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Clip Fix"
+msgstr "Cursor Drecha"
+
+#: plug-ins/clipfix.ny
+msgid "Reconstructing clips..."
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Threshold of Clipping (%)"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+msgid "Crossfade Clips"
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+msgid "Crossfading..."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Crossfade Tracks"
+msgstr "Pista de nòta"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Fade type"
+msgstr "Tipe de fichièr :"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Constant Gain"
+msgstr "Constanta"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Constant Power 1"
+msgstr "Constanta"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Constant Power 2"
+msgstr "Constanta"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Custom Curve"
+msgstr "Personalizat"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Custom curve"
+msgstr "Personalizat"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Fade direction"
+msgstr "Resolucion de bruch"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Retard"
 
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Applying Delay Effect..."
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay type"
+msgstr "Retard"
+
+#: plug-ins/delay.ny
+msgid "Regular"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Delay level per echo (dB)"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay time (seconds)"
+msgstr "Durada de la sosta (segondas) :"
+
+#: plug-ins/delay.ny
+msgid "Pitch change effect"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Pitch/Tempo"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Pitch change per echo (semitones)"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Number of echoes"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Select target EQ effect"
+msgstr "Seleccionar un fichièr"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Equalization XML file"
+msgstr "Egalisacion"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "XML file"
+msgstr "Fichièrs XML"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Append number"
+msgstr "Enregistrar"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%Unable to open file~%~s"
+msgstr "Error de dubèrtura de fichièr"
+
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, lisp-format
+msgid "Error.~%File cannot be written:~%\"~a.txt\""
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
+
+#. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Create labels based on"
+msgstr "Novèla·pista de marcadors creada"
+
+#: plug-ins/equalabel.ny
+msgid "Number & Interval"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Number of Labels"
+msgstr "Importar los m&arcadors"
+
+#: plug-ins/equalabel.ny
+msgid "Label Interval"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Number of labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Label interval (seconds)"
+msgstr "Durada (segondas)"
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Length of label region (seconds)"
+msgstr "Durada (segondas)"
+
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
+#. i18n-hint: Do not translate '##1'
+#: plug-ins/equalabel.ny plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Label text"
+msgstr "Edicion de marcador"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Message on completion"
+msgstr ""
+
 #: plug-ins/equalabel.ny
 msgid "Details"
 msgstr "Detalhs"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Warnings only"
+msgstr "Avertiments"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
+#. i18n-hint:  Type of label
+#: plug-ins/equalabel.ny
+msgid "region labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "point labels"
+msgstr "Importar los m&arcadors"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
+#: plug-ins/highpass.ny
+msgid "High-Pass Filter"
+msgstr ""
+
+#: plug-ins/highpass.ny
+msgid "Performing High-Pass Filter..."
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequéncia (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#, fuzzy
+msgid "Frequency must be at least 0.1 Hz."
+msgstr "Frequéncia LFO (Hz) :"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
+
+#. i18n-hint: Name of effect that labels sounds
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Label Sounds"
+msgstr "Marcadors"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Threshold level (dB)"
+msgstr "Sulhet"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Threshold measurement"
+msgstr "Sulhet"
+
+#: plug-ins/label-sounds.ny
+msgid "Peak level"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "Mejana"
+
+#: plug-ins/label-sounds.ny
+msgid "RMS level"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Minimum silence duration"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Minimum label interval"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Label type"
+msgstr "Edicion de marcador"
+
+#: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Point after sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum leading silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum trailing silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
+#. i18n-hint: '~a' will be replaced by a time duration
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Error.~%Selection must be less than ~a."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiting..."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Type"
 msgstr "Tipe"
 
+#: plug-ins/limiter.ny
+msgid "Soft Limit"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Hard Limit"
+msgstr ""
+
+#. i18n-hint: clipping of wave peaks and troughs, not division of a track into clips
+#: plug-ins/limiter.ny
+msgid "Soft Clip"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Hard Clip"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limit to (dB)"
+msgstr ""
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
+
+#: plug-ins/lowpass.ny
+msgid "Low-Pass Filter"
+msgstr ""
+
+#: plug-ins/lowpass.ny
+msgid "Performing Low-Pass Filter..."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Noise Gate"
+msgstr "Bruch"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Select Function"
+msgstr "Seleccion"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Stereo Linking"
+msgstr "Esterèo"
+
+#: plug-ins/noisegate.ny
+msgid "Link Stereo Tracks"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Don't Link Stereo"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Gate threshold (dB)"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Gate frequencies above (kHz)"
+msgstr "Frequéncia LFO (Hz) :"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Level reduction (dB)"
+msgstr "Resolucion de bruch"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Attack (ms)"
+msgstr "Atac :"
+
+#: plug-ins/noisegate.ny
+msgid "Decay (ms)"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Notch Filter"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, fuzzy
+msgid "Applying Notch Filter..."
+msgstr "Aplicacion d'efièch \"Nyquist\"..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Nyquist Plug-in Installer"
+msgstr ""
+
+#. i18n-hint: "Browse..." is text on a button that launches a file browser.
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Select file(s) to install"
+msgstr "Seleccionar fins a la fin"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Plug-in"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Lisp file"
+msgstr "%s fichièrs"
+
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "HTML file"
 msgstr "Fichièr HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Fichièr tèxte"
 
@@ -3004,20 +19618,504 @@ msgid "All supported"
 msgstr "Totes los fichièrs preses en carga"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Allow overwriting"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Disallow"
+msgstr "Desactivat"
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Allow"
 msgstr "Autorizar"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Warning.~%Failed to copy some files:~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Plug-ins updated:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files copied to plug-ins folder:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Unsupported file type:"
+msgstr "Taus preses en cargar :\n"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Cannot be written to plug-ins folder:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Generating pluck sound..."
+msgstr "Congrear de silence"
+
+#: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Fade-out type"
+msgstr "Tipe de fichièr :"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Duration (60s max)"
+msgstr "Durada"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Rhythm Track"
+msgstr "Suprimir· la pista"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Generating Rhythm..."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Number of bars"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Rhythm track duration"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Used if 'Number of bars' = 0"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Start time offset"
+msgstr "Ora iniciala"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Silence before first beat"
+msgstr "enclure l'audiò abans lo premièr marcador"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Beat sound"
+msgstr "Rèireplan"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Resonant Noise"
+msgstr "Resonància:"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Noise Click"
+msgstr "Bruch"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Risset Drum"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Generating Risset Drum..."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Decay (seconds)"
+msgstr "Durada de la sosta (segondas) :"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Center frequency of noise (Hz)"
+msgstr "Frequéncia LFO (Hz) :"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Amount of noise in mix (percent)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amplitude (0 - 1)"
+msgstr "Amplitud (0 a 1)"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample Data Export"
+msgstr "Edicion d'escandilh"
 
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Analisi en cors…"
 
 #: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Measurement scale"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Export data to"
+msgstr " '%s' importat"
+
+#: plug-ins/sample-data-export.ny
 msgid "CSV files"
 msgstr "Fichièrs CSV"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "HTML files"
+msgstr "Fichièr HTML"
+
+#: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample Count"
+msgstr "Edicion d'escandilh"
+
+#: plug-ins/sample-data-export.ny
+msgid "Time Indexed"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Informacions de generacion"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Minimal"
+msgstr "&Reduire"
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Totas"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
+
+#. i18n-hint: L for Left
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "L Channel First"
+msgstr "%d Canals"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Show messages"
+msgstr "Messatge"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Errors Only"
+msgstr "Error de dubèrtura de fichièr"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Left Channel.~%~%"
+msgstr "Canal esquèrra"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~%~%Right Channel.~%~%"
+msgstr "Canal de drecha"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a samples."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~a seconds."
+msgstr "segondas"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "sample data"
+msgstr "Edicion d'escandilh"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample #"
+msgstr "Edicion d'escandilh"
+
+#: plug-ins/sample-data-export.ny
+msgid "Value (linear)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Value (dB)"
+msgstr "Valor"
+
+#: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Left (linear)"
+msgstr "Lineariá"
+
+#: plug-ins/sample-data-export.ny
+msgid "Right (linear)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Left (dB)"
+msgstr "Esquèrra"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Right (dB)"
+msgstr "Drecha"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "linear"
+msgstr "Lineariá"
 
 #: plug-ins/sample-data-export.ny
 msgid "2 channels (stereo)"
@@ -3027,16 +20125,350 @@ msgstr "2 canals (estereofonic)"
 msgid "1 channel (mono)"
 msgstr "1 canal (Mono)"
 
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, fuzzy
+msgid "Sample Data Import"
+msgstr "Frequéncia d'escandalhatge :"
+
+#: plug-ins/sample-data-import.ny
+msgid "Reading and rendering samples..."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, fuzzy
+msgid "Select file"
+msgstr "Seleccionar un fichièr"
+
+#: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#  i18n-hint: You do not need to translate "LOF"
+#: plug-ins/sample-data-import.ny
+#, fuzzy
+msgid "Throw Error"
+msgstr "Error de LOF"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, fuzzy, lisp-format
+msgid "Error.~%Unable to open file"
+msgstr "Error de dubèrtura de fichièr"
+
+#: plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "Spectral Delete"
+msgstr "Definir un punt de seleccion"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+#, fuzzy
+msgid "Applying Tremolo..."
+msgstr "Aplicacion..."
+
+#: plug-ins/tremolo.ny
+msgid "Waveform type"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+#, fuzzy
+msgid "Inverse Sawtooth"
+msgstr "Dents de raissa"
+
+#: plug-ins/tremolo.ny
+msgid "Starting phase (degrees)"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Applying Action..."
+msgstr "Aplicacion..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Remove Vocals: to mono"
+msgstr "Suprimir la (las) pista(s)"
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Remove Vocals"
+msgstr "Suprimir la (las) pista(s)"
+
+#: plug-ins/vocalrediso.ny
+msgid "Isolate Vocals"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Isolate Vocals and Invert"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Remove Center: to mono"
+msgstr "Suprimir· la pista"
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Remove Center"
+msgstr "Suprimir· la pista"
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Isolate Center"
+msgstr "Centrat"
+
+#: plug-ins/vocalrediso.ny
+msgid "Isolate Center and Invert"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Analyze"
 msgstr "Analisar"
 
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Strength"
+msgstr "Estirat"
+
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Processing Vocoder..."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Output choice"
+msgstr "Volum de sortida"
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Both Channels"
+msgstr "%d Canals"
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Right Only"
+msgstr "Canal de drecha"
+
+#: plug-ins/vocoder.ny
+msgid "Number of vocoder bands"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of original audio (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of white noise (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of Radar Needles (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Frequency of Radar Needles (Hz)"
+msgstr "Frequéncia LFO (Hz) :"
+
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "&A prepaus de \"Audacity\"..."
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Passar"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Canal"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Enregistrament"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Fonts d'enregistrament disponiblas :\n"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&A prepaus de \"Audacity\"..."
+
 #, fuzzy
 #~ msgid "Unknown error"
 #~ msgstr "Format desconegut"
-
-#~ msgid "available"
-#~ msgstr "disponible"
 
 #~ msgid "Check Online"
 #~ msgstr "Verificar en linha"
@@ -3055,16 +20487,8 @@ msgstr "Analisar"
 #~ msgstr "&Telecargar"
 
 #, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "Causir un fichièr audio pas comprimit..."
-
-#, fuzzy
 #~ msgid "Error Decoding File"
 #~ msgstr "Error de dubèrtura de fichièr"
-
-#, fuzzy
-#~ msgid "Discard Projects"
-#~ msgstr "&Enregistrar lo projècte"
 
 #, fuzzy
 #~ msgid "No Action"
@@ -3079,29 +20503,13 @@ msgstr "Analisar"
 #~ msgstr " '%s' importat"
 
 #, fuzzy
-#~ msgid "Export as MP3"
-#~ msgstr " '%s' importat"
-
-#, fuzzy
 #~ msgid "Export as Ogg"
 #~ msgstr " '%s' importat"
-
-#, fuzzy
-#~ msgid "Export as WAV"
-#~ msgstr "Exportar los marcadors jos :"
-
-#, fuzzy
-#~ msgid "Select to Ends"
-#~ msgstr "Seleccionar fins a la fin"
 
 #, fuzzy
 #~ msgid ""
 #~ "Export recording to %s\n"
 #~ "/%s/%s.%s"
-#~ msgstr "Enregistrament"
-
-#, fuzzy
-#~ msgid "Export recording"
 #~ msgstr "Enregistrament"
 
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
@@ -3118,20 +20526,8 @@ msgstr "Analisar"
 #~ msgid "Renamed file: %s\n"
 #~ msgstr "Tornar nomenar lo fichièr : %s\n"
 
-#, fuzzy
-#~ msgid "Could not remove old autosave file: %s"
-#~ msgstr "Impossible d'enregistrar lo fichièr : "
-
-#, fuzzy
-#~ msgid "%sSave Compressed Copy of Project \"%s\" As..."
-#~ msgstr "Enregistrar lo projècte &jos..."
-
 #~ msgid "Audacity was unable to convert an Audacity 1.0 project to the new project format."
 #~ msgstr "Audacity pòt pas convertir un projècte Audacity 1.0 al novèl format de projècte."
-
-#, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Compressor..."
 
 #, fuzzy
 #~ msgid ""
@@ -3141,40 +20537,12 @@ msgstr "Analisar"
 #~ msgstr "Enregistrament"
 
 #, fuzzy
-#~ msgid "Clip Rig&ht"
-#~ msgstr "Cursor Drecha"
-
-#, fuzzy
-#~ msgid "Save Lossless Copy of Project..."
-#~ msgstr "Enregistrar lo projècte &jos..."
-
-#, fuzzy
 #~ msgid "&Save Compressed Copy of Project..."
 #~ msgstr "Enregistrar lo projècte &jos..."
 
 #, fuzzy
-#~ msgid "Silence Finder"
-#~ msgstr "Silenci"
-
-#, fuzzy
 #~ msgid "Sound Finder"
 #~ msgstr "Silenci"
-
-#, fuzzy
-#~ msgid "Finding sound..."
-#~ msgstr "Congrear de silence"
-
-#, fuzzy
-#~ msgid "Gating audio..."
-#~ msgstr "Cambiar lo nom de la pista en : "
-
-#, fuzzy
-#~ msgid "Apply Low-Cut filter"
-#~ msgstr "Aplicacion de \"Phaser\""
-
-#, fuzzy
-#~ msgid "<h3>Audacity "
-#~ msgstr "Primièr desmarratge d'Audacity"
 
 #, fuzzy
 #~ msgid ""
@@ -3199,16 +20567,8 @@ msgstr "Analisar"
 #~ msgstr "Error d'importacion"
 
 #, fuzzy
-#~ msgid "Click to unpin"
-#~ msgstr "Enrèire a la començança"
-
-#, fuzzy
 #~ msgid "Click to pin"
 #~ msgstr "Enrèire a la començança"
-
-#, fuzzy
-#~ msgid "Disable dragging selection"
-#~ msgstr "Fa venir la seleccion muda"
 
 #, fuzzy
 #~ msgid "Only avformat.dll|*avformat*.dll|Dynamically Linked Libraries (*.dll)|*.dll|All Files|*"
@@ -3219,16 +20579,8 @@ msgstr "Analisar"
 #~ msgstr "Sonque lame_enc.dll|lame_enc.dll|Dynamically Linked Libraries (*.dll)|*.dll|All Files (*.*)|*"
 
 #, fuzzy
-#~ msgid "Add to History:"
-#~ msgstr "&Istoric..."
-
-#, fuzzy
 #~ msgid "Delete:"
 #~ msgstr "Escafar"
-
-#, fuzzy
-#~ msgid "Selected:"
-#~ msgstr "Seleccion"
 
 #, fuzzy
 #~ msgid "Only lame_enc.dll|lame_enc.dll|Dynamically Linked Libraries (*.dll)|*.dll|All Files|*"
@@ -3243,90 +20595,20 @@ msgstr "Analisar"
 #~ msgstr "Sonque· libmp3lame.so|libmp3lame.so|Fichiers Primary Shared Object (*.so)|*.so|Librarias espandidas (*.so*)|*.so*|Tot fichièrs (*)|*"
 
 #, fuzzy
-#~ msgid "Remove Center Classic: Mono"
-#~ msgstr "Suprimir· la pista"
-
-#, fuzzy
-#~ msgid "Could not decode file: %s"
-#~ msgstr "Impossible de dubrir lo fichièr : "
-
-#, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "Suprimir la (las) pista(s)"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "Supression· dels clics e pòps "
-
-#, fuzzy
-#~ msgid "Remove vocals or view Help"
-#~ msgstr "Suprimir la (las) pista(s)"
 
 #, fuzzy
 #~ msgid "Removal choice"
 #~ msgstr "Supression· del bruch"
 
 #, fuzzy
-#~ msgid "Remove Frequency Band"
-#~ msgstr "Frequéncia linearia"
-
-#, fuzzy
-#~ msgid "Retain Frequency Band"
-#~ msgstr "Frequéncia linearia"
-
-#, fuzzy
 #~ msgid "Frequency band from (Hz)"
-#~ msgstr "Frequéncia LFO (Hz) :"
-
-#, fuzzy
-#~ msgid "Frequency band to (Hz)"
 #~ msgstr "Frequéncia LFO (Hz) :"
 
 #, fuzzy
 #~ msgid "Current settings returned the original audio."
 #~ msgstr "Ny"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Aplicacion d'efièch \"Nyquist\"..."
-
-#, fuzzy
-#~ msgid "Error.~%~a"
-#~ msgstr "Error"
-
-#, fuzzy
-#~ msgid "Left"
-#~ msgstr "Esquèrra"
-
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "Drecha"
-
-#, fuzzy
-#~ msgid "&Select Chain"
-#~ msgstr "Seleccion"
-
-#, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "Aisina·de·seleccion"
-
-#, fuzzy
-#~ msgid "Transcri&ption"
-#~ msgstr "Aisina·de·seleccion"
-
-#, fuzzy
-#~ msgid ""
-#~ "Error opening sound device.\n"
-#~ "Try changing the audio host, recording device and the project sample rate."
-#~ msgstr "Error a la dubèrtura del periferic son. Verificatz los reglatges del periferic e l'escandalhatge del projècte"
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "Enregistrament"
-
-#, fuzzy
-#~ msgid "Slider Playback"
-#~ msgstr "Lectura"
 
 #, fuzzy
 #~ msgid "Length - End"
@@ -3340,30 +20622,9 @@ msgstr "Analisar"
 #~ msgid "High Frequency:"
 #~ msgstr "Frequéncia (Hz) :"
 
-#~ msgid "Change track name to:"
-#~ msgstr "Cambiar lo nom de la pista en : "
-
 #, fuzzy
 #~ msgid "and"
 #~ msgstr "Panoramic"
-
-#, fuzzy
-#~ msgid "end to end"
-#~ msgstr "Seleccionar fins a la fin"
-
-#, fuzzy
-#~ msgid "End to End"
-#~ msgstr "Anar a la fin"
-
-#, fuzzy
-#~ msgid "Aligned %s"
-#~ msgstr "Alinhat"
-
-#, fuzzy
-#~ msgid ""
-#~ "Timer Recording completed.\n"
-#~ "\n"
-#~ msgstr "Enregistrament\n"
 
 #~ msgid "Exporting the entire project using command-line encoder"
 #~ msgstr "Exportacion del projècte entièr en utilizant un encodaire a linha de comanda"
@@ -3376,72 +20637,8 @@ msgstr "Analisar"
 #~ msgstr "Durada (segondas)"
 
 #, fuzzy
-#~ msgid "Length-Center"
-#~ msgstr "Centrat"
-
-#, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Seleccionar fins a la fin"
-
-#, fuzzy
-#~ msgid "Start - Length - End"
-#~ msgstr "Alinhar amb la &fin de la seleccion"
-
-#, fuzzy
 #~ msgid "Start - Center - End"
 #~ msgstr "Alinhar amb la &fin de la seleccion"
-
-#, fuzzy
-#~ msgid "Click to verticaly zoom in, Shift-click to zoom out, Drag to create a particular zoom region."
-#~ msgstr "Clic per zoom vertical, Maj+clic per zoom en arrièr, rossegar per ajustar lo zoom a una zòna"
-
-#, fuzzy
-#~ msgid "Percentage"
-#~ msgstr "Percentatge de modificacion :"
-
-#, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "Atac :"
-
-#, fuzzy
-#~ msgid "Repeats"
-#~ msgstr "Repetir"
-
-#, fuzzy
-#~ msgid "Sequence"
-#~ msgstr "Frequéncia (Hz) :"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Amplitud (0 a 1)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "Nom..."
-
-#, fuzzy
-#~ msgid "InterpolateLin"
-#~ msgstr "Interpolacion rapida"
-
-#, fuzzy
-#~ msgid "InterpolationMethod"
-#~ msgstr "Interpolacion rapida"
-
-#, fuzzy
-#~ msgid "Noise Threshold:"
-#~ msgstr "Eliminacion del bruch"
-
-#, fuzzy
-#~ msgid "RemoveDcOffset"
-#~ msgstr "Supression· del bruch"
-
-#, fuzzy
-#~ msgid "Stretch Factor"
-#~ msgstr "Factor de decreissença :"
-
-#, fuzzy
-#~ msgid "Time Resolution"
-#~ msgstr "Durada de la sosta (segondas) :"
 
 #, fuzzy
 #~ msgid "Freq"
@@ -3454,30 +20651,6 @@ msgstr "Analisar"
 #, fuzzy
 #~ msgid "Depth"
 #~ msgstr "Pregondor :"
-
-#, fuzzy
-#~ msgid "Feedback"
-#~ msgstr "Enrèire (%) :"
-
-#, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Talha"
-
-#, fuzzy
-#~ msgid "Reverberance"
-#~ msgstr "Enrèire (%) :"
-
-#, fuzzy
-#~ msgid "HfDamping"
-#~ msgstr "Pregondor (%) :"
-
-#, fuzzy
-#~ msgid "WetGain"
-#~ msgstr "Ganh"
-
-#, fuzzy
-#~ msgid "DryGain"
-#~ msgstr "Ganh"
 
 #, fuzzy
 #~ msgid "RatePercentChangeStart"
@@ -3495,19 +20668,8 @@ msgstr "Analisar"
 #~ msgid "PitchPercentChangeEnd"
 #~ msgstr "Percentatge de modificacion :"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Inversion"
-
 #~ msgid "Size"
 #~ msgstr "Talha"
-
-#~ msgid "Fit &Vertically"
-#~ msgstr "Afichar totas las pistas"
-
-#, fuzzy
-#~ msgid "Co&mbined Meter Toolbar"
-#~ msgstr "Enregistrament"
 
 #, fuzzy
 #~ msgid "S&kip to Start"
@@ -3516,14 +20678,6 @@ msgstr "Analisar"
 #, fuzzy
 #~ msgid "Skip to E&nd"
 #~ msgstr "Anar a la fin"
-
-#, fuzzy
-#~ msgid "Appen&d Record"
-#~ msgstr "Enregistrar"
-
-#, fuzzy
-#~ msgid "&Mono"
-#~ msgstr "Mono"
 
 #, fuzzy
 #~ msgid "&Left Channel"
@@ -3538,10 +20692,6 @@ msgstr "Analisar"
 #~ msgstr "Clicar e rossegar per bolegar a esquèrra los limits de la seleccion."
 
 #, fuzzy
-#~ msgid "Record Below"
-#~ msgstr "Enregistrar"
-
-#, fuzzy
 #~ msgid "Audacity Support Team"
 #~ msgstr "Primièr desmarratge d'Audacity"
 
@@ -3553,31 +20703,12 @@ msgstr "Analisar"
 #~ msgstr "Canal de drecha"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "Amplificacion (dB) :"
-
-#, fuzzy
 #~ msgid "No wave tracks exist."
 #~ msgstr " '%s' pista suprimida"
 
 #, fuzzy
 #~ msgid "-Left-Click"
 #~ msgstr "Clic d'esquèrra"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "Alt + Clic esquèrra"
-
-#~ msgid "Multi-Tool Mode"
-#~ msgstr "Mòde multi aisinas"
-
-#, fuzzy
-#~ msgid "Recording Meter Preferences"
-#~ msgstr "Enregistrament"
-
-#, fuzzy
-#~ msgid "Playback Meter Preferences"
-#~ msgstr "Lectura"
 
 #, fuzzy
 #~ msgid "Modified"
@@ -3604,22 +20735,11 @@ msgstr "Analisar"
 #~ msgstr "Nautor (EAC)"
 
 #, fuzzy
-#~ msgid "Set Sample &Format"
-#~ msgstr "Causir un format d'escandilh"
-
-#, fuzzy
 #~ msgid "Set Ra&nge..."
 #~ msgstr "Reglar l'amplitud..."
 
-#, fuzzy
-#~ msgid "Plug-ins %i to %i"
-#~ msgstr "Moduls de %i a %i"
-
 #~ msgid "MP3 Export Setup"
 #~ msgstr "Reglatge de l'exportacion MP3"
-
-#~ msgid "Export format:"
-#~ msgstr "Format d'expòrt :"
 
 #, fuzzy
 #~ msgid "(Not all combinations of headers and encodings are possible.)"
@@ -3627,19 +20747,6 @@ msgstr "Analisar"
 #~ "(Las combinasons d'encap\n"
 #~ "e d'encodatge son pas\n"
 #~ "totas possiblas."
-
-#~ msgid "Ctrl-Left-Drag"
-#~ msgstr "Ctrl + rossegar a esquèrra"
-
-#, fuzzy
-#~ msgid "Spectral Selection log(f)"
-#~ msgstr "Definir un punt de seleccion"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "Interpolacion de qualitat nauta"
-
-#~ msgid "Fast Sinc Interpolation"
-#~ msgstr "Interpolacion rapida"
 
 #~ msgid "Libsamplerate error: %d\n"
 #~ msgstr "Error LibSampleRate : %d\n"
@@ -3657,9 +20764,6 @@ msgstr "Analisar"
 #~ msgid "Applied effect: %s %.2f semitones"
 #~ msgstr "Efièch·aplicat·: %s %.2f mièches-tons"
 
-#~ msgid "Change Pitch..."
-#~ msgstr "Cambiament la nautor..."
-
 #~ msgid "Changing Pitch"
 #~ msgstr "Cambiament de nautor"
 
@@ -3671,9 +20775,6 @@ msgstr "Analisar"
 
 #~ msgid "Change Tempo..."
 #~ msgstr "Cambiar lo tempò..."
-
-#~ msgid "Click Removal..."
-#~ msgstr "Supression dels clics..."
 
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "Aplicacion de compression dinamica..."
@@ -3690,9 +20791,6 @@ msgstr "Analisar"
 #~ msgid "Equalization..."
 #~ msgstr "Egalisacion..."
 
-#~ msgid "Performing Equalization"
-#~ msgstr "Egalisacion en cors"
-
 #~ msgid "Fading In"
 #~ msgstr "Fondut en dubèrtura"
 
@@ -3701,12 +20799,6 @@ msgstr "Analisar"
 
 #~ msgid "Noise Removal..."
 #~ msgstr "Eliminacion del bruch..."
-
-#~ msgid "Creating Noise Profile"
-#~ msgstr "Creacion d'un perfil de bruch"
-
-#~ msgid "Normalize..."
-#~ msgstr "Normalizar......"
 
 #, fuzzy
 #~ msgid "Applied effect: %s stretch factor = %f times, time resolution = %f seconds"
@@ -3729,10 +20821,6 @@ msgstr "Analisar"
 #~ msgid "Applied effect: Generate Silence, %.6lf seconds"
 #~ msgstr "Efièch·aplicat·: Congrear un silenci de, %.6lf segondas"
 
-#, fuzzy
-#~ msgid "Buffer Delay Compensation"
-#~ msgstr "Combinason de clau"
-
 #~ msgid "Applied effect: %s frequency = %.1f Hz, start phase = %.0f deg, depth = %.0f%%, resonance = %.1f, frequency offset = %.0f%%"
 #~ msgstr "Efièch·aplicat·: %s frequéncia = %.1f Hz, fasa de partença = %.0f deg, amplitud = %.0f%%, resonància = %.1f, frequéncia offset = %.0f%%"
 
@@ -3746,13 +20834,6 @@ msgstr "Analisar"
 #~ msgid "Recording Level (Click to monitor.)"
 #~ msgstr "Vistmètre d'intrada - clicar per visualizar"
 
-#, fuzzy
-#~ msgid "Spectral Selection Specifications"
-#~ msgstr "Definir un punt de seleccion"
-
-#~ msgid "Multi-Tool Mode: Ctrl-P for Mouse and Keyboard Preferences"
-#~ msgstr "Mòde·multi-aisinas : Ctrl+P per Preferéncias mirga e clavièr"
-
 #~ msgid "Input Meter"
 #~ msgstr "Vistmètre d'intrada"
 
@@ -3763,17 +20844,6 @@ msgstr "Analisar"
 #, fuzzy
 #~ msgid "Effect Refresh"
 #~ msgstr "Reglatges de l'efièch"
-
-#, fuzzy
-#~ msgid "Input Channels"
-#~ msgstr "%d Canals"
-
-#, fuzzy
-#~ msgid "Select Input Channels"
-#~ msgstr "Seleccion"
-
-#~ msgid "Output Volume"
-#~ msgstr "Volum de sortida"
 
 #~ msgid "Input Volume"
 #~ msgstr "Volum d'intrada"
@@ -3786,9 +20856,6 @@ msgstr "Analisar"
 #~ msgid "Output Volume: %.2f%s"
 #~ msgstr "Volum de sortida"
 
-#~ msgid "Align with &Zero"
-#~ msgstr "Alinhar amb lo &Zèro"
-
 #~ msgid "Align with &Cursor"
 #~ msgstr "Alinhar amb lo &Cursor"
 
@@ -3796,14 +20863,8 @@ msgstr "Analisar"
 #~ msgid "Align End with Cu&rsor"
 #~ msgstr "Alinhar la fin amb lo cursor"
 
-#~ msgid "Aligned cursor"
-#~ msgstr "Cursor alinhat"
-
 #~ msgid "Aligned end with cursor"
 #~ msgstr "Fin·alinhada·amb lo cursor"
-
-#~ msgid "Aligned end with selection start"
-#~ msgstr "Fin·alinhada·amb la començança de la seleccion"
 
 #~ msgid "Libresample by Dominic Mazzoni and Julius Smith"
 #~ msgstr "Libresample per Dominic Mazzoni e Julius Smith"
@@ -3813,6 +20874,3 @@ msgstr "Analisar"
 
 #~ msgid "Click and Pop Removal by Craig DeForest"
 #~ msgstr "Supression· dels clics e pòps per Craig de Forèst"
-
-#~ msgid "Output level meter"
-#~ msgstr "Vistmètre de sortida"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -21,84 +21,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-07 18:56+0000\n"
 "Last-Translator: Rafał Zygmunt <wanda233a@o2.pl>\n"
-"Language-Team: Polish <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"pl/>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/tenacity/tenacity/pl/>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Zaktualizuj Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Pomiń"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "Za&instaluj aktualizację"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Dziennik zmian"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Czytaj więcej na GitHubie"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Błąd sprawdzania aktualizacji"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Nie można połączyć się z serwerem aktualizacji Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Dane aktualizacji były uszkodzone."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Błąd pobierania aktualizacji."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Nie można otworzyć linku pobierania Tenacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s jest dostępny!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Nagrywanie"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -108,6 +40,24 @@ msgstr "Nie można określić"
 #, c-format
 msgid "%s bytes"
 msgstr "%s bajtów"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -234,7 +184,8 @@ msgid "Script"
 msgstr "Skrypt"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Wyjście"
 
@@ -250,7 +201,12 @@ msgstr "Skrypty Nyquista (*.ny)|*.ny|Skrypty Lispa (*.lsp)|*.lsp|Wszystkie pliki
 msgid "Script was not saved."
 msgstr "Skrypt nie został zapisany."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
@@ -263,17 +219,25 @@ msgid "Find dialog"
 msgstr "Znajdź okno dialogowe"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr "Harvey Lubin (logo)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galeria ikon Tango (pasek narzędziowy ikon)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009, Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
-msgstr ""
-"Zewnętrzny moduł Tenacity, który zapewnia prosty IDE do pisania efektów."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr "Zewnętrzny moduł Tenacity, który zapewnia prosty IDE do pisania efektów."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -295,7 +259,8 @@ msgstr "Bez nazwy"
 msgid "Nyquist Effect Workbench - "
 msgstr "Efekty stołu roboczego Nyquista - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nowy"
 
@@ -335,7 +300,8 @@ msgstr "Kopiuj"
 msgid "Copy to clipboard"
 msgstr "Kopiuj do schowka"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Wytnij"
 
@@ -343,7 +309,8 @@ msgstr "Wytnij"
 msgid "Cut to clipboard"
 msgstr "Wytnij do schowka"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Wklej"
 
@@ -368,7 +335,8 @@ msgstr "Zaznacz wszystko"
 msgid "Select all text"
 msgstr "Zaznacz cały tekst"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Cofnij"
 
@@ -376,7 +344,8 @@ msgstr "Cofnij"
 msgid "Undo last change"
 msgstr "Cofnij ostatnią zmianę"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Ponów"
 
@@ -433,7 +402,8 @@ msgid "Go to next S-expr"
 msgstr "Idź do następnego S-wyrażenia"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Początek"
 
@@ -441,7 +411,8 @@ msgstr "Początek"
 msgid "Start script"
 msgstr "Uruchom skrypt"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Zatrzymaj"
 
@@ -455,15 +426,23 @@ msgstr "Zatrzymaj skrypt"
 msgid "About %s"
 msgstr "O %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "OK"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informacje o kompilacji"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Włączone"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Wyłączone"
 
@@ -473,8 +452,9 @@ msgid "The Build"
 msgstr "Kompilacja"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Obowiązkowy Id:"
+#, fuzzy
+msgid "Version:"
+msgstr "Wersja: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -484,22 +464,28 @@ msgstr "Typ kompilacji:"
 msgid "Compiler:"
 msgstr "Kompilator:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Przedrostek instalacji:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Folder ustawień:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Folder ustawień:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Obsługa formatów plików"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Wieloplatformowa biblioteka GUI"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -513,7 +499,6 @@ msgstr "Przekształcanie częstotliwości próbkowania"
 msgid "MP3 Importing"
 msgstr "Importowanie MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importowanie i eksportowanie Ogg Vorbis"
@@ -522,7 +507,6 @@ msgstr "Importowanie i eksportowanie Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Obsługa znaczników ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importowanie i eksportowanie FLAC"
@@ -540,14 +524,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importowanie/eksportowanie FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importowanie przez GStreamera"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Funkcje"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Obsługa wtyczki"
 
@@ -562,6 +538,10 @@ msgstr "Obsługa zmiany wysokości i tempa"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Ekstremalna obsługa zmiany wysokości i tempa"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Funkcje"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -654,6 +634,12 @@ msgstr "%s, kompozytor Audacity"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, tester"
+msgstr "%s, tester Audacity"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, wtyczki Nyquista Audacity"
 
@@ -674,16 +660,22 @@ msgstr "%s, grafiki Audacity"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (obejmuje %s, %s, %s, %s i %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Darmowy, otwarty, wieloplatformowy program do nagrywania i edytowania "
-"dźwięku."
+msgstr "Darmowy, otwarty, wieloplatformowy program do nagrywania i edytowania dźwięku."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Współtwórcy"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Pamiętaj, że nazwiska są posortowane w kolejności alfabetycznej, a nie według ważności."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -716,6 +708,10 @@ msgid "%s Team Members"
 msgstr "Członkowie zespołu %s"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr "Emeritus Audacity:"
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Współtwórcy Audacity"
 
@@ -728,11 +724,10 @@ msgstr "Strona internetowa i grafiki Audacity"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
-msgstr ""
-"Polskie tłumaczenie Tenacity: Grzegorz \"Gootector\" Pruchniakowski, "
-"ilidans01"
+msgstr "Polskie tłumaczenie Tenacity: Grzegorz \"Gootector\" Pruchniakowski, ilidans01"
 
 #: src/AboutDialog.cpp
 msgid "Translators"
@@ -747,6 +742,22 @@ msgstr "Specjalne podziękowania Audacity dla:"
 #, c-format
 msgid "%s website: "
 msgstr "Strona internetowa %s: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s współtwórcy"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Znak towarowy Audacity%s jest używany w tym programie wyłącznie w celach opisowych i informacyjnych."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity nie jest produkowany ani wspierany przez MuseCY SM Ltd. lub Dominica M. Mazzoniego."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -769,6 +780,7 @@ msgstr "Oś czasu"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kliknij i przeciągnij, aby rozpocząć szukanie"
@@ -776,6 +788,7 @@ msgstr "Kliknij i przeciągnij, aby rozpocząć szukanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Kliknij i przeciągnij, aby rozpocząć przewijanie"
@@ -783,6 +796,7 @@ msgstr "Kliknij i przeciągnij, aby rozpocząć przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Kliknij i przesuń, aby przewinąć. Kliknij i przeciągnij, aby szukać."
@@ -790,6 +804,7 @@ msgstr "Kliknij i przesuń, aby przewinąć. Kliknij i przeciągnij, aby szukać
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Przesuń, aby szukać"
@@ -797,6 +812,7 @@ msgstr "Przesuń, aby szukać"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Przesuń, aby przewinąć"
@@ -853,7 +869,17 @@ msgstr ""
 "Nie można zablokować obszaru poza\n"
 "końcem projektu."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Błąd"
 
@@ -877,7 +903,8 @@ msgstr ""
 "Jest to jednorazowe pytanie po 'zainstalowaniu', w którym poprosiłeś/aś o zresetowanie ustawień."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Zresetuj ustawienia Tenacity"
 
 #: src/AudacityApp.cpp
@@ -892,10 +919,9 @@ msgstr ""
 "Zostało usunięte z listy ostatnich plików."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
-msgstr ""
-"Inicjowanie biblioteki SQLite zakończone niepowodzeniem. Tenacity nie może "
-"kontynuować."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr "Inicjowanie biblioteki SQLite zakończone niepowodzeniem. Tenacity nie może kontynuować."
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -919,7 +945,7 @@ msgstr "&Otwórz..."
 msgid "Open &Recent..."
 msgstr "O&twórz ostatnie..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&O Tenacity..."
 
@@ -932,33 +958,34 @@ msgid "&File"
 msgstr "&Plik"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity nie może znaleźć miejsca na przechowywanie plików tymczasowych.\n"
-"Tenacity potrzebuje miejsca, gdzie automatyczne programy oczyszczania nie "
-"usuną plików tymczasowych.\n"
+"Tenacity potrzebuje miejsca, gdzie automatyczne programy oczyszczania nie usuną plików tymczasowych.\n"
 "Podaj odpowiedni katalog w oknie dialogowym Ustawienia."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity nie może znaleźć miejsca na przechowywanie plików tymczasowych.\n"
 "Podaj odpowiedni katalog w oknie dialogowym Ustawienia."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"Tenacity zakończy teraz swoją pracę. Uruchom Tenacity ponownie, aby użyć "
-"nowego katalogu tymczasowego."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "Tenacity zakończy teraz swoją pracę. Uruchom Tenacity ponownie, aby użyć nowego katalogu tymczasowego."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -967,15 +994,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity nie był w stanie zablokować katalogu z plikami tymczasowymi.\n"
 "Folder ten może być używany przez inną kopię Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Nadal chcesz uruchomić Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -983,19 +1012,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Błąd blokowania katalogu tymczasowego"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "System wykrył, że uruchomiona jest jeszcze jedna kopia Tenacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Użyj poleceń Nowy lub Otwórz w obecnie uruchomionym procesie\n"
 "Tenacity, aby otworzyć wiele projektów naraz.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity jest już uruchomiony"
 
 #: src/AudacityApp.cpp
@@ -1011,7 +1043,8 @@ msgstr ""
 "i może być wymagane ponowne uruchomienie."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Błąd uruchamiania Tenacity"
 
 #: src/AudacityApp.cpp
@@ -1051,8 +1084,9 @@ msgstr ""
 "i może być wymagane ponowne uruchomienie."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1084,7 +1118,8 @@ msgstr "uruchom samodiagnostykę"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "wyświetl wersję Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1094,32 +1129,34 @@ msgid "audio or project file name"
 msgstr "nazwa pliku dźwiękowego lub projektu"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
 "Pliki projektów Tenacity (.aup3) nie są \n"
 "obecnie przypisane do programu Tenacity. \n"
 "\n"
-"Przypisać je, aby móc otworzyć je programem przez podwójne kliknięcie "
-"przyciskiem myszki?"
+"Przypisać je, aby móc otworzyć je programem przez podwójne kliknięcie przyciskiem myszki?"
 
 #: src/AudacityApp.cpp
 msgid "Audacity Project Files"
 msgstr "Pliki projektów Tenacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Komunikat"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Błąd konfiguracji Tenacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1129,28 +1166,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Nie można uzyskać dostępu do następującego pliku konfiguracyjnego:\n"
 "\n"
 "\t%s\n"
 "\n"
-"Może to mieć wiele przyczyn, ale najprawdopodobniej dysk jest pełny lub nie "
-"masz uprawnień do zapisu do pliku. Więcej informacji można uzyskać, klikając "
-"poniższy przycisk pomocy.\n"
+"Może to mieć wiele przyczyn, ale najprawdopodobniej dysk jest pełny lub nie masz uprawnień do zapisu do pliku. Więcej informacji można uzyskać, klikając poniższy przycisk pomocy.\n"
 "\n"
-"Możesz spróbować rozwiązać problem, a następnie kliknąć \"Spróbuj ponownie\""
-", aby kontynuować.\n"
+"Możesz spróbować rozwiązać problem, a następnie kliknąć \"Spróbuj ponownie\", aby kontynuować.\n"
 "\n"
-"Jeśli wybierzesz opcję \"Opuść Tenacity\", Twój projekt może pozostać w "
-"stanie niezapisanym, który zostanie odzyskany przy następnym otwarciu."
+"Jeśli wybierzesz opcję \"Opuść Tenacity\", Twój projekt może pozostać w stanie niezapisanym, który zostanie odzyskany przy następnym otwarciu."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Pomoc"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Opuść Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1158,7 +1194,8 @@ msgid "&Retry"
 msgstr "&Spróbuj ponownie"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Dziennik Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1170,7 +1207,8 @@ msgstr "&Zapisz..."
 msgid "Cl&ear"
 msgstr "Wy&czyść"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Zamknij"
 
@@ -1225,7 +1263,8 @@ msgid "Error Initializing Midi"
 msgstr "Błąd przy uruchamianiu MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Dźwięk Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1240,37 +1279,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Brak pamięci!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa była jego dalsza optymalizacja. Nadal jest on za wysoki."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Zautomatyzowane dostosowywanie poziomu nagrywania zmniejszyło głośność do %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa była jego dalsza optymalizacja. Nadal jest on za niski."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Zautomatyzowane dostosowywanie poziomu nagrywania zwiększyło głośność do %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. Nadal jest ona za wysoka."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. Nadal jest ona za niska."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. %.2f wydaje się być akceptowalną głośnością."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1369,43 +1377,6 @@ msgstr "Nie znaleziono urządzenia odtwarzającego '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Nie można sprawdzić wzajemnych częstotliwości próbkowania bez obu urządzeń.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Odebrano %d podczas otwierania urządzenia\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Nie można otworzyć portmiksera\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Dostępne miksery:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Dostępne źródła nagrywania:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Dostępne głośności odtwarzania:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Głośność nagrywania jest emulowana\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Głośność nagrywania jest natywna\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Głośność odtwarzania jest emulowana\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Głośność odtwarzania jest natywna\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1448,28 +1419,29 @@ msgid "Automatic Crash Recovery"
 msgstr "Samoczynne przywracanie po awarii"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
-"Następujące projekty nie zostały poprawnie zapisane przy ostatnim "
-"uruchomieniu Tenacity\n"
+"Następujące projekty nie zostały poprawnie zapisane przy ostatnim uruchomieniu Tenacity\n"
 "i mogą być automatycznie odzyskane.\n"
-"Po odzyskaniu zapisz projekty, aby mieć pewność, że zmiany zostaną zapisane "
-"na dysku."
+"Po odzyskaniu zapisz projekty, aby mieć pewność, że zmiany zostaną zapisane na dysku."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "&Projekty możliwe do odzyskania"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Zaznacz"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nazwa"
 
@@ -1555,6 +1527,11 @@ msgstr "Efekt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menu poleceń (z parametrami)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1700,7 +1677,8 @@ msgstr "&Przywróć"
 msgid "I&mport..."
 msgstr "I&mportuj..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&ksportuj..."
 
@@ -1741,7 +1719,8 @@ msgstr "Przesuń w &górę"
 msgid "Move &Down"
 msgstr "Przesuń w &dół"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Zapisz"
 
@@ -1788,6 +1767,11 @@ msgstr "Nazwy nie mogą zawierać '%c' ani '%c'"
 msgid "Are you sure you want to delete %s?"
 msgstr "Na pewno chcesz usunąć %s?"
 
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+msgid "Benchmark"
+msgstr "Benchmark"
+
 #: src/Benchmark.cpp
 msgid "Disk Block Size (KB):"
 msgstr "Rozmiar bloku dysku (KB):"
@@ -1819,9 +1803,16 @@ msgid "Run"
 msgstr "Uruchom"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Zamknij"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "benchmark.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1959,10 +1950,6 @@ msgid "No revision identifier was provided"
 msgstr "Nie podano identyfikatora wersji"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Nieznana data i czas"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Kompilacja debugowania (poziom debugowania %d)"
@@ -2045,6 +2032,11 @@ msgid ""
 msgstr ""
 "Najpierw musisz zaznaczyć dźwięk, aby wykonać to działanie.\n"
 "(Zaznaczenie innych rodzajów ścieżki nie zadziała.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2207,6 +2199,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopiuj nazwy do schowka"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Brakuje"
 
@@ -2215,18 +2212,17 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Jeśli będziesz kontynuować, Twój projekt nie zostanie zapisany na dysku. Chcesz to zrobić?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
-"Twój projekt jest obecnie samowystarczalny; nie zależy on od żadnych "
-"zewnętrznych plików dźwiękowych. \n"
+"Twój projekt jest obecnie samowystarczalny; nie zależy on od żadnych zewnętrznych plików dźwiękowych. \n"
 "\n"
-"Niektóre starsze projekty Tenacity mogą być niesamodzielne i należy zachować "
-"ostrożność,\n"
+"Niektóre starsze projekty Tenacity mogą być niesamodzielne i należy zachować ostrożność,\n"
 "aby utrzymać ich zewnętrzne zależności we właściwym miejscu.\n"
 "Nowe projekty będą niezależne i mniej ryzykowne."
 
@@ -2234,7 +2230,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Sprawdzanie zależności"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Żaden"
 
@@ -2242,7 +2241,7 @@ msgstr "Żaden"
 msgid "Rectangle"
 msgstr "Prostokątny"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trójkątny"
 
@@ -2253,6 +2252,36 @@ msgstr "Ukształtowany"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Prostokątny"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2274,17 +2303,17 @@ msgid "FFmpeg support not compiled in"
 msgstr "Obsługa FFmpeg nie została skompilowana"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
 "FFmpeg został wcześniej skonfigurowany w Ustawieniach i pomyślnie\n"
 "wczytany, ale tym razem nie udało się Tenacity wczytać go przy starcie.\n"
 "\n"
-"Możesz rozważyć powrót do 'Ustawienia... > Biblioteki' i ponownie go "
-"skonfigurować."
+"Możesz rozważyć powrót do 'Ustawienia... > Biblioteki' i ponownie go skonfigurować."
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -2299,10 +2328,9 @@ msgid "Locate FFmpeg"
 msgstr "Ustal położenie FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"Tenacity potrzebuje pliku '%s' do importu i eksportu dźwięku przez FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "Tenacity potrzebuje pliku '%s' do importu i eksportu dźwięku przez FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2314,7 +2342,8 @@ msgstr "Położenie '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Aby znaleźć '%s', kliknij tutaj -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Wybierz..."
 
@@ -2340,8 +2369,9 @@ msgid "FFmpeg not found"
 msgstr "Nie znaleziono FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2371,24 +2401,24 @@ msgid "Only libavformat.so"
 msgstr "Tylko libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity nie otworzył pliku %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity nie odczytał z pliku %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Tenacity pomyślnie zapisał plik w %s, ale nie zmienił nazwy na %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2426,7 +2456,9 @@ msgstr "&Nie kopiuj żadnego dźwięku"
 msgid "As&k"
 msgstr "&Pytaj"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Wszystkie pliki"
 
@@ -2451,6 +2483,10 @@ msgstr "Pliki tekstowe"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Pliki XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ", "
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2492,6 +2528,13 @@ msgstr "Autokorelacja Cuberoot"
 msgid "Enhanced Autocorrelation"
 msgstr "Ulepszona autokorelacja"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+msgid "Cepstrum"
+msgstr "Cepstrum"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2508,6 +2551,17 @@ msgstr "Skala liniowa"
 msgid "Log frequency"
 msgstr "Skala logarytmiczna"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Rolka"
@@ -2515,6 +2569,15 @@ msgstr "Rolka"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Powiększanie"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
@@ -2573,6 +2636,23 @@ msgstr "Zaznaczono za dużą próbkę dźwięku. Tylko pierwsze %.1f sekund zost
 msgid "Not enough data selected."
 msgstr "Za mało zaznaczonych danych."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2595,7 +2675,8 @@ msgstr "widmo.txt"
 msgid "Export Spectral Data As:"
 msgstr "Eksportuj dane widma jako:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Nie można zapisać pliku: %s"
@@ -2672,15 +2753,11 @@ msgstr "Brak lokalnej pomocy"
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
-msgstr ""
-"<br><br>Wersja programu Tenacity, którą używasz, to <b>wersja testowa "
-"alpha</b>."
+msgstr "<br><br>Wersja programu Tenacity, którą używasz, to <b>wersja testowa alpha</b>."
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
-msgstr ""
-"<br><br>Wersja programu Tenacity, którą używasz, to <b>wersja testowa "
-"beta</b>."
+msgstr "<br><br>Wersja programu Tenacity, którą używasz, to <b>wersja testowa beta</b>."
 
 #: src/HelpText.cpp
 msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
@@ -2688,9 +2765,7 @@ msgstr "Zdecydowanie zalecamy korzystać z naszej najnowszej stabilnej wersji, k
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"Możesz pomóc nam stworzyć gotowego do wydania Tenacity, dołączając do naszej "
-"[[https://tenacityaudio.org/community/|społeczności]].<hr><br><br>"
+msgstr "Możesz pomóc nam stworzyć gotowego do wydania Tenacity, dołączając do naszej [[https://tenacityaudio.org/community/|społeczności]].<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2703,16 +2778,12 @@ msgstr "To są nasze metody wsparcia:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[help:Quick_Help|Szybka pomoc]] - jeśli nie jest zainstalowana lokalnie, "
-"zobacz online"
+msgstr "[[help:Quick_Help|Szybka pomoc]] - jeśli nie jest zainstalowana lokalnie, zobacz online"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
-msgstr ""
-" [[help:Main_Page|Podręcznik]] - jeśli nie jest zainstalowany lokalnie, "
-"zobacz online"
+msgstr " [[help:Main_Page|Podręcznik]] - jeśli nie jest zainstalowany lokalnie, zobacz online"
 
 #: src/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
@@ -2720,23 +2791,15 @@ msgstr " Forum - zadaj swoje pytanie bezpośrednio w Internecie"
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"Więcej:</b> Odwiedź naszą wiki, gdzie znajdziesz porady, wskazówki, "
-"samouczki i wtyczki."
+msgstr "Więcej:</b> Odwiedź naszą wiki, gdzie znajdziesz porady, wskazówki, samouczki i wtyczki."
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"Tenacity może importować niechronione pliki w wielu formatach (takich jak "
-"M4A i WMA, skompresowane pliki WAV z podręcznych dyktafonów i dźwięki z "
-"filmów), jeśli tylko na swoim komputerze, pobierzesz i zainstalujesz "
-"opcjonalną bibliotekę FFmpeg."
+msgstr "Tenacity może importować niechronione pliki w wielu formatach (takich jak M4A i WMA, skompresowane pliki WAV z podręcznych dyktafonów i dźwięki z filmów), jeśli tylko na swoim komputerze, pobierzesz i zainstalujesz opcjonalną bibliotekę FFmpeg."
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"Możesz również przeczytać naszą pomoc na temat importowania plików MIDI "
-"ścieżek z płyt Audio CD."
+msgstr "Możesz również przeczytać naszą pomoc na temat importowania plików MIDI ścieżek z płyt Audio CD."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
@@ -2744,11 +2807,7 @@ msgstr "Podręcznik wydaje się być niezainstalowany. [[*URL*|Zobacz Podręczni
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Podręcznik wydaje się być niezainstalowany. [[*URL*|Zobacz Podręcznik "
-"online]] lub pobierz Podręcznik.<br><br>Aby zawsze móc korzystać z "
-"Podręcznika online, zmień \"Lokalizację Podręcznika\" w Ustawieniach "
-"interfejsu na \"Z Internetu\"."
+msgstr "Podręcznik wydaje się być niezainstalowany. [[*URL*|Zobacz Podręcznik online]] lub pobierz Podręcznik.<br><br>Aby zawsze móc korzystać z Podręcznika online, zmień \"Lokalizację Podręcznika\" w Ustawieniach interfejsu na \"Z Internetu\"."
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2807,19 +2866,19 @@ msgid "&History..."
 msgstr "&Historia..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Błąd wewnętrzny w %s w %s, linia %d.\n"
 "Poinformuj zespół Tenacity przez https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Błąd wewnętrzny w %s w %s, linia %d.\n"
 "Poinformuj zespół Tenacity przez https://tenacityaudio.org/."
@@ -2838,7 +2897,9 @@ msgid "Track"
 msgstr "Ścieżka"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etykieta"
 
@@ -2898,7 +2959,8 @@ msgstr "Wprowadź nazwę ścieżki"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Etykieta ścieżki"
 
@@ -2909,11 +2971,13 @@ msgstr "Nie można było przeczytać jednej lub więcej zapisanych etykiet."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Pierwsze uruchomienie programu Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Wybierz język używany w Tenacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2923,7 +2987,8 @@ msgstr "Wybierz język używany w Tenacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Wybrany przez Ciebie język %s (%s), nie jest taki sam jak język systemowy %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Potwierdź"
 
@@ -2941,8 +3006,18 @@ msgstr ""
 "Stary plik został zapisany jako '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Otwieranie projektu Tenacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Tenacity Karaoke%s"
+
+#: src/LyricsWindow.cpp
+msgid "&Karaoke..."
+msgstr "&Karaoke..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2988,19 +3063,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Miksowanie i renderowanie ścieżek"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Panel miksera Tenacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Wzmocnienie"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Prędkość"
 
@@ -3009,28 +3088,42 @@ msgid "Musical Instrument"
 msgstr "Instrument muzyczny"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panorama"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Cisza"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Miernik poziomu sygnału"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Przesunięto suwak czułości"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Przesunięto suwak prędkości"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Przesunięto suwak panoramy"
 
@@ -3065,9 +3158,9 @@ msgstr ""
 "Nie zostanie załadowany."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3101,16 +3194,19 @@ msgstr ""
 "\n"
 "Używaj modułów tylko z zaufanych źródeł"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Tak"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nie"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Ładowarka modułu Tenacity"
 
 #: src/ModuleManager.cpp
@@ -3133,6 +3229,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Ścieżka nut"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "C"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "C♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "D"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "D♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "E"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "F"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "F♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "G"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "G♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "A"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "A♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "B"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "D♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "E♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "G♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "A♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "B♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "C♯/D♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "D♯/E♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "F♯/G♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "G♯/A♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "A♯/B♭"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3244,7 +3450,8 @@ msgstr "&Zaznacz wszystko"
 msgid "C&lear All"
 msgstr "Wy&czyść wszystko"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "W&łącz"
 
@@ -3317,18 +3524,17 @@ msgstr ""
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "The tracks selected for recording must all have the same sampling rate"
-msgstr ""
-"Wszystkie zaznaczone ścieżki do nagrania muszą mieć taką samą częstotliwość "
-"próbkowania"
+msgstr "Wszystkie zaznaczone ścieżki do nagrania muszą mieć taką samą częstotliwość próbkowania"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "Mismatched Sampling Rates"
 msgstr "Niedopasowane częstotliwości próbkowania"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Zaznaczono za mało ścieżek do nagrania z tą częstotliwością próbkowania.\n"
@@ -3357,10 +3563,11 @@ msgid "Dropouts"
 msgstr "Przerwy"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3400,11 +3607,11 @@ msgid "Inspecting project file data"
 msgstr "Inspekcja danych pliku projektu"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3447,11 +3654,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Ostrzeżenie - Brakuje pliku(ów) z aliasami"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Sprawdzanie projektu folderu \"%s\" \n"
@@ -3476,12 +3683,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Ostrzeżenie - Brakuje pliku(ów) podsumowania z aliasami"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3492,8 +3699,7 @@ msgid ""
 "may not show silence."
 msgstr ""
 "Sprawdzanie projektu folderu \"%s\" \n"
-"wykryło %lld brakujące(ych) dane(ych) dźwiękowe(ych) (.au) pliku(ów) "
-"blokowego(ych), \n"
+"wykryło %lld brakujące(ych) dane(ych) dźwiękowe(ych) (.au) pliku(ów) blokowego(ych), \n"
 "prawdopodobnie ze względu na błąd, awarię systemu lub przypadkowe \n"
 "usunięcie. Tenacity nie może przywrócić tych plików \n"
 "samoczynnie. \n"
@@ -3540,7 +3746,8 @@ msgstr "Ostrzeżenie - Porzucony(e) plik(i) blokowy(e)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Postęp"
 
@@ -3561,6 +3768,15 @@ msgstr ""
 #: src/ProjectFSCK.cpp
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Ostrzeżenie - Problemy z samoczynnym odzyskiwaniem"
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr "<bez nazwy>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3630,12 +3846,14 @@ msgstr ""
 "(Nie można utworzyć wymaganych plików tymczasowych)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "To nie jest plik projektu Tenacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3767,9 +3985,9 @@ msgid "Error Writing to File"
 msgstr "Błąd zapisywania do pliku"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3783,9 +4001,16 @@ msgstr "Kompaktowanie projektu"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekt %02i] Tenacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3794,14 +4019,13 @@ msgstr "(Odzyskane)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Ten plik został zapisany przy użyciu Tenacity %s.\n"
-"Używasz Tenacity %s. Musisz zaktualizować do nowszej wersji, aby otworzyć "
-"ten plik."
+"Używasz Tenacity %s. Musisz zaktualizować do nowszej wersji, aby otworzyć ten plik."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
@@ -3870,25 +4094,25 @@ msgid "Backing up project"
 msgstr "Tworzenie kopii zapasowej projektu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
-"Ten projekt nie został poprawnie zapisany przy ostatnim uruchomieniu "
-"Tenacity.\n"
+"Ten projekt nie został poprawnie zapisany przy ostatnim uruchomieniu Tenacity.\n"
 "\n"
 "Został odzyskany do ostatniej migawki."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
 msgstr ""
-"Ten projekt nie został poprawnie zapisany przy ostatnim uruchomieniu "
-"Tenacity.\n"
+"Ten projekt nie został poprawnie zapisany przy ostatnim uruchomieniu Tenacity.\n"
 "\n"
 "Został odzyskany do ostatniej migawki, ale musisz go zapisać,\n"
 "aby zachować jego zawartość."
@@ -3962,13 +4186,13 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sZapisz projekt \"%s\" jako..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Zapisz projekt' jest dla projektu Tenacity, nie dla pliku dźwiękowego.\n"
-"Do pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj "
-"'Eksportuj'.\n"
+"Do pliku dźwiękowego, który zostanie otwarty w innych aplikacjach, użyj 'Eksportuj'.\n"
 
 #. i18n-hint: In each case, %s is the name
 #. of the file being overwritten.
@@ -4041,11 +4265,12 @@ msgid "Error Opening Project"
 msgstr "Błąd otwierania projektu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Próbujesz otworzyć samoczynnie utworzony plik kopii zapasowej.\n"
 "Zrobienie tego może skutkować poważną utratą danych.\n"
@@ -4154,8 +4379,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatyczna kopia zapasowa bazy danych zakończona niepowodzeniem."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Witamy w wersji %s Tenacity"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4374,7 +4599,8 @@ msgstr "Wszystkie ustawienia"
 msgid "SelectionBar"
 msgstr "Pasek zaznaczenia"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Zaznaczenie widma"
 
@@ -4382,42 +4608,55 @@ msgstr "Zaznaczenie widma"
 msgid "Timer"
 msgstr "Czasomierz"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Narzędzia"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+msgid "Transport"
+msgstr "Transport"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mikser"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Miernik"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Miernik odtwarzania"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Miernik nagrywania"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Edycja"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Urządzenie"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Odtwarzaj z prędkością"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Przewijaj"
 
@@ -4432,7 +4671,10 @@ msgstr "Linijka"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Ścieżki"
 
@@ -4542,7 +4784,8 @@ msgid "Activation level (dB):"
 msgstr "Poziom aktywacji (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Witamy w Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4689,9 +4932,9 @@ msgstr ""
 "Aby uzyskać wskazówki dotyczące odpowiednich nośników, kliknij przycisk pomocy."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity nie mógł zapisać pliku:\n"
@@ -4711,9 +4954,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4722,9 +4965,9 @@ msgstr ""
 "do zapisu."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity nie mógł zapisać obrazów do pliku:\n"
@@ -4741,9 +4984,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4753,9 +4996,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4764,8 +5007,9 @@ msgstr ""
 "Być może format png jest nieprawidłowy?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity nie mógł odczytać tego domyślnego motywu.\n"
@@ -4803,9 +5047,9 @@ msgstr ""
 "były już obecne. Zastąpić?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity nie mógł zapisać pliku:\n"
@@ -4844,7 +5088,11 @@ msgstr "Niestandardowy"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Długość"
 
@@ -4855,7 +5103,8 @@ msgid "Time Track"
 msgstr "Ścieżka czasowa"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Nagrywanie czasowe Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4929,7 +5178,8 @@ msgstr "Bieżący projekt"
 msgid "Recording start:"
 msgstr "Początek nagrywania:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Długość:"
 
@@ -4950,7 +5200,8 @@ msgid "Action after Timer Recording:"
 msgstr "Działanie po nagrywaniu czasowym:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Postęp nagrywania czasowego Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5046,6 +5297,7 @@ msgstr "099 dni 024 g 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data i czas początku"
@@ -5090,7 +5342,8 @@ msgstr "Włączyć automatyczny &eksport?"
 msgid "Export Project As:"
 msgstr "Eksportuj projekt jako:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcje"
 
@@ -5103,7 +5356,8 @@ msgid "Do nothing"
 msgstr "Nic nie rób"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Zakończ Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5127,7 +5381,8 @@ msgid "Scheduled to stop at:"
 msgstr "Zaplanowane, aby zatrzymać się na:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Nagrywanie czasowe Tenacity - Oczekiwanie na rozpoczęcie"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5153,7 +5408,8 @@ msgid "Recording Exported:"
 msgstr "Nagrywanie wyeksportowane:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Nagrywanie czasowe Tenacity - Oczekiwanie"
 
 #: src/TrackInfo.cpp
@@ -5349,6 +5605,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Stosowanie %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "NIEPOWODZENIE"
@@ -5367,13 +5633,15 @@ msgstr "%s nie jest parametrem zaakceptowanym przez %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Nieprawidłowa wartość parametru '%s': powinna być %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Polecenie"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Powtórz %s"
@@ -5408,6 +5676,10 @@ msgid "Compares a range on two tracks."
 msgstr "Porównuje zakres na dwóch ścieżkach."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr "Demo"
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Czas opóźnienia (sekundy):"
 
@@ -5422,6 +5694,10 @@ msgstr "Robi działanie demo."
 #: src/commands/DragCommand.cpp
 msgid "Drag"
 msgstr "Przeciągnięcie"
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+msgid "Panel"
+msgstr "Panel"
 
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
@@ -5492,13 +5768,24 @@ msgstr "Przycięcia"
 msgid "Envelopes"
 msgstr "Obwiednie"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etykiety"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Pudełka"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr "JSON"
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr "LISP"
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5507,6 +5794,11 @@ msgstr "Streszczenie"
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Typ:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+msgid "Format:"
+msgstr "Format:"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -5532,6 +5824,10 @@ msgstr "Komentarz"
 msgid "Command:"
 msgstr "Polecenie:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr "_"
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Daje pomoc na polecenie."
@@ -5539,6 +5835,10 @@ msgstr "Daje pomoc na polecenie."
 #: src/commands/HelpCommand.h
 msgid "For comments in a macro."
 msgstr "Komentarze w makrze."
+
+#: src/commands/ImportExportCommands.cpp
+msgid "Import2"
+msgstr "Import2"
 
 #: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
 msgid "File Name:"
@@ -5564,12 +5864,17 @@ msgstr "Eksporty do pliku."
 msgid "Builtin Commands"
 msgstr "Polecenia wbudowane"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Zespół Tenacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Zapewnia polecenia wbudowane w Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5632,7 +5937,10 @@ msgstr "Czyści zawartość dziennika."
 msgid "Get Preference"
 msgstr "Uzyskaj ustawienia"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nazwa:"
 
@@ -5680,7 +5988,8 @@ msgstr "Pełny ekran"
 msgid "Toolbars"
 msgstr "Paski narzędziowe"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efekty"
 
@@ -5820,7 +6129,8 @@ msgstr "Ustaw"
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Usuń"
 
@@ -5905,7 +6215,8 @@ msgid "Edited Envelope"
 msgstr "Edytowana obwiednia"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Obwiednia"
 
@@ -5948,6 +6259,14 @@ msgstr "Częstotliwość:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Zmień rozmiar:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr "X:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr "Y:"
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5997,7 +6316,10 @@ msgstr "Panorama:"
 msgid "Set Track Visuals"
 msgstr "Ustaw ślady ścieżki"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Liniowa"
 
@@ -6080,6 +6402,10 @@ msgid "Allo&w clipping"
 msgstr "Zez&walaj na obcinanie"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr "Auto Duck"
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Redukuje (ducks) liczbę jednej lub większej liczby ścieżek, gdy objętość określona jako \"kontrola\" ścieżki osiągnie określony poziom"
 
@@ -6097,12 +6423,18 @@ msgstr "Zaznaczyłeś/aś ścieżkę, która nie zawiera dźwięku. Auto Duck mo
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck potrzebuje ścieżki kontrolnej, która ma być umieszczona poniżej zaznaczonej(ych) ścieżki(ek)."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr "db"
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Liczba &duck:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekundy"
 
@@ -6126,7 +6458,8 @@ msgstr "Długość wewnętrznego ści&szenia:"
 msgid "Inner &fade up length:"
 msgstr "Długość wewnętrznego &zgłośnienia:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Próg:"
 
@@ -6264,11 +6597,13 @@ msgstr "do (Hz)"
 msgid "t&o"
 msgstr "d&o"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Zmiana &procentowa:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Zmiana procentowa"
 
@@ -6276,9 +6611,23 @@ msgstr "Zmiana procentowa"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Użyj wysokiej jakości rozciągania (wolne)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr "33⅓"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr "45"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr "78"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "niedostępna"
 
@@ -6306,6 +6655,7 @@ msgstr "Pr. obrotowa standardowego winyla:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Od RPM"
@@ -6318,6 +6668,7 @@ msgstr "&od"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Do RPM"
@@ -6460,6 +6811,12 @@ msgstr "Kompresor"
 msgid "Compresses the dynamic range of audio"
 msgstr "Kompresuje zakres dynamiki dźwięku"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6469,6 +6826,20 @@ msgstr "%.2f sek."
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f sek."
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr "%.1f:1"
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6585,7 +6956,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analizator kontrastu do pomiaru różnic głośności RMS między dwoma odcinkami dźwięku."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Koniec"
 
@@ -6645,9 +7017,32 @@ msgstr "&Różnica:"
 msgid "&Help"
 msgstr "&Pomoc"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr "RMS = %s."
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr "%s dB"
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr "zero"
+
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "nieoznaczona"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB RMS"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6701,6 +7096,12 @@ msgstr "Bieżąca różnica"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Poziom zmierzonego pierwszego planu"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6837,6 +7238,10 @@ msgstr "Twarde obcięcie -12 dB, 80%"
 #, no-c-format
 msgid "Soft clip -12dB, 80% make-up gain"
 msgstr "Miękkie obcięcie -12 dB, 80%"
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr "Fuzz Box"
 
 #: src/effects/Distortion.cpp src/effects/Equalization.cpp
 msgid "Walkie-talkie"
@@ -7050,7 +7455,9 @@ msgstr "&Sekwencja DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Amplituda (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Długość:"
 
@@ -7063,18 +7470,40 @@ msgid "Duty cycle:"
 msgstr "Cykl:"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr "%.1f %%"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Długość dźwięku:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Długość ciszy:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr "%0.f ms"
+
+#: src/effects/Echo.cpp
+msgid "Echo"
+msgstr "Echo"
+
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Powtarza wielokrotnie zaznaczony dźwięk"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Żądana wartość przekracza pojemność pamięci."
 
@@ -7098,7 +7527,8 @@ msgstr "Presety"
 msgid "Export Effect Parameters"
 msgstr "Eksportuj parametry efektu"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Nie można otworzyć pliku: \"%s\""
@@ -7136,6 +7566,14 @@ msgstr "Przygotowywanie podglądu"
 msgid "Previewing"
 msgstr "Podglądanie"
 
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr "Nyquist"
+
 #: src/effects/EffectManager.cpp
 #, c-format
 msgid "Applied effect: %s"
@@ -7149,6 +7587,10 @@ msgstr "Zastosowano polecenie: %s"
 #: src/effects/EffectManager.cpp
 msgid "Select Preset"
 msgstr "Zaznacz preset"
+
+#: src/effects/EffectManager.cpp
+msgid "&Preset:"
+msgstr "&Preset:"
 
 #: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
 msgid "User Presets"
@@ -7179,8 +7621,7 @@ msgstr ""
 "\n"
 "%s\n"
 "\n"
-"Więcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż "
-"dziennik...'"
+"Więcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż dziennik...'"
 
 #: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
@@ -7199,8 +7640,7 @@ msgstr ""
 "\n"
 "%s\n"
 "\n"
-"Więcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż "
-"dziennik...'"
+"Więcej informacji może być dostępne w 'Pomoc > Diagnostyka > Pokaż dziennik...'"
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -7465,6 +7905,10 @@ msgid "Low rolloff for speech"
 msgstr "Niski poziom wycofania dla mowy"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr "RIAA"
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefon"
 
@@ -7501,12 +7945,41 @@ msgid "Effect Unavailable"
 msgstr "Efekt niedostępny"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr "+ dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Maks. dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr "%d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Min. dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr "- dB"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr "%g kHz"
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr "%gk"
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7581,8 +8054,20 @@ msgid "D&efault"
 msgstr "D&omyślny"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr "&SSE"
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr "SSE &Threaded"
+
+#: src/effects/Equalization.cpp
 msgid "A&VX"
 msgstr "&AVX"
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr "AV&X Threaded"
 
 #: src/effects/Equalization.cpp
 msgid "&Bench"
@@ -7823,7 +8308,8 @@ msgid "Builtin Effects"
 msgstr "Efekty wbudowane"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Zapewnia efekty wbudowane w Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7833,6 +8319,10 @@ msgstr "Nieznana nazwa efektu wbudowanego"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "postrzegana głośność"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr "RMS"
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7864,6 +8354,10 @@ msgstr "&Normalizuj"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Głośność LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr "LUFS"
 
 #: src/effects/Loudness.cpp
 msgid "RMS dB"
@@ -7937,8 +8431,20 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (domyślny)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr "Blackman, Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
 msgstr "Hamming, brak"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr "Hamming, Hann"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr "Hamming, Reciprocal Hamming"
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -7966,8 +8472,7 @@ msgstr "Musisz podać ten sam rozmiar okna dla kroków 1 i 2."
 
 #: src/effects/NoiseReduction.cpp
 msgid "Warning: window types are not the same as for profiling."
-msgstr ""
-"Ostrzeżenie - Typy okien nie są takie same jak w przypadku profilowania."
+msgstr "Ostrzeżenie - Typy okien nie są takie same jak w przypadku profilowania."
 
 #: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
@@ -8034,8 +8539,9 @@ msgid "Step 1"
 msgstr "Krok 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Zaznacz kilka sekund szumu, aby Tenacity wiedział, co odfiltrować,\n"
@@ -8087,13 +8593,62 @@ msgstr "Typy &okna:"
 msgid "Window si&ze:"
 msgstr "Ro&zmiar okna:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr "16"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr "32"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr "64"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr "128"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr "256"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr "512"
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr "1024"
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (domyślny)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr "4096"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr "8192"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr "16384"
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Kroki na okna:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8209,12 +8764,17 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&ormalizuj kanały stereo niezależnie"
 
 #: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr "Paulstretch"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch jest tylko dla ekstremalnego odcinku czasu lub efektu \"zastój\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "W&spółczynnik rozciągania:"
@@ -8496,6 +9056,11 @@ msgstr "Odwraca zaznaczony dźwięk"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Czas SBSMS/rozciąganie wysokości"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr "Butterworth"
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8651,6 +9216,11 @@ msgstr "Użyj domyślnych"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Przywróć domyślne"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr "%.3f"
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8810,6 +9380,10 @@ msgstr "Wykryj ciszę"
 msgid "Tr&uncate to:"
 msgstr "Obe&tnij do:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr "%"
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "K&ompresuj do:"
@@ -8823,7 +9397,8 @@ msgid "VST Effects"
 msgstr "Efekty VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Dodaje możliwość korzystania z efektów VST w Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8835,7 +9410,8 @@ msgstr "Skanowanie Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Rejestrowanie %d z %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Nie można wczytać biblioteki"
 
@@ -8855,19 +9431,17 @@ msgstr "Rozmiar bufora kontroluje liczbę sampli wysyłanych do efektu przy każ
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Rozmiar &bufora (od 8 do 1048576 sampli):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Kompensata opóźnienia"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
-msgstr ""
-"W ramach przetwarzania niektóre efekty VST muszą opóźniać powrót dźwięku do "
-"Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku "
-"została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, "
-"ale może nie działać dla wszystkich efektów VST."
+msgstr "W ramach przetwarzania niektóre efekty VST muszą opóźniać powrót dźwięku do Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, ale może nie działać dla wszystkich efektów VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Włącz &kompensatę"
 
@@ -8901,7 +9475,8 @@ msgid "Standard VST program file"
 msgstr "Standardowy plik programu VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Pliki presetów VST Tenacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8928,7 +9503,8 @@ msgstr "Błąd wczytywania presetów VST"
 msgid "Unable to load presets file."
 msgstr "Nie można wczytać pliku presetów."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Ustawienia efektu"
 
@@ -8944,6 +9520,16 @@ msgstr "Nie można wczytać pliku presetów."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Ten plik parametryczny został zapisany z %s. Kontynuować?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr "VST"
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr "Wahwah"
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8975,7 +9561,8 @@ msgid "Audio Unit Effects"
 msgstr "Efekty jednostki dźwiękowej"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Zapewnia efekty jednostki dźwiękowej w Tenacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8991,12 +9578,9 @@ msgid "Audio Unit Effect Options"
 msgstr "Opcje efektu jednostki dźwiękowej"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
-msgstr ""
-"W ramach przetwarzania niektóre efekty Audio Unit muszą opóźnić powrót "
-"dźwięku do Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do "
-"dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni "
-"kompensację, ale może nie działać dla wszystkich efektów Audio Unit."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr "W ramach przetwarzania niektóre efekty Audio Unit muszą opóźnić powrót dźwięku do Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni kompensację, ale może nie działać dla wszystkich efektów Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9029,6 +9613,10 @@ msgstr "Importuj presety jednostki dźwiękowej"
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Presets (may select multiple)"
 msgstr "Presety (można zaznaczyć kilka)"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+msgid "Preset"
+msgstr "Preset"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
@@ -9135,6 +9723,7 @@ msgstr "Jednostka dźwiękowa"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efekty LADSPA"
@@ -9144,7 +9733,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Zapewnia efekty LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity nie używa już vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9152,16 +9742,29 @@ msgid "LADSPA Effect Options"
 msgstr "Opcje efektów LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
-msgstr ""
-"W ramach przetwarzania niektóre efekty LADSPA muszą opóźniać powrót dźwięku "
-"do Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku "
-"została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, "
-"ale może nie działać dla wszystkich efektów LADSPA."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr "W ramach przetwarzania niektóre efekty LADSPA muszą opóźniać powrót dźwięku do Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tej opcji zapewni tę kompensację, ale może nie działać dla wszystkich efektów LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr "%s:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Wyjście efektu"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9173,12 +9776,9 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Rozmiar &bufora (8 do %d) sampli:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
-msgstr ""
-"W ramach przetwarzania niektóre efekty LV2 muszą opóźniać powrót dźwięku do "
-"Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku "
-"została wprowadzona mała cisza. Włączenie tego ustawienia zapewni "
-"kompensację, ale może nie działać dla wszystkich efektów LV2."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr "W ramach przetwarzania niektóre efekty LV2 muszą opóźniać powrót dźwięku do Tenacity. Gdy nie kompensujesz tego opóźnienia, zauważysz, że do dźwięku została wprowadzona mała cisza. Włączenie tego ustawienia zapewni kompensację, ale może nie działać dla wszystkich efektów LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -9198,12 +9798,23 @@ msgstr "%s wymaga nieobsługiwanej funkcji %s\n"
 msgid "%s requires unsupported option %s\n"
 msgstr "%s wymaga nieobsługiwanej opcji %s\n"
 
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Generator"
+msgstr "Generator"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efekty LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Zapewnia efekty LV2 w Tenacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9211,7 +9822,8 @@ msgid "Nyquist Effects"
 msgstr "Efekty Nyquista"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Zapewnia efekty Nyquista w Tenacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9439,7 +10051,8 @@ msgstr "Wybierz plik"
 msgid "Save file as"
 msgstr "Zapisz plik jako"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "bez nazwy"
 
@@ -9448,7 +10061,8 @@ msgid "Vamp Effects"
 msgstr "Efekty Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Zapewnia efekty Vamp w Tenacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9466,6 +10080,16 @@ msgstr "Niestety, inicjowanie wtyczki Vamp zakończone niepowodzeniem."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Ustawienia wtyczki"
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Program"
+msgstr "Program"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9545,6 +10169,12 @@ msgstr "Opcje formatu"
 msgid "Channel: %2d"
 msgstr "Kanał: %2d"
 
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr "%s - L"
+
 #. i18n-hint: track name and R abbreviating Right channel
 #: src/export/Export.cpp
 #, c-format
@@ -9616,6 +10246,10 @@ msgstr "Eksportowanie dźwięku przy użyciu komendy z wiersza poleceń"
 #: src/export/ExportCL.cpp
 msgid "Command Output"
 msgstr "Wyjście polecenia"
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr "&OK"
 
 #: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
@@ -9756,7 +10390,8 @@ msgstr "Eksportowanie dźwięku jako %s"
 msgid "Invalid sample rate"
 msgstr "Nieprawidłowa częstotliwość próbkowania"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Zmień próbkowanie"
 
@@ -9786,6 +10421,14 @@ msgstr "Możesz zmienić próbkowanie na jedno z poniższych."
 msgid "Sample Rates"
 msgstr "Częstotliwości próbkowania"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Szybkość transmisji:"
@@ -9794,6 +10437,48 @@ msgstr "Szybkość transmisji:"
 msgid "Quality (kbps):"
 msgstr "Jakość (kbps):"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr "0"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr "3"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr "5"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr "6"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr "9"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr "10"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Włączony"
@@ -9801,6 +10486,10 @@ msgstr "Włączony"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Constrained"
 msgstr "Ograniczony"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr "VOIP"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -9813,6 +10502,26 @@ msgstr "Niskie opóźnienie"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr "5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr "10 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr "20 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr "40 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr "60 ms"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9899,8 +10608,16 @@ msgid "Replace preset '%s'?"
 msgstr "Zastąpić preset '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Główny"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr "LTP"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9955,6 +10672,10 @@ msgid "Configure custom FFmpeg options"
 msgstr "Skonfiguruj niestandardowe opcje FFmpeg"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Preset:"
+msgstr "Preset:"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Load Preset"
 msgstr "Wczytaj preset"
 
@@ -10004,6 +10725,10 @@ msgstr "Język:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Rezerwuar bitów"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr "VBL"
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10139,6 +10864,10 @@ msgstr ""
 "maks. - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr "LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -10167,6 +10896,10 @@ msgstr ""
 "-1 - domyślne\n"
 "min. - 0\n"
 "maks. - 32 (z LPC) lub 4 (bez LPC)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr "Min. PdO"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10199,6 +10932,10 @@ msgstr ""
 "-1 - domyślne\n"
 "min. - 0\n"
 "maks. - 8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr "Min. PtO"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10385,6 +11122,38 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (najlepsza jakość)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr "200-250 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr "170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr "155-195 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr "145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr "110-150 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr "95-135 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr "80-120 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr "65-105 kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (mniejsze pliki)"
 
@@ -10414,7 +11183,8 @@ msgstr "Najlepsza"
 msgid "Extreme"
 msgstr "Ekstremalna"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standardowa"
 
@@ -10439,6 +11209,10 @@ msgid "Joint Stereo"
 msgstr "Połączone stereo"
 
 #: src/export/ExportMP3.cpp
+msgid "Stereo"
+msgstr "Stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Tryb szybkości transmisji:"
 
@@ -10461,8 +11235,8 @@ msgid "Locate LAME"
 msgstr "Ustal położenie LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity potrzebuje pliku %s do utworzenia pliku MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10490,13 +11264,12 @@ msgid "Where is %s?"
 msgstr "Gdzie jest %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
-"Łączysz do lame_enc.dll v%d.%d. Ta wersja nie współpracuje z Tenacity "
-"%d.%d.%d.\n"
+"Łączysz do lame_enc.dll v%d.%d. Ta wersja nie współpracuje z Tenacity %d.%d.%d.\n"
 "Pobierz najnowszą wersję 'LAME dla Tenacity'."
 
 #: src/export/ExportMP3.cpp
@@ -10623,6 +11396,10 @@ msgstr ""
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Eksportuj pliki do:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr "Folder:"
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -10795,6 +11572,14 @@ msgstr "Eksportowanie zaznaczenia jako Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Eksportowanie dźwięku jako Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr "AIFF (Apple/SGI)"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft)"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Nagłówek:"
@@ -10808,9 +11593,10 @@ msgid "Other uncompressed files"
 msgstr "Inne nieskompresowane pliki"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Próbowano wyeksportować plik WAV lub AIFF, który był większy niż 4 GB.\n"
 "Tenacity nie może tego zrobić, eksport został przerwany."
@@ -10820,12 +11606,11 @@ msgid "Error Exporting"
 msgstr "Błąd eksportowania"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
-msgstr ""
-"Wyeksportowany plik WAV został obcięty, ponieważ Tenacity nie może "
-"eksportować plików WAV większych niż 4 GB."
+msgstr "Wyeksportowany plik WAV został obcięty, ponieważ Tenacity nie może eksportować plików WAV większych niż 4 GB."
 
 #: src/export/ExportPCM.cpp
 msgid "GSM 6.10 requires mono"
@@ -10861,25 +11646,24 @@ msgid "All supported files"
 msgstr "Wszystkie obsługiwane pliki"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
 "jest plikiem MIDI, a nie plikiem dźwiękowym. \n"
-"Tenacity nie może otworzyć tego typu pliku do odtwarzania, ale może go "
-"edytować\n"
+"Tenacity nie może otworzyć tego typu pliku do odtwarzania, ale może go edytować\n"
 "przez kliknięcie na 'Plik > Importuj > MIDI...'."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "nie jest plikiem dźwiękowym. \n"
@@ -10890,18 +11674,18 @@ msgid "Select stream(s) to import"
 msgstr "Zaznacz źródło(a) do importu"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Ta wersja Tenacity nie była kompilowana ze wsparciem %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest ścieżką Audio CD. \n"
 "Tenacity nie może otworzyć bezpośrednio ścieżek Audio CD. \n"
@@ -10910,52 +11694,48 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" jest plikiem listy.\n"
-"Tenacity nie może otworzyć tego pliku, ponieważ zawiera on tylko linki do "
-"innych plików. \n"
+"Tenacity nie może otworzyć tego pliku, ponieważ zawiera on tylko linki do innych plików. \n"
 "Możesz otworzyć go w edytorze tekstowym i pobrać aktualne pliki dźwiękowe."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem Windows Media Audio. \n"
 "Tenacity nie może otworzyć tego typu pliku z powodów patentowych. \n"
-"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
-"AIFF."
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem Advanced Audio Coding.\n"
-"Bez opcjonalnej biblioteki FFmpeg, Tenacity nie może otworzyć tego typu "
-"pliku.\n"
-"W przeciwnym razie musisz przekonwertować plik do obsługiwanego formatu, "
-"takiego jak WAV lub AIFF."
+"Bez opcjonalnej biblioteki FFmpeg, Tenacity nie może otworzyć tego typu pliku.\n"
+"W przeciwnym razie musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest zakodowanym plikiem dźwiękowym. \n"
@@ -10966,95 +11746,88 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem RealPlayer. \n"
 "Tenacity nie może otworzyć tego typu pliku. \n"
-"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
-"AIFF."
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" jest plikiem opartym o nuty, a nie plikiem dźwiękowym. \n"
 "Tenacity nie może otworzyć tego typu pliku. \n"
-"Spróbuj przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
-"AIFF, \n"
+"Spróbuj przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF, \n"
 "a następnie importuj go lub nagraj w Tenacity."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem dźwiękowym Musepack. \n"
 "Tenacity nie może otworzyć tego typu pliku. \n"
-"Jeśli myślisz, że może to być plik mp3, to zmień jego nazwę na zakończoną \"."
-"mp3\" \n"
-"i spróbuj ponownie go importować. W przeciwnym razie musisz przekonwertować "
-"plik\n"
+"Jeśli myślisz, że może to być plik mp3, to zmień jego nazwę na zakończoną \".mp3\" \n"
+"i spróbuj ponownie go importować. W przeciwnym razie musisz przekonwertować plik\n"
 "do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem dźwiękowym Wavpack. \n"
 "Tenacity nie może otworzyć tego typu pliku. \n"
-"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
-"AIFF."
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem dźwiękowym Dolby Digital. \n"
 "Tenacity nie może otworzyć tego typu pliku. \n"
-"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
-"AIFF."
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem dźwiękowym Ogg Speex. \n"
 "Tenacity nie może otworzyć tego typu pliku. \n"
-"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub "
-"AIFF."
+"Musisz przekonwertować plik do obsługiwanego formatu, takiego jak WAV lub AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" jest plikiem zawierającym film. \n"
@@ -11068,16 +11841,15 @@ msgstr "Nie znaleziono pliku \"%s\"."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Tenacity nie rozpoznał typu pliku '%s'.\n"
 "\n"
-"%sDla nieskompresowanych plików spróbuj również 'Plik > Importuj > Dane "
-"surowe...'."
+"%sDla nieskompresowanych plików spróbuj również 'Plik > Importuj > Dane surowe...'."
 
 #: src/import/Import.cpp
 msgid ""
@@ -11087,11 +11859,16 @@ msgstr ""
 "Spróbuj zainstalować FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr "%s, %s"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11121,12 +11898,13 @@ msgid "Import Project"
 msgstr "Importuj projekt"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Ten projekt został zapisany przez wersję 1.0 Audacity lub wcześniejszą.\n"
 "Format został zmieniony i ta wersja Tenacity nie może importować projektu.\n"
@@ -11177,10 +11955,9 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Nie można odnaleźć folderu projektu: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
-msgstr ""
-"Ścieżki MIDI znalezione w pliku projektu, ale ta kompilacja Tenacity nie "
-"obejmuje obsługi MIDI, pomijając ścieżkę."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr "Ścieżki MIDI znalezione w pliku projektu, ale ta kompilacja Tenacity nie obejmuje obsługi MIDI, pomijając ścieżkę."
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
@@ -11284,40 +12061,6 @@ msgstr "Indeks[%02x] Kodek[%s], Język[%s], Częstotliwość próbkowania[%s], K
 msgid "FLAC files"
 msgstr "Pliki FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Pliki kompatybilne z GStreamerem"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Nie można dodać dekodera do rurociągu"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importer GStreamera"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Nie można ustawić stanu strumienia, aby został wstrzymany."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indeks[%02d], Typ[%s], Kanały[%d], Częstotliwość[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Plik nie zawiera żadnych strumieni dźwięku."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Nie można importować pliku. Zmiana stanu zakończona niepowodzeniem."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Błąd GStreamera: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Lista plików w podstawowym formacie tekstowym"
@@ -11420,6 +12163,14 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF i inne nieskompresowane typy"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr "AU (Sun/NeXT)"
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr "AVR (Audio Visual Research)"
+
+#: src/import/ImportPCM.cpp
 msgid "CAF (Apple Core Audio File)"
 msgstr "CAF (plik dźwiękowy Apple Core)"
 
@@ -11429,8 +12180,32 @@ msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (bezstratny kodek dźwiękowy FLAC)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr "HTK (HMM Tool Kit)"
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr "IFF (Amiga IFF/SVX8/SV16)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr "MPC (Akai MPC 2k)"
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (format kontenera OGG)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr "PAF (Ensoniq PARIS)"
 
 #: src/import/ImportPCM.cpp
 msgid "PVF (Portable Voice Format)"
@@ -11441,8 +12216,44 @@ msgid "RAW (header-less)"
 msgstr "RAW (bez nagłówka)"
 
 #: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr "RF64 (RIFF 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr "SD2 (Sound Designer II)"
+
+#: src/import/ImportPCM.cpp
 msgid "SDS (Midi Sample Dump Standard)"
 msgstr "SDS (Standard MIDI Sample Dump)"
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr "SF (Berkeley/IRCAM/CARL)"
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr "VOC (Creative Labs)"
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr "W64 (SoundFoundry WAVE 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr "WAV (NIST Sphere)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr "WAVEX (Microsoft)"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr "WVE (Psion Series 3)"
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr "XI (FastTracker 2)"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11473,6 +12284,34 @@ msgid "64 bit float"
 msgstr "64-bitowy float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr "U-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr "A-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr "IMA ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr "Microsoft ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr "GSM 6.10"
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr "32kbs G721 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr "24kbs G723 ADPCM"
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12-bitowy DWVW"
 
@@ -11485,12 +12324,20 @@ msgid "24 bit DWVW"
 msgstr "24-bitowy DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr "VOX ADPCM"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bitowy DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8-bitowy DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr "Vorbis"
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11539,6 +12386,18 @@ msgstr "Importuj dane surowe"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Bez endianness"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr "Little-endian"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Big-endian"
+msgstr "Big-endian"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -11613,6 +12472,7 @@ msgstr "%s prawo"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11638,6 +12498,7 @@ msgstr "koniec"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11668,7 +12529,8 @@ msgstr "Przesunięte w czasie klipy w prawo"
 msgid "Time shifted clips to the left"
 msgstr "Przesunięte w czasie klipy w lewo"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Przesunięcie fazowe"
 
@@ -11806,7 +12668,8 @@ msgstr "Przytnij zaznaczone ścieżki od %.2f sekund do %.2f sekund"
 msgid "Trim Audio"
 msgstr "Przytnij dźwięk"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Rozdziel"
 
@@ -11929,34 +12792,6 @@ msgstr "K&lawisz kasowania­ 2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "Ekst&ra"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Mi&kser"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Do&stosuj głośność odtwarzania..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Z&większ głośność odtwarzania"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Z&mniejsz głośność odtwarzania"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Dos&tosuj głośność nagrywania..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Zwię&ksz głośność nagrywania"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Zmnie&jsz głośność nagrywania"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12132,6 +12967,10 @@ msgid "&Labels..."
 msgstr "&Etykiety..."
 
 #: src/menus/FileMenus.cpp
+msgid "&MIDI..."
+msgstr "&MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Dane surowe..."
 
@@ -12220,8 +13059,9 @@ msgid "&Getting Started"
 msgstr "&Pierwsze kroki"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Podręcznik Tenacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Podręcznik..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12247,11 +13087,8 @@ msgstr "Informacje o urządzeniu &MIDI..."
 msgid "Show &Log..."
 msgstr "Pokaż &dziennik..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&O Tenacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Dodaj etykietę"
 
@@ -12501,6 +13338,10 @@ msgid "Uncategorized"
 msgstr "Bez kategorii"
 
 #: src/menus/PluginMenus.cpp
+msgid "..."
+msgstr "..."
+
+#: src/menus/PluginMenus.cpp
 msgid "Unknown"
 msgstr "Nieznany"
 
@@ -12719,6 +13560,10 @@ msgid "Select Sync-Locked"
 msgstr "Zaznacz zsynchronizowane-zablokowane"
 
 #: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr "R&egion"
+
+#: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
 msgstr "Na &lewo od miejsca odtwarzania"
 
@@ -12933,6 +13778,7 @@ msgstr "Kursor mo&cno w prawo"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Szu&kaj"
@@ -13144,20 +13990,21 @@ msgid "Created new label track"
 msgstr "Utworzono nową etykietę ścieżki"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
-msgstr ""
-"Ta wersja Tenacity pozwala tylko na jedną ścieżkę czasową dla każdego okna "
-"projektu."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr "Ta wersja Tenacity pozwala tylko na jedną ścieżkę czasową dla każdego okna projektu."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Utworzono nową ścieżkę czasową"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nowa częstotliwość próbkowania (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Wprowadzona wartość jest nieprawidłowa"
 
@@ -13414,7 +14261,9 @@ msgstr "Odtwarzanie"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Nagrywanie"
 
@@ -13563,10 +14412,6 @@ msgstr "&Overdub (włącz/wyłącz)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "&Oprogramowanie odtwarzania (włącz/wyłącz)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomatyczna regulacja poziomu nagrywania (włącz/wyłącz)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13781,7 +14626,8 @@ msgid "Preferences for Application"
 msgstr "Ustawienia aplikacji"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Zaktualizuj Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13818,11 +14664,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Interfejs"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr "&Host:"
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "Wykorzystując:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Odtwarzanie"
 
@@ -13842,7 +14694,8 @@ msgstr "Ka&nały:"
 msgid "Latency"
 msgstr "Opóźnienie"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisekundy"
 
@@ -13871,7 +14724,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Katalogi"
 
@@ -13979,10 +14833,9 @@ msgid "Directory %s is not writable"
 msgstr "Katalog %s nie jest przeznaczony do zapisu"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
-msgstr ""
-"Zmiana katalogu tymczasowego będzie nieaktywna aż do zrestartowania programu "
-"Tenacity"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr "Zmiana katalogu tymczasowego będzie nieaktywna aż do zrestartowania programu Tenacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -14012,6 +14865,39 @@ msgstr "Grupuj według wydawcy"
 msgid "Grouped by Type"
 msgstr "Grupuj według typu"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr "LV&2"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr "N&yquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr "&Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr "V&ST"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Włącz efekty"
@@ -14033,11 +14919,13 @@ msgid "Plugin Options"
 msgstr "Opcje wtyczki"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Sprawdź aktualizacje wtyczek po uruchomieniu Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Skanuj ponownie wtyczki przy następnym uruchomieniu Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14108,11 +14996,7 @@ msgstr "Nieużywane filtry:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"W jednym z elementów istnieją znaki odstępu (spacje, nowe linie, tabulatory)"
-". Na pewno popsują one dopasowywanie do wzorca. Zalecane jest obcięcie "
-"spacji, chyba że wiesz, co robisz. Chcesz, aby Tenacity obciął spacje za "
-"Ciebie?"
+msgstr "W jednym z elementów istnieją znaki odstępu (spacje, nowe linie, tabulatory). Na pewno popsują one dopasowywanie do wzorca. Zalecane jest obcięcie spacji, chyba że wiesz, co robisz. Chcesz, aby Tenacity obciął spacje za Ciebie?"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -14221,7 +15105,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "&Zachowaj etykiety, jeśli zaznaczenie jest przyciągane do etykiety"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "B&lend systemu i motyw Tenacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14245,6 +15130,10 @@ msgstr "Pokaż linijkę przewijania"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "Język \"%s\" jest nieznany"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr "GUI"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14395,7 +15284,8 @@ msgstr ""
 "   *   \"%s\"  (ponieważ skrót '%s' jest używany przez \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Wybierz plik XML zawierający skróty klawiaturowe programu Tenacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14483,6 +15373,10 @@ msgstr ""
 "\n"
 "W przeciwnym razie kliknij 'Anuluj'."
 
+#: src/prefs/KeyConfigPrefs.h
+msgid "Key Config"
+msgstr "Key Config"
+
 #: src/prefs/LibraryPrefs.cpp
 msgid "Preferences for Library"
 msgstr "Ustawienia biblioteki"
@@ -14524,8 +15418,9 @@ msgid "Dow&nload"
 msgstr "Po&bierz"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity samoczynnie wykrył prawidłowe biblioteki FFmpeg.\n"
@@ -14584,8 +15479,9 @@ msgid "Preferences for Module"
 msgstr "Ustawienia modułu"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "To są moduły eksperymentalne. Włącz je, jeśli już\n"
@@ -14593,17 +15489,15 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
-msgstr ""
-"  'Zapytaj' oznacza, że Tenacity zapyta, czy chcesz załadować moduł przy "
-"każdym uruchomieniu."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr "  'Zapytaj' oznacza, że Tenacity zapyta, czy chcesz załadować moduł przy każdym uruchomieniu."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr ""
-"  'Niepowodzenie' oznacza, że Tenacity sądzi, że moduł jest uszkodzony i nie "
-"chce go uruchomić."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr "  'Niepowodzenie' oznacza, że Tenacity sądzi, że moduł jest uszkodzony i nie chce go uruchomić."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -14611,9 +15505,9 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Nowy' oznacza wybór, który nie został jeszcze wykonany."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
-msgstr ""
-"Zmiany tych ustawień wejdą w życie tylko po ponownym uruchomieniu Tenacity."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "Zmiany tych ustawień wejdą w życie tylko po ponownym uruchomieniu Tenacity."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -14630,6 +15524,10 @@ msgstr "Nie znaleziono żadnych modułów"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Moduł"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr "Ctrl"
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14671,7 +15569,10 @@ msgstr "Przeciągnięcie lewym przyciskiem myszki"
 msgid "Set Selection Range"
 msgstr "Ustaw zakres zaznaczenia"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift i kliknięcie lewym przyciskiem myszki"
 
@@ -14759,6 +15660,15 @@ msgstr "+przeciągnięcie lewym przyciskiem myszki"
 msgid "Move clip up/down between tracks"
 msgstr "Przesuń klip w górę/w dół między ścieżkami"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "+przeciągnięcie lewym przyciskiem myszki"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14787,6 +15697,10 @@ msgstr "Zmień kilka sampli"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Zmień tylko JEDEN sampel"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Multi"
+msgstr "Multi"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14878,7 +15792,8 @@ msgid "Always scrub un&pinned"
 msgstr "Zawsze przewijaj od&piętą"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Ustawienia Tenacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14892,6 +15807,11 @@ msgstr "Ustawienia:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Ustawienia jakości"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr "%i Hz"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14917,6 +15837,11 @@ msgstr "Przekształcanie w czasie rzeczywistym"
 msgid "Sample Rate Con&verter:"
 msgstr "Prze&kształcanie częstotliwości próbkowania:"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr "&Dither:"
+
 #: src/prefs/QualityPrefs.cpp
 msgid "High-quality Conversion"
 msgstr "Przekształcanie wysokiej jakości"
@@ -14924,6 +15849,11 @@ msgstr "Przekształcanie wysokiej jakości"
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "Przeksz&tałcanie częstotliwości próbkowania:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr "Dit&her:"
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -15001,39 +15931,6 @@ msgid "System T&ime"
 msgstr "&Czas systemowy"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatyczna regulacja poziomu nagrywania"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Włącz automatyczną regulację poziomu nagrywania."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Szczyt docelowy:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Wewnątrz:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Czas analizy:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisekundy (czas jednej analizy)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Liczba kolejnych analiz:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 oznacza bez końca"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Nagrywanie Punch and Roll"
 
@@ -15044,6 +15941,21 @@ msgstr "Pre-ro&lka:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "&Przenikanie:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr "Mel"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr "Bark"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr "ERB"
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15178,6 +16090,10 @@ msgid "1024 - default"
 msgstr "1024 - domyślne"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr "2048"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - najwęższe pasmo"
 
@@ -15271,28 +16187,30 @@ msgid "Preferences for Theme"
 msgstr "Ustawienia motywu"
 
 #: src/prefs/ThemePrefs.cpp
+msgid "Info"
+msgstr "Info"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
 msgstr ""
 "Ubieranie w motywy jest funkcją eksperymentalną.\n"
 "\n"
-"Wypróbuj ją przez kliknięcie na \"Zapisz pamięć podręczną motywu\", a "
-"następnie znajdź i zmodyfikuj obrazy i kolory w\n"
+"Wypróbuj ją przez kliknięcie na \"Zapisz pamięć podręczną motywu\", a następnie znajdź i zmodyfikuj obrazy i kolory w\n"
 "ImageCacheVxx.png, wykorzystując edytor obrazów, np. Gimpa.\n"
 "\n"
-"Kliknij \"Wczytaj pamięć podręczną motywu\", aby wczytać zmienione obrazy i "
-"kolory z powrotem do Tenacity.\n"
+"Kliknij \"Wczytaj pamięć podręczną motywu\", aby wczytać zmienione obrazy i kolory z powrotem do Tenacity.\n"
 "\n"
-"(Na razie tylko pasek narzędzi transportu i kolory na ścieżce fali są "
-"zmieniane, nawet\n"
+"(Na razie tylko pasek narzędzi transportu i kolory na ścieżce fali są zmieniane, nawet\n"
 "w przypadku, gdy plik obrazu pokazuje także inne ikony.)"
 
 #: src/prefs/ThemePrefs.cpp
@@ -15463,7 +16381,8 @@ msgstr "Sampli"
 msgid "4 Pixels per Sample"
 msgstr "4 piksele na sampel"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Maksymalne powiększenie"
 
@@ -15519,6 +16438,14 @@ msgstr "Ścieżka dźwiękowa"
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Zoom Toggle"
 msgstr "Przełącz powiększenie"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Preset 1:"
+msgstr "Preset 1:"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Preset 2:"
+msgstr "Preset 2:"
 
 #: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
 msgid "Warnings"
@@ -15577,16 +16504,24 @@ msgid "Stopped"
 msgstr "Zatrzymano"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pauza"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Skocz do początku"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Skocz do końca"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pauza"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Zaznacz do początku"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Zaznacz do końca"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15600,20 +16535,17 @@ msgstr "Nagrywaj nową ścieżkę"
 msgid "Append Record"
 msgstr "Dołącz nagranie"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Zaznacz do końca"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Zaznacz do początku"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s Zapauzowano."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr "%s."
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15693,11 +16625,17 @@ msgstr "Wycisz zaznaczony dźwięk"
 msgid "Sync-Lock Tracks"
 msgstr "Synchronizuj-zablokuj ścieżki"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Powiększ"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Pomniejsz"
 
@@ -15764,43 +16702,6 @@ msgstr "Pasek miernika &nagrywania"
 msgid "&Playback Meter Toolbar"
 msgstr "Pasek miernika &odtwarzania"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Głośność nagrywania"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Głośność odtwarzania"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Głośność nagrywania: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Głośność nagrywania (Niedostępna; użyj miksera systemowego.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Głośność odtwarzania: %.2f (emulowana)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Głośność odtwarzania: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Głośność odtwarzania (Niedostępna; użyj miksera systemowego.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Pasek narzędziowy mi&ksera"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Szukaj"
@@ -15816,6 +16717,7 @@ msgstr "Przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Zatrzymaj przewijanie"
@@ -15823,6 +16725,7 @@ msgstr "Zatrzymaj przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Rozpocznij przewijanie"
@@ -15830,6 +16733,7 @@ msgstr "Rozpocznij przewijanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Zatrzymaj szukanie"
@@ -15837,6 +16741,7 @@ msgstr "Zatrzymaj szukanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Rozpocznij szukanie"
@@ -15891,7 +16796,9 @@ msgstr "Przyczep do"
 msgid "Length"
 msgstr "Długość"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Wyśrodkuj"
 
@@ -15955,8 +16862,8 @@ msgstr "Pasek narzędziowy &czasu"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Pasek %s Tenacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15983,7 +16890,8 @@ msgstr "Narzędzie do przesuwania w czasie"
 msgid "Zoom Tool"
 msgstr "Narzędzie powiększania"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Narzędzie rysowania"
 
@@ -16059,11 +16967,13 @@ msgstr "Pociągnij za jedną lub więcej granic etykiety."
 msgid "Drag label boundary."
 msgstr "Pociągnij za granicę etykiety."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Zmodyfikowana etykieta"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Etykieta edycji"
 
@@ -16118,31 +17028,42 @@ msgstr "Edytowane etykiety"
 msgid "New label"
 msgstr "Nowa etykieta"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "&Oktawa w górę"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Okta&wa w dół"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Kliknij, aby powiększyć w pionie. Kliknij z Shift, aby pomniejszyć. Przeciągnij, aby określić obszar powiększenia."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Kliknij prawym przyciskiem myszki, aby wyświetlić menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zresetuj powiększenie"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift i kliknięcie prawym przyciskiem myszki"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Kliknij lewym przyciskiem myszki/przeciągnij lewym przyciskiem myszki"
 
@@ -16184,7 +17105,8 @@ msgstr "Połącz"
 msgid "Expanded Cut Line"
 msgstr "Rozszerzona linia cięcia"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Rozszerz"
 
@@ -16207,6 +17129,11 @@ msgstr "Przeniesiono sample"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Edycja sampla"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr "k"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16233,6 +17160,10 @@ msgid "S&pectrogram Settings..."
 msgstr "Ustawienia s&pektrogramu..."
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "&Format"
+msgstr "&Format"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Zmienianie formatu sampla"
 
@@ -16248,7 +17179,8 @@ msgstr "Przetwarzanie...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Zmieniono '%s' na %s"
@@ -16260,6 +17192,54 @@ msgstr "Zmień format"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Częstotliwość"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr "8000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr "11025 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr "16000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr "22050 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr "44100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr "48000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr "88200 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr "96000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr "176400 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr "192000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr "352800 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr "384000 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16279,7 +17259,8 @@ msgstr "Zmień stosunek"
 msgid "Set Rate"
 msgstr "Ustaw częstotliwość"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Multiwidok"
 
@@ -16298,6 +17279,10 @@ msgstr "Roz&dziel ścieżkę stereo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Rozdziel stereo do mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16367,14 +17352,23 @@ msgstr "Lewy, %d Hz"
 msgid "Right, %dHz"
 msgstr "Prawy, %d Hz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr "%+.1f dB"
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% lewo"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% prawo"
@@ -16414,6 +17408,11 @@ msgstr "Kształt &fali"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Kolor &fali"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr "Instrument %i"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -16487,10 +17486,8 @@ msgstr "&Interpolacja logarytmiczna"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
 msgstr ""
-"Kliknij i przeciągnij, aby dostosować, kliknij podwójnie myszką, aby "
-"zresetować"
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16541,6 +17538,7 @@ msgstr "Wyrównana obwiednia."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Prze&wijaj"
@@ -16552,6 +17550,7 @@ msgstr "Szukanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Linijka przewijania"
@@ -16735,11 +17734,23 @@ msgstr "Naciśnij"
 msgid "Button"
 msgstr "Przycisk"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr "L"
+
 #. i18n-hint: One-letter abbreviation for Right, in the Pan slider
 #. i18n-hint: One-letter abbreviation for Right, in VU Meter
 #: src/widgets/ASlider.cpp src/widgets/Meter.cpp
 msgid "R"
 msgstr "P"
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr "%.2fx"
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
@@ -16774,13 +17785,27 @@ msgstr "Pusty"
 msgid "Backwards"
 msgstr "Do tyłu"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr "<"
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Do przodu"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ">"
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Pomoc w Internecie"
+
+#: src/widgets/KeyView.cpp
+msgid "Menu"
+msgstr "Menu"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -16839,6 +17864,10 @@ msgstr "Częstotliwość odświeżania miernika na sekundę [1-100]: "
 #: src/widgets/Meter.cpp
 msgid "Meter Style"
 msgstr "Styl miernika"
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr "Gradient"
 
 #: src/widgets/Meter.cpp
 msgid "Meter Type"
@@ -16981,6 +18010,7 @@ msgstr "0100 g 060 m 060 s+># sampli"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "sample"
@@ -17134,9 +18164,30 @@ msgstr "klatki CDDA (75 fps)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 klatek|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr "010,01000>0100 Hz"
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centihertz"
 msgstr "centyherc"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr "kHz"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr "01000>01000 kHz|0.001"
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hertz"
@@ -17206,6 +18257,11 @@ msgstr "(Użyj menu kontekstowego, aby zmienić format.)"
 msgid "centiseconds"
 msgstr "setnych sekundy"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Miniony czas:"
@@ -17248,6 +18304,11 @@ msgstr "Potwierdź zamknięcie"
 msgid "Unable to write files to directory: %s."
 msgstr "Nie można zainicjować pliku projektu"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr "Sprawdź, czy katalog istnieje, ma niezbędne uprawnienia, a dysk nie jest pełny."
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17262,6 +18323,10 @@ msgstr "Ustawienia > Katalogi"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Nie pokazuj ponownie tego ostrzeżenia"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr "NaN"
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17345,15 +18410,27 @@ msgstr "Nie można przeanalizować XML"
 msgid "Spectral edit multi tool"
 msgstr "Multinarzędzie edycji widma"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrowanie..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr "Paul Licameli"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Wydany na warunkach licencji GNU General Public License wersja 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aZaznacz częstotliwości."
@@ -17380,7 +18457,8 @@ msgstr ""
 "                      Spróbuj zwiększyć granicę niskiej częstotliwości~%~\n"
 "                      lub zredukuj filtr 'Szerokość'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Błąd.~%"
@@ -17441,6 +18519,24 @@ msgstr "Studio ściszania"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Stosowanie przejścia..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr "Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Wydany na warunkach licencji GNU General Public License wersja 2 lub następnej."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17584,6 +18680,10 @@ msgstr "Szukaj uderzenia"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Znajdowanie uderzeń..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17908,13 +19008,38 @@ msgstr "Filtr górnoprzepustowy"
 msgid "Performing High-Pass Filter..."
 msgstr "Tworzenie filtra górnoprzepustowego..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr "Dominic Mazzoni"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Częstotliwość (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Rolloff (dB na oktawę)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr "6 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr "12 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr "24 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr "36 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr "48 dB"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17935,10 +19060,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Etykieta dźwięków"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Wydany na warunkach licencji GNU General Public License wersja 2 lub następnej."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18026,6 +19147,10 @@ msgstr "Nie znaleziono dźwięków.~%Spróbuj obniżyć 'Próg' lub zredukuj 'Mi
 #, lisp-format
 msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
 msgstr "Oznaczanie obszarów między dźwiękami wymaga~%a przynajmniej dwóch dźwięków.~%Wykryto tylko jeden dźwięk."
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr "Limiter"
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -18234,7 +19359,8 @@ msgstr "Plik Lispa"
 msgid "HTML file"
 msgstr "Plik HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Plik tekstowy"
 
@@ -18299,6 +19425,10 @@ msgid "Error.~%No file selected."
 msgstr "Błąd.~%Nie wybrano pliku."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr "Pluck"
+
+#: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Generowanie dźwięku pluck..."
 
@@ -18339,6 +19469,10 @@ msgid "Generating Rhythm..."
 msgstr "Generowanie rytmu..."
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr "Tempo (bpm)"
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 uderzeń/minutę"
 
@@ -18353,6 +19487,10 @@ msgstr "1 - 20 uderzeń/takt"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Wartość swingu"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr "+/- 1"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18423,6 +19561,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Wysokość MIDI mocnego uderzenia"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr "18 - 116"
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Wysokość MIDI słabego uderzenia"
 
@@ -18435,8 +19577,16 @@ msgstr ""
 "'Długość ścieżki rytmu' na więcej niż zero."
 
 #: plug-ins/rissetdrum.ny
+msgid "Risset Drum"
+msgstr "Risset Drum"
+
+#: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Generowanie Risset Drum..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr "Steven Jones"
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18539,6 +19689,11 @@ msgstr "Pokaż komunikaty"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Tylko błędy"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr "[-inf]"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18807,6 +19962,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Błąd.~%Częstotliwość próbkowania poniżej 100 Hz nie jest obsługiwana."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr "Tremolo"
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Stosowanie tremola..."
 
@@ -18833,6 +19992,10 @@ msgstr "Redukcja i izolacja wokalu"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Stosowanie działania..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr "Robert Haenggi"
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18983,6 +20146,10 @@ msgid "Processing Vocoder..."
 msgstr "Przetwarzanie wokodera..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr "Edgar-RFT"
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "Odległość: (1 do 120, domyślna = 20)"
 
@@ -19022,6 +20189,229 @@ msgstr "Częstotliwość igieł radaru (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Błąd.~%Wymagana ścieżka stereo."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Zaktualizuj Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Pomiń"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "Za&instaluj aktualizację"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Dziennik zmian"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Czytaj więcej na GitHubie"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Błąd sprawdzania aktualizacji"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Nie można połączyć się z serwerem aktualizacji Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Dane aktualizacji były uszkodzone."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Błąd pobierania aktualizacji."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Nie można otworzyć linku pobierania Tenacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s jest dostępny!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Nagrywanie"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Obowiązkowy Id:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Wieloplatformowa biblioteka GUI"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importowanie przez GStreamera"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa była jego dalsza optymalizacja. Nadal jest on za wysoki."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Zautomatyzowane dostosowywanie poziomu nagrywania zmniejszyło głośność do %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Niemożliwa była jego dalsza optymalizacja. Nadal jest on za niski."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Zautomatyzowane dostosowywanie poziomu nagrywania zwiększyło głośność do %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. Nadal jest ona za wysoka."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. Całkowita liczba analiz została przekroczona bez znalezienia akceptowalnej głośności. Nadal jest ona za niska."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Zatrzymano zautomatyzowane dostosowywanie poziomu nagrywania. %.2f wydaje się być akceptowalną głośnością."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Odebrano %d podczas otwierania urządzenia\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Nie można otworzyć portmiksera\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Dostępne miksery:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Dostępne źródła nagrywania:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Dostępne głośności odtwarzania:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Głośność nagrywania jest emulowana\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Głośność nagrywania jest natywna\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Głośność odtwarzania jest emulowana\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Głośność odtwarzania jest natywna\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Nieznana data i czas"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Pliki kompatybilne z GStreamerem"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Nie można dodać dekodera do rurociągu"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importer GStreamera"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Nie można ustawić stanu strumienia, aby został wstrzymany."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indeks[%02d], Typ[%s], Kanały[%d], Częstotliwość[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Plik nie zawiera żadnych strumieni dźwięku."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Nie można importować pliku. Zmiana stanu zakończona niepowodzeniem."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Błąd GStreamera: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Mi&kser"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Do&stosuj głośność odtwarzania..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Z&większ głośność odtwarzania"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Z&mniejsz głośność odtwarzania"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Dos&tosuj głośność nagrywania..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Zwię&ksz głośność nagrywania"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Zmnie&jsz głośność nagrywania"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Podręcznik Tenacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&O Tenacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomatyczna regulacja poziomu nagrywania (włącz/wyłącz)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatyczna regulacja poziomu nagrywania"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Włącz automatyczną regulację poziomu nagrywania."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Szczyt docelowy:"
+
+#~ msgid "Within:"
+#~ msgstr "Wewnątrz:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Czas analizy:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisekundy (czas jednej analizy)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Liczba kolejnych analiz:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 oznacza bez końca"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Głośność nagrywania"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Głośność odtwarzania"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Głośność nagrywania: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Głośność nagrywania (Niedostępna; użyj miksera systemowego.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Głośność odtwarzania: %.2f (emulowana)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Głośność odtwarzania: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Głośność odtwarzania (Niedostępna; użyj miksera systemowego.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Pasek narzędziowy mi&ksera"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Kliknij i przeciągnij, aby dostosować, kliknij podwójnie myszką, aby zresetować"
 
 #~ msgid "Program build date:"
 #~ msgstr "Data kompilacji programu:"
@@ -19109,1256 +20499,6 @@ msgstr "Błąd.~%Wymagana ścieżka stereo."
 #~ msgid "Gra&yscale"
 #~ msgstr "&Skala szarości"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "384000 Hz"
-msgstr "384000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "352800 Hz"
-msgstr "352800 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "192000 Hz"
-msgstr "192000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "176400 Hz"
-msgstr "176400 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "96000 Hz"
-msgstr "96000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "88200 Hz"
-msgstr "88200 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "48000 Hz"
-msgstr "48000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "44100 Hz"
-msgstr "44100 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "22050 Hz"
-msgstr "22050 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "16000 Hz"
-msgstr "16000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "11025 Hz"
-msgstr "11025 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "8000 Hz"
-msgstr "8000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "&Format"
-msgstr "&Format"
-
-#. i18n-hint k abbreviating kilo meaning thousands
-#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
-msgid "k"
-msgstr "k"
-
-#: src/toolbars/ControlToolBar.cpp
 #, c-format
-msgid "%s."
-msgstr "%s."
-
-#: src/prefs/TracksPrefs.cpp
-msgid "Preset 2:"
-msgstr "Preset 2:"
-
-#: src/prefs/TracksPrefs.cpp
-msgid "Preset 1:"
-msgstr "Preset 1:"
-
-#: src/prefs/ThemePrefs.cpp
-msgid "Info"
-msgstr "Info"
-
-#: src/prefs/SpectrumPrefs.cpp
-msgid "2048"
-msgstr "2048"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
-#: src/prefs/SpectrogramSettings.cpp
-msgid "ERB"
-msgstr "ERB"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Bark"
-msgstr "Bark"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Mel"
-msgstr "Mel"
-
-#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
-#: src/prefs/QualityPrefs.cpp
-msgid "Dit&her:"
-msgstr "Dit&her:"
-
-#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
-#: src/prefs/QualityPrefs.cpp
-msgid "&Dither:"
-msgstr "&Dither:"
-
-#: src/prefs/QualityPrefs.cpp
-#, c-format
-msgid "%i Hz"
-msgstr "%i Hz"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Multi"
-msgstr "Multi"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Ctrl"
-msgstr "Ctrl"
-
-#: src/prefs/KeyConfigPrefs.h
-msgid "Key Config"
-msgstr "Key Config"
-
-#: src/prefs/GUIPrefs.h
-msgid "GUI"
-msgstr "GUI"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/prefs/EffectsPrefs.cpp
-msgid "V&ST"
-msgstr "V&ST"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/prefs/EffectsPrefs.cpp
-msgid "&Vamp"
-msgstr "&Vamp"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/prefs/EffectsPrefs.cpp
-msgid "N&yquist"
-msgstr "N&yquist"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/prefs/EffectsPrefs.cpp
-msgid "LV&2"
-msgstr "LV&2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/prefs/EffectsPrefs.cpp
-msgid "&LADSPA"
-msgstr "&LADSPA"
-
-#. i18n-hint: (noun)
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
-msgid "&Host:"
-msgstr "&Host:"
-
-#: src/menus/SelectMenus.cpp
-msgid "R&egion"
-msgstr "R&egion"
-
-#: src/menus/PluginMenus.cpp
-msgid "..."
-msgstr "..."
-
-#: src/menus/FileMenus.cpp
-msgid "&MIDI..."
-msgstr "&MIDI..."
-
-#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
-#. know the correct technical word.
-#: src/import/ImportRaw.cpp
-msgid "Big-endian"
-msgstr "Big-endian"
-
-#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
-#. know the correct technical word.
-#: src/import/ImportRaw.cpp
-msgid "Little-endian"
-msgstr "Little-endian"
-
-#: src/import/ImportPCM.cpp
-msgid "Vorbis"
-msgstr "Vorbis"
-
-#: src/import/ImportPCM.cpp
-msgid "VOX ADPCM"
-msgstr "VOX ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "24kbs G723 ADPCM"
-msgstr "24kbs G723 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "32kbs G721 ADPCM"
-msgstr "32kbs G721 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "GSM 6.10"
-msgstr "GSM 6.10"
-
-#: src/import/ImportPCM.cpp
-msgid "Microsoft ADPCM"
-msgstr "Microsoft ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "IMA ADPCM"
-msgstr "IMA ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "A-Law"
-msgstr "A-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "U-Law"
-msgstr "U-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "XI (FastTracker 2)"
-msgstr "XI (FastTracker 2)"
-
-#: src/import/ImportPCM.cpp
-msgid "WVE (Psion Series 3)"
-msgstr "WVE (Psion Series 3)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAVEX (Microsoft)"
-msgstr "WAVEX (Microsoft)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAV (NIST Sphere)"
-msgstr "WAV (NIST Sphere)"
-
-#: src/import/ImportPCM.cpp
-msgid "W64 (SoundFoundry WAVE 64)"
-msgstr "W64 (SoundFoundry WAVE 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "SF (Berkeley/IRCAM/CARL)"
-msgstr "SF (Berkeley/IRCAM/CARL)"
-
-#: src/import/ImportPCM.cpp
-msgid "VOC (Creative Labs)"
-msgstr "VOC (Creative Labs)"
-
-#: src/import/ImportPCM.cpp
-msgid "SD2 (Sound Designer II)"
-msgstr "SD2 (Sound Designer II)"
-
-#: src/import/ImportPCM.cpp
-msgid "RF64 (RIFF 64)"
-msgstr "RF64 (RIFF 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "PAF (Ensoniq PARIS)"
-msgstr "PAF (Ensoniq PARIS)"
-
-#: src/import/ImportPCM.cpp
-msgid "MPC (Akai MPC 2k)"
-msgstr "MPC (Akai MPC 2k)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-
-#: src/import/ImportPCM.cpp
-msgid "IFF (Amiga IFF/SVX8/SV16)"
-msgstr "IFF (Amiga IFF/SVX8/SV16)"
-
-#: src/import/ImportPCM.cpp
-msgid "HTK (HMM Tool Kit)"
-msgstr "HTK (HMM Tool Kit)"
-
-#: src/import/ImportPCM.cpp
-msgid "AVR (Audio Visual Research)"
-msgstr "AVR (Audio Visual Research)"
-
-#: src/import/ImportPCM.cpp
-msgid "AU (Sun/NeXT)"
-msgstr "AU (Sun/NeXT)"
-
-#: src/import/Import.cpp src/menus/ClipMenus.cpp
-#, c-format
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "WAV (Microsoft)"
-msgstr "WAV (Microsoft)"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "AIFF (Apple/SGI)"
-msgstr "AIFF (Apple/SGI)"
-
-#: src/export/ExportMultiple.cpp
-msgid "Folder:"
-msgstr "Folder:"
-
-#: src/export/ExportMP3.cpp
-msgid "Stereo"
-msgstr "Stereo"
-
-#: src/export/ExportMP3.cpp
-msgid "65-105 kbps"
-msgstr "65-105 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "80-120 kbps"
-msgstr "80-120 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "95-135 kbps"
-msgstr "95-135 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "110-150 kbps"
-msgstr "110-150 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "145-185 kbps"
-msgstr "145-185 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "155-195 kbps"
-msgstr "155-195 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "170-210 kbps"
-msgstr "170-210 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "200-250 kbps"
-msgstr "200-250 kbps"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Min. PtO"
-msgstr "Min. PtO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Min. PdO"
-msgstr "Min. PdO"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LPC"
-msgstr "LPC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VBL"
-msgstr "VBL"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "Preset:"
-msgstr "Preset:"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LTP"
-msgstr "LTP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LC"
-msgstr "LC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "60 ms"
-msgstr "60 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "40 ms"
-msgstr "40 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "20 ms"
-msgstr "20 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10 ms"
-msgstr "10 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "5 ms"
-msgstr "5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VOIP"
-msgstr "VOIP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10"
-msgstr "10"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "9"
-msgstr "9"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "7"
-msgstr "7"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "6"
-msgstr "6"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "5"
-msgstr "5"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "4"
-msgstr "4"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "3"
-msgstr "3"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "1"
-msgstr "1"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "0"
-msgstr "0"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#: src/export/ExportFFmpegDialogs.cpp
-#, c-format
-msgid "%.2f kbps"
-msgstr "%.2f kbps"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
-#, c-format
-msgid "%d kbps"
-msgstr "%d kbps"
-
-#: src/export/ExportCL.cpp
-msgid "&OK"
-msgstr "&OK"
-
-#. i18n-hint: track name and L abbreviating Left channel
-#: src/export/Export.cpp
-#, c-format
-msgid "%s - L"
-msgstr "%s - L"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/effects/vamp/VampEffect.h
-msgid "Vamp"
-msgstr "Vamp"
-
-#: src/effects/vamp/VampEffect.cpp
-msgid "Program"
-msgstr "Program"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/effects/lv2/LV2Effect.h
-msgid "LV2"
-msgstr "LV2"
-
-#: src/effects/lv2/LV2Effect.cpp
-msgid "Generator"
-msgstr "Generator"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/effects/ladspa/LadspaEffect.h
-msgid "LADSPA"
-msgstr "LADSPA"
-
-#. i18n-hint: An item name introducing a value, which is not part of the string but
-#. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
-#, c-format
-msgid "%s:"
-msgstr "%s:"
-
-#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
-msgid "Preset"
-msgstr "Preset"
-
-#: src/effects/Wahwah.cpp
-msgid "Wahwah"
-msgstr "Wahwah"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/effects/VST/VSTEffect.h
-msgid "VST"
-msgstr "VST"
-
-#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
-msgid "%"
-msgstr "%"
-
-#: src/effects/ScoreAlignDialog.cpp
-#, c-format
-msgid "%.3f"
-msgstr "%.3f"
-
-#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
-#: src/effects/ScienFilter.cpp
-msgid "Butterworth"
-msgstr "Butterworth"
-
-#: src/effects/Paulstretch.cpp
-msgid "Paulstretch"
-msgstr "Paulstretch"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "2"
-msgstr "2"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16384"
-msgstr "16384"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "8192"
-msgstr "8192"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "4096"
-msgstr "4096"
-
-#: src/effects/NoiseReduction.cpp
-msgid "1024"
-msgstr "1024"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "512"
-msgstr "512"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "256"
-msgstr "256"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "128"
-msgstr "128"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "64"
-msgstr "64"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "32"
-msgstr "32"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16"
-msgstr "16"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
-msgid "8"
-msgstr "8"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Hamming, Reciprocal Hamming"
-msgstr "Hamming, Reciprocal Hamming"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Hamming, Hann"
-msgstr "Hamming, Hann"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Blackman, Hann"
-msgstr "Blackman, Hann"
-
-#: src/effects/Loudness.cpp
-msgid "LUFS"
-msgstr "LUFS"
-
-#: src/effects/Loudness.cpp src/widgets/Meter.cpp
-msgid "RMS"
-msgstr "RMS"
-
-#: src/effects/Equalization.cpp
-msgid "AV&X Threaded"
-msgstr "AV&X Threaded"
-
-#: src/effects/Equalization.cpp
-msgid "SSE &Threaded"
-msgstr "SSE &Threaded"
-
-#: src/effects/Equalization.cpp
-msgid "&SSE"
-msgstr "&SSE"
-
-#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%gk"
-msgstr "%gk"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%g kHz"
-msgstr "%g kHz"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "- dB"
-msgstr "- dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-#, c-format
-msgid "%d dB"
-msgstr "%d dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "+ dB"
-msgstr "+ dB"
-
-#: src/effects/Equalization.cpp
-msgid "RIAA"
-msgstr "RIAA"
-
-#: src/effects/EffectManager.cpp
-msgid "&Preset:"
-msgstr "&Preset:"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/effects/Effect.h
-msgid "Nyquist"
-msgstr "Nyquist"
-
-#: src/effects/Echo.cpp
-msgid "Echo"
-msgstr "Echo"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%0.f ms"
-msgstr "%0.f ms"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.0f ms"
-msgstr "%.0f ms"
-
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.1f %%"
-msgstr "%.1f %%"
-
-#: src/effects/Distortion.cpp
-msgid "Fuzz Box"
-msgstr "Fuzz Box"
-
-#. i18n-hint: short form of 'decibels'
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB"
-msgstr "%.2f dB"
-
-#. i18n-hint: dB abbreviates decibels
-#. * RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB RMS"
-msgstr "%.2f dB RMS"
-
-#: src/effects/Contrast.cpp
-msgid "zero"
-msgstr "zero"
-
-#. i18n-hint: dB abbreviates decibels
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%s dB"
-msgstr "%s dB"
-
-#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "RMS = %s."
-msgstr "RMS = %s."
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.1f:1"
-msgstr "%.1f:1"
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.0f:1"
-msgstr "%.0f:1"
-
-#. i18n-hint: usually leave this as is as dB doesn't get translated
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%3d dB"
-msgstr "%3d dB"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "78"
-msgstr "78"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "45"
-msgstr "45"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "33⅓"
-msgstr "33⅓"
-
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
-msgid "db"
-msgstr "db"
-
-#: src/effects/AutoDuck.cpp
-msgid "Auto Duck"
-msgstr "Auto Duck"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "Y:"
-msgstr "Y:"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "X:"
-msgstr "X:"
-
-#: src/commands/ImportExportCommands.cpp
-msgid "Import2"
-msgstr "Import2"
-
-#: src/commands/HelpCommand.cpp
-msgid "_"
-msgstr "_"
-
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
-msgid "Format:"
-msgstr "Format:"
-
-#. i18n-hint name of a computer programming language
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "LISP"
-msgstr "LISP"
-
-#. i18n-hint JavaScript Object Notation
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "JSON"
-msgstr "JSON"
-
-#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
-msgid "Panel"
-msgstr "Panel"
-
-#: src/commands/Demo.cpp
-msgid "Demo"
-msgstr "Demo"
-
-#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%s: %s"
-msgstr "%s: %s"
-
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
-msgid "Transport"
-msgstr "Transport"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Projekt %02i] "
-
-#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
-msgid "<untitled>"
-msgstr "<bez nazwy>"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "G♯/A♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "D♯/E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "B♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "G♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "A♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "G♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "F♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "E"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "D"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#: src/FileNames.cpp
-msgid ", "
-msgstr ", "
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#: plug-ins/vocoder.ny
-msgid "Edgar-RFT"
-msgstr "Edgar-RFT"
-
-#: plug-ins/vocalrediso.ny
-msgid "Robert Haenggi"
-msgstr "Robert Haenggi"
-
-#: plug-ins/tremolo.ny
-msgid "Tremolo"
-msgstr "Tremolo"
-
-#. i18n-hint abbreviates negative infinity
-#: plug-ins/sample-data-export.ny
-msgid "[-inf]"
-msgstr "[-inf]"
-
-#: plug-ins/rissetdrum.ny
-msgid "Steven Jones"
-msgstr "Steven Jones"
-
-#: plug-ins/rissetdrum.ny
-msgid "Risset Drum"
-msgstr "Risset Drum"
-
-#: plug-ins/rhythmtrack.ny
-msgid "18 - 116"
-msgstr "18 - 116"
-
-#: plug-ins/rhythmtrack.ny
-msgid "+/- 1"
-msgstr "+/- 1"
-
-#: plug-ins/rhythmtrack.ny
-msgid "Tempo (bpm)"
-msgstr "Tempo (bpm)"
-
-#: plug-ins/pluck.ny
-msgid "Pluck"
-msgstr "Pluck"
-
-#: plug-ins/limiter.ny
-msgid "Limiter"
-msgstr "Limiter"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "48 dB"
-msgstr "48 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "36 dB"
-msgstr "36 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "24 dB"
-msgstr "24 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "12 dB"
-msgstr "12 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "6 dB"
-msgstr "6 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
-msgid "Dominic Mazzoni"
-msgstr "Dominic Mazzoni"
-
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
-msgid "Steve Daulton"
-msgstr "Steve Daulton"
-
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
-msgid "Paul Licameli"
-msgstr "Paul Licameli"
-
-#: src/widgets/numformatter.cpp
-msgid "NaN"
-msgstr "NaN"
-
-#. i18n-hint: This message describes the error in the Error dialog.
-#: src/widgets/UnwritableLocationErrorDialog.cpp
-msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
-msgstr ""
-"Sprawdź, czy katalog istnieje, ma niezbędne uprawnienia, a dysk nie jest "
-"pełny."
-
-#: src/widgets/PopupMenuTable.h
-#, c-format
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. i18n-hint: Format string for displaying frequency in kilohertz. Change
-#. * the decimal point for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
-#. * to '>' if your language uses a '.'.
-#: src/widgets/NumericTextCtrl.cpp
-msgid "01000>01000 kHz|0.001"
-msgstr "01000>01000 kHz|0.001"
-
-#. i18n-hint: Name of display format that shows frequency in kilohertz
-#: src/widgets/NumericTextCtrl.cpp
-msgid "kHz"
-msgstr "kHz"
-
-#. i18n-hint: Format string for displaying frequency in hertz. Change
-#. * the decimal point for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
-#. * to '>' if your language uses a '.'.
-#: src/widgets/NumericTextCtrl.cpp
-msgid "010,01000>0100 Hz"
-msgstr "010,01000>0100 Hz"
-
-#: src/widgets/Meter.cpp
-msgid "Gradient"
-msgstr "Gradient"
-
-#: src/widgets/KeyView.cpp
-msgid "Menu"
-msgstr "Menu"
-
-#. i18n-hint arrowhead meaning forward movement
-#: src/widgets/HelpSystem.cpp
-msgid ">"
-msgstr ">"
-
-#. i18n-hint arrowhead meaning backward movement
-#: src/widgets/HelpSystem.cpp
-msgid "<"
-msgstr "<"
-
-#. i18n-hint: "x" suggests a multiplicative factor
-#: src/widgets/ASlider.cpp
-#, c-format
-msgid "%.2fx"
-msgstr "%.2fx"
-
-#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
-#. i18n-hint: One-letter abbreviation for Left, in VU Meter
-#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
-msgid "L"
-msgstr "L"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
-#, c-format
-msgid "Instrument %i"
-msgstr "Instrument %i"
-
-#. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%+.1f dB"
-msgstr "%+.1f dB"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "Mono"
-msgstr "Mono"
-
-#: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
-msgstr "Tenacity Karaoke%s"
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Znak towarowy Audacity%s jest używany w tym programie wyłącznie w celach "
-"opisowych i informacyjnych."
-
-#: src/AboutDialog.cpp
-msgid "Emeritus:"
-msgstr "Emeritus Audacity:"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "benchmark.txt"
-
-#. i18n-hint: Benchmark means a software speed test
-#: src/Benchmark.cpp
-msgid "Benchmark"
-msgstr "Benchmark"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity nie jest produkowany ani wspierany przez MuseCY SM Ltd. lub "
-"Dominica M. Mazzoniego."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s współtwórcy"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Pamiętaj, że nazwiska są posortowane w kolejności alfabetycznej, a nie "
-"według ważności."
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s, tester"
-msgstr "%s, tester Audacity"
-
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "OK"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Harvey Lubin (logo)"
-msgstr "Harvey Lubin (logo)"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s KB"
-msgstr "%s kB"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "A♯/B♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "F♯/G♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "C♯/D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "A♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "B"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "A"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "G"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "F"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "D♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "C♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "C"
-
-#. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Solo"
-msgstr "Solo"
-
-#: src/LyricsWindow.cpp
-msgid "&Karaoke..."
-msgstr "&Karaoke..."
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#. i18n-hint: This is a technical term, derived from the word
-#. * "spectrum".  Do not translate it unless you are sure you
-#. * know the correct technical word in your language.
-#: src/FreqWindow.cpp
-msgid "Cepstrum"
-msgstr "Cepstrum"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -16,11 +16,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-30 17:56+0000\n"
 "Last-Translator: SC <lalocas@protonmail.com>\n"
-"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
-"tenacity/tenacity/pt_BR/>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/tenacity/tenacity/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,69 +27,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Atualizar o Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Pular"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Instalar atualização"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Leia mais no Github"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Erro ao verificar atualização"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Não foi possível conectar ao servidor de atualização do Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Dados de atualização estavam corrompidos."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Erro ao baixar atualização."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Não foi possível abrir o link de download do Tenacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "O Tenacity %s está disponível!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Gravação"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Não foi possível determinar"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr "%s bytes"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -212,8 +174,13 @@ msgstr "P&arar\tF6"
 msgid "&About"
 msgstr "&Sobre"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script"
+msgstr "Script"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Saída"
 
@@ -229,7 +196,12 @@ msgstr "Scripts nyquist (*.ny)|*.ny|Scripts lisp (*.lsp)|*.lsp|Todo os arquivos|
 msgid "Script was not saved."
 msgstr "Script não foi salvo."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Aviso"
 
@@ -242,17 +214,25 @@ msgid "Find dialog"
 msgstr "Diálogo localizar"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr "Harvey Lubin (logo)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galeria de ícones Tango (barra de ferramentas)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 por Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
-msgstr ""
-"Módulo externo do Tenacity fornece um IDE simples para escrever os efeitos."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr "Módulo externo do Tenacity fornece um IDE simples para escrever os efeitos."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -274,7 +254,8 @@ msgstr "Sem-título"
 msgid "Nyquist Effect Workbench - "
 msgstr "Efeitos Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Novo"
 
@@ -314,7 +295,8 @@ msgstr "Copiar"
 msgid "Copy to clipboard"
 msgstr "Copiar para área de transferência"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Recortar"
 
@@ -322,7 +304,8 @@ msgstr "Recortar"
 msgid "Cut to clipboard"
 msgstr "Recortar para área de transferência"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Colar"
 
@@ -347,7 +330,8 @@ msgstr "Selecionar Tudo"
 msgid "Select all text"
 msgstr "Selecion&ar todo o texto"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Desfazer"
 
@@ -355,7 +339,8 @@ msgstr "Desfazer"
 msgid "Undo last change"
 msgstr "Desfazer última alteração"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Refazer"
 
@@ -412,7 +397,8 @@ msgid "Go to next S-expr"
 msgstr "Ir para próxima S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Início"
 
@@ -420,7 +406,8 @@ msgstr "Início"
 msgid "Start script"
 msgstr "Iniciar script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Parar"
 
@@ -434,15 +421,23 @@ msgstr "Parar script"
 msgid "About %s"
 msgstr "Sobre o %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "OK"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informações da Compilação"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Ativado"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Desativado"
 
@@ -452,8 +447,9 @@ msgid "The Build"
 msgstr "Compilação"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Id de Alteração:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versão: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -463,22 +459,28 @@ msgstr "Tipo de compilação:"
 msgid "Compiler:"
 msgstr "Compilador:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Pasta de Instalação:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Pasta de configurações:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Pasta de configurações:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Suporte aos formatos de arquivo"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Biblioteca de GUI multi-plataforma"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -492,7 +494,6 @@ msgstr "Conversão de taxa de amostragem"
 msgid "MP3 Importing"
 msgstr "Importar em MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importar e exportar em Ogg Vorbis"
@@ -501,7 +502,6 @@ msgstr "Importar e exportar em Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Suporte a etiquetas ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importar e exportar em FLAC"
@@ -519,14 +519,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importar/Exportar FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importar via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Recursos"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Suporte ao plugin"
 
@@ -541,6 +533,10 @@ msgstr "Suporte a Alteração de Tempo e Tom"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Suporte a alteração estrema de Tempo e Tom"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Recursos"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -660,15 +656,22 @@ msgstr "%s, gráficos do Audacity"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (incorporando %s, %s, %s, %s e %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Livre, de código aberto e multiplataforma para gravação e edição de áudio."
+msgstr "Livre, de código aberto e multiplataforma para gravação e edição de áudio."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Créditos"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Por favor, perceba que os nomes estão em ordem alfabética, não em ordem de importância."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -717,6 +720,7 @@ msgstr "Website e Gráficos do Audacity"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -736,6 +740,22 @@ msgstr "Agradecimentos especiais do Audacity:"
 #, c-format
 msgid "%s website: "
 msgstr "Site do %s: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s contribuidores"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "A marca Audacity%s é usada neste software unicamente por motivos informacionais e de descrição."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity não é produzido ou endossado por MuseCY SM Ltd. ou Dominic M Mazzoni."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -758,6 +778,7 @@ msgstr "Linha do tempo"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Clique ou arraste para iniciar busca"
@@ -765,6 +786,7 @@ msgstr "Clique ou arraste para iniciar busca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Clique e arraste para iniciar Percorrer"
@@ -772,6 +794,7 @@ msgstr "Clique e arraste para iniciar Percorrer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Clique e mova para Percorrer. Clique e segure para Buscar."
@@ -779,6 +802,7 @@ msgstr "Clique e mova para Percorrer. Clique e segure para Buscar."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Mova para Buscar"
@@ -786,6 +810,7 @@ msgstr "Mova para Buscar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Mova para Percorrer"
@@ -842,7 +867,17 @@ msgstr ""
 "Não pode bloquear a região para além\n"
 "fim do projeto."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Erro"
 
@@ -866,7 +901,8 @@ msgstr ""
 "Essa pergunta é feita apenas uma vez, após uma instalação para redefinir as Preferências."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Redefinir preferências do Tenacity"
 
 #: src/AudacityApp.cpp
@@ -881,9 +917,9 @@ msgstr ""
 "O arquivo foi removido do histórico."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
-msgstr ""
-"A biblioteca SQLite não conseguiu inicializar. O Tenacity não pode continuar."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr "A biblioteca SQLite não conseguiu inicializar. O Tenacity não pode continuar."
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -907,7 +943,7 @@ msgstr "&Abrir..."
 msgid "Open &Recent..."
 msgstr "Abrir &Recentes..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&Sobre o Tenacity..."
 
@@ -920,35 +956,35 @@ msgid "&File"
 msgstr "&Arquivo"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
-"O Tenacity não conseguiu encontrar uma pasta para salvar os arquivos "
-"temporários. \n"
+"O Tenacity não conseguiu encontrar uma pasta para salvar os arquivos temporários. \n"
 "O programa precisa de uma pasta onde outros programas não apaguem seus\n"
 "arquivos temporários.\n"
 "Por favor, indique uma pasta apropriada no menu \"Preferências\"."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
-"O Tenacity não conseguiu encontrar uma pasta para salvar os arquivos "
-"temporários. \n"
+"O Tenacity não conseguiu encontrar uma pasta para salvar os arquivos temporários. \n"
 "Por favor, indique uma pasta apropriada no menu \"Preferências\"."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"O Tenacity irá encerrar agora. Abra o programa novamente para usar a nova "
-"pasta temporária."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "O Tenacity irá encerrar agora. Abra o programa novamente para usar a nova pasta temporária."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -957,15 +993,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "O Tenacity não conseguiu bloquear à pasta de arquivos temporários.\n"
 "Esta pasta pode estar em uso por outra cópia do Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Tem certeza que deseja iniciar o Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -973,19 +1011,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Erro ao obter acesso exclusivo à pasta temporária"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "O sistema detectou que outra cópia do Tenacity está em execução.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Use o comando Novo ou Abrir na janela existente do Tenacity\n"
 "para abrir outros arquivos de projeto simultaneamente.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "O Tenacity já está em execução"
 
 #: src/AudacityApp.cpp
@@ -1001,7 +1042,8 @@ msgstr ""
 "e pode ser necessário reiniciar o computador."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Falha ao iniciar o Tenacity"
 
 #: src/AudacityApp.cpp
@@ -1041,8 +1083,9 @@ msgstr ""
 "e pode ser necessário reiniciar o computador."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1074,7 +1117,8 @@ msgstr "executa os testes de diagnóstico"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "mostra a versão do Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1084,9 +1128,10 @@ msgid "audio or project file name"
 msgstr "áudio ou nome do arquivo de projeto"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1100,16 +1145,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Arquivos de Projetos do Tenacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Mensagem"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Erro de configuração do Tenacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1119,28 +1166,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "O seguinte arquivo de configuração não pôde ser acessado:\n"
 "\n"
 "\t%s\n"
 "\n"
-"Isto poderia ser causado por muitas razões, mas as mais prováveis são que o "
-"disco está cheio ou você não tem permissão de gravação no arquivo. Mais "
-"informações podem ser obtidas clicando no botão de ajuda abaixo.\n"
+"Isto poderia ser causado por muitas razões, mas as mais prováveis são que o disco está cheio ou você não tem permissão de gravação no arquivo. Mais informações podem ser obtidas clicando no botão de ajuda abaixo.\n"
 "\n"
-"Você pode tentar corrigir o problema e depois clicar em \"Tentar novamente\" "
-"para continuar.\n"
+"Você pode tentar corrigir o problema e depois clicar em \"Tentar novamente\" para continuar.\n"
 "\n"
-"Se você optar por \"Sair do Tenacity\", seu projeto poderá não ser salvo e "
-"será recuperado na próxima vez que você o abrir projeto."
+"Se você optar por \"Sair do Tenacity\", seu projeto poderá não ser salvo e será recuperado na próxima vez que você o abrir projeto."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Ajuda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Sair do Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1148,7 +1194,8 @@ msgid "&Retry"
 msgstr "Tenta&r novamente"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Log do Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1160,9 +1207,14 @@ msgstr "&Salvar..."
 msgid "Cl&ear"
 msgstr "&Limpar"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Fechar"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr "log.txt"
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1211,7 +1263,8 @@ msgid "Error Initializing Midi"
 msgstr "Erro ao iniciar o MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Áudio do Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1226,37 +1279,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Memória cheia!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "O ajuste automático do volume de gravação terminou. Não foi possível otimizar completamente, o nível continua muito alto."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "O ajuste automático do volume de gravação diminuiu o volume para %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "O ajuste automático do volume de gravação terminou. Não foi possível otimizar completamente, o nível continua muito baixo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "O ajuste automático do volume de gravação aumentou o volume para %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "O ajuste automático de volume de gravação terminou. O número total de análises foi excedido sem encontrar um volume aceitável. Ainda está muito alto."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "O ajuste automático de volume de gravação terminou. O número total de análises foi excedido sem encontrar um volume aceitável. O volume ainda está muito baixo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "O Ajuste automático de volume de gravação terminou. %.2f parece um volume aceitável."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1355,43 +1377,6 @@ msgstr "Nenhum dispositivo de reprodução encontrado para '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Não é possível verificar as taxas de amostra mútua sem ambos os dispositivos.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Recebido %d ao abrir dispositivos\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Não foi possível abrir Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Misturadores disponíveis:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Fontes de gravação disponíveis:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volumes de reprodução disponíveis:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Volume da gravação é emulado\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Volume de gravação é nativo\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Volume de reprodução é emulado\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Volume de reprodução é nativo\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1434,28 +1419,29 @@ msgid "Automatic Crash Recovery"
 msgstr "Recuperação Automática de Falhas"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
-"Os seguintes projetos não foram salvos adequadamente na última vez em que o "
-"Tenacity foi executado e podem ser recuperados automaticamente.\n"
+"Os seguintes projetos não foram salvos adequadamente na última vez em que o Tenacity foi executado e podem ser recuperados automaticamente.\n"
 "\n"
-"Após a recuperação, salve os projetos para garantir que as alterações sejam "
-"gravadas em disco."
+"Após a recuperação, salve os projetos para garantir que as alterações sejam gravadas em disco."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "&Projetos recuperáveis"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Selecionar"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nome"
 
@@ -1544,6 +1530,11 @@ msgstr "Efeito"
 msgid "Menu Command (With Parameters)"
 msgstr "Comando do Menu (com parâmetros)"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
+
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
 msgstr "Comando do Menu (sem parâmetros)"
@@ -1612,6 +1603,11 @@ msgstr "Gerenciar Macros"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Selecionar Macro"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+msgid "Macro"
+msgstr "Macro"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
@@ -1683,7 +1679,8 @@ msgstr "Res&taurar"
 msgid "I&mport..."
 msgstr "&Importar..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Exportar..."
 
@@ -1724,7 +1721,8 @@ msgstr "Mover para &Cima"
 msgid "Move &Down"
 msgstr "Mover para &Baixo"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Salvar"
 
@@ -1807,9 +1805,16 @@ msgid "Run"
 msgstr "Executar"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Fechar"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "benchmark.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1947,10 +1952,6 @@ msgid "No revision identifier was provided"
 msgstr "Não foi fornecido um identificador de revisão"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Data e Hora desconhecida"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Compilação de depuração (nível %d de depuração)"
@@ -1959,6 +1960,10 @@ msgstr "Compilação de depuração (nível %d de depuração)"
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Compilação de lançamento (nível %d de depuração)"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ", 64 bits"
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -2029,6 +2034,11 @@ msgid ""
 msgstr ""
 "Você deve selecionar um trecho de áudio antes de executar esse comando.\n"
 "(Outros tipos de faixas não podem ser utilizadas.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2124,10 +2134,8 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Arquivos marcados como Em Falta foram movidos ou excluídos e não podem ser "
-"copiados.\n"
-"Recoloque os arquivos na sua localização original para poder copiá-los para "
-"o projeto."
+"Arquivos marcados como Em Falta foram movidos ou excluídos e não podem ser copiados.\n"
+"Recoloque os arquivos na sua localização original para poder copiá-los para o projeto."
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -2193,6 +2201,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Copiar nomes para área de transferência"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Faltando"
 
@@ -2201,18 +2214,17 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ao prosseguir, seu projeto não será salvo em disco. Tem certeza de que deseja continuar?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
-"Seu projeto é independente; ele não depende de quaisquer arquivos de áudio "
-"externos. \n"
+"Seu projeto é independente; ele não depende de quaisquer arquivos de áudio externos. \n"
 "\n"
-"Alguns projetos mais antigos do Tenacity podem não ser independentes, e o "
-"cuidado \n"
+"Alguns projetos mais antigos do Tenacity podem não ser independentes, e o cuidado \n"
 "é necessário para manter suas dependências externas no lugar certo.\n"
 "Novos projetos serão independentes e são menos arriscados."
 
@@ -2220,7 +2232,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Verificar Dependências"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nenhum"
 
@@ -2228,7 +2243,7 @@ msgstr "Nenhum"
 msgid "Rectangle"
 msgstr "Retangular"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triangular"
 
@@ -2239,6 +2254,36 @@ msgstr "Formatado"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Retangular"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2260,9 +2305,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Suporte a FFmpeg não compilado"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2285,10 +2331,9 @@ msgid "Locate FFmpeg"
 msgstr "Localizar o FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"O Tenacity precisa do arquivo '%s' para importar e exportar áudio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "O Tenacity precisa do arquivo '%s' para importar e exportar áudio via FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2300,7 +2345,8 @@ msgstr "Localização de '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Para encontrar '%s', clique aqui -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Procurar..."
 
@@ -2326,8 +2372,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg não encontrado"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2357,25 +2404,24 @@ msgid "Only libavformat.so"
 msgstr "Apenas libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "O Tenacity não conseguiu abrir o arquivo %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "O Tenacity não conseguiu ler o arquivo: %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
-msgstr ""
-"O Tenacity salvou com sucesso o arquivo em %s mas falhou ao renomear como %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr "O Tenacity salvou com sucesso o arquivo em %s mas falhou ao renomear como %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2413,7 +2459,9 @@ msgstr "Não &copiar áudio"
 msgid "As&k"
 msgstr "Per&guntar ao usuário"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Todos os arquivos"
 
@@ -2439,6 +2487,10 @@ msgstr "Arquivos de texto"
 msgid "XML files"
 msgstr "Arquivo XML"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ", "
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
@@ -2455,7 +2507,7 @@ msgid "Specify New Filename:"
 msgstr "Especifique o Novo Nome para o Arquivo:"
 
 #: src/FileNames.cpp
-#, c-format, fuzzy
+#, fuzzy, c-format
 msgid "Directory %s does not have write permissions"
 msgstr "A pasta %s não existe. Deseja criá-la?"
 
@@ -2502,9 +2554,33 @@ msgstr "Frequência linear"
 msgid "Log frequency"
 msgstr "Frequência logarítmica"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Rolagem"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+msgid "Zoom"
+msgstr "Zoom"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
@@ -2513,6 +2589,10 @@ msgstr "Dividir &Horizontalmente"
 #: src/FreqWindow.cpp
 msgid "Zoom Horizontal"
 msgstr "Dividir &Horizontalmente"
+
+#: src/FreqWindow.cpp
+msgid "Cursor:"
+msgstr "Cursor:"
 
 #: src/FreqWindow.cpp
 msgid "Peak:"
@@ -2559,6 +2639,23 @@ msgstr "Muito áudio selecionado. Só os primeiros %.1f segundos serão analisad
 msgid "Not enough data selected."
 msgstr "Dados insuficientes selecionados."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2574,10 +2671,15 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f seg (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+msgid "spectrum.txt"
+msgstr "spectrum.txt"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Exportar Dados Espectrais Como:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Não foi possível escrever no arquivo: %s"
@@ -2667,9 +2769,7 @@ msgstr "Recomendamos que você use nossa versão estável mais recente, com supo
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"Você pode ajudar a deixar o Tenacity pronto para a versão estável entrando "
-"em nossa [[https://tenacityaudio.org|comunidade]].<hr><br><br>"
+msgstr "Você pode ajudar a deixar o Tenacity pronto para a versão estável entrando em nossa [[https://tenacityaudio.org|comunidade]].<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2682,15 +2782,12 @@ msgstr "Estas são as nossas opções de suporte:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[help:Quick_Help|Quick Help]] - se não estiver instalado localmente, veja "
-"online"
+msgstr "[[help:Quick_Help|Quick Help]] - se não estiver instalado localmente, veja online"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
-msgstr ""
-" [[help:Main_Page|Manual]] - se não estiver instalado localmente, veja online"
+msgstr " [[help:Main_Page|Manual]] - se não estiver instalado localmente, veja online"
 
 #: src/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
@@ -2698,23 +2795,15 @@ msgstr " Fórum - Faça sua pergunta diretamente na internet."
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"Mais:</b> Visite nossa Wiki para ver as últimas dicas, truques e tutoriais "
-"pela internet."
+msgstr "Mais:</b> Visite nossa Wiki para ver as últimas dicas, truques e tutoriais pela internet."
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"O Tenacity pode importar arquivos não-protegidos em vários formatos (Como "
-"M4A e WMA, arquivos WAV comprimidos de gravadores portáteis e áudio de "
-"arquivos de vídeo) se você baixar e instalar a biblioteca opcional FFmpeg no "
-"seu computador."
+msgstr "O Tenacity pode importar arquivos não-protegidos em vários formatos (Como M4A e WMA, arquivos WAV comprimidos de gravadores portáteis e áudio de arquivos de vídeo) se você baixar e instalar a biblioteca opcional FFmpeg no seu computador."
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"Você também pode ler a ajuda em como importar arquivos MIDI e faixas de CDs "
-"de áudio."
+msgstr "Você também pode ler a ajuda em como importar arquivos MIDI e faixas de CDs de áudio."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
@@ -2722,11 +2811,7 @@ msgstr "A pasta 'Ajuda' não está instalada. <br> Por favor, [[*URL*|consulte o
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"O Manual não está instalado. <br> Por favor, [[*URL*|consulte o conteúdo "
-"online]] ou baixe o Manual.<br><br>Para visualizar apenas o Manual online, "
-"altere a opção \"Localização do Manual\" em Preferências de Interface para "
-"\"Na Internet\"."
+msgstr "O Manual não está instalado. <br> Por favor, [[*URL*|consulte o conteúdo online]] ou baixe o Manual.<br><br>Para visualizar apenas o Manual online, altere a opção \"Localização do Manual\" em Preferências de Interface para \"Na Internet\"."
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2785,19 +2870,19 @@ msgid "&History..."
 msgstr "&Histórico..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Erro interno em %s na %s linha %d.\n"
 "Por favor, nos informe do erro em https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Erro interno em %s, em %s, linha %d.\n"
 "Por favor, informe ao time do Tenacity em https://tenacityaudio.org/."
@@ -2816,7 +2901,9 @@ msgid "Track"
 msgstr "Faixa"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Rótulo"
 
@@ -2876,7 +2963,8 @@ msgstr "Digite o nome da faixa"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Faixa de Rótulos"
 
@@ -2887,11 +2975,13 @@ msgstr "Uma ou mais faixas de rótulo não puderam ser lidas."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Primeira Execução do Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Escolha o Idioma que o Tenacity deverá usar:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2901,7 +2991,8 @@ msgstr "Escolha o Idioma que o Tenacity deverá usar:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "O idioma escolhido, %s (%s), não é o mesmo do idioma do sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -2919,8 +3010,18 @@ msgstr ""
 "Uma cópia foi salva como  '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Abrindo Projeto do Tenacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Karaoke Tenacity%s"
+
+#: src/LyricsWindow.cpp
+msgid "&Karaoke..."
+msgstr "&Karaoke..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2967,19 +3068,23 @@ msgid "Mixing and rendering tracks"
 msgstr "A misturar e a processar faixas"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Painel de Mixagem do Tenacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Ganho"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocidade"
 
@@ -2988,28 +3093,42 @@ msgid "Musical Instrument"
 msgstr "Instrumento musical"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balanço"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Silenciar"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Mostrador do Nível do Sinal"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Movido o controle de ganho"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Movido controle de velocidade"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Movido o controle de balanço"
 
@@ -3043,9 +3162,9 @@ msgstr ""
 "Ele não será carregado."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3054,7 +3173,7 @@ msgstr ""
 "Ele não será carregado."
 
 #: src/ModuleManager.cpp
-#, c-format, fuzzy
+#, fuzzy, c-format
 msgid ""
 "The module \"%s\" failed to initialize.\n"
 "\n"
@@ -3079,16 +3198,19 @@ msgstr ""
 "\n"
 "Use apenas módulos de fontes seguras"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Sim"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Não"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Carregador de Módulos Tenacity"
 
 #: src/ModuleManager.cpp
@@ -3111,6 +3233,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Faixa de Notas"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "C"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "C♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "D"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "D♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "E"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "F"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "F♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "G"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "G♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "A"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "A♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "B"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "D♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "E♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "G♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "A♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "B♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "C♯/D♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "D♯/E♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "F♯/G♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "G♯/A♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "A♯/B♭"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3220,7 +3452,8 @@ msgstr "Selecion&ar Todos"
 msgid "C&lear All"
 msgstr "&Limpar Todos"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Ativar"
 
@@ -3300,9 +3533,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Taxas de Amostragem Incompatíveis"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Poucas faixas foram selecionadas para gravação a esta taxa de amostragem.\n"
@@ -3331,15 +3565,15 @@ msgid "Dropouts"
 msgstr "Quedas"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
-"Áudio gravado foi perdido nos locais marcados com rótulos. Causas possíveis:"
-"\n"
+"Áudio gravado foi perdido nos locais marcados com rótulos. Causas possíveis:\n"
 "\n"
 "Outras aplicações estão competindo por tempo de processador com o Tenacity\n"
 "\n"
@@ -3375,11 +3609,11 @@ msgid "Inspecting project file data"
 msgstr "Inspecionando os dados do projeto"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3423,11 +3657,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Aviso!!! Arquivo(s) externo(s) não encontrado(s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "A verificação de projetos na pasta \n"
@@ -3455,12 +3689,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Aviso!!! Sumário do arquivo de áudio externo não encontrado"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3520,7 +3754,8 @@ msgstr "Aviso!!! Bloco de arquivo(s) sem procedência"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progresso"
 
@@ -3545,6 +3780,11 @@ msgstr "Aviso: Problemas na recuperação automática"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sem-título>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projeto %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3614,12 +3854,14 @@ msgstr ""
 "(Não foi possível criar os arquivos temporários necessários)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Este arquivo não é um Projeto do Tenacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3710,6 +3952,10 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Total de arquivos sem procedência apagados %d"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr "Falha ao desfazer a transação durante a importação"
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Não foi possível anexar o banco de dados de destino"
 
@@ -3747,9 +3993,9 @@ msgid "Error Writing to File"
 msgstr "Erro ao Escrever Arquivo"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3763,9 +4009,16 @@ msgstr "Compactando projeto"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projeto %02i] Tenacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3774,14 +4027,13 @@ msgstr "(Recuperado)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Este arquivo foi salvo no Tenacity %s.\n"
-"Você está usando a versão %s. Você terá que atualizar o Tenacity para "
-"conseguir abrir esse arquivo."
+"Você está usando a versão %s. Você terá que atualizar o Tenacity para conseguir abrir esse arquivo."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
@@ -3852,29 +4104,28 @@ msgid "Backing up project"
 msgstr "Fazendo Back-up do Projeto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
-"Alguns arquivos de projeto não foram salvos corretamente desde a última "
-"execução do Tenacity.\n"
+"Alguns arquivos de projeto não foram salvos corretamente desde a última execução do Tenacity.\n"
 "\n"
 "Os arquivos que puderam ser recuperados estão no último snapshot."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
 msgstr ""
-"Alguns arquivos de projeto não foram salvos corretamente desde a última "
-"execução do Tenacity.\n"
+"Alguns arquivos de projeto não foram salvos corretamente desde a última execução do Tenacity.\n"
 "\n"
 "Os arquivos que puderam ser recuperados estão no último snapshot.\n"
-"Após a recuperação, salve os projetos para garantir que as alterações sejam "
-"gravadas em disco."
+"Após a recuperação, salve os projetos para garantir que as alterações sejam gravadas em disco."
 
 #: src/ProjectFileManager.cpp
 msgid "Project Recovered"
@@ -3945,14 +4196,13 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sSalvar Projeto \"%s\" como..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
-"'Salvar Projeto' é utilizado para salvar um Arquivo de Projeto do Tenacity, "
-"e não um arquivo de áudio.\n"
-"Para obter um arquivo de áudio que poderá ser aberto em outros programas, "
-"utilize o comando 'Exportar'.\n"
+"'Salvar Projeto' é utilizado para salvar um Arquivo de Projeto do Tenacity, e não um arquivo de áudio.\n"
+"Para obter um arquivo de áudio que poderá ser aberto em outros programas, utilize o comando 'Exportar'.\n"
 
 #. i18n-hint: In each case, %s is the name
 #. of the file being overwritten.
@@ -4025,11 +4275,12 @@ msgid "Error Opening Project"
 msgstr "Erro ao abrir Arquivo de Projeto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Você está tentando abrir um arquivo de backup\n"
 "gerado automaticamente. Continuar nessa operação\n"
@@ -4140,8 +4391,8 @@ msgid "Automatic database backup failed."
 msgstr "Falha ao fazer back-up do banco de dados."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Bem-vindo ao Tenacity versão %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4357,7 +4608,8 @@ msgstr "Todas as Preferências"
 msgid "SelectionBar"
 msgstr "Barra de seleção"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Seleção Espectral"
 
@@ -4365,42 +4617,55 @@ msgstr "Seleção Espectral"
 msgid "Timer"
 msgstr "Temporizador"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Controle"
 
+#: src/Screenshot.cpp
+msgid "Mixer"
+msgstr "Mixador"
+
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Medidor"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Medidor de Reprodução"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Medidor de Gravação"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Edição"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Dispositivos"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Reproduzir na velocidade ajustada"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Percorrer"
 
@@ -4415,7 +4680,10 @@ msgstr "Régua"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Faixas"
 
@@ -4525,7 +4793,8 @@ msgid "Activation level (dB):"
 msgstr "Nível de ativação (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Bem-vindo ao Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4672,9 +4941,9 @@ msgstr ""
 "Para obter dicas sobre como liberar espaço, clique no botão de ajuda."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "O Tenacity não conseguiu salvar o arquivo:\n"
@@ -4694,9 +4963,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4705,9 +4974,9 @@ msgstr ""
 "para escrita."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "O Tenacity não conseguiu salvar imagens para o arquivo:\n"
@@ -4724,9 +4993,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4736,9 +5005,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4747,8 +5016,9 @@ msgstr ""
 "Provável problema no formato PNG?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "O Tenacity não consegue ler o tema padrão.\n"
@@ -4786,9 +5056,9 @@ msgstr ""
 "já estão presentes.  Gravar por cima?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "O Tenacity não pôde salvar o arquivo:\n"
@@ -4827,7 +5097,11 @@ msgstr "Personalizado"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Duração"
 
@@ -4838,7 +5112,8 @@ msgid "Time Track"
 msgstr "Faixa de Tempo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Gravação Programada do Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4912,7 +5187,8 @@ msgstr "Projeto Atual"
 msgid "Recording start:"
 msgstr "Início da gravação:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Duração:"
 
@@ -4933,7 +5209,8 @@ msgid "Action after Timer Recording:"
 msgstr "Ação após Gravação Programada:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Progresso de Gravação Programada do Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5014,6 +5291,11 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Gravação Programada"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr "099 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -5024,6 +5306,7 @@ msgstr "099 dias 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data e hora de início"
@@ -5068,7 +5351,8 @@ msgstr "Habilitar &Exportação Automática?"
 msgid "Export Project As:"
 msgstr "Exportar Projeto como:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opções"
 
@@ -5081,7 +5365,8 @@ msgid "Do nothing"
 msgstr "Não executar outras ações"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Sair do Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5105,7 +5390,8 @@ msgid "Scheduled to stop at:"
 msgstr "Programado para parar em:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Gravação programada do Tenacity - Aguardando para iniciar"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5131,7 +5417,8 @@ msgid "Recording Exported:"
 msgstr "Gravação exportada:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Gravação programada do Tenacity - Aguardando para iniciar"
 
 #: src/TrackInfo.cpp
@@ -5327,6 +5614,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Aplicando %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "Falhou"
@@ -5345,13 +5642,15 @@ msgstr "%s não é um parâmetro aceito por %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Valor inválido para o parâmetro '%s': deve ser %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Comando"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repetir %s"
@@ -5386,6 +5685,10 @@ msgid "Compares a range on two tracks."
 msgstr "Compara a extensão entre duas faixas."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr "Demonstração"
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Atraso (segundos):"
 
@@ -5416,6 +5719,11 @@ msgstr "Faixa 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Faixa 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr "Id:"
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5453,6 +5761,10 @@ msgstr "Obter Info"
 msgid "Commands"
 msgstr "Comandos"
 
+#: src/commands/GetInfoCommand.cpp
+msgid "Menus"
+msgstr "Menus"
+
 #: src/commands/GetInfoCommand.cpp src/commands/ScreenshotCommand.cpp
 msgid "Preferences"
 msgstr "Preferências"
@@ -5461,13 +5773,28 @@ msgstr "Preferências"
 msgid "Clips"
 msgstr "Clipes"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Envelopes"
+msgstr "Envelopes"
+
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Rótulos"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Caixas"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr "JSON"
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr "LISP"
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5477,7 +5804,8 @@ msgstr "Resumos"
 msgid "Type:"
 msgstr "Tipo:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formato:"
 
@@ -5504,6 +5832,10 @@ msgstr "Comentário"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Comando:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr "_"
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5541,12 +5873,17 @@ msgstr "Exporta para arquivo."
 msgid "Builtin Commands"
 msgstr "Comandos embutidos"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Equipe do Tenacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Proporciona comandos embutidos para Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5609,7 +5946,10 @@ msgstr "Limpa conteúdo do log."
 msgid "Get Preference"
 msgstr "Usar Preferência"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nome:"
 
@@ -5657,9 +5997,14 @@ msgstr "Tela cheia"
 msgid "Toolbars"
 msgstr "Barras de Ferramentas"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efeitos"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Scriptables"
+msgstr "Scriptáveis"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -5793,7 +6138,8 @@ msgstr "Definir"
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Excluir"
 
@@ -5877,6 +6223,12 @@ msgstr "Excluir"
 msgid "Edited Envelope"
 msgstr "Envelope ajustado"
 
+#. i18n-hint: The envelope is a curve that controls the audio loudness.
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
+msgid "Envelope"
+msgstr "Envelope"
+
 #: src/commands/SetEnvelopeCommand.h
 msgid "Sets an envelope point position."
 msgstr "Define uma posição do ponto de envelope."
@@ -5916,6 +6268,14 @@ msgstr "Taxa de Amostragem:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Redimensionar:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr "X:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr "Y:"
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5965,6 +6325,13 @@ msgstr "Balanço:"
 msgid "Set Track Visuals"
 msgstr "Definir visual da Faixa"
 
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Linear"
+msgstr "Linear"
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Reiniciar"
@@ -5984,6 +6351,10 @@ msgstr "Exibir:"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
 msgstr "Escala:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "VZoom:"
+msgstr "VZoom:"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
@@ -6040,6 +6411,10 @@ msgid "Allo&w clipping"
 msgstr "&Permitir clipping"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr "Ducking Automático"
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Reduz (ducks) o volume de uma ou mais faixas, sempre que o volume de uma faixa de \"controle\" especificado atinge um determinado nível"
 
@@ -6057,12 +6432,18 @@ msgstr "Foi selecionada uma faixa sem áudio. O AutoDuck só pode processar faix
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "O Auto Duck requer uma faixa de controle logo abaixo da(s) faixa(s) selecionada(s)."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr "db"
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Quantidade de &Duck:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segundos"
 
@@ -6086,7 +6467,8 @@ msgstr "Tamanho da &queda gradual interior:"
 msgid "Inner &fade up length:"
 msgstr "Tamanho da subida gradual &interior:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Limiar:"
 
@@ -6125,6 +6507,10 @@ msgstr "&Agudos (dB):"
 #: src/effects/BassTreble.cpp
 msgid "Treble"
 msgstr "Agudos"
+
+#: src/effects/BassTreble.cpp
+msgid "&Volume (dB):"
+msgstr "&Volume (dB):"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
@@ -6220,11 +6606,13 @@ msgstr "para (Hz)"
 msgid "t&o"
 msgstr "p&ara"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "&Porcentagem de Alteração:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Percentagem a alterar"
 
@@ -6232,9 +6620,23 @@ msgstr "Percentagem a alterar"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Usar extensão de alta qualidade (mais lento)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr "33⅓"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr "45"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr "78"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n/d"
 
@@ -6262,6 +6664,7 @@ msgstr "RPM padrão do vinil:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "De RPM"
@@ -6274,6 +6677,7 @@ msgstr "&de"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Para o RPM"
@@ -6409,8 +6813,18 @@ msgid "Max Spike Width"
 msgstr "Largura máxima do pico"
 
 #: src/effects/Compressor.cpp
+msgid "Compressor"
+msgstr "Compressor"
+
+#: src/effects/Compressor.cpp
 msgid "Compresses the dynamic range of audio"
 msgstr "Comprime a faixa dinâmica de áudio"
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -6421,6 +6835,20 @@ msgstr "%.2f segs"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f segs"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr "%.1f:1"
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6535,9 +6963,14 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analisador de Contraste, mede a diferença de volume em RMS entre dois trechos de áudio selecionados."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Fim"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr "Volume    "
 
 #: src/effects/Contrast.cpp
 msgid "&Foreground:"
@@ -6591,9 +7024,32 @@ msgstr "&Diferença:"
 msgid "&Help"
 msgstr "A&juda"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr "RMS = %s."
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr "%s dB"
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr "zero"
+
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "indeterminado"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr "%.2f dB RMS"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6647,6 +7103,12 @@ msgstr "Diferença atual"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Nível medido no primeiro plano"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6716,6 +7178,12 @@ msgstr "Critério de sucesso 1.4.7 do WCAG 2.0: falhou"
 msgid "Data gathered"
 msgstr "Dados recolhidos"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr "%d %s %02d %02dh %02dm %02ds"
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Análise de Contraste (Compatível com WCAG 2)"
@@ -6781,6 +7249,10 @@ msgstr "Corte suave -12dB, 80% ganho fabricado"
 #: src/effects/Distortion.cpp
 msgid "Fuzz Box"
 msgstr "Caixa de Fuzz"
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr "Walkie talkie"
 
 #: src/effects/Distortion.cpp
 msgid "Blues drive sustain"
@@ -6891,6 +7363,10 @@ msgid "Clipping level"
 msgstr "Nível de clipping"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr "Drive"
+
+#: src/effects/Distortion.cpp
 msgid "Make-up Gain"
 msgstr "Ganho fabricado"
 
@@ -6982,7 +7458,13 @@ msgstr ""
 msgid "DTMF &sequence:"
 msgstr "&Sequência DTMF:"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
+msgid "&Amplitude (0-1):"
+msgstr "&Amplitude (0-1):"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Duração:"
 
@@ -6995,12 +7477,29 @@ msgid "Duty cycle:"
 msgstr "Ciclo de trabalho:"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr "%.1f %%"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Duração do tom:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Duração do silêncio:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr "%0.f ms"
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7010,7 +7509,8 @@ msgstr "Eco"
 msgid "Repeats the selected audio again and again"
 msgstr "Repetir áudio selecionado novamente e novamente"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "O valor inserido excede a capacidade da memória."
 
@@ -7034,7 +7534,8 @@ msgstr "Ajustes"
 msgid "Export Effect Parameters"
 msgstr "Exportar Parâmetros de Efeito"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Não foi possível abrir o arquivo: \"%s\""
@@ -7071,6 +7572,14 @@ msgstr "Preparando visualização"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Visualizando"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7383,8 +7892,16 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "Ajusta os níveis de volume de frequências independentes"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr "100Hz Rumble"
+
+#: src/effects/Equalization.cpp
 msgid "AM Radio"
 msgstr "Radio AM"
+
+#: src/effects/Equalization.cpp
+msgid "Bass Boost"
+msgstr "Amplificação de Grave"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
@@ -7393,6 +7910,10 @@ msgstr "Corte de Graves"
 #: src/effects/Equalization.cpp
 msgid "Low rolloff for speech"
 msgstr "Baixo rolloff para fala"
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr "RIAA"
 
 #: src/effects/Equalization.cpp
 msgid "Telephone"
@@ -7431,12 +7952,41 @@ msgid "Effect Unavailable"
 msgstr "Efeito não disponível"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr "+ dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Máximo (dB)"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr "%d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Mínimo (dB)"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr "- dB"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr "%g kHz"
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr "%gk"
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7511,12 +8061,24 @@ msgid "D&efault"
 msgstr "&Padrão"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr "&SSE"
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &Agrupados"
 
 #: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr "A&VX"
+
+#: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
 msgstr "AV&X Agrupados"
+
+#: src/effects/Equalization.cpp
+msgid "&Bench"
+msgstr "&Banco"
 
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
@@ -7725,6 +8287,10 @@ msgid "Creates labels where clipping is detected"
 msgstr "Cria rótulos onde é detectado clipping"
 
 #: src/effects/FindClipping.cpp
+msgid "Clipping"
+msgstr "Recorte"
+
+#: src/effects/FindClipping.cpp
 msgid "&Start threshold (samples):"
 msgstr "&Limiar para iniciar (amostras):"
 
@@ -7749,7 +8315,8 @@ msgid "Builtin Effects"
 msgstr "Efeitos Embutidos"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Proporciona efeitos embutidos para Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7759,6 +8326,10 @@ msgstr "Nome de efeito embutido desconhecido"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "altura percebida"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr "RMS"
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7790,6 +8361,14 @@ msgstr "&Normalizar"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Altura LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr "LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr "RMS dB"
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7859,8 +8438,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (padrão)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr "Blackman, Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
 msgstr "Hamming, nenhum"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr "Hamming, Hann"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Hamming, Reciprocal Hamming"
@@ -7959,12 +8546,12 @@ msgid "Step 1"
 msgstr "Passo 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
-"Selecione alguns segundos apenas de ruído para que o Tenacity saiba o que "
-"filtrar.\n"
+"Selecione alguns segundos apenas de ruído para que o Tenacity saiba o que filtrar.\n"
 "depois clique em \"Obter perfil de ruído\":"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
@@ -8013,13 +8600,62 @@ msgstr "&Tipo de janela:"
 msgid "Window si&ze:"
 msgstr "Tamanho da &janela:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr "16"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr "32"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr "64"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr "128"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr "256"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr "512"
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr "1024"
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048  (padrão)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr "4096"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr "8192"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr "16384"
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Passos por janela:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8135,12 +8771,17 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&ormalizar canais estéreo independentemente"
 
 #: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr "Paulstretch"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Use Paulstretch apenas para um extensão do tempo extrema ou um efeito de êxtase sonoro"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "&Fator de extensão:"
@@ -8190,6 +8831,10 @@ msgstr ""
 "\n"
 "Tente aumentar a seleção de áudio para no mínimo %.1f segundos,\n"
 "ou reduzir a resolução em ‘Time Resolution’ para menos de %.1f segundos."
+
+#: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr "Phaser"
 
 #: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
@@ -8418,6 +9063,11 @@ msgstr "Exportando áudio selecionado como"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Tempo SBSMS / Extensão de tom"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr "Butterworth"
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8573,6 +9223,11 @@ msgstr "Usar padrões"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Restaurar padrões"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr "%.3f"
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8732,6 +9387,10 @@ msgstr "Detectar silêncio"
 msgid "Tr&uncate to:"
 msgstr "&Descartar para:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr "%"
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "C&omprimir para:"
@@ -8745,7 +9404,8 @@ msgid "VST Effects"
 msgstr "Efeitos VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Adiciona suporte a efeitos VST no Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8757,7 +9417,8 @@ msgstr "Procurando plugins VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registrando %d de %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Não foi possível abrir a biblioteca"
 
@@ -8777,20 +9438,17 @@ msgstr "O tamanho do buffer controla o número de amostras enviadas para o efeit
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Tamanho do &Buffer (8 a 1048576 amostras):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Compensação de latência"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
-msgstr ""
-"Como parte de seu processamento, alguns efeitos VST devem atrasar o retorno "
-"do áudio ao Tenacity. Quando não compensar este atraso, você notará que "
-"pequenos silêncios foram inseridos no áudio. A ativação desta opção "
-"proporcionará essa compensação, mas pode não funcionar para todos os efeitos "
-"VST."
+msgstr "Como parte de seu processamento, alguns efeitos VST devem atrasar o retorno do áudio ao Tenacity. Quando não compensar este atraso, você notará que pequenos silêncios foram inseridos no áudio. A ativação desta opção proporcionará essa compensação, mas pode não funcionar para todos os efeitos VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Habilitar &compensação"
 
@@ -8824,7 +9482,8 @@ msgid "Standard VST program file"
 msgstr "Arquivo do programa padrão VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Arquivo de predefinições VST do Tenacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8851,7 +9510,8 @@ msgstr "Erro ao abrir programação VST"
 msgid "Unable to load presets file."
 msgstr "Não foi possível abrir o arquivo de predefinições."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Configuração de efeitos"
 
@@ -8867,6 +9527,12 @@ msgstr "Não foi possível ler o arquivo de predefinições."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Este parâmetro foi salvo como %s. Continuar?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr "VST"
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -8902,7 +9568,8 @@ msgid "Audio Unit Effects"
 msgstr "Efeitos Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Provê suporte a efeitos Audio Unit no Tenacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8918,13 +9585,9 @@ msgid "Audio Unit Effect Options"
 msgstr "Opções de efeitos Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
-msgstr ""
-"Como parte de seu processamento, alguns efeitos Audio Unit devem atrasar o "
-"retorno do áudio ao Tenacity. Quando não compensar este atraso, você notará "
-"que pequenos silêncios foram inseridos no áudio. A ativação desta opção "
-"proporcionará essa compensação, mas pode não funcionar para todos os efeitos "
-"Audio Unit."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr "Como parte de seu processamento, alguns efeitos Audio Unit devem atrasar o retorno do áudio ao Tenacity. Quando não compensar este atraso, você notará que pequenos silêncios foram inseridos no áudio. A ativação desta opção proporcionará essa compensação, mas pode não funcionar para todos os efeitos Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9067,6 +9730,7 @@ msgstr "Unidade de Áudio"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efeitos LADSPA"
@@ -9076,7 +9740,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Provê efeitos LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "O Tenacity não usa mais o vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9084,17 +9749,29 @@ msgid "LADSPA Effect Options"
 msgstr "Configuração de efeitos LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
-msgstr ""
-"Como parte de seu processamento, alguns efeitos LADSPA devem atrasar o "
-"retorno do áudio ao Tenacity. Quando não compensar este atraso, você notará "
-"que pequenos silêncios foram inseridos no áudio. A habilitação desta opção "
-"proporcionará essa compensação, mas pode não funcionar para todos os efeitos "
-"LADSPA."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr "Como parte de seu processamento, alguns efeitos LADSPA devem atrasar o retorno do áudio ao Tenacity. Quando não compensar este atraso, você notará que pequenos silêncios foram inseridos no áudio. A habilitação desta opção proporcionará essa compensação, mas pode não funcionar para todos os efeitos LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr "%s:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Saída do efeito"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9106,13 +9783,9 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Tamanho do &Buffer (8 a %damostras):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
-msgstr ""
-"Como parte de seu processamento, alguns efeitos do LV2 devem atrasar o "
-"retorno do áudio para o Tenacity. Quando não compensar este atraso, você "
-"notará que pequenos silêncios foram inseridos no áudio. A ativação desta "
-"configuração proporcionará esta compensação, mas pode não funcionar para "
-"todos os efeitos do LV2."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr "Como parte de seu processamento, alguns efeitos do LV2 devem atrasar o retorno do áudio para o Tenacity. Quando não compensar este atraso, você notará que pequenos silêncios foram inseridos no áudio. A ativação desta configuração proporcionará esta compensação, mas pode não funcionar para todos os efeitos do LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -9136,12 +9809,19 @@ msgstr "%s requer a opção não suportada %s\n"
 msgid "Generator"
 msgstr "Gerador"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efeitos LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Provê suporte a efeitos LV2 no Tenacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9149,7 +9829,8 @@ msgid "Nyquist Effects"
 msgstr "Efeitos Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Provê suporte a efeitos Nyquist no Tenacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9236,6 +9917,10 @@ msgid "nyx_error returned from %s.\n"
 msgstr "nyx_error retorna de %s.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "plug-in"
+msgstr "plug-in"
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist returned a list."
 msgstr "O Nyquist retornou uma lista."
 
@@ -9272,9 +9957,7 @@ msgstr "[Aviso!!! O Nyquist retornou uma mensagem inválida em formato UTF-8, aq
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
-msgstr ""
-"Essa versão do Tenacity não foi compilada com suporte para plug-in Nyquist "
-"versão %ld"
+msgstr "Essa versão do Tenacity não foi compilada com suporte para plug-in Nyquist versão %ld"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not open file"
@@ -9375,7 +10058,8 @@ msgstr "Selecione arquivo"
 msgid "Save file as"
 msgstr "Salvar Arquivo como"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "sem-título"
 
@@ -9384,7 +10068,8 @@ msgid "Vamp Effects"
 msgstr "Efeitos Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Provê suporte a efeitos VAMP no Tenacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9406,6 +10091,12 @@ msgstr "Configurações do plugin"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9564,6 +10255,10 @@ msgid "Command Output"
 msgstr "Saída do comando"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr "&OK"
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "Selecionou um arquivo sem uma extensão conhecida. Deseja continuar?"
 
@@ -9702,7 +10397,8 @@ msgstr "Exportando áudio como %s"
 msgid "Invalid sample rate"
 msgstr "Taxa de amostragem inválida"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Reamostrar"
 
@@ -9732,6 +10428,14 @@ msgstr "Você deve recriar a amostra para uma das taxas abaixo."
 msgid "Sample Rates"
 msgstr "Taxas de amostragem"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Taxa de Bits:"
@@ -9739,6 +10443,48 @@ msgstr "Taxa de Bits:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualidade (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr "0"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr "3"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr "5"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr "6"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr "9"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr "10"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9749,12 +10495,40 @@ msgid "Constrained"
 msgstr "Constrito"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr "VOIP"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Áudio"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Baixo Atraso"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr "2.5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr "5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr "10 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr "20 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr "40 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr "60 ms"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9841,8 +10615,16 @@ msgid "Replace preset '%s'?"
 msgstr "Substituir predefinição '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principal"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr "LTP"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9951,6 +10733,10 @@ msgstr "Idioma:"
 msgid "Bit Reservoir"
 msgstr "Reservatório de bit"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr "VBL"
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9974,8 +10760,7 @@ msgid ""
 "Recommended - 192000"
 msgstr ""
 "Taxa de bits (bits/segundo) - influencia o tamanho e qualidade do ficheiro \n"
-"Alguns codificadores podem aceitar apenas valores específicos (128k, 192k, "
-"256k, etc.) \n"
+"Alguns codificadores podem aceitar apenas valores específicos (128k, 192k, 256k, etc.) \n"
 "0 - automático \n"
 "Recomendado - 192000"
 
@@ -10084,6 +10869,10 @@ msgstr ""
 "0 - padrão \n"
 "mín - 1 \n"
 "máx - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr "LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10264,6 +11053,14 @@ msgid "Failed to find the codec"
 msgstr "Não foi possível encontrar o codec"
 
 #: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr "16 bit"
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr "24 bit"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (mais rápido)"
 
@@ -10332,6 +11129,38 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (Melhor Qualidade)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr "200-250 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr "170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr "155-195 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr "145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr "110-150 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr "95-135 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr "80-120 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr "65-105 kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (Arquivos menores)"
 
@@ -10361,7 +11190,8 @@ msgstr "Insano"
 msgid "Extreme"
 msgstr "Extremo"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Padrão"
 
@@ -10412,8 +11242,8 @@ msgid "Locate LAME"
 msgstr "Localizar LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "O Tenacity precisa do arquivo %s para salvar em formato MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10441,13 +11271,12 @@ msgid "Where is %s?"
 msgstr "Onde está %s ?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
-"Você está vinculando o lame_enc.dll v%d.%d. Essa versão não é compatível com "
-"o Tenacity %d.%d.%d.\n"
+"Você está vinculando o lame_enc.dll v%d.%d. Essa versão não é compatível com o Tenacity %d.%d.%d.\n"
 "Por favor baixe a última versão da biblioteca 'LAME para Tenacity'."
 
 #: src/export/ExportMP3.cpp
@@ -10748,6 +11577,14 @@ msgstr "Exportando o áudio selecionado para Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Exportando áudio para Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr "AIFF (Apple/SGI)"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft)"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Cabeçalho:"
@@ -10761,9 +11598,10 @@ msgid "Other uncompressed files"
 msgstr "Outros arquivos sem compactação"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Você tentou exportar um arquivo WAV ou AIFF que seria maior do que 4GB.\n"
 "Tenacity não pode fazer isso, a Exportação foi abandonada."
@@ -10773,12 +11611,12 @@ msgid "Error Exporting"
 msgstr "Erro ao Exportar"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
-"Seu arquivo WAV exportado foi truncado, pois o Tenacity não pode exportar "
-"WAV\n"
+"Seu arquivo WAV exportado foi truncado, pois o Tenacity não pode exportar WAV\n"
 "arquivos maiores do que 4GB."
 
 #: src/export/ExportPCM.cpp
@@ -10815,11 +11653,11 @@ msgid "All supported files"
 msgstr "Todos os arquivos suportados"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\"  \n"
@@ -10829,11 +11667,11 @@ msgstr ""
 "Arquivo > Importar > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\"  \n"
 "Não é um arquivo de áudio. \n"
@@ -10844,18 +11682,18 @@ msgid "Select stream(s) to import"
 msgstr "Selecione o(s) fluxo(s) para importar"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Essa versão do Tenacity não foi compilada com suporte para %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é uma faixa de um CD de áudio. \n"
 "O Tenacity não abre CDs de áudio diretamente. \n"
@@ -10864,24 +11702,22 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" é uma lista de reprodução. \n"
-"O Tenacity não pode abrir esse arquivo diretamente porque ele contém apenas "
-"links para outros arquivos. \n"
-"Você pode abrir esse arquivo num editor de textos e localizar os arquivos de "
-"áudio."
+"O Tenacity não pode abrir esse arquivo diretamente porque ele contém apenas links para outros arquivos. \n"
+"Você pode abrir esse arquivo num editor de textos e localizar os arquivos de áudio."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um arquivo Windows Media Audio. \n"
@@ -10890,41 +11726,37 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um arquivo Advanced Audio Coding.\n"
-"Sem a biblioteca opcional FFmpeg o Tenacity não pode abrir este tipo de "
-"arquivo.\n"
-"Caso contrário, você precisa convertê-lo em um formato de áudio suportado, "
-"como WAV ou AIFF."
+"Sem a biblioteca opcional FFmpeg o Tenacity não pode abrir este tipo de arquivo.\n"
+"Caso contrário, você precisa convertê-lo em um formato de áudio suportado, como WAV ou AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
-"\"%s\" é um arquivo de áudio encriptado e pode ter sido copiado de uma loja "
-"de músicas online. \n"
+"\"%s\" é um arquivo de áudio encriptado e pode ter sido copiado de uma loja de músicas online. \n"
 "O Tenacity não abre estes arquivos devido à sua encriptação. \n"
-"Experimente gravar o arquivo no Tenacity ou gravá-lo em um CD de áudio e "
-"depois\n"
+"Experimente gravar o arquivo no Tenacity ou gravá-lo em um CD de áudio e depois\n"
 "extrair a faixa para um formato suportado, como WAV ou AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um arquivo RealPlayer media. \n"
@@ -10933,12 +11765,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" é um arquivo de notas e não de áudio. \n"
 "O Tenacity não pode abrir esse tipo de arquivo. \n"
@@ -10947,10 +11779,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10963,10 +11795,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um arquivo Wavpack. \n"
@@ -10975,10 +11807,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um arquivo Dolby Digital. \n"
@@ -10987,10 +11819,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um arquivo Ogg Speex. \n"
@@ -10999,10 +11831,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um arquivo de vídeo. \n"
@@ -11016,9 +11848,9 @@ msgstr "Arquivo \"%s\" não encontrado."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11034,11 +11866,16 @@ msgstr ""
 "Tentando instalar o FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr "%s, %s"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11068,18 +11905,18 @@ msgid "Import Project"
 msgstr "Importar Projeto"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Este projeto foi salvo pela Tenacity versão 1.0 ou anterior. O formato \n"
 "atual desta versão da Tenacity não pode importar o projeto.\n"
 "\n"
-"Use uma versão do Tenacity anterior à v3.0.0 para atualizar o projeto e "
-"depois\n"
+"Use uma versão do Tenacity anterior à v3.0.0 para atualizar o projeto e depois\n"
 "você pode importá-la com esta versão de Tenacity."
 
 #: src/import/ImportAUP.cpp
@@ -11125,10 +11962,9 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Não foi possível encontrar a pasta de dados do projeto: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
-msgstr ""
-"Faixas MIDI encontradas no arquivo do projeto, mas esta compilação do "
-"Tenacity não inclui suporte MIDI, ignorando a faixa."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr "Faixas MIDI encontradas no arquivo do projeto, mas esta compilação do Tenacity não inclui suporte MIDI, ignorando a faixa."
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
@@ -11232,40 +12068,6 @@ msgstr "Index[%02x] Codificador[%s], Idioma[%s], Taxa de Bits[%s], Canais[%d], D
 msgid "FLAC files"
 msgstr "Arquivos FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Arquivos compatíveis GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Não foi possível adicionar a decodificação à fila"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importação GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Não é possível mudar o estado do fluxo para pausado."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index[%02d], Tipo[%s], Canais[%d], Taxa de Bits[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "O arquivo não contém dados de áudio."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Não foi possível importar arquivo, falha na mudança de estado."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Erro no GStreamer: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Lista de arquivos em formato de texto básico"
@@ -11367,8 +12169,97 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, e outros arquivos sem compactação"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr "AU (Sun/NeXT)"
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr "AVR (Audio Visual Research)"
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr "CAF (Apple Core Audio File)"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr "FLAC (FLAC Lossless Audio Codec)"
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr "HTK (HMM Tool Kit)"
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr "IFF (Amiga IFF/SVX8/SV16)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr "MPC (Akai MPC 2k)"
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (Formato de contêiner OGG)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr "PAF (Ensoniq PARIS)"
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr "PVF (Portable Voice Format)"
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr "RAW (header-less)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr "RF64 (RIFF 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr "SD2 (Sound Designer II)"
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr "SDS (Midi Sample Dump Standard)"
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr "SF (Berkeley/IRCAM/CARL)"
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr "VOC (Creative Labs)"
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr "W64 (SoundFoundry WAVE 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr "WAV (NIST Sphere)"
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr "WAVEX (Microsoft)"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr "WVE (Psion Series 3)"
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr "XI (FastTracker 2)"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11397,6 +12288,62 @@ msgstr "32-bit flut"
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "64-bit flut"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr "U-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr "A-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr "IMA ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr "Microsoft ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr "GSM 6.10"
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr "32kbs G721 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr "24kbs G723 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr "12 bit DWVW"
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr "16 bit DWVW"
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr "24 bit DWVW"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr "VOX ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr "16 bit DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr "8 bit DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr "Vorbis"
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11491,6 +12438,10 @@ msgid "Start offset:"
 msgstr "Compensação de início:"
 
 #: src/import/ImportRaw.cpp
+msgid "bytes"
+msgstr "bytes"
+
+#: src/import/ImportRaw.cpp
 msgid "Amount to import:"
 msgstr "Quantidade a importar:"
 
@@ -11527,6 +12478,7 @@ msgstr "%s direita"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11550,6 +12502,7 @@ msgstr "fim"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11576,7 +12529,8 @@ msgstr "Faixas movidas no tempo à direita"
 msgid "Time shifted clips to the left"
 msgstr "Faixas movidas no tempo à esquerda"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Mover"
 
@@ -11714,7 +12668,8 @@ msgstr "Aparar as faixas selecionadas entre o segundo %.2f e o segundo %.2f"
 msgid "Trim Audio"
 msgstr "Aparar Áudio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Separar"
 
@@ -11835,32 +12790,8 @@ msgid "Delete Key&2"
 msgstr "Tecla E&xcluir 2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "&Volume"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Ajustar volume de &reprodução..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Aumentar volume de reprodução"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Diminuir volume de reprodução"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Ajustar volume de &gravação..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "A&umentar volume de gravação"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "D&iminuir volume de gravação"
+msgid "Ext&ra"
+msgstr "Ext&ra"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12036,6 +12967,10 @@ msgid "&Labels..."
 msgstr "&Rótulos..."
 
 #: src/menus/FileMenus.cpp
+msgid "&MIDI..."
+msgstr "&MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Áudio sem formatação (&RAW)..."
 
@@ -12124,12 +13059,17 @@ msgid "&Getting Started"
 msgstr "&Conhecendo o básico"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manual do Tenacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manual..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "Ajuda &Rápida..."
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr "&Manual..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -12147,11 +13087,8 @@ msgstr "Informações do Dispositivo de &MIDI..."
 msgid "Show &Log..."
 msgstr "Exibir &Log..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Sobre o Tenacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Rótulo adicionado"
 
@@ -12353,6 +13290,10 @@ msgid "Move Forward Through Active Windows"
 msgstr "Mover-se para frente entre janelas ativas"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr "Foc&o"
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "&Voltar da barra de ferramentas para as faixas"
 
@@ -12395,6 +13336,10 @@ msgstr "Alterar &Foco da Faixa"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Sem categoria"
+
+#: src/menus/PluginMenus.cpp
+msgid "..."
+msgstr "..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12447,6 +13392,10 @@ msgid "Repeat Last Tool"
 msgstr "Repetir Última Ferramenta"
 
 #: src/menus/PluginMenus.cpp
+msgid "&Macros..."
+msgstr "&Macros..."
+
+#: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
 msgstr "&Aplicar macro"
 
@@ -12473,6 +13422,11 @@ msgstr "Simular erros de gravação"
 #: src/menus/PluginMenus.cpp
 msgid "Detect Upstream Dropouts"
 msgstr "Detectar quedas no fluxo de entrada"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+msgid "Script&ables I"
+msgstr "Script&áveis I"
 
 #: src/menus/PluginMenus.cpp
 msgid "Select Time..."
@@ -12521,6 +13475,11 @@ msgstr "Ajustar Rótulos..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Ajustar Projeto..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+msgid "Scripta&bles II"
+msgstr "Scriptá&veis II"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -12789,6 +13748,10 @@ msgid "Cursor to Project End"
 msgstr "Ir para Fim do Projeto"
 
 #: src/menus/SelectMenus.cpp
+msgid "&Cursor"
+msgstr "&Cursor"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor &Left"
 msgstr "Mover Cursor à &Esquerda (extracurto)"
 
@@ -12815,6 +13778,7 @@ msgstr "&Mover Cursor à &Direita (longo)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Busca&r"
@@ -13026,20 +13990,21 @@ msgid "Created new label track"
 msgstr "Criada nova faixa de rótulos"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
-msgstr ""
-"Essa versão do Tenacity permite apenas uma faixa de tempo para cada janela "
-"de projeto."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr "Essa versão do Tenacity permite apenas uma faixa de tempo para cada janela de projeto."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Criada nova faixa de tempo"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nova taxa de amostragem (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "O valor digitado não é válido"
 
@@ -13296,7 +14261,9 @@ msgstr "Reproduzindo"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Gravação"
 
@@ -13447,10 +14414,6 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "Reprodução via &Software (lig/desl)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Aj&uste Automático do Nível de Gravação (lig/desl)"
-
-#: src/menus/TransportMenus.cpp
 msgid "T&ransport"
 msgstr "&Controle"
 
@@ -13541,9 +14504,19 @@ msgstr "Mover para o &próximo rótulo"
 msgid "&View"
 msgstr "E&xibir"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+msgid "&Zoom"
+msgstr "&Zoom"
+
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
 msgstr "&Aumentar Zoom"
+
+#: src/menus/ViewMenus.cpp
+msgid "Zoom &Normal"
+msgstr "Zoom &Normal"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &Out"
@@ -13653,7 +14626,8 @@ msgid "Preferences for Application"
 msgstr "Preferências para Qualidade"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Atualizar o Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13684,6 +14658,12 @@ msgstr "Dispositivos"
 msgid "Preferences for Device"
 msgstr "Preferências para Dispositivo"
 
+#. i18n-hint Software interface to audio devices
+#: src/prefs/DevicePrefs.cpp
+msgctxt "device"
+msgid "Interface"
+msgstr "Interface"
+
 #. i18n-hint: (noun)
 #: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
 msgid "&Host:"
@@ -13693,7 +14673,8 @@ msgstr "&Dispositivo:"
 msgid "Using:"
 msgstr "Usando:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Reprodução"
 
@@ -13713,7 +14694,8 @@ msgstr "Ca&nais:"
 msgid "Latency"
 msgstr "Latência"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milissegundos"
 
@@ -13734,11 +14716,16 @@ msgid "No devices found"
 msgstr "Nenhum dispositivo encontrado"
 
 #: src/prefs/DevicePrefs.cpp
+msgid "1 (Mono)"
+msgstr "1 (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "2 (Stereo)"
 msgstr "2 (Estéreo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Pastas"
 
@@ -13846,10 +14833,9 @@ msgid "Directory %s is not writable"
 msgstr "A pasta de arquivos temporários %s não tem permissão de escrita"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
-msgstr ""
-"Alterações na pasta de arquivos temporários só terão efeito ao reiniciar o "
-"Tenacity"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr "Alterações na pasta de arquivos temporários só terão efeito ao reiniciar o Tenacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -13879,6 +14865,39 @@ msgstr "Agrupar por Fabricante"
 msgid "Grouped by Type"
 msgstr "Agrupar por Tipo"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr "LV&2"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr "N&yquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr "&Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr "V&ST"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Ativar efeitos"
@@ -13900,11 +14919,13 @@ msgid "Plugin Options"
 msgstr "Configurações do Plugin"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Verificar atualização de plugins ao iniciar o Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Procurar por novos plugins ao iniciar o Tenacity novamente"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13975,11 +14996,7 @@ msgstr "Filtros não usados:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"Há caracteres com espaço em um dos itens (Espaços, enter ou tab). Estes "
-"caracteres podem quebrar a busca de padrões. A não ser em casos muito "
-"específicos, recomenda-se excluir estes caracteres. Gostaria que o Tenacity "
-"excluísse estes espaços dos itens?"
+msgstr "Há caracteres com espaço em um dos itens (Espaços, enter ou tab). Estes caracteres podem quebrar a busca de padrões. A não ser em casos muito específicos, recomenda-se excluir estes caracteres. Gostaria que o Tenacity excluísse estes espaços dos itens?"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -13992,6 +15009,16 @@ msgstr "Tem certeza que deseja excluir a regra selecionada?"
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Rule deletion confirmation"
 msgstr "Confirmar exclusão de regra"
+
+#: src/prefs/ExtImportPrefs.h
+msgid "Ext Import"
+msgstr "Importar Ext"
+
+#. i18n-hint: refers to Audacity's user interface settings
+#: src/prefs/GUIPrefs.cpp
+msgctxt "GUI"
+msgid "Interface"
+msgstr "Interface"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Preferences for GUI"
@@ -14028,6 +15055,10 @@ msgstr "-120 dB (Limite aproximado da audição humana)"
 #: src/prefs/GUIPrefs.cpp
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (Intervalo PCM para amostras de 24 bit)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Local"
+msgstr "Local"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
@@ -14074,7 +15105,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Manter &rótulos se houver sobreposição de rótulos diferentes"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Mesc&lar temas do Sistema e do Tenacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14098,6 +15130,10 @@ msgstr "Exibir barra de Percorrer"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "Idioma \"%s\" é desconhecido"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr "GUI"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14151,6 +15187,10 @@ msgstr "Estilo de rótulo exportado:"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "Ao exportar arquivos Allegro (.gro) salvar tempo como:"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr "IMPORTAR EXPORTAR"
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14244,9 +15284,9 @@ msgstr ""
 "   *   \"%s\"  (porque o atalho '%s' está sendo usado por \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
-msgstr ""
-"Selecione um arquivo XML que contenha atalhos do teclado para o Tenacity..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
+msgstr "Selecione um arquivo XML que contenha atalhos do teclado para o Tenacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Importing Keyboard Shortcuts"
@@ -14377,8 +15417,9 @@ msgid "Dow&nload"
 msgstr "&Baixar"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "O Tenacity já detectou automaticamente bibliotecas FFmpeg válidas.\n"
@@ -14405,6 +15446,12 @@ msgstr "Preferências para MidiIO"
 msgid "No MIDI interfaces"
 msgstr "Sem interfaces MIDI"
 
+#. i18n-hint Software interface to MIDI
+#: src/prefs/MidiIOPrefs.cpp
+msgctxt "MIDI"
+msgid "Interface"
+msgstr "Interface"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Using: PortMidi"
 msgstr "Usando: PortMidi"
@@ -14417,6 +15464,10 @@ msgstr "&Latência do Sintetizador MIDI (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "A latência do sintetizador MIDI deve ser um número inteiro"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr "ES Midi"
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -14427,24 +15478,23 @@ msgid "Preferences for Module"
 msgstr "Preferências para Módulo"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr "Estes são módulos experimentais. Ative apenas se tiver lido o manual e souber o que está fazendo."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
-msgstr ""
-"  'Perguntar' faz o Tenacity solicitar quais módulos deve carregar a cada "
-"inicialização."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr "  'Perguntar' faz o Tenacity solicitar quais módulos deve carregar a cada inicialização."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr ""
-"  'Falhou' indica que o Tenacity não conseguiu validar o módulo e não poderá "
-"executá-lo."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr "  'Falhou' indica que o Tenacity não conseguiu validar o módulo e não poderá executá-lo."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -14452,9 +15502,9 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Novo' significa que nenhuma opção foi selecionada."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
-msgstr ""
-"Alterações nestas configurações só terão efeito ao reiniciar o Tenacity."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "Alterações nestas configurações só terão efeito ao reiniciar o Tenacity."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -14471,6 +15521,14 @@ msgstr "Nenhum módulo encontrado"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Módulo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
+msgid "Mouse"
+msgstr "Mouse"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Preferences for Mouse"
@@ -14508,7 +15566,10 @@ msgstr "Arrastar à Esquerda"
 msgid "Set Selection Range"
 msgstr "Definir o Intervalo da Seleção"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-botão-esquerdo"
 
@@ -14596,6 +15657,15 @@ msgstr "Arrastar à esquerda"
 msgid "Move clip up/down between tracks"
 msgstr "Mover clipe para cima/baixo entre faixas"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Arrastar à esquerda"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14624,6 +15694,10 @@ msgstr "Alterar Várias Amostras"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Alterar Apenas uma Amostra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Multi"
+msgstr "Multi"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14707,11 +15781,16 @@ msgid "&Vari-Speed Play"
 msgstr "Reproduzir na &velocidade ajustada"
 
 #: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr "&Micro-fades"
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "Always scrub un&pinned"
 msgstr "Sempre percorrer &destravados"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferências do Tenacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14725,6 +15804,11 @@ msgstr "Preferências:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferências para Qualidade"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr "%i Hz"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14767,6 +15851,14 @@ msgstr "Conversor da &Taxa de Amostragem:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "&Tremor:"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr "16-bit"
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr "24-bit"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14836,41 +15928,31 @@ msgid "System T&ime"
 msgstr "&Hora do sistema"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Ajuste automático do nível de gravação"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Ativar o Ajuste automático do nível de gravação."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Pico Alvo:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Entre:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Tempo de Análise:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milissegundos (tempo de uma análise)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Número de análises consecutivas:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 = infinitas"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Gravação Punch and Roll"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr "Pre-ro&ll:"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Cross&fade:"
+msgstr "Cross&fade:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr "Mel"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr "Bark"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr "ERB"
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15005,6 +16087,10 @@ msgid "1024 - default"
 msgstr "1024 - padrão"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr "2048"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - banda mais estreita"
 
@@ -15098,13 +16184,18 @@ msgid "Preferences for Theme"
 msgstr "Preferências para Tema"
 
 #: src/prefs/ThemePrefs.cpp
+msgid "Info"
+msgstr "Informação"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15292,7 +16383,8 @@ msgstr "Amostras"
 msgid "4 Pixels per Sample"
 msgstr "4 Pixels por amostra"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom Máx"
 
@@ -15414,16 +16506,24 @@ msgid "Stopped"
 msgstr "Parado"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Ir para o Início"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Ir para o Fim"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Selecionar até o Início"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Selecionar até o Fim"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15437,20 +16537,17 @@ msgstr "Gravar Nova Faixa"
 msgid "Append Record"
 msgstr "Gravar ao Final da Faixa Atual"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Selecionar até o Fim"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Selecionar até o Início"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s Pausado."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr "%s."
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15530,11 +16627,17 @@ msgstr "Silenciar o áudio da seleção"
 msgid "Sync-Lock Tracks"
 msgstr "Exibir Sincronia de Faixas"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Aumentar Zoom"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Diminuir Zoom"
 
@@ -15601,43 +16704,6 @@ msgstr "Barra de &Nível de Gravação"
 msgid "&Playback Meter Toolbar"
 msgstr "Barra do Medidor de &Reprodução"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volume da Gravação"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volume de Reprodução"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volume de Gravação: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volume de Gravação (Indisponível; use o mixer do sistema)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volume de Reprodução: %.2f (emulado)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volume de Reprodução: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volume de Deprodução (Indisponível; use o mixer do sistema)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra de &Volume"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Buscar"
@@ -15653,6 +16719,7 @@ msgstr "Percorrer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Parar Percorrer"
@@ -15660,6 +16727,7 @@ msgstr "Parar Percorrer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Iniciar Percorrer"
@@ -15667,6 +16735,7 @@ msgstr "Iniciar Percorrer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Parar busca"
@@ -15674,6 +16743,7 @@ msgstr "Parar busca"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Iniciar Busca"
@@ -15728,7 +16798,9 @@ msgstr "Ajustar Para"
 msgid "Length"
 msgstr "Tamanho"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centro"
 
@@ -15792,8 +16864,8 @@ msgstr "Barra de &Timer"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra de %s do Tenacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15820,7 +16892,8 @@ msgstr "Ferramenta Mover"
 msgid "Zoom Tool"
 msgstr "Ferramenta Zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Ferramenta Desenho"
 
@@ -15896,11 +16969,13 @@ msgstr "Arraste um ou mais limites dos rótulos."
 msgid "Drag label boundary."
 msgstr "Arraste o limite do rótulo."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Rótulo Modificado"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Editar Rótulo"
 
@@ -15955,31 +17030,42 @@ msgstr "Rótulos editados"
 msgid "New label"
 msgstr "Novo rótulo"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Subir &oitava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Descer oita&va"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Clique para alterar o zoom verticalmente. Shift-Clique para diminuir o zoom. Arraste para especificar a região do zoom."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clique-Botão Direito para Menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Redefinir Zoom"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-botão-direito"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Clicar/Arrastar com o botão esquerdo"
 
@@ -16021,7 +17107,8 @@ msgstr "Mesclar"
 msgid "Expanded Cut Line"
 msgstr "Linha de Corte Expandida"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expandir"
 
@@ -16044,6 +17131,11 @@ msgstr "Amostragem Movida"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Editar amostra"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr "k"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16089,7 +17181,8 @@ msgstr "Processando... %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Alterado '%s' para %s"
@@ -16101,6 +17194,54 @@ msgstr "Alterar Formato"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Taxa"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr "8000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr "11025 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr "16000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr "22050 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr "44100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr "48000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr "88200 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr "96000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr "176400 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr "192000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr "352800 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr "384000 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16121,6 +17262,11 @@ msgid "Set Rate"
 msgstr "Definir Taxa"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+msgid "&Multi-view"
+msgstr "&Multi-view"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Ma&ke Stereo Track"
 msgstr "&Unir Faixas Estéreo"
 
@@ -16135,6 +17281,10 @@ msgstr "&Separar Faixas Estéreo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Separar Estéreo para Mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16191,6 +17341,11 @@ msgstr "Estéreo, %dHz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
+msgid "Mono, %dHz"
+msgstr "Mono, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
 msgid "Left, %dHz"
 msgstr "Esquerdo, %dHz"
 
@@ -16199,14 +17354,23 @@ msgstr "Esquerdo, %dHz"
 msgid "Right, %dHz"
 msgstr "Direito, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr "%+.1f dB"
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Esquerda"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Direita"
@@ -16226,6 +17390,14 @@ msgstr "Rearranjar sub-vistas"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Close sub-view"
 msgstr "Fechar sub-vistas"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom x1/2"
+msgstr "Zoom x1/2"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Zoom x2"
+msgstr "Zoom x2"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
@@ -16316,8 +17488,8 @@ msgstr "&Interpolação logarítmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Clique e arraste para ajustar, duplo clique para resetar"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16368,6 +17540,7 @@ msgstr "Envelope ajustado."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Percorrer"
@@ -16379,6 +17552,7 @@ msgstr "Buscar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Barra de &Percorrer"
@@ -16574,6 +17748,12 @@ msgstr "E"
 msgid "R"
 msgstr "D"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr "%.2fx"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16607,13 +17787,27 @@ msgstr "Vazio"
 msgid "Backwards"
 msgstr "Retroceder"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr "<"
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Avançar"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ">"
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Ajuda na internet"
+
+#: src/widgets/KeyView.cpp
+msgid "Menu"
+msgstr "Menu"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -16691,6 +17885,14 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: src/widgets/Meter.cpp
+msgid "Horizontal"
+msgstr "Horizontal"
+
+#: src/widgets/Meter.cpp
+msgid "Vertical"
+msgstr "Vertical"
+
+#: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr " Monitorando "
 
@@ -16726,6 +17928,27 @@ msgstr "Por favor, selecione uma ação"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000,01000 seconds"
 msgstr "01000,01000 segundos"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr "0100 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr "dd:hh:mm:ss"
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -16790,6 +18013,7 @@ msgstr "0100 h 060 m 060 s+<# amostras"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "amostras"
@@ -16951,6 +18175,15 @@ msgstr "01000,01000 quadros|75"
 msgid "010,01000>0100 Hz"
 msgstr "010,01000<0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr "centihertz"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr "kHz"
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -16958,6 +18191,10 @@ msgstr "010,01000<0100 Hz"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "01000<01000 kHz|0,001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr "hertz"
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -16998,6 +18235,12 @@ msgstr "1000 semitons <0100 centos|17,312340491"
 msgid "hundredths of cents"
 msgstr "centésimos de centos"
 
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr "décadas"
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
@@ -17016,6 +18259,11 @@ msgstr "(Use a tecla de contexto para alterar o formato)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "centésimos de segundo"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr "%s (%s)"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -17058,6 +18306,11 @@ msgstr "Confirma sair"
 #, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Não foi possível inicializar o arquivo do projeto"
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr "Por favor, verifique se o diretório existe, se tem as permissões necessárias e se o disco não está cheio."
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -17162,15 +18415,27 @@ msgstr "Não foi possível ler XML"
 msgid "Spectral edit multi tool"
 msgstr "Multiferramenta de edição Espectral"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrando..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr "Paul Licameli"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Liberado nos termos da GNU General Public License version 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aPor favor, selecione frequências."
@@ -17197,7 +18462,8 @@ msgstr ""
 "                      Tente aumentar o limite baixo de frequência~%~\n"
 "                      ou reduzir o filtro 'Width'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Erro.~%"
@@ -17258,6 +18524,24 @@ msgstr "Suavização na Saída tipo estúdio (Fade out)"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Aplicando suavização..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr "Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Licenciado nos termos da GNU General Public License versão 2 ou mais recente."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17403,6 +18687,10 @@ msgid "Finding beats..."
 msgstr "Encontrando batidas..."
 
 #: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
+
+#: plug-ins/beat.ny
 msgid "Threshold Percentage"
 msgstr "Percentagem do limiar"
 
@@ -17433,6 +18721,10 @@ msgstr "Reduzir a amplitude para permitir picos restaurados (dB)"
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Crossfade de clipes"
+
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+msgid "Crossfading..."
+msgstr "Crossfading..."
 
 #: plug-ins/crossfadeclips.ny
 #, lisp-format
@@ -17505,6 +18797,14 @@ msgstr "Aplicando Efeito Atraso..."
 #: plug-ins/delay.ny
 msgid "Delay type"
 msgstr "Tipo de Atraso"
+
+#: plug-ins/delay.ny
+msgid "Regular"
+msgstr "Regular"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr "Bouncing Ball"
 
 #: plug-ins/delay.ny
 msgid "Reverse Bouncing Ball"
@@ -17713,13 +19013,38 @@ msgstr "Filtros Passa-alta"
 msgid "Performing High-Pass Filter..."
 msgstr "Executando Filtro PAssa-alta..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr "Dominic Mazzoni"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequência (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB por oitava)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr "6 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr "12 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr "24 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr "36 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr "48 dB"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17740,10 +19065,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Rótulo de sons"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Licenciado nos termos da GNU General Public License versão 2 ou mais recente."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17804,6 +19125,12 @@ msgstr "Máximo de silêncio pós-trilha"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Som ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr "~ah ~am ~as"
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -17875,6 +19202,10 @@ msgstr ""
 msgid "Limit to (dB)"
 msgstr "Limitar em (dB)"
 
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr "Aguardar (ms)"
+
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
 msgstr "Aplicar Ganho fabricado"
@@ -17894,6 +19225,10 @@ msgstr "Gate de ruído"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Selecionar função"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr "Gate"
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -17975,6 +19310,12 @@ msgstr ""
 "Pico baseado no primeiro ~a segundos ~a dB~%\n"
 "Sugestão de Ajuste de Limiar ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr "~ah ~am"
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Filtro Notch"
@@ -18012,6 +19353,10 @@ msgid "Select file(s) to install"
 msgstr "Selecione o(s) arquivos(s) para importar"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Plug-in"
+msgstr "Plug-in"
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Lisp file"
 msgstr "Arquivo Lisp"
 
@@ -18019,7 +19364,8 @@ msgstr "Arquivo Lisp"
 msgid "HTML file"
 msgstr "Arquivo HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Arquivo de texto"
 
@@ -18084,12 +19430,20 @@ msgid "Error.~%No file selected."
 msgstr "Erro.~% Nenhum arquivo selecionado."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr "Pluck"
+
+#: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Gerando som pluck..."
 
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Valores MIDI para notas C: 36, 48, 60 [meio C], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr "David R.Sky"
 
 #: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
@@ -18104,6 +19458,10 @@ msgid "Abrupt"
 msgstr "Abrupto"
 
 #: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr "Gradual"
+
+#: plug-ins/pluck.ny
 msgid "Duration (60s max)"
 msgstr "Duração (60s máx)"
 
@@ -18114,6 +19472,10 @@ msgstr "Faixa de Ritmo"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Gerando ritmo..."
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr "Tempo (bpm)"
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -18130,6 +19492,10 @@ msgstr "1 - 20 batidas/medida"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Quantidade de Swing"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr "+/- 1"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18176,6 +19542,10 @@ msgid "Ping (long)"
 msgstr "Ping (longo)"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr "Cowbell"
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Ruído de ressonância"
 
@@ -18196,6 +19566,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Tom MIDI da batida forte"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr "18 - 116"
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Tom MIDI da batida suave"
 
@@ -18214,6 +19588,10 @@ msgstr "Tambor de Risset"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Gerando Tambor de Risset...."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr "Steven Jones"
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18369,6 +19747,11 @@ msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~a linear, ~a dB."
+msgstr "~a linear, ~a dB."
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
 msgstr "Esquerdo: ~a lin, ~a dB | Direito: ~a lin, ~a dB."
 
@@ -18397,11 +19780,22 @@ msgstr "<b>Taxa de amostragem:</b> &nbsp;&nbsp;~a Hz."
 msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
 msgstr "<b>Amplitude de pico:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
 
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr "<b>RMS</b> (sem peso): &nbsp;&nbsp;~a dB."
+
 #. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
 msgstr "<b>Compensação DC:</b> &nbsp;&nbsp;~a"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr "~a linear, &nbsp;&nbsp;~a dB."
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18454,6 +19848,10 @@ msgstr ""
 "Produzido com <span>Sample Data Export</span> for\n"
 "<a href=\"~a\">Tenacity</a> by Steve\n"
 "Daulton"
+
+#: plug-ins/sample-data-export.ny
+msgid "linear"
+msgstr "linear"
 
 #: plug-ins/sample-data-export.ny
 msgid "2 channels (stereo)"
@@ -18569,6 +19967,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Erro.~%Taxa de amostragem da faixa abaixo de 100 Hz não é suportado."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr "Tremolo"
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Aplicando Tremolo..."
 
@@ -18595,6 +19997,10 @@ msgstr "Redução de vocal e isolamento"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Aplicando ação..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr "Robert Haenggi"
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18737,8 +20143,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Este plug-in funciona apenas com faixas estéreo."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr "Vocoder"
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Processando Vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr "Edgar-RFT"
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18780,6 +20194,225 @@ msgstr "Frequência das agulhas no radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Erro.~%Requer faixa estéreo."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Atualizar o Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Pular"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Instalar atualização"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Leia mais no Github"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Erro ao verificar atualização"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Não foi possível conectar ao servidor de atualização do Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Dados de atualização estavam corrompidos."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Erro ao baixar atualização."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Não foi possível abrir o link de download do Tenacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "O Tenacity %s está disponível!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Gravação"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Id de Alteração:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Biblioteca de GUI multi-plataforma"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importar via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "O ajuste automático do volume de gravação terminou. Não foi possível otimizar completamente, o nível continua muito alto."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "O ajuste automático do volume de gravação diminuiu o volume para %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "O ajuste automático do volume de gravação terminou. Não foi possível otimizar completamente, o nível continua muito baixo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "O ajuste automático do volume de gravação aumentou o volume para %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "O ajuste automático de volume de gravação terminou. O número total de análises foi excedido sem encontrar um volume aceitável. Ainda está muito alto."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "O ajuste automático de volume de gravação terminou. O número total de análises foi excedido sem encontrar um volume aceitável. O volume ainda está muito baixo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "O Ajuste automático de volume de gravação terminou. %.2f parece um volume aceitável."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Recebido %d ao abrir dispositivos\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Não foi possível abrir Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Misturadores disponíveis:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Fontes de gravação disponíveis:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volumes de reprodução disponíveis:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Volume da gravação é emulado\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Volume de gravação é nativo\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Volume de reprodução é emulado\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Volume de reprodução é nativo\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Data e Hora desconhecida"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Arquivos compatíveis GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Não foi possível adicionar a decodificação à fila"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importação GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Não é possível mudar o estado do fluxo para pausado."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index[%02d], Tipo[%s], Canais[%d], Taxa de Bits[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "O arquivo não contém dados de áudio."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Não foi possível importar arquivo, falha na mudança de estado."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Erro no GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "&Volume"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Ajustar volume de &reprodução..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Aumentar volume de reprodução"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Diminuir volume de reprodução"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Ajustar volume de &gravação..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "A&umentar volume de gravação"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "D&iminuir volume de gravação"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manual do Tenacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Sobre o Tenacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Aj&uste Automático do Nível de Gravação (lig/desl)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Ajuste automático do nível de gravação"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Ativar o Ajuste automático do nível de gravação."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Pico Alvo:"
+
+#~ msgid "Within:"
+#~ msgstr "Entre:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Tempo de Análise:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milissegundos (tempo de uma análise)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Número de análises consecutivas:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 = infinitas"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volume da Gravação"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volume de Reprodução"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volume de Gravação: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume de Gravação (Indisponível; use o mixer do sistema)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volume de Reprodução: %.2f (emulado)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volume de Reprodução: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume de Deprodução (Indisponível; use o mixer do sistema)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra de &Volume"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Clique e arraste para ajustar, duplo clique para resetar"
 
 #~ msgid "Program build date:"
 #~ msgstr "Data de compilação:"
@@ -18908,1488 +20541,10 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "Select any uncompressed audio file"
 #~ msgstr "Selecione áudio sem compactação"
 
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "OK"
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Histórico de mudanças"
 
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Script"
-msgstr "Script"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
 #, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s KB"
-msgstr "%s kB"
-
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s bytes"
-msgstr "%s bytes"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Histórico de mudanças"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#: src/ProjectFileIO.cpp
-msgid "Failed to rollback transaction during import"
-msgstr "Falha ao desfazer a transação durante a importação"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Projeto %02i] "
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "A♯/B♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "G♯/A♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "F♯/G♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "D♯/E♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "C♯/D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "B♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "A♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "G♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "B"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "A♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "A"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "G♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "G"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "F♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "F"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "E"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "D♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "D"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "C♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "C"
-
-#. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Solo"
-msgstr "Solo"
-
-#: src/LyricsWindow.cpp
-msgid "&Karaoke..."
-msgstr "&Karaoke..."
-
-#: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
-msgstr "Karaoke Tenacity%s"
-
-#: src/FreqWindow.cpp
-msgid "spectrum.txt"
-msgstr "spectrum.txt"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#: src/FreqWindow.cpp
-msgid "Cursor:"
-msgstr "Cursor:"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
-msgid "Zoom"
-msgstr "Zoom"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#: src/FileNames.cpp
-msgid ", "
-msgstr ", "
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#: src/BuildInfo.h
-msgid ", 64 bits"
-msgstr ", 64 bits"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "benchmark.txt"
-
-#. i18n-hint: This is the heading for a column in the edit macros dialog
-#: src/BatchProcessDialog.cpp
-msgid "Macro"
-msgstr "Macro"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#: src/AudacityLogger.cpp
-msgid "log.txt"
-msgstr "log.txt"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity não é produzido ou endossado por MuseCY SM Ltd. ou Dominic M "
-"Mazzoni."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"A marca Audacity%s é usada neste software unicamente por motivos "
-"informacionais e de descrição."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s contribuidores"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Harvey Lubin (logo)"
-msgstr "Harvey Lubin (logo)"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Por favor, perceba que os nomes estão em ordem alfabética, não em ordem de "
-"importância."
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#: plug-ins/vocoder.ny
-msgid "Edgar-RFT"
-msgstr "Edgar-RFT"
-
-#: plug-ins/vocoder.ny
-msgid "Vocoder"
-msgstr "Vocoder"
-
-#: plug-ins/vocalrediso.ny
-msgid "Robert Haenggi"
-msgstr "Robert Haenggi"
-
-#: plug-ins/tremolo.ny
-msgid "Tremolo"
-msgstr "Tremolo"
-
-#: plug-ins/sample-data-export.ny
-msgid "linear"
-msgstr "linear"
-
-#: plug-ins/sample-data-export.ny
-#, lisp-format
-msgid "~a linear, &nbsp;&nbsp;~a dB."
-msgstr "~a linear, &nbsp;&nbsp;~a dB."
-
-#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
-#: plug-ins/sample-data-export.ny
-#, lisp-format
-msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
-msgstr "<b>RMS</b> (sem peso): &nbsp;&nbsp;~a dB."
-
-#: plug-ins/sample-data-export.ny
-#, lisp-format
-msgid "~a linear, ~a dB."
-msgstr "~a linear, ~a dB."
-
-#: plug-ins/rissetdrum.ny
-msgid "Steven Jones"
-msgstr "Steven Jones"
-
-#: plug-ins/rhythmtrack.ny
-msgid "18 - 116"
-msgstr "18 - 116"
-
-#: plug-ins/rhythmtrack.ny
-msgid "Cowbell"
-msgstr "Cowbell"
-
-#: plug-ins/rhythmtrack.ny
-msgid "+/- 1"
-msgstr "+/- 1"
-
-#: plug-ins/rhythmtrack.ny
-msgid "Tempo (bpm)"
-msgstr "Tempo (bpm)"
-
-#: plug-ins/pluck.ny
-msgid "Gradual"
-msgstr "Gradual"
-
-#: plug-ins/pluck.ny
-msgid "David R.Sky"
-msgstr "David R.Sky"
-
-#: plug-ins/pluck.ny
-msgid "Pluck"
-msgstr "Pluck"
-
-#: plug-ins/nyquist-plug-in-installer.ny
-msgid "Plug-in"
-msgstr "Plug-in"
-
-#. i18n-hint: hours and minutes. Do not translate "~a".
-#: plug-ins/noisegate.ny
-#, lisp-format
-msgid "~ah ~am"
-msgstr "~ah ~am"
-
-#: plug-ins/noisegate.ny
-msgid "Gate"
-msgstr "Gate"
-
-#: plug-ins/limiter.ny plug-ins/noisegate.ny
-msgid "Hold (ms)"
-msgstr "Aguardar (ms)"
-
-#. i18n-hint: hours minutes and seconds. Do not translate "~a".
-#: plug-ins/label-sounds.ny
-#, lisp-format
-msgid "~ah ~am ~as"
-msgstr "~ah ~am ~as"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "48 dB"
-msgstr "48 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "36 dB"
-msgstr "36 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "24 dB"
-msgstr "24 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "12 dB"
-msgstr "12 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "6 dB"
-msgstr "6 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
-msgid "Dominic Mazzoni"
-msgstr "Dominic Mazzoni"
-
-#: plug-ins/delay.ny
-msgid "Bouncing Ball"
-msgstr "Bouncing Ball"
-
-#: plug-ins/delay.ny
-msgid "Regular"
-msgstr "Regular"
-
-#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
-msgid "Crossfading..."
-msgstr "Crossfading..."
-
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
-msgid "Steve Daulton"
-msgstr "Steve Daulton"
-
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
-msgid "Paul Licameli"
-msgstr "Paul Licameli"
-
-#. i18n-hint: This message describes the error in the Error dialog.
-#: src/widgets/UnwritableLocationErrorDialog.cpp
-msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
-msgstr ""
-"Por favor, verifique se o diretório existe, se tem as permissões necessárias "
-"e se o disco não está cheio."
-
-#: src/widgets/PopupMenuTable.h
-#, c-format
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. i18n-hint: Name of display format that shows log of frequency
-#. * in decades
-#: src/widgets/NumericTextCtrl.cpp
-msgid "decades"
-msgstr "décadas"
-
-#: src/widgets/NumericTextCtrl.cpp
-msgid "hertz"
-msgstr "hertz"
-
-#. i18n-hint: Name of display format that shows frequency in kilohertz
-#: src/widgets/NumericTextCtrl.cpp
-msgid "kHz"
-msgstr "kHz"
-
-#: src/widgets/NumericTextCtrl.cpp
-msgid "centihertz"
-msgstr "centihertz"
-
-#. i18n-hint: Name of time display format that shows time in days, hours,
-#. * minutes and seconds
-#: src/widgets/NumericTextCtrl.cpp
-msgid "dd:hh:mm:ss"
-msgstr "dd:hh:mm:ss"
-
-#. i18n-hint: Format string for displaying time in hours, minutes and
-#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
-#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
-#. * change the numbers unless there aren't 60 seconds in a minute in your
-#. * locale
-#: src/widgets/NumericTextCtrl.cpp
-msgid "0100 h 060 m 060 s"
-msgstr "0100 h 060 m 060 s"
-
-#. i18n-hint: Name of time display format that shows time in hours, minutes
-#. * and seconds
-#: src/widgets/NumericTextCtrl.cpp
-msgid "hh:mm:ss"
-msgstr "hh:mm:ss"
-
-#: src/widgets/Meter.cpp
-msgid "Vertical"
-msgstr "Vertical"
-
-#: src/widgets/Meter.cpp
-msgid "Horizontal"
-msgstr "Horizontal"
-
-#: src/widgets/KeyView.cpp
-msgid "Menu"
-msgstr "Menu"
-
-#. i18n-hint arrowhead meaning forward movement
-#: src/widgets/HelpSystem.cpp
-msgid ">"
-msgstr ">"
-
-#. i18n-hint arrowhead meaning backward movement
-#: src/widgets/HelpSystem.cpp
-msgid "<"
-msgstr "<"
-
-#. i18n-hint: "x" suggests a multiplicative factor
-#: src/widgets/ASlider.cpp
-#, c-format
-msgid "%.2fx"
-msgstr "%.2fx"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
-msgid "Zoom x2"
-msgstr "Zoom x2"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
-msgid "Zoom x1/2"
-msgstr "Zoom x1/2"
-
-#. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%+.1f dB"
-msgstr "%+.1f dB"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-#, c-format
-msgid "Mono, %dHz"
-msgstr "Mono, %dHz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "Mono"
-msgstr "Mono"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
-msgid "&Multi-view"
-msgstr "&Multi-view"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "384000 Hz"
-msgstr "384000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "352800 Hz"
-msgstr "352800 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "192000 Hz"
-msgstr "192000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "176400 Hz"
-msgstr "176400 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "96000 Hz"
-msgstr "96000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "88200 Hz"
-msgstr "88200 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "48000 Hz"
-msgstr "48000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "44100 Hz"
-msgstr "44100 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "22050 Hz"
-msgstr "22050 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "16000 Hz"
-msgstr "16000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "11025 Hz"
-msgstr "11025 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "8000 Hz"
-msgstr "8000 Hz"
-
-#. i18n-hint k abbreviating kilo meaning thousands
-#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
-msgid "k"
-msgstr "k"
-
-#: src/toolbars/ControlToolBar.cpp
-#, c-format
-msgid "%s."
-msgstr "%s."
-
-#: src/prefs/ThemePrefs.cpp
-msgid "Info"
-msgstr "Informação"
-
-#: src/prefs/SpectrumPrefs.cpp
-msgid "2048"
-msgstr "2048"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
-#: src/prefs/SpectrogramSettings.cpp
-msgid "ERB"
-msgstr "ERB"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Bark"
-msgstr "Bark"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Mel"
-msgstr "Mel"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Cross&fade:"
-msgstr "Cross&fade:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Pre-ro&ll:"
-msgstr "Pre-ro&ll:"
-
-#: src/prefs/QualitySettings.cpp
-msgid "24-bit"
-msgstr "24-bit"
-
-#: src/prefs/QualitySettings.cpp
-msgid "16-bit"
-msgstr "16-bit"
-
-#: src/prefs/QualityPrefs.cpp
-#, c-format
-msgid "%i Hz"
-msgstr "%i Hz"
-
-#: src/prefs/PlaybackPrefs.cpp
-msgid "&Micro-fades"
-msgstr "&Micro-fades"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Multi"
-msgstr "Multi"
-
-#: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
-msgid "Mouse"
-msgstr "Mouse"
-
-#: src/prefs/MousePrefs.cpp
-msgid "Ctrl"
-msgstr "Ctrl"
-
-#: src/prefs/MidiIOPrefs.h
-msgid "Midi IO"
-msgstr "ES Midi"
-
-#. i18n-hint Software interface to MIDI
-#: src/prefs/MidiIOPrefs.cpp
-msgctxt "MIDI"
-msgid "Interface"
-msgstr "Interface"
-
-#: src/prefs/ImportExportPrefs.h
-msgid "IMPORT EXPORT"
-msgstr "IMPORTAR EXPORTAR"
-
-#: src/prefs/GUIPrefs.h
-msgid "GUI"
-msgstr "GUI"
-
-#: src/prefs/GUIPrefs.cpp
-msgid "Local"
-msgstr "Local"
-
-#. i18n-hint: refers to Audacity's user interface settings
-#: src/prefs/GUIPrefs.cpp
-msgctxt "GUI"
-msgid "Interface"
-msgstr "Interface"
-
-#: src/prefs/ExtImportPrefs.h
-msgid "Ext Import"
-msgstr "Importar Ext"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/prefs/EffectsPrefs.cpp
-msgid "V&ST"
-msgstr "V&ST"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/prefs/EffectsPrefs.cpp
-msgid "&Vamp"
-msgstr "&Vamp"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/prefs/EffectsPrefs.cpp
-msgid "N&yquist"
-msgstr "N&yquist"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/prefs/EffectsPrefs.cpp
-msgid "LV&2"
-msgstr "LV&2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/prefs/EffectsPrefs.cpp
-msgid "&LADSPA"
-msgstr "&LADSPA"
-
-#: src/prefs/DevicePrefs.cpp
-msgid "1 (Mono)"
-msgstr "1 (Mono)"
-
-#. i18n-hint Software interface to audio devices
-#: src/prefs/DevicePrefs.cpp
-msgctxt "device"
-msgid "Interface"
-msgstr "Interface"
-
-#: src/menus/ViewMenus.cpp
-msgid "Zoom &Normal"
-msgstr "Zoom &Normal"
-
-#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
-#. * window) full sized
-#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
-msgid "&Zoom"
-msgstr "&Zoom"
-
-#: src/menus/SelectMenus.cpp
-msgid "&Cursor"
-msgstr "&Cursor"
-
-#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
-#: src/menus/PluginMenus.cpp
-msgid "Scripta&bles II"
-msgstr "Scriptá&veis II"
-
-#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
-#: src/menus/PluginMenus.cpp
-msgid "Script&ables I"
-msgstr "Script&áveis I"
-
-#: src/menus/PluginMenus.cpp
-msgid "&Macros..."
-msgstr "&Macros..."
-
-#: src/menus/PluginMenus.cpp
-msgid "..."
-msgstr "..."
-
-#: src/menus/NavigationMenus.cpp
-msgid "Foc&us"
-msgstr "Foc&o"
-
-#: src/menus/HelpMenus.cpp
-msgid "&Manual..."
-msgstr "&Manual..."
-
-#: src/menus/FileMenus.cpp
-msgid "&MIDI..."
-msgstr "&MIDI..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ext&ra"
-msgstr "Ext&ra"
-
-#: src/import/ImportRaw.cpp
-msgid "bytes"
-msgstr "bytes"
-
-#: src/import/ImportPCM.cpp
-msgid "Vorbis"
-msgstr "Vorbis"
-
-#: src/import/ImportPCM.cpp
-msgid "8 bit DPCM"
-msgstr "8 bit DPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "16 bit DPCM"
-msgstr "16 bit DPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "VOX ADPCM"
-msgstr "VOX ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "24 bit DWVW"
-msgstr "24 bit DWVW"
-
-#: src/import/ImportPCM.cpp
-msgid "16 bit DWVW"
-msgstr "16 bit DWVW"
-
-#: src/import/ImportPCM.cpp
-msgid "12 bit DWVW"
-msgstr "12 bit DWVW"
-
-#: src/import/ImportPCM.cpp
-msgid "24kbs G723 ADPCM"
-msgstr "24kbs G723 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "32kbs G721 ADPCM"
-msgstr "32kbs G721 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "GSM 6.10"
-msgstr "GSM 6.10"
-
-#: src/import/ImportPCM.cpp
-msgid "Microsoft ADPCM"
-msgstr "Microsoft ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "IMA ADPCM"
-msgstr "IMA ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "A-Law"
-msgstr "A-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "U-Law"
-msgstr "U-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "XI (FastTracker 2)"
-msgstr "XI (FastTracker 2)"
-
-#: src/import/ImportPCM.cpp
-msgid "WVE (Psion Series 3)"
-msgstr "WVE (Psion Series 3)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAVEX (Microsoft)"
-msgstr "WAVEX (Microsoft)"
-
-#: src/import/ImportPCM.cpp
-msgid "WAV (NIST Sphere)"
-msgstr "WAV (NIST Sphere)"
-
-#: src/import/ImportPCM.cpp
-msgid "W64 (SoundFoundry WAVE 64)"
-msgstr "W64 (SoundFoundry WAVE 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "VOC (Creative Labs)"
-msgstr "VOC (Creative Labs)"
-
-#: src/import/ImportPCM.cpp
-msgid "SF (Berkeley/IRCAM/CARL)"
-msgstr "SF (Berkeley/IRCAM/CARL)"
-
-#: src/import/ImportPCM.cpp
-msgid "SDS (Midi Sample Dump Standard)"
-msgstr "SDS (Midi Sample Dump Standard)"
-
-#: src/import/ImportPCM.cpp
-msgid "SD2 (Sound Designer II)"
-msgstr "SD2 (Sound Designer II)"
-
-#: src/import/ImportPCM.cpp
-msgid "RF64 (RIFF 64)"
-msgstr "RF64 (RIFF 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "RAW (header-less)"
-msgstr "RAW (header-less)"
-
-#: src/import/ImportPCM.cpp
-msgid "PVF (Portable Voice Format)"
-msgstr "PVF (Portable Voice Format)"
-
-#: src/import/ImportPCM.cpp
-msgid "PAF (Ensoniq PARIS)"
-msgstr "PAF (Ensoniq PARIS)"
-
-#: src/import/ImportPCM.cpp
-msgid "MPC (Akai MPC 2k)"
-msgstr "MPC (Akai MPC 2k)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-msgstr "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-msgstr "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-
-#: src/import/ImportPCM.cpp
-msgid "IFF (Amiga IFF/SVX8/SV16)"
-msgstr "IFF (Amiga IFF/SVX8/SV16)"
-
-#: src/import/ImportPCM.cpp
-msgid "HTK (HMM Tool Kit)"
-msgstr "HTK (HMM Tool Kit)"
-
-#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
-#: src/import/ImportPCM.cpp
-msgid "FLAC (FLAC Lossless Audio Codec)"
-msgstr "FLAC (FLAC Lossless Audio Codec)"
-
-#: src/import/ImportPCM.cpp
-msgid "CAF (Apple Core Audio File)"
-msgstr "CAF (Apple Core Audio File)"
-
-#: src/import/ImportPCM.cpp
-msgid "AVR (Audio Visual Research)"
-msgstr "AVR (Audio Visual Research)"
-
-#: src/import/ImportPCM.cpp
-msgid "AU (Sun/NeXT)"
-msgstr "AU (Sun/NeXT)"
-
-#: src/import/Import.cpp src/menus/ClipMenus.cpp
-#, c-format
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "WAV (Microsoft)"
-msgstr "WAV (Microsoft)"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "AIFF (Apple/SGI)"
-msgstr "AIFF (Apple/SGI)"
-
-#: src/export/ExportMP3.cpp
-msgid "65-105 kbps"
-msgstr "65-105 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "80-120 kbps"
-msgstr "80-120 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "95-135 kbps"
-msgstr "95-135 kbps"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "1"
-msgstr "1"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "0"
-msgstr "0"
-
-#: src/export/ExportCL.cpp
-msgid "&OK"
-msgstr "&OK"
-
-#: src/effects/nyquist/Nyquist.cpp
-msgid "plug-in"
-msgstr "plug-in"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/effects/lv2/LV2Effect.h
-msgid "LV2"
-msgstr "LV2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/effects/ladspa/LadspaEffect.h
-msgid "LADSPA"
-msgstr "LADSPA"
-
-#. i18n-hint: An item name introducing a value, which is not part of the string but
-#. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
-#, c-format
-msgid "%s:"
-msgstr "%s:"
-
-#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
-msgid "%"
-msgstr "%"
-
-#: src/effects/ScoreAlignDialog.cpp
-#, c-format
-msgid "%.3f"
-msgstr "%.3f"
-
-#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
-#: src/effects/ScienFilter.cpp
-msgid "Butterworth"
-msgstr "Butterworth"
-
-#: src/effects/Phaser.cpp
-msgid "Phaser"
-msgstr "Phaser"
-
-#: src/effects/Paulstretch.cpp
-msgid "Paulstretch"
-msgstr "Paulstretch"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "2"
-msgstr "2"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16384"
-msgstr "16384"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "8192"
-msgstr "8192"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "4096"
-msgstr "4096"
-
-#: src/effects/NoiseReduction.cpp
-msgid "1024"
-msgstr "1024"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "512"
-msgstr "512"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "256"
-msgstr "256"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "128"
-msgstr "128"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "64"
-msgstr "64"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "32"
-msgstr "32"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16"
-msgstr "16"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
-msgid "8"
-msgstr "8"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Hamming, Hann"
-msgstr "Hamming, Hann"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Blackman, Hann"
-msgstr "Blackman, Hann"
-
-#: src/effects/Loudness.cpp
-msgid "RMS dB"
-msgstr "RMS dB"
-
-#: src/effects/Loudness.cpp
-msgid "LUFS"
-msgstr "LUFS"
-
-#: src/effects/Loudness.cpp src/widgets/Meter.cpp
-msgid "RMS"
-msgstr "RMS"
-
-#: src/effects/FindClipping.cpp
-msgid "Clipping"
-msgstr "Recorte"
-
-#: src/effects/Equalization.cpp
-msgid "&Bench"
-msgstr "&Banco"
-
-#: src/effects/Equalization.cpp
-msgid "A&VX"
-msgstr "A&VX"
-
-#: src/effects/Equalization.cpp
-msgid "&SSE"
-msgstr "&SSE"
-
-#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%gk"
-msgstr "%gk"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%g kHz"
-msgstr "%g kHz"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "- dB"
-msgstr "- dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-#, c-format
-msgid "%d dB"
-msgstr "%d dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "+ dB"
-msgstr "+ dB"
-
-#: src/effects/Equalization.cpp
-msgid "RIAA"
-msgstr "RIAA"
-
-#: src/effects/Equalization.cpp
-msgid "Bass Boost"
-msgstr "Amplificação de Grave"
-
-#: src/effects/Equalization.cpp
-msgid "100Hz Rumble"
-msgstr "100Hz Rumble"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/effects/Effect.h
-msgid "Nyquist"
-msgstr "Nyquist"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%0.f ms"
-msgstr "%0.f ms"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.0f ms"
-msgstr "%.0f ms"
-
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.1f %%"
-msgstr "%.1f %%"
-
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
-msgid "&Amplitude (0-1):"
-msgstr "&Amplitude (0-1):"
-
-#: src/effects/Distortion.cpp
-msgid "Drive"
-msgstr "Drive"
-
-#: src/effects/Distortion.cpp src/effects/Equalization.cpp
-msgid "Walkie-talkie"
-msgstr "Walkie talkie"
-
-#. i18n-hint: day of month, month, year, hour, minute, second
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%d %s %02d %02dh %02dm %02ds"
-msgstr "%d %s %02d %02dh %02dm %02ds"
-
-#. i18n-hint: short form of 'decibels'
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB"
-msgstr "%.2f dB"
-
-#. i18n-hint: dB abbreviates decibels
-#. * RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB RMS"
-msgstr "%.2f dB RMS"
-
-#: src/effects/Contrast.cpp
-msgid "zero"
-msgstr "zero"
-
-#. i18n-hint: dB abbreviates decibels
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%s dB"
-msgstr "%s dB"
-
-#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "RMS = %s."
-msgstr "RMS = %s."
-
-#: src/effects/Contrast.cpp
-msgid "Volume    "
-msgstr "Volume    "
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.1f:1"
-msgstr "%.1f:1"
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.0f:1"
-msgstr "%.0f:1"
-
-#. i18n-hint: usually leave this as is as dB doesn't get translated
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%3d dB"
-msgstr "%3d dB"
-
-#: src/effects/Compressor.cpp
-msgid "Compressor"
-msgstr "Compressor"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "78"
-msgstr "78"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "45"
-msgstr "45"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "33⅓"
-msgstr "33⅓"
-
-#: src/effects/BassTreble.cpp
-msgid "&Volume (dB):"
-msgstr "&Volume (dB):"
-
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
-msgid "db"
-msgstr "db"
-
-#: src/effects/AutoDuck.cpp
-msgid "Auto Duck"
-msgstr "Ducking Automático"
-
-#: src/commands/SetTrackInfoCommand.cpp
-msgid "VZoom:"
-msgstr "VZoom:"
-
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "Linear"
-msgstr "Linear"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "Y:"
-msgstr "Y:"
-
-#: src/commands/SetProjectCommand.cpp
-msgid "X:"
-msgstr "X:"
-
-#. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
-msgid "Envelope"
-msgstr "Envelope"
-
-#: src/commands/ScreenshotCommand.cpp
-msgid "Scriptables"
-msgstr "Scriptáveis"
-
-#: src/commands/HelpCommand.cpp
-msgid "_"
-msgstr "_"
-
-#. i18n-hint name of a computer programming language
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "LISP"
-msgstr "LISP"
-
-#. i18n-hint JavaScript Object Notation
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "JSON"
-msgstr "JSON"
-
-#: src/commands/GetInfoCommand.cpp
-msgid "Envelopes"
-msgstr "Envelopes"
-
-#: src/commands/GetInfoCommand.cpp
-msgid "Menus"
-msgstr "Menus"
-
-#. i18n-hint abbreviates "Identity" or "Identifier"
-#: src/commands/DragCommand.cpp
-msgid "Id:"
-msgstr "Id:"
-
-#: src/commands/Demo.cpp
-msgid "Demo"
-msgstr "Demonstração"
-
-#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%s: %s"
-msgstr "%s: %s"
-
-#. i18n-hint a format string for hours, minutes, and seconds
-#: src/TimerRecordDialog.cpp
-msgid "099 h 060 m 060 s"
-msgstr "099 h 060 m 060 s"
-
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
-msgid "Mixer"
-msgstr "Mixador"
-
-#: src/export/ExportMP3.cpp
-msgid "110-150 kbps"
-msgstr "110-150 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "145-185 kbps"
-msgstr "145-185 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "155-195 kbps"
-msgstr "155-195 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "170-210 kbps"
-msgstr "170-210 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "200-250 kbps"
-msgstr "200-250 kbps"
-
-#: src/export/ExportFLAC.cpp
-msgid "24 bit"
-msgstr "24 bit"
-
-#: src/export/ExportFLAC.cpp
-msgid "16 bit"
-msgstr "16 bit"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LPC"
-msgstr "LPC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VBL"
-msgstr "VBL"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LTP"
-msgstr "LTP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LC"
-msgstr "LC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "60 ms"
-msgstr "60 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "40 ms"
-msgstr "40 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "20 ms"
-msgstr "20 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10 ms"
-msgstr "10 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "5 ms"
-msgstr "5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "2.5 ms"
-msgstr "2.5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VOIP"
-msgstr "VOIP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10"
-msgstr "10"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "9"
-msgstr "9"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "7"
-msgstr "7"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "6"
-msgstr "6"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "5"
-msgstr "5"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "4"
-msgstr "4"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "3"
-msgstr "3"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#: src/export/ExportFFmpegDialogs.cpp
-#, c-format
-msgid "%.2f kbps"
-msgstr "%.2f kbps"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
-#, c-format
-msgid "%d kbps"
-msgstr "%d kbps"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/effects/vamp/VampEffect.h
-msgid "Vamp"
-msgstr "Vamp"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/effects/VST/VSTEffect.h
-msgid "VST"
-msgstr "VST"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -3,11 +3,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-30 17:56+0000\n"
 "Last-Translator: SC <lalocas@protonmail.com>\n"
-"Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
-"tenacity/tenacity/pt_PT/>\n"
+"Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/tenacity/tenacity/pt_PT/>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,71 +15,32 @@ msgstr ""
 "X-Generator: Weblate 4.8.1-dev\n"
 "X-Poedit-SourceCharset: iso-8859-1\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Atualizar o Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Ignorar"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Instalar atualização"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Ler mais no GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Erro ao verificar a atualização"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Não foi possível ligar ao servidor de atualização do Tenacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Os dados de atualização estavam corrompidos."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Erro ao descarregar atualização."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Não foi possível abrir a hiperligação de atualização do Tenacity."
-
-# Diz assim 'barra de dispositivo do audacity' 'barra de transcrição do
-# audacity'
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Está disponível o Tenacity %s !"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Gravação"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Não foi possível determinar"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -202,8 +162,14 @@ msgstr "P&arar\tF6"
 msgid "&About"
 msgstr "S&obre"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Guardar script"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Saída"
 
@@ -212,10 +178,19 @@ msgid "Load Nyquist script"
 msgstr "Carregar script Nyquist"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr "Scripts Nyquist (*.ny)|*.ny|Scripts Lisp (*.lsp)|*.lsp|Todos os ficheiros|*"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Script was not saved."
 msgstr "O script não foi guardado."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Aviso"
 
@@ -228,10 +203,25 @@ msgid "Find dialog"
 msgstr "Encontrar diálogo"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "Harvey Lubin (logo)"
 msgstr ""
-"Módulo externo do Tenacity que disponibiliza um IDE simples para fazer "
-"efeitos."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr "Tango Icon Gallery (ícones da barra de ferramentas)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr "Módulo externo do Tenacity que disponibiliza um IDE simples para fazer efeitos."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -253,7 +243,8 @@ msgstr "Sem-título"
 msgid "Nyquist Effect Workbench - "
 msgstr "Painel de efeitos Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Novo"
 
@@ -293,7 +284,8 @@ msgstr "Copiar"
 msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Cortar"
 
@@ -301,7 +293,8 @@ msgstr "Cortar"
 msgid "Cut to clipboard"
 msgstr "Cortar para a área de transferência"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Colar"
 
@@ -326,7 +319,8 @@ msgstr "Selecionar tudo"
 msgid "Select all text"
 msgstr "Selecionar todo o texto"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Desfazer"
 
@@ -334,7 +328,8 @@ msgstr "Desfazer"
 msgid "Undo last change"
 msgstr "Desfazer última alteração"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Refazer"
 
@@ -391,7 +386,8 @@ msgid "Go to next S-expr"
 msgstr "Ir à S-expr seguinte"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Início"
 
@@ -399,7 +395,8 @@ msgstr "Início"
 msgid "Start script"
 msgstr "Iniciar script"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Parar"
 
@@ -413,15 +410,23 @@ msgstr "Parar script"
 msgid "About %s"
 msgstr "Sobre %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "OK"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informações da compilação"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Ativado"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Desativado"
 
@@ -431,6 +436,11 @@ msgid "The Build"
 msgstr "Informação da compilação"
 
 #: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Versão"
+
+#: src/AboutDialog.cpp
 msgid "Build type:"
 msgstr "Tipo de compilação:"
 
@@ -438,22 +448,28 @@ msgstr "Tipo de compilação:"
 msgid "Compiler:"
 msgstr "Compilador:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefixo de instalação:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Pasta de configurações:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Pasta de configurações:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Suporte ao formato de ficheiros"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Biblioteca GUI multi-plataforma"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -467,7 +483,6 @@ msgstr "Conversão da frequência de amostragem"
 msgid "MP3 Importing"
 msgstr "Importar MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Importar e exportar Ogg Vorbis"
@@ -476,7 +491,6 @@ msgstr "Importar e exportar Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Suporte a etiquetas ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Importar e exportar FLAC"
@@ -494,14 +508,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Importar/exportar FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importar via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Funcionalidades"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Suporte a plug-in"
 
@@ -516,6 +522,10 @@ msgstr "Suporte a alteração de tom e ritmo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Suporte a alteração extrema de tom e ritmo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Funcionalidades"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -608,8 +618,20 @@ msgstr "%s, compositor do Audacity"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, tester"
+msgstr "%s, testagem do Audacity"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, plug-ins Nyquist do Audacity"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, web developer"
+msgstr "%s, desenvolvimento web do Audacity"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -622,16 +644,22 @@ msgstr "%s, gráficos do Audacity"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (incorporando %s, %s, %s, %s e %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Programa multiplataforma, livre e de código aberto, para gravar e editar "
-"sons."
+msgstr "Programa multiplataforma, livre e de código aberto, para gravar e editar sons."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Créditos"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Note que os nomes estão ordenados alfabeticamente e não por ordem de importância."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -664,6 +692,10 @@ msgid "%s Team Members"
 msgstr "%s membros da equipa"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr "Eméritos do Audacity:"
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Colaboradores do Audacity"
 
@@ -676,11 +708,10 @@ msgstr "Website e gráficos do Audacity"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
-msgstr ""
-"Tradução para Português por Bruno Ramalhete (2019), Bruno Gravato, Inácio "
-"Barroso, Cleber Tavano (2002-2021) e SC (2021)."
+msgstr "Tradução para Português por Bruno Ramalhete (2019), Bruno Gravato, Inácio Barroso, Cleber Tavano (2002-2021) e SC (2021)."
 
 #: src/AboutDialog.cpp
 msgid "Translators"
@@ -689,6 +720,28 @@ msgstr "Tradutores do Audacity"
 #: src/AboutDialog.cpp
 msgid "Special thanks:"
 msgstr "Agradecimentos especiais do Audacity:"
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s website: "
+msgstr "%s sítio na web: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s colaboradores"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "A marca Audacity%s é usada neste software unicamente por motivos informativos e de descrição."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "O Tenacity não é produzido ou endossado pela empresa MuseCY SM Ltd. nem Dominic M Mazzoni."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -711,6 +764,7 @@ msgstr "Linha de tempo"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Clique e arraste para iniciar a Procura"
@@ -718,6 +772,7 @@ msgstr "Clique e arraste para iniciar a Procura"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Clique ou arraste para iniciar o Percorrer"
@@ -725,6 +780,7 @@ msgstr "Clique ou arraste para iniciar o Percorrer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Clicar e mover para Percorrer. Clicar & arrastar para Procurar."
@@ -732,6 +788,7 @@ msgstr "Clicar e mover para Percorrer. Clicar & arrastar para Procurar."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Mover para Procurar"
@@ -739,6 +796,7 @@ msgstr "Mover para Procurar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Mover para Percorrer"
@@ -795,7 +853,17 @@ msgstr ""
 "Não foi possível bloquear a região para além\n"
 "do final do projeto."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Erro"
 
@@ -816,11 +884,11 @@ msgid ""
 msgstr ""
 "Repor as preferências de origem? \n"
 "\n"
-"Esta pergunta só é feita uma vez, após uma instalação, para saber se "
-"pretende repor as preferências originais."
+"Esta pergunta só é feita uma vez, após uma instalação, para saber se pretende repor as preferências originais."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Repor preferências do Tenacity"
 
 #: src/AudacityApp.cpp
@@ -835,10 +903,9 @@ msgstr ""
 "Foi removido da lista de ficheiros recentes."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
-msgstr ""
-"Não foi possível iniciar a biblioteca SQLite. O Tenacity não consegue "
-"continuar."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr "Não foi possível iniciar a biblioteca SQLite. O Tenacity não consegue continuar."
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -862,7 +929,7 @@ msgstr "&Abrir..."
 msgid "Open &Recent..."
 msgstr "Abrir &recente..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&Sobre o Tenacity…"
 
@@ -875,35 +942,34 @@ msgid "&File"
 msgstr "&Ficheiro"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
-"O Tenacity não conseguiu encontrar um lugar seguro onde guardar os ficheiros "
-"temporários.\n"
-"É necessário um sítio onde os programas de limpeza externos não eliminem os "
-"ficheiros temporários do Tenacity.\n"
+"O Tenacity não conseguiu encontrar um lugar seguro onde guardar os ficheiros temporários.\n"
+"É necessário um sítio onde os programas de limpeza externos não eliminem os ficheiros temporários do Tenacity.\n"
 "Por favor indique um diretório apropriado nas preferências."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
-"O Tenacity não conseguiu encontrar um sítio onde guardar os ficheiros "
-"temporários.\n"
+"O Tenacity não conseguiu encontrar um sítio onde guardar os ficheiros temporários.\n"
 "Por favor indique um diretório apropriado nas preferências."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"O Tenacity irá agora fechar. Abra o programa novamente para utilizar a nova "
-"pasta temporária."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "O Tenacity irá agora fechar. Abra o programa novamente para utilizar a nova pasta temporária."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -912,16 +978,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
-"O Tenacity não conseguiu acesso exclusivo ao diretório de ficheiros "
-"temporários.\n"
+"O Tenacity não conseguiu acesso exclusivo ao diretório de ficheiros temporários.\n"
 "O diretório pode estar a ser usado por outra cópia do Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Mesmo assim quer iniciar o Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -929,19 +996,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Erro ao bloquear a pasta temporária"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "O sistema detetou outra cópia do Tenacity em execução.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Use os comandos Novo ou Abrir na janela aberta do Tenacity\n"
 "para abrir vários projetos em simultâneo.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "O Tenacity já está em execução"
 
 #: src/AudacityApp.cpp
@@ -957,7 +1027,8 @@ msgstr ""
 "e pode ser necessário reiniciar o computador."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "O arranque do Tenacity falhou"
 
 #: src/AudacityApp.cpp
@@ -997,8 +1068,9 @@ msgstr ""
 "e pode ser necessário reiniciar o computador."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1030,7 +1102,8 @@ msgstr "correr testes de diagnóstico"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "mostrar a versão do Tenacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1040,9 +1113,10 @@ msgid "audio or project file name"
 msgstr "áudio ou nome do ficheiro do projeto"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1055,16 +1129,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Ficheiros de projeto do Tenacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Mensagem"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Erro de configuração do Tenacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1074,28 +1150,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Não foi possível aceder ao ficheiro de configuração seguinte:\n"
 "\n"
 "\t%s\n"
 "\n"
-"Isto pode ser causado por várias razões, mas o mais provável é que o disco "
-"esteja cheio ou não tem permissões de escrita para o ficheiro. Pode obter "
-"mais informação clicando no botão de ajuda abaixo.\n"
+"Isto pode ser causado por várias razões, mas o mais provável é que o disco esteja cheio ou não tem permissões de escrita para o ficheiro. Pode obter mais informação clicando no botão de ajuda abaixo.\n"
 "\n"
-"Pode tentar corrigir o problema e depois clicar em \"Repetir\" para "
-"continuar.\n"
+"Pode tentar corrigir o problema e depois clicar em \"Repetir\" para continuar.\n"
 "\n"
-"Se escolher em \"Sair do Tenacity\", o seu projeto pode ser deixado num "
-"estado não guardado que poderá ser recuperado da próxima vez que o abrir."
+"Se escolher em \"Sair do Tenacity\", o seu projeto pode ser deixado num estado não guardado que poderá ser recuperado da próxima vez que o abrir."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Ajuda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Sair do Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1103,7 +1178,8 @@ msgid "&Retry"
 msgstr "Tenta&r novamente"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Relatório do Tenacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1115,7 +1191,8 @@ msgstr "&Guardar..."
 msgid "Cl&ear"
 msgstr "&Limpar"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Fechar"
 
@@ -1170,7 +1247,8 @@ msgid "Error Initializing Midi"
 msgstr "Erro ao inicializar o MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Áudio do Tenacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1185,49 +1263,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Memória cheia!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr ""
-"O ajuste automático do volume de gravação terminou. Não foi possível "
-"otimizar mais. Ainda está muito elevado."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "O ajuste automático do volume de gravação diminuiu o volume para %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr ""
-"O ajuste automático do volume de gravação terminou. Não foi possível "
-"otimizar mais. Ainda está muito baixo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "O ajuste automático do volume de gravação aumentou o volume para %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr ""
-"O ajuste automático de volume de gravação terminou. O número total de "
-"análises foi excedido sem encontrar um volume aceitável. Ainda está muito "
-"alto."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr ""
-"O ajuste automático de volume de gravação terminou. O número total de "
-"análises foi excedido sem encontrar um volume aceitável. O volume ainda está "
-"muito baixo."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr ""
-"O Ajuste automático de volume de gravação terminou. %.2f parece um volume "
-"aceitável."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1324,46 +1359,7 @@ msgstr "Não foi encontrado nenhum dispositivo de reprodução para '%s'.\n"
 
 #: src/AudioIOBase.cpp
 msgid "Cannot check mutual sample rates without both devices.\n"
-msgstr ""
-"Não é possível verificar frequências de amostragem mútuas sem ambos os "
-"dispositivos.\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Recebido %d ao abrir os dispositivos\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Não foi possível abrir o Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Misturadores disponíveis:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Fontes de gravação disponíveis:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volumes de reprodução disponíveis:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "O volume de gravação é emulado\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "O volume de gravação é nativo\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "O volume de reprodução é emulado\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "O volume de reprodução é nativo\n"
+msgstr "Não é possível verificar frequências de amostragem mútuas sem ambos os dispositivos.\n"
 
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
@@ -1407,28 +1403,29 @@ msgid "Automatic Crash Recovery"
 msgstr "Recuperação automática de falhas"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
-"Os projetos seguintes não foram guardados corretamente da última vez que "
-"executou o Tenacity e podem ser automaticamente recuperados.\n"
+"Os projetos seguintes não foram guardados corretamente da última vez que executou o Tenacity e podem ser automaticamente recuperados.\n"
 "\n"
-"Após a recuperação, guarde os projetos para garantir que as alterações sejam "
-"gravadas no disco."
+"Após a recuperação, guarde os projetos para garantir que as alterações sejam gravadas no disco."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "&Projetos recuperáveis"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Selecionar"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nome"
 
@@ -1456,8 +1453,7 @@ msgid ""
 msgstr ""
 "Tem a certeza que quer descartar os projetos selecionados?\n"
 "\n"
-"Escolher \"Sim\" elimina permanentemente os projetos selecionados "
-"imediatamente."
+"Escolher \"Sim\" elimina permanentemente os projetos selecionados imediatamente."
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -1492,6 +1488,10 @@ msgid "MP3 Conversion"
 msgstr "Conversão MP3"
 
 #: src/BatchCommands.cpp
+msgid "Fade Ends"
+msgstr "Suavização na saída (fade-end)"
+
+#: src/BatchCommands.cpp
 msgid "Import Macro"
 msgstr "Importar macro"
 
@@ -1511,6 +1511,11 @@ msgstr "Efeito"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Comando de menu (com parâmetros)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1580,6 +1585,11 @@ msgstr "Gerir macros"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Selecionar macro"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+msgid "Macro"
+msgstr "Macro"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply Macro to:"
@@ -1651,13 +1661,19 @@ msgstr "Res&taurar"
 msgid "I&mport..."
 msgstr "&Importar…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xportar…"
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Editar passos"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr "Número"
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1687,7 +1703,8 @@ msgstr "Mover para &cima"
 msgid "Move &Down"
 msgstr "Mover para &baixo"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Guardar"
 
@@ -1734,6 +1751,11 @@ msgstr "Os nomes não podem conter '%c' e '%c'"
 msgid "Are you sure you want to delete %s?"
 msgstr "Tem a certeza que quer eliminar %s?"
 
+#. i18n-hint: Benchmark means a software speed test
+#: src/Benchmark.cpp
+msgid "Benchmark"
+msgstr "Teste de desempenho"
+
 #: src/Benchmark.cpp
 msgid "Disk Block Size (KB):"
 msgstr "Tamanho do bloco do disco (KB):"
@@ -1765,9 +1787,16 @@ msgid "Run"
 msgstr "Executar"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Fechar"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "testedesempenho.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1788,8 +1817,7 @@ msgstr "O tamanho dos dados de teste devem estar entre 1 e 2000 MB."
 #: src/Benchmark.cpp
 #, c-format
 msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
-msgstr ""
-"A utilizar %lld pedaços de %lld amostras cada, para um total de %.1f MB.\n"
+msgstr "A utilizar %lld pedaços de %lld amostras cada, para um total de %.1f MB.\n"
 
 #: src/Benchmark.cpp
 msgid "Preparing...\n"
@@ -1906,10 +1934,6 @@ msgid "No revision identifier was provided"
 msgstr "Não foi fornecido nenhum identificador de revisão"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Data e hora desconhecidos"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Compilação de depuração (nível de depuração %d)"
@@ -1918,6 +1942,10 @@ msgstr "Compilação de depuração (nível de depuração %d)"
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "Compilação de lançamento (nível de depuração %d)"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ", 64 bits"
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1935,17 +1963,13 @@ msgstr ""
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
-msgstr ""
-"Selecione o áudio para o %s para usar (por exemplo, Cmd + A para selecionar "
-"tudo) e tente de novo."
+msgstr "Selecione o áudio para o %s para usar (por exemplo, Cmd + A para selecionar tudo) e tente de novo."
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
 #, c-format
 msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
-msgstr ""
-"Selecione o áudio para o %s para usar (por exemplo, Ctrl + A para selecionar "
-"tudo) e tente de novo."
+msgstr "Selecione o áudio para o %s para usar (por exemplo, Ctrl + A para selecionar tudo) e tente de novo."
 
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
@@ -1995,6 +2019,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Não foi possível entrar no modo de segurança na conexão primária com %s"
 
@@ -2006,6 +2035,11 @@ msgstr "Não foi possível entrar no modo de segurança no ponto de conexão com
 #: src/DBConnection.cpp
 msgid "Checkpointing project"
 msgstr "A criar o ponto de restauração no projeto"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "Checkpointing %s"
+msgstr "A criar o ponto de restauração %s"
 
 #: src/DBConnection.cpp src/ProjectFileIO.cpp
 msgid "This may take several seconds"
@@ -2082,10 +2116,8 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Os ficheiros mostrados como EM FALTA foram movidos ou eliminados e não podem "
-"ser copiados.\n"
-"Restaure os ficheiros para a sua localização original para poder copiá-los "
-"para o projeto."
+"Os ficheiros mostrados como EM FALTA foram movidos ou eliminados e não podem ser copiados.\n"
+"Restaure os ficheiros para a sua localização original para poder copiá-los para o projeto."
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -2151,28 +2183,30 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Copiar nomes para a área de transferência"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Em falta"
 
 #: src/Dependencies.cpp
 msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
-msgstr ""
-"Se continuar, o projeto não será guardado no disco. Tem a certeza que quer "
-"continuar?"
+msgstr "Se continuar, o projeto não será guardado no disco. Tem a certeza que quer continuar?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
-"O seu projeto é independente. Ele não depende de quaisquer ficheiros de "
-"áudio externos. \n"
+"O seu projeto é independente. Ele não depende de quaisquer ficheiros de áudio externos. \n"
 "\n"
-"Alguns projetos mais antigos do Tenacity podem não ser independentes, e é "
-"preciso cuidado \n"
+"Alguns projetos mais antigos do Tenacity podem não ser independentes, e é preciso cuidado \n"
 "para manter as suas dependências externas no lugar certo.\n"
 "Os projetos novos serão independentes e são menos arriscados."
 
@@ -2182,7 +2216,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Verificar dependências"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nenhum"
 
@@ -2190,7 +2227,7 @@ msgstr "Nenhum"
 msgid "Rectangle"
 msgstr "Retângulo"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triângulo"
 
@@ -2202,19 +2239,65 @@ msgstr "Moldado"
 msgid "Rectangular"
 msgstr "Retangular"
 
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Bem-vindo(a)!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr "Gaussiano(a=2.5)"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr "Gaussiano(a=3.5)"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr "Gaussiano(a=4.5)"
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Suporte a FFmpeg não compilado"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
-"O FFmpeg foi configurado nas preferências e carregado com sucesso "
-"anteriormente, \n"
+"O FFmpeg foi configurado nas preferências e carregado com sucesso anteriormente, \n"
 "mas o Tenacity desta vez não conseguiu carregá-lo no arranque. \n"
 "\n"
 "Tente reconfigurá-lo em Preferências > Bibliotecas."
@@ -2232,10 +2315,9 @@ msgid "Locate FFmpeg"
 msgstr "Localizar o FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"O Tenacity precisa do ficheiro %s para importar e exportar áudio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "O Tenacity precisa do ficheiro %s para importar e exportar áudio via FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2247,7 +2329,8 @@ msgstr "Localização de '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Para encontrar '%s', clique aqui -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Explorar..."
 
@@ -2273,8 +2356,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg não encontrado"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2304,26 +2388,24 @@ msgid "Only libavformat.so"
 msgstr "Apenas libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "O Tenacity não conseguiu abrir o ficheiro em %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "O Tenacity não conseguiu ler o ficheiro em %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
-msgstr ""
-"O Tenacity gravou com sucesso um ficheiro em %s mas não conseguiu alterar o "
-"nome para %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr "O Tenacity gravou com sucesso um ficheiro em %s mas não conseguiu alterar o nome para %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2361,7 +2443,9 @@ msgstr "Não &copiar qualquer áudio"
 msgid "As&k"
 msgstr "Per&guntar"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Todos os ficheiros"
 
@@ -2370,6 +2454,10 @@ msgstr "Todos os ficheiros"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Ficheiros de projeto AUP3"
+
+#: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr "Bibliotecas dinâmicas do sistema"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -2382,6 +2470,10 @@ msgstr "Ficheiros de texto"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Ficheiros XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ", "
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2446,9 +2538,33 @@ msgstr "Frequência linear"
 msgid "Log frequency"
 msgstr "Frequência logarítmica"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Deslocamento"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+msgid "Zoom"
+msgstr "Ampliação"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
@@ -2457,6 +2573,10 @@ msgstr "Dividir &horizontalmente"
 #: src/FreqWindow.cpp
 msgid "Zoom Horizontal"
 msgstr "Dividir &horizontalmente"
+
+#: src/FreqWindow.cpp
+msgid "Cursor:"
+msgstr "Cursor:"
 
 #: src/FreqWindow.cpp
 msgid "Peak:"
@@ -2492,26 +2612,58 @@ msgstr "&Redesenhar..."
 
 #: src/FreqWindow.cpp
 msgid "To plot the spectrum, all selected tracks must be the same sample rate."
-msgstr ""
-"Para desenhar o espectro, todas as pistas selecionadas devem ter a mesma "
-"frequência de amostragem."
+msgstr "Para desenhar o espectro, todas as pistas selecionadas devem ter a mesma frequência de amostragem."
 
 #: src/FreqWindow.cpp
 #, c-format
 msgid "Too much audio was selected. Only the first %.1f seconds of audio will be analyzed."
-msgstr ""
-"Foi selecionado demasiado áudio. Só os primeiros %.1f segundos de áudio "
-"serão analisados."
+msgstr "Foi selecionado demasiado áudio. Só os primeiros %.1f segundos de áudio serão analisados."
 
 #: src/FreqWindow.cpp
 msgid "Not enough data selected."
 msgstr "Não foram selecionados dados suficientes."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr "%.4f seg (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr "%.4f seg (%d Hz) (%s) = %.3f"
+
+#: src/FreqWindow.cpp
+msgid "spectrum.txt"
+msgstr "espectro.txt"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Exportar dados do espectro como:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Não foi possível gravar no ficheiro: %s"
@@ -2588,21 +2740,15 @@ msgstr "Sem ajuda local"
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
-msgstr ""
-"<br><br>A versão do Tenacity que está a utilizar é uma <b>versão de teste "
-"Alfa</b>."
+msgstr "<br><br>A versão do Tenacity que está a utilizar é uma <b>versão de teste Alfa</b>."
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
-msgstr ""
-"<br><br>A versão do Tenacity que está a utilizar é uma <b>versão de teste "
-"Beta</b>."
+msgstr "<br><br>A versão do Tenacity que está a utilizar é uma <b>versão de teste Beta</b>."
 
 #: src/HelpText.cpp
 msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
-msgstr ""
-"Recomendamos a utilização da versão final estável, que contém toda a "
-"documentação e suporte.<br><br>"
+msgstr "Recomendamos a utilização da versão final estável, que contém toda a documentação e suporte.<br><br>"
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
@@ -2619,16 +2765,12 @@ msgstr "Estas são as nossas opções de suporte:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[help:Quick_Help|Ajuda rápida]] - se não estiver instalado localmente, "
-"[[https://manual.audacityteam.org/quick_help.html|ver na internet]]"
+msgstr "[[help:Quick_Help|Ajuda rápida]] - se não estiver instalado localmente, [[https://manual.audacityteam.org/quick_help.html|ver na internet]]"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
-msgstr ""
-" [[help:Main_Page|Manual]] - se não estiver instalado localmente, "
-"[[https://manual.audacityteam.org/|ver na internet]]"
+msgstr " [[help:Main_Page|Manual]] - se não estiver instalado localmente, [[https://manual.audacityteam.org/|ver na internet]]"
 
 #: src/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
@@ -2636,38 +2778,23 @@ msgstr " Fórum - faça a sua pergunta diretamente na internet."
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"Mais:</b> visite a nossa wiki para dicas, truques, tutoriais extra e plug-"
-"ins de efeitos."
+msgstr "Mais:</b> visite a nossa wiki para dicas, truques, tutoriais extra e plug-ins de efeitos."
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"O Tenacity pode importar ficheiros desprotegidos em muitos outros formatos ("
-"como M4A e WMA, ficheiros WAV comprimidos de gravadores portáteis e áudio de "
-"ficheiros de vídeo) se descarregar e instalar a biblioteca FFmpeg opcional "
-"para o seu computador."
+msgstr "O Tenacity pode importar ficheiros desprotegidos em muitos outros formatos (como M4A e WMA, ficheiros WAV comprimidos de gravadores portáteis e áudio de ficheiros de vídeo) se descarregar e instalar a biblioteca FFmpeg opcional para o seu computador."
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"Também pode ler a nossa ajuda ao importar ficheiros MIDI e faixas de CDs de "
-"áudio."
+msgstr "Também pode ler a nossa ajuda ao importar ficheiros MIDI e faixas de CDs de áudio."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Parece que a pasta 'help' não está instalada. <br> Por favor,  [[*URL*|veja "
-"o Manual na internet]].<br><br>Para ver sempre o Manual na internet, altere "
-"nas preferências a \"Localização do manual\" para a opção \"Da internet\"."
+msgstr "Parece que a pasta 'help' não está instalada. <br> Por favor,  [[*URL*|veja o Manual na internet]].<br><br>Para ver sempre o Manual na internet, altere nas preferências a \"Localização do manual\" para a opção \"Da internet\"."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Parece que o Manual não está instalado. Por favor [[*URL*|veja o Manual na "
-"internet]] ou descarregue o Manual.<br><br>Para poder ver sempre o Manual na "
-"internet, altere nas preferências a \"Localização do manual\" para a opção "
-"\"Da internet\"."
+msgstr "Parece que o Manual não está instalado. Por favor [[*URL*|veja o Manual na internet]] ou descarregue o Manual.<br><br>Para poder ver sempre o Manual na internet, altere nas preferências a \"Localização do manual\" para a opção \"Da internet\"."
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2726,19 +2853,19 @@ msgid "&History..."
 msgstr "&Histórico..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Erro interno em %s em %s linha %d.\n"
 "Por favor informe a equipa do Tenacity em https://tenacityaudio.org/"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Erro interno em %s em %s na linha %d.\n"
 "Por favor informe a equipa do Tenacity em https://tenacityaudio.org/"
@@ -2757,7 +2884,9 @@ msgid "Track"
 msgstr "Faixa"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Rótulo"
 
@@ -2787,8 +2916,7 @@ msgstr "Novo…"
 
 #: src/LabelDialog.cpp
 msgid "Press F2 or double click to edit cell contents."
-msgstr ""
-"Clique duplo ou pressione a tecla F2 para editar o conteúdo das células."
+msgstr "Clique duplo ou pressione a tecla F2 para editar o conteúdo das células."
 
 #: src/LabelDialog.cpp src/menus/FileMenus.cpp
 msgid "Select a text file containing labels"
@@ -2818,7 +2946,8 @@ msgstr "Introduza o nome da faixa"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Faixa de rótulos"
 
@@ -2829,11 +2958,13 @@ msgstr "Não foi possível ler um ou mais rótulos guardados."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Primeira execução do Tenacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Escolha o idioma a utilizar no Tenacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2843,7 +2974,8 @@ msgstr "Escolha o idioma a utilizar no Tenacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "O idioma escolhido, %s (%s), não é o mesmo do idioma do sistema, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -2861,8 +2993,18 @@ msgstr ""
 "O ficheiro antigo foi guardado como '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "A abrir um projeto do Tenacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Karaoke do Tenacity%s"
+
+#: src/LyricsWindow.cpp
+msgid "&Karaoke..."
+msgstr "&Karaoke..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2908,19 +3050,23 @@ msgid "Mixing and rendering tracks"
 msgstr "A misturar e a renderizar faixas"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Mesa de mistura do Tenacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Ganho"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Velocidade"
 
@@ -2929,32 +3075,46 @@ msgid "Musical Instrument"
 msgstr "Instrumento musical"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Balanço"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Silenciar"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Mostrador do nível do sinal"
 
 # historico
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Movido o controlo do ganho"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Movido o controlo da velocidade"
 
 # verifica se "moved" aparece qdo o usuario altera o valor no slider de
 # balanço
 # - aparece no historico!
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Movido o controlo do balanço"
 
@@ -2989,9 +3149,9 @@ msgstr ""
 "Não vai ser carregado."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3025,16 +3185,19 @@ msgstr ""
 "\n"
 "Use apenas módulos de fontes seguras"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Sim"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Não"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Carregador de módulos do Tenacity"
 
 #: src/ModuleManager.cpp
@@ -3058,6 +3221,116 @@ msgstr ""
 msgid "Note Track"
 msgstr "Faixa de notas"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "Dó"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "Dó♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "Ré"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "Ré♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "Mi"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "Fá"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "Fá♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "Sol"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "Sol♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "Lá"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "Lá♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "Si"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "Ré♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "Mi♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "Sol♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "Lá♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "Si♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "Dó♯/Ré♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "Ré♯/Mi♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "Fá♯/Sol♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "Sol♯/Lá♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "Lá♯/Si♭"
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
@@ -3069,8 +3342,7 @@ msgstr "O plug-in já existe"
 
 #: src/PluginManager.cpp
 msgid "Plug-in file is in use. Failed to overwrite"
-msgstr ""
-"O ficheiro do plug-in está a ser utilizado. Não foi possível substituí-lo"
+msgstr "O ficheiro do plug-in está a ser utilizado. Não foi possível substituí-lo"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3104,9 +3376,7 @@ msgstr "Gerir plug-ins"
 
 #: src/PluginRegistrationDialog.cpp
 msgid "Select effects, click the Enable or Disable button, then click OK."
-msgstr ""
-"Selecionar efeitos, clique no botão Ativar ou Desativar e depois clique em "
-"OK."
+msgstr "Selecionar efeitos, clique no botão Ativar ou Desativar e depois clique em OK."
 
 #. i18n-hint: This is before radio buttons selecting which effects to show
 #: src/PluginRegistrationDialog.cpp
@@ -3169,7 +3439,8 @@ msgstr "Selecionar &tudo"
 msgid "C&lear All"
 msgstr "&Limpar tudo"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Ativar"
 
@@ -3238,27 +3509,24 @@ msgid ""
 "Try changing the audio host, playback device and the project sample rate."
 msgstr ""
 "Surgiu um erro ao abrir dispositivo de som.\n"
-"Tente alterar o anfitrião de áudio, dispositivo de reprodução e a frequência "
-"de amostragem do projeto."
+"Tente alterar o anfitrião de áudio, dispositivo de reprodução e a frequência de amostragem do projeto."
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "The tracks selected for recording must all have the same sampling rate"
-msgstr ""
-"As faixas selecionadas para gravação devem ter a mesma frequência de "
-"amostragem"
+msgstr "As faixas selecionadas para gravação devem ter a mesma frequência de amostragem"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "Mismatched Sampling Rates"
 msgstr "Frequências de amostragem incompatíveis"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
-"Foram selecionadas poucas faixas para gravar a esta frequência de amostragem."
-"\n"
+"Foram selecionadas poucas faixas para gravar a esta frequência de amostragem.\n"
 "(O Tenacity requer dois canais na mesma frequência de amostragem para\n"
 "cada faixa estéreo)"
 
@@ -3274,16 +3542,25 @@ msgstr "Áudio gravado"
 msgid "Record"
 msgstr "Gravar"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
 #: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr "Perdas"
+
+#: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
-"O áudio guardado foi perdido nos locais marcados com rótulo. Causas "
-"possíveis:\n"
+"O áudio guardado foi perdido nos locais marcados com rótulo. Causas possíveis:\n"
 "\n"
 "Outras aplicações estão a competir com o Tenacity pelo tempo do processador\n"
 "\n"
@@ -3309,10 +3586,7 @@ msgstr "Fechar o projeto imediatamente sem alterações"
 # Fechar projeto sem alterações
 #: src/ProjectFSCK.cpp
 msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
-msgstr ""
-"Continuar as correções anotadas no relatório e procurar mais erros. Isto "
-"guardará o projeto no estado atual, a não ser que faça \"Fechar projeto "
-"imediatamente\" nos próximos alertas."
+msgstr "Continuar as correções anotadas no relatório e procurar mais erros. Isto guardará o projeto no estado atual, a não ser que faça \"Fechar projeto imediatamente\" nos próximos alertas."
 
 #: src/ProjectFSCK.cpp
 msgid "Warning - Problems Reading Sequence Tags"
@@ -3324,11 +3598,11 @@ msgstr "A inspecionar os dados do ficheiro do projeto"
 
 # como traduzir 'aliased files'?
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3371,11 +3645,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Aviso - Faltam ficheiros alias"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "A verificação do projeto na pasta \"%s\" \n"
@@ -3400,12 +3674,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Aviso - Faltam os ficheiros de alias de resumo"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3463,7 +3737,8 @@ msgstr "Aviso - Ficheiros do bloco órfãos"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progresso"
 
@@ -3488,6 +3763,11 @@ msgstr "Aviso: problemas na recuperação automática"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<sem-título>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projeto %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3557,12 +3837,14 @@ msgstr ""
 "(Impossível criar os ficheiros temporários necessários)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Isto não é um ficheiro de projeto do Tenacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3577,9 +3859,7 @@ msgstr "Não foi possível iniciar o ficheiro de projeto"
 #. i18n-hint: An error message.  Don't translate inset or blockids.
 #: src/ProjectFileIO.cpp
 msgid "Unable to add 'inset' function (can't verify blockids)"
-msgstr ""
-"Impossível adicionar a função 'inset' (não foi possível verificar os "
-"identificadores de bloco)"
+msgstr "Impossível adicionar a função 'inset' (não foi possível verificar os identificadores de bloco)"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
 #: src/ProjectFileIO.cpp
@@ -3696,9 +3976,9 @@ msgid "Error Writing to File"
 msgstr "Erro ao gravar para o ficheiro"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3712,9 +3992,16 @@ msgstr "A compactar o projeto"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projeto %02i] Tenacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3723,14 +4010,13 @@ msgstr "(Recuperado)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Este ficheiro foi guardado utilizando o Tenacity %s.\n"
-"Está a utilizar a versão %s. Poderá ter que atualizar o Tenacity para "
-"conseguir abrir este ficheiro."
+"Está a utilizar a versão %s. Poderá ter que atualizar o Tenacity para conseguir abrir este ficheiro."
 
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
@@ -3799,25 +4085,25 @@ msgid "Backing up project"
 msgstr "A fazer a cópia de segurança do projeto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
-"Este projeto não foi corretamente guardado da última vez que abriu o "
-"Tenacity.\n"
+"Este projeto não foi corretamente guardado da última vez que abriu o Tenacity.\n"
 "\n"
 "Foi recuperada a última gravação rápida."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
 msgstr ""
-"Este projeto não foi corretamente guardado da última vez que abriu o "
-"Tenacity.\n"
+"Este projeto não foi corretamente guardado da última vez que abriu o Tenacity.\n"
 "\n"
 "Foi recuperada a última gravação rápida, mas tem de o guardar\n"
 "para preservar o conteúdo."
@@ -3871,9 +4157,7 @@ msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
-msgstr ""
-"O projeto excede o tamanho máximo de 4GB quando gravado num sistema de "
-"ficheiro formatado em FAT32."
+msgstr "O projeto excede o tamanho máximo de 4GB quando gravado num sistema de ficheiro formatado em FAT32."
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -3894,14 +4178,13 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sGuardar o projeto \"%s\" como…"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
-"'Guardar projeto' aplica-se a projetos do Tenacity, não a ficheiros de "
-"áudio. \n"
-"Para um ficheiro de áudio que será aberto noutras aplicações, utilize "
-"'Exportar'.\n"
+"'Guardar projeto' aplica-se a projetos do Tenacity, não a ficheiros de áudio. \n"
+"Para um ficheiro de áudio que será aberto noutras aplicações, utilize 'Exportar'.\n"
 
 #. i18n-hint: In each case, %s is the name
 #. of the file being overwritten.
@@ -3974,14 +4257,14 @@ msgid "Error Opening Project"
 msgstr "Erro ao abrir o projeto"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
-"Está a tentar abrir um ficheiro de cópia de segurança automaticamente "
-"criado. \n"
+"Está a tentar abrir um ficheiro de cópia de segurança automaticamente criado. \n"
 "Se continuar pode resultar em perda de dados.\n"
 "\n"
 "Em vez disso, abra o ficheiro de projeto atual Tenacity."
@@ -4046,9 +4329,7 @@ msgstr "Erro ao importar"
 
 #: src/ProjectFileManager.cpp
 msgid "Cannot import AUP3 format.  Use File > Open instead"
-msgstr ""
-"Não é possível importar o formato AUP3.  Em vez disso utilize a opção "
-"Ficheiro > Abrir"
+msgstr "Não é possível importar o formato AUP3.  Em vez disso utilize a opção Ficheiro > Abrir"
 
 #: src/ProjectFileManager.cpp
 msgid "Compact Project"
@@ -4065,15 +4346,11 @@ msgid ""
 "\n"
 "Do you want to continue?"
 msgstr ""
-"Se compactar este projeto irá libertar espaço em disco removendo bytes "
-"inutilizados dentro do ficheiro.\n"
+"Se compactar este projeto irá libertar espaço em disco removendo bytes inutilizados dentro do ficheiro.\n"
 "\n"
-"Existe %s de espaço livre no disco e este projeto está atualmente a usar %s."
+"Existe %s de espaço livre no disco e este projeto está atualmente a usar %s.\n"
 "\n"
-"\n"
-"Se continuar, o atual histórico de Desfazer/Refazer e os conteúdos da área "
-"de transferência irão ser eliminados e irá recuperar aproximadamente %s de "
-"espaço livre.\n"
+"Se continuar, o atual histórico de Desfazer/Refazer e os conteúdos da área de transferência irão ser eliminados e irá recuperar aproximadamente %s de espaço livre.\n"
 "\n"
 "Quer continuar?"
 
@@ -4094,8 +4371,8 @@ msgid "Automatic database backup failed."
 msgstr "A cópia de segurança da base de dados automático falhou."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Bem-vindo(a) ao Tenacity versão %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4180,15 +4457,12 @@ msgstr "Barra de deslocação vertical"
 #: src/Registry.cpp
 #, c-format
 msgid "Plug-in group at %s was merged with a previously defined group"
-msgstr ""
-"O grupo de plug-in em %s foi fundido com um grupo anteriormente definido"
+msgstr "O grupo de plug-in em %s foi fundido com um grupo anteriormente definido"
 
 #: src/Registry.cpp
 #, c-format
 msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
-msgstr ""
-"O item de plug-in em %s está em conflito com um item anteriormente definido "
-"e foi descartado"
+msgstr "O item de plug-in em %s está em conflito com um item anteriormente definido e foi descartado"
 
 #: src/Registry.cpp
 #, c-format
@@ -4220,6 +4494,11 @@ msgstr "16 bit PCM"
 #: src/SampleFormat.cpp
 msgid "24-bit PCM"
 msgstr "24 bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr "32-bit flutuante"
 
 #: src/SampleFormat.cpp
 msgid "Unknown format"
@@ -4309,7 +4588,8 @@ msgstr "Todas as preferências"
 msgid "SelectionBar"
 msgstr "Barra de seleção"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Seleção do espectro"
 
@@ -4317,42 +4597,55 @@ msgstr "Seleção do espectro"
 msgid "Timer"
 msgstr "Temporizador"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Transporte"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Misturador"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Medidor"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Medidor de reprodução"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Medidor de gravação"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Edição"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Dispositivo"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
+msgid "Play-at-Speed"
+msgstr "Reproduzir na velocidade ajustada"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Percorrer"
 
@@ -4367,7 +4660,10 @@ msgstr "Régua"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Faixas"
 
@@ -4477,7 +4773,8 @@ msgid "Activation level (dB):"
 msgstr "Nível de ativação (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Bem-vindo(a) ao Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4518,8 +4815,7 @@ msgstr "Comentários"
 
 #: src/Tags.cpp
 msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
-msgstr ""
-"Use as teclas de setas (ou ENTER após editar) para navegar entre os campos."
+msgstr "Use as teclas de setas (ou ENTER após editar) para navegar entre os campos."
 
 #: src/Tags.cpp
 msgid "Tag"
@@ -4579,8 +4875,7 @@ msgstr "Repor géneros"
 
 #: src/Tags.cpp
 msgid "Are you sure you want to reset the genre list to defaults?"
-msgstr ""
-"Tem a certeza que quer repor a lista de géneros para os valores predefinidos?"
+msgstr "Tem a certeza que quer repor a lista de géneros para os valores predefinidos?"
 
 #: src/Tags.cpp
 msgid "Unable to open genre file."
@@ -4626,9 +4921,9 @@ msgstr ""
 "Para sugestões de unidades de armazenamento adequadas, clique no botão ajuda."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "O Tenacity não conseguiu guardar o ficheiro:\n"
@@ -4648,9 +4943,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4659,9 +4954,9 @@ msgstr ""
 "para escrita."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "O Tenacity não conseguiu guardar as imagens no ficheiro:\n"
@@ -4678,9 +4973,9 @@ msgstr ""
 "%s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4690,9 +4985,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4701,8 +4996,9 @@ msgstr ""
 "Talvez seja um problema do formato PNG?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "O Tenacity não consegue ler o tema predefinido.\n"
@@ -4740,9 +5036,9 @@ msgstr ""
 "já estavam presentes. substituí-los?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "O Tenacity não conseguiu guardar o ficheiro:\n"
@@ -4781,7 +5077,11 @@ msgstr "Personalizado"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Duração"
 
@@ -4792,7 +5092,8 @@ msgid "Time Track"
 msgstr "Faixa de tempo"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Gravação programada do Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4847,8 +5148,7 @@ msgid ""
 "Planned recording duration:   %s\n"
 "Recording time remaining on disk:   %s"
 msgstr ""
-"Pode não ter espaço suficiente no disco para completar esta gravação "
-"programada, com base nas suas opções.\n"
+"Pode não ter espaço suficiente no disco para completar esta gravação programada, com base nas suas opções.\n"
 "\n"
 "Quer continuar?\n"
 "\n"
@@ -4867,7 +5167,8 @@ msgstr "Projeto atual"
 msgid "Recording start:"
 msgstr "Início da gravação:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Duração:"
 
@@ -4888,7 +5189,8 @@ msgid "Action after Timer Recording:"
 msgstr "Ação após gravação programada:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Progresso da gravação programada do Tenacity"
 
 # Gravação programada
@@ -4970,6 +5272,11 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Gravação programada"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr "099 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -4980,6 +5287,7 @@ msgstr "099 dias 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Data e hora do início"
@@ -5024,7 +5332,8 @@ msgstr "Ativar &exportação automática?"
 msgid "Export Project As:"
 msgstr "Exportar projeto como:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opções"
 
@@ -5037,7 +5346,8 @@ msgid "Do nothing"
 msgstr "Não fazer nada"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Sair do Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5061,7 +5371,8 @@ msgid "Scheduled to stop at:"
 msgstr "Agendado para parar em:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Gravação programada do Tenacity - à espera para começar"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5087,7 +5398,8 @@ msgid "Recording Exported:"
 msgstr "Gravação Exportada:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Gravação programada do Tenacity - a esperar"
 
 #: src/TrackInfo.cpp
@@ -5098,6 +5410,11 @@ msgstr "Estéreo, 999999Hz"
 #: src/TrackPanel.cpp
 msgid "(Esc to cancel)"
 msgstr "(Esc para cancelar)"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Faixa"
 
 #. i18n-hint: The %d is replaced by the number of the track.
 #. i18n-hint: compose a name identifying an unnamed track by number
@@ -5280,6 +5597,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "A aplicar %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "(%d): %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "FALHA"
@@ -5298,13 +5625,15 @@ msgstr "%s não é um parâmetro aceito por %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Valor inválido para o parâmetro '%s': deve ser %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Comando"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repetir %s"
@@ -5339,6 +5668,10 @@ msgid "Compares a range on two tracks."
 msgstr "Compara um intervalo em duas faixas."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Atraso (segundos):"
 
@@ -5370,6 +5703,11 @@ msgstr "Faixa 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Faixa 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5407,17 +5745,43 @@ msgstr "Obter Info"
 msgid "Commands"
 msgstr "Comandos"
 
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Menus"
+msgstr "Todos os Menus"
+
 #: src/commands/GetInfoCommand.cpp src/commands/ScreenshotCommand.cpp
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Definir Clip"
+
+#: src/commands/GetInfoCommand.cpp
+#, fuzzy
+msgid "Envelopes"
+msgstr "Definir Envelope"
+
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Rótulos"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Caixas"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5427,7 +5791,8 @@ msgstr "Breve"
 msgid "Type:"
 msgstr "Tipo:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formato:"
 
@@ -5454,6 +5819,10 @@ msgstr "Comentário"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Comando:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5491,12 +5860,17 @@ msgstr "Exporta para um ficheiro."
 msgid "Builtin Commands"
 msgstr "Comandos Incorporados"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "A equipa do Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Fornece comandos incorporados para o Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5559,7 +5933,10 @@ msgstr "Limpa o conteúdo log."
 msgid "Get Preference"
 msgstr "Obter Preferência"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nome:"
 
@@ -5584,6 +5961,11 @@ msgid "Sets the value of a single preference."
 msgstr "Define um valor de uma única preferência."
 
 #: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "&Screenshot…"
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Window"
 msgstr "Janela"
 
@@ -5603,9 +5985,15 @@ msgstr "Ecrã Inteiro"
 msgid "Toolbars"
 msgstr "Barras de Ferramentas"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efeitos"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Todos os scriptables"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -5739,7 +6127,8 @@ msgstr "Definir"
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Remover"
 
@@ -5823,6 +6212,13 @@ msgstr "Apagar"
 msgid "Edited Envelope"
 msgstr "Envelope Editado"
 
+#. i18n-hint: The envelope is a curve that controls the audio loudness.
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Envelope"
+msgstr "Definir Envelope"
+
 #: src/commands/SetEnvelopeCommand.h
 msgid "Sets an envelope point position."
 msgstr "Define uma posição do ponto do envelope."
@@ -5862,6 +6258,14 @@ msgstr "Taxa:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Redimensionar:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5911,6 +6315,14 @@ msgstr "Balanço:"
 msgid "Set Track Visuals"
 msgstr "Definir Faixa de Visuais"
 
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Linear"
+msgstr "Linear Dentro"
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Redefinir"
@@ -5930,6 +6342,11 @@ msgstr "Exibição:"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
 msgstr "Escala:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "Ampliação"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
@@ -5986,6 +6403,11 @@ msgid "Allo&w clipping"
 msgstr "Permiti&r clipping"
 
 #: src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "Auto Duck"
+msgstr "Auto Duck ..."
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "Reduz (ducks) o volume de um ou mais faixas sempre que o volume de uma faixa \"controlo\" específica chegar a um nível particular"
 
@@ -6003,12 +6425,18 @@ msgstr "Selecionou uma faixa que não contém áudio. O AutoDuck só pode proces
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "O Auto Duck requer uma faixa de controlo que deve ser colocada abaixo da(s) faixa(s) selecionada(s)."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Quanti&dade de Baixo:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "segundos"
 
@@ -6032,7 +6460,8 @@ msgstr "Tamanh&o da queda gradual interior:"
 msgid "Inner &fade up length:"
 msgstr "Tamanho da &subida gradual interior:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Li&mite:"
 
@@ -6071,6 +6500,11 @@ msgstr "&Agudos (dB):"
 #: src/effects/BassTreble.cpp
 msgid "Treble"
 msgstr "Agudos"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Volume (dB):"
+msgstr "Valor (dB)"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
@@ -6166,11 +6600,13 @@ msgstr "para (Hz)"
 msgid "t&o"
 msgstr "p&ara"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Percenta&gem a Alterar:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Percentagem a Alterar"
 
@@ -6178,9 +6614,23 @@ msgstr "Percentagem a Alterar"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Use alongamento de alta qualidade (lento)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "n/d"
 
@@ -6208,6 +6658,7 @@ msgstr "Rpm do Vinil Predefinido:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "De rpm"
@@ -6220,6 +6671,7 @@ msgstr "&de"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Para rpm"
@@ -6355,8 +6807,19 @@ msgid "Max Spike Width"
 msgstr "Largura Máx. do Pico"
 
 #: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Comprimir"
+
+#: src/effects/Compressor.cpp
 msgid "Compresses the dynamic range of audio"
 msgstr "Comprimir o alcance dinâmico do áudio"
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -6368,6 +6831,20 @@ msgstr "%.2f segs"
 msgid "%.1f secs"
 msgstr "%.1f segs"
 
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
@@ -6377,6 +6854,16 @@ msgstr "Rácio %.0f para 1"
 #, c-format
 msgid "Ratio %.1f to 1"
 msgstr "Rácio: %.1f para 1"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "Limite Base do Ruído"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "Limite Base do Ruído"
 
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
@@ -6431,6 +6918,11 @@ msgid "Threshold %d dB"
 msgstr "Limite %d dB"
 
 #: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Noise Floor %d dB"
+msgstr "Limite Base do Ruído"
+
+#: src/effects/Compressor.cpp
 #, c-format
 msgid "Attack Time %.2f secs"
 msgstr "Tempo de ataque: %.2f segundos"
@@ -6470,9 +6962,14 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analista de Contraste, para medir diferenças de volume RMS entre duas seleções de áudio."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Fim"
+
+#: src/effects/Contrast.cpp
+msgid "Volume    "
+msgstr ""
 
 # foreground = primeiro plano?? backgorund=fundo????
 #: src/effects/Contrast.cpp
@@ -6529,9 +7026,32 @@ msgstr "&Diferença:"
 msgid "&Help"
 msgstr "&Ajuda"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "indeterminado"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.1f dB Valor médio da potência (RMS)"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6586,6 +7106,12 @@ msgstr "Diferença atual"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Nível medido no primeiro plano"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f segs"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6655,6 +7181,12 @@ msgstr "Critério de Sucesso 1.4.7 do WCAG 2.0: Falhou"
 msgid "Data gathered"
 msgstr "Dados recolhidos"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Análise de Contraste (compatível com WCAG 2)"
@@ -6718,8 +7250,21 @@ msgid "Soft clip -12dB, 80% make-up gain"
 msgstr "Corte suave -12dB, 80% ganho make-up"
 
 #: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Blues drive sustain"
 msgstr "Sustento Blues"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Extenuar Médio"
 
 #: src/effects/Distortion.cpp
 msgid "Heavy Overdrive"
@@ -6917,7 +7462,14 @@ msgstr ""
 msgid "DTMF &sequence:"
 msgstr "&Sequência DTMF:"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
+#, fuzzy
+msgid "&Amplitude (0-1):"
+msgstr "Amplitude Final"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Duração:"
 
@@ -6930,12 +7482,29 @@ msgid "Duty cycle:"
 msgstr "Ciclo de trabalho:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f segs"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Duração do tom:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Duração do silêncio:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -6945,7 +7514,8 @@ msgstr "Eco"
 msgid "Repeats the selected audio again and again"
 msgstr "A exportar o áudio selecionado outra e outra vez"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Valor requerido excede a capacidade da memória."
 
@@ -6970,7 +7540,8 @@ msgstr "Predefinições"
 msgid "Export Effect Parameters"
 msgstr "Exportar Parâmetros de Efeitos"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Não foi possível abrir o ficheiro: \"%s\""
@@ -7007,6 +7578,15 @@ msgstr "A preparar antevisão"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "A Antever"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Erro Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7319,6 +7899,10 @@ msgid "Adjusts the volume levels of particular frequencies"
 msgstr "Ajusta os níveis de volume de frequências particulares"
 
 #: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "AM Radio"
 msgstr "Rádio AM"
 
@@ -7333,6 +7917,10 @@ msgstr "Corte de Graves"
 #: src/effects/Equalization.cpp
 msgid "Low rolloff for speech"
 msgstr "Rolloff baixo para falar"
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Telephone"
@@ -7371,8 +7959,41 @@ msgid "Effect Unavailable"
 msgstr "Efeito não disponível"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Mín dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7447,8 +8068,16 @@ msgid "D&efault"
 msgstr "Repor &Valores"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "Linha de &Tratamento SSE"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7641,6 +8270,16 @@ msgstr ""
 "SSE Threaded: %s\n"
 
 #: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade In"
+msgstr "Suavização na saída (fade-end)"
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade Out"
+msgstr "A Executar Fade Out"
+
+#: src/effects/Fade.cpp
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Aplica um fade-in linear para o áudio selecionado"
 
@@ -7655,6 +8294,11 @@ msgstr "Localizar Clipping"
 #: src/effects/FindClipping.cpp
 msgid "Creates labels where clipping is detected"
 msgstr "Cria rótulos onde o clipping está detetado"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Clipping Rígido"
 
 #: src/effects/FindClipping.cpp
 msgid "&Start threshold (samples):"
@@ -7682,7 +8326,8 @@ msgid "Builtin Effects"
 msgstr "Efeitos Preparados"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Fornece efeitos preparados para o Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7692,6 +8337,10 @@ msgstr "Nome de efeito built-in desconhecido"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "sonoridade percebida"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7718,6 +8367,19 @@ msgstr "A processar: %s"
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "&Normalizar"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7787,8 +8449,21 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (padrão)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
 msgstr "Hamming, nenhum"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
+msgstr "Hamming, nenhum"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -7884,12 +8559,12 @@ msgid "Step 1"
 msgstr "Passo 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
-"Selecione alguns segundos apenas de ruído para que o Tenacity saiba o que "
-"filtrar,\n"
+"Selecione alguns segundos apenas de ruído para que o Tenacity saiba o que filtrar,\n"
 "depois clique em Obter perfil de ruído:"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
@@ -7938,13 +8613,62 @@ msgstr "&Tipos de janela:"
 msgid "Window si&ze:"
 msgstr "Tamanho da &janela:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (definição)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "P&assos por janela:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8060,6 +8784,11 @@ msgid "N&ormalize stereo channels independently"
 msgstr "N&ormalizar canais estéreo independentemente"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Estender"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Utilizar Paulstretch é apenas por um efeito \"stasis\" ou tempo-esticado extremo"
 
@@ -8067,6 +8796,7 @@ msgstr "Utilizar Paulstretch é apenas por um efeito \"stasis\" ou tempo-esticad
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Fator da &Extensão:"
@@ -8284,6 +9014,11 @@ msgid "Cathedral"
 msgstr "Catedral"
 
 #: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Reverberar ..."
+
+#: src/effects/Reverb.cpp
 msgid "Adds ambience or a \"hall effect\""
 msgstr "Adiciona ambiente ou um \"efeito de sala\""
 
@@ -8327,6 +9062,11 @@ msgstr "Largura do Es&téreo (%):"
 msgid "Wet O&nly"
 msgstr "&Apenas Húmido"
 
+#: src/effects/Reverb.cpp
+#, fuzzy, c-format
+msgid "Reverb: %s"
+msgstr "Reverter"
+
 #: src/effects/Reverse.cpp
 msgid "Reverse"
 msgstr "Reverter"
@@ -8338,6 +9078,11 @@ msgstr "Reverte o áudio selecionado"
 #: src/effects/SBSMSEffect.h
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Tempo SBSMS / Esticar Tom"
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
 
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
@@ -8495,6 +9240,11 @@ msgstr "Usar Definições"
 msgid "Restore Defaults"
 msgstr "Restaurar Definições"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8582,6 +9332,10 @@ msgid "Square, no alias"
 msgstr "Quadrado, sem gradações"
 
 #: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr "Tom"
 
@@ -8649,6 +9403,10 @@ msgstr "Detectar Silêncio"
 msgid "Tr&uncate to:"
 msgstr "Tr&uncar para:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "C&omprimir para:"
@@ -8662,7 +9420,8 @@ msgid "VST Effects"
 msgstr "Efeitos VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Adiciona o suporte a efeitos VST no Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8674,7 +9433,8 @@ msgstr "A configurar Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registando %d de %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Não pode carregar a biblioteca"
 
@@ -8694,19 +9454,17 @@ msgstr "O tamanho do buffer controla o número de samples enviadas para o efeito
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Tamanho do &Buffer (8 a 1048576 samples):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Latência de Compensação"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
-msgstr ""
-"Como parte do seu processamento, alguns efeitos VST devem atrasar o retorno "
-"do áudio ao Tenacity. Ao não compensar esse atraso, irá notar que foram "
-"inseridos no áudio pequenos silêncios. Se ativar esta opção será adicionada "
-"essa compensação, mas pode não funcionar para todos os efeitos VST."
+msgstr "Como parte do seu processamento, alguns efeitos VST devem atrasar o retorno do áudio ao Tenacity. Ao não compensar esse atraso, irá notar que foram inseridos no áudio pequenos silêncios. Se ativar esta opção será adicionada essa compensação, mas pode não funcionar para todos os efeitos VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Ativar &compensação"
 
@@ -8740,7 +9498,8 @@ msgid "Standard VST program file"
 msgstr "Ficheiro de programa VST padrão"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Ficheiro de predefinições VST do Tenacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8767,7 +9526,8 @@ msgstr "Erro ao Carregar Predefinições VST"
 msgid "Unable to load presets file."
 msgstr "Não é possível carregar o ficheiro de predefinições."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Configurações de Efeitos"
 
@@ -8783,6 +9543,12 @@ msgstr "Não foi possível ler o ficheiro de predefinição."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Este ficheiro parâmetro foi guardado em %s. Continuar?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -8819,7 +9585,8 @@ msgid "Audio Unit Effects"
 msgstr "Efeitos Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Fornece suporte a efeitos de \"Audio Unit\" no Tenacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8836,13 +9603,9 @@ msgid "Audio Unit Effect Options"
 msgstr "Opções de Efeitos Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
-msgstr ""
-"Como parte do seu processamento, alguns efeitos de \"Audio Unit\" devem "
-"atrasar o retorno do áudio ao Tenacity. Ao não compensar esse atraso, irá "
-"notará que foram inseridos no áudio pequenos silêncio. Se ativar esta opção "
-"fornecerá essa compensação, mas pode não funcionar para todos os efeitos de "
-"\"Audio Unit\"."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr "Como parte do seu processamento, alguns efeitos de \"Audio Unit\" devem atrasar o retorno do áudio ao Tenacity. Ao não compensar esse atraso, irá notará que foram inseridos no áudio pequenos silêncio. Se ativar esta opção fornecerá essa compensação, mas pode não funcionar para todos os efeitos de \"Audio Unit\"."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -8977,8 +9740,17 @@ msgstr "Falha ao criar lista proprietária para a predefinição"
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "Falha ao definir informação de classe para \"%s\" predefinição"
 
+# Audio Unit é um tipo de efeitos/plugins tal como VST ou LADSPA, não traduzir
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Efeitos Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efeitos LADSPA"
@@ -8988,7 +9760,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Oferece Efeitos LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "O Tenacity já não usa vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -8996,12 +9769,30 @@ msgid "LADSPA Effect Options"
 msgstr "Opções de Efeitos LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Como parte do seu processamento, alguns efeitos LADSPA devem atrasar o retorno do áudio ao Audacity. Ao não compensar esse atraso, você notará que pequenos silêncios foram inseridos no áudio. Habilitar essa opção proporcionará essa compensação, mas pode não funcionar para todos os efeitos LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s em:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Saída de Efeito"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Efeitos LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9013,7 +9804,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Tamanho do &Buffer (8 a %d) samples:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Como parte do seu processamento, alguns efeitos LV2 devem atrasar o retorno do áudio ao Audacity. Ao não compensar esse atraso, você notará que pequenos silêncios foram inseridos no áudio. Habilitar esta configuração proporcionará essa compensação, mas pode não funcionar para todos os efeitos de LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9038,12 +9830,19 @@ msgstr "%s requer opção não suportada %s\n"
 msgid "Generator"
 msgstr "Gerador"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efeitos LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Oferece suporte de Efeitos LV2 para o Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9051,7 +9850,8 @@ msgid "Nyquist Effects"
 msgstr "Efeitos Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Fornece suporte a efeitos Nyquist no Tenacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9136,6 +9936,10 @@ msgstr "';type tool' efeitos não podem devolver rótulos do Nyquist.\n"
 #, c-format
 msgid "nyx_error returned from %s.\n"
 msgstr "nyx_error retornou em %s.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "plug-in"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist returned a list."
@@ -9227,6 +10031,18 @@ msgstr "Indique o Comando Nyquist: "
 msgid "&Load"
 msgstr "&Carregar"
 
+#. i18n-hint: Nyquist is the name of a programming language
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist scripts"
+msgstr "Carregar script Nyquist"
+
+#. i18n-hint: Lisp is the name of a programming language
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Lisp scripts"
+msgstr "Parar script"
+
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
 "Current program has been modified.\n"
@@ -9264,7 +10080,8 @@ msgstr "Selecionar um ficheiro"
 msgid "Save file as"
 msgstr "Guardar ficheiro como"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "sem-título"
 
@@ -9273,7 +10090,8 @@ msgid "Vamp Effects"
 msgstr "Efeitos Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Fornece suporte a efeitos Vamp no Tenacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9295,6 +10113,12 @@ msgstr "Definições de Plugin"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Programa"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9374,6 +10198,18 @@ msgstr "Opções de Formato"
 msgid "Channel: %2d"
 msgstr "Canal: %2d"
 
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "%s - L"
+msgstr " - E"
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "%s - R"
+msgstr " - D"
+
 #: src/export/Export.cpp
 #, c-format
 msgid "Output Channels: %2d"
@@ -9441,6 +10277,11 @@ msgid "Command Output"
 msgstr "Saída do Comando"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "&OK"
+msgstr "OK"
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "Você especificou um nome de ficheiro sem uma extensão. Tem a certeza?"
 
@@ -9482,9 +10323,7 @@ msgstr "FFmpeg : ERRO - Não pôde alocar saída do formato de contexto."
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
-msgstr ""
-"FFmpeg : ERRO - Não foi possível adicionar o fluxo de áudio ao ficheiro de "
-"saída \"%s\"."
+msgstr "FFmpeg : ERRO - Não foi possível adicionar o fluxo de áudio ao ficheiro de saída \"%s\"."
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -9581,6 +10420,12 @@ msgstr "A exportar o áudio como %s"
 msgid "Invalid sample rate"
 msgstr "Taxa de sample inválida"
 
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample"
+msgstr "&Resample…"
+
 #: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid ""
@@ -9607,6 +10452,14 @@ msgstr "Pode fazer resample para uma das taxas abaixo."
 msgid "Sample Rates"
 msgstr "Taxas de Sample"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Taxa de Bits:"
@@ -9614,6 +10467,48 @@ msgstr "Taxa de Bits:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Qualidade (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f segs"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9624,12 +10519,62 @@ msgid "Constrained"
 msgstr "Restrito"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Áudio"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Atraso Baixo"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mediumband"
+msgstr "Médio"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Fullband"
+msgstr "Cheio"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Compression"
@@ -9696,8 +10641,17 @@ msgid "Replace preset '%s'?"
 msgstr "Substituir predefinição '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "E"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Principal"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9710,6 +10664,11 @@ msgstr "Ficheiros AC3 (FFmpeg)"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "AMR (narrow band) Files (FFmpeg)"
 msgstr "Ficheiros AMR (banda estreita) (FFmpeg)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr "Ficheiros M4A (AAC) (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "WMA (version 2) Files (FFmpeg)"
@@ -9763,6 +10722,12 @@ msgstr "Importar Predefinições"
 msgid "Export Presets"
 msgstr "Exportar Predefinições"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Codec Atual:"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
 msgstr "Nem todos os formatos e codecs são compatíveis. Nem todas as combinações são compatíveis com todos os codecs."
@@ -9796,6 +10761,10 @@ msgstr "Idioma:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Reservatório de Bit"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9913,6 +10882,11 @@ msgstr ""
 "máx - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Nome:"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "LPC coefficients precision\n"
 "Optional\n"
@@ -9925,6 +10899,11 @@ msgstr ""
 "0 - definição\n"
 "mín - 1\n"
 "máx - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Usar LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10105,6 +11084,16 @@ msgid "Failed to find the codec"
 msgstr "Não foi possível encontrar o codec"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr ", 64 bits"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr ", 64 bits"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (mais rápido)"
 
@@ -10173,6 +11162,42 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (Melhor Qualidade)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Extremo, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "Padrão, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "Médio, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "Médio, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (Ficheiros Pequenos)"
 
@@ -10202,7 +11227,8 @@ msgstr "Insano"
 msgid "Extreme"
 msgstr "Extremo"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Padrão"
 
@@ -10221,6 +11247,16 @@ msgstr "Média"
 #: src/export/ExportMP3.cpp
 msgid "Constant"
 msgstr "Constante"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "Não Ligar Estéreo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Estéreo, "
 
 #: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
@@ -10245,8 +11281,8 @@ msgid "Locate LAME"
 msgstr "Localizar LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "O Tenacity precisa do ficheiro %s para criar MP3s."
 
 #: src/export/ExportMP3.cpp
@@ -10274,13 +11310,12 @@ msgid "Where is %s?"
 msgstr "Onde está %s ?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
-"Está a vincular a lame_enc.dll v%d.%d. Esta versão não é compatível com o "
-"Tenacity %d.%d.%d.\n"
+"Está a vincular a lame_enc.dll v%d.%d. Esta versão não é compatível com o Tenacity %d.%d.%d.\n"
 "Por favor descarregue a versão mais recente do 'LAME for Tenacity'."
 
 #: src/export/ExportMP3.cpp
@@ -10383,6 +11418,11 @@ msgstr ""
 #: src/export/ExportMP3.cpp
 msgid "MP3 export library not found"
 msgstr "Biblioteca de exportação MP3 não encontrada"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "(Built-in)"
+msgstr "Construído"
 
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
@@ -10579,6 +11619,15 @@ msgstr "A exportar o áudio selecionado como Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "A exportar o áudio como Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft) 16 bit PCM com sinal"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Cabeçalho:"
@@ -10592,9 +11641,10 @@ msgid "Other uncompressed files"
 msgstr "Outros ficheiros sem compressão"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Tentou exportar um ficheiro WAV ou AIFF que pode ser maior do que 4GB.\n"
 "O Tenacity não pode fazer isto, a exportação foi cancelada."
@@ -10604,12 +11654,12 @@ msgid "Error Exporting"
 msgstr "Erro ao Exportar"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
-"O ficheiro WAV exportado foi truncado porque o Tenacity não pode exportar "
-"ficheiros WAV\n"
+"O ficheiro WAV exportado foi truncado porque o Tenacity não pode exportar ficheiros WAV\n"
 "maiores que 4GB."
 
 #: src/export/ExportPCM.cpp
@@ -10646,11 +11696,11 @@ msgid "All supported files"
 msgstr "Todos os ficheiros suportados"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\"  \n"
@@ -10659,11 +11709,11 @@ msgstr ""
 "mas pode editá-lo se for a Ficheiro > Importar > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "não é um ficheiro de áudio. \n"
@@ -10674,18 +11724,18 @@ msgid "Select stream(s) to import"
 msgstr "Selecione os fluxos a importar"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Esta versão do Tenacity não foi compilada com suporte a %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é uma faixa de um CD de áudio. \n"
 "O Tenacity não abre CDs de áudio diretamente. \n"
@@ -10694,23 +11744,22 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" é uma lista de reprodução. \n"
 "O Tenacity não a abre porque apenas contém ligações para outros ficheiros. \n"
-"Pode abrir este ficheiro num editor de texto e transferir os ficheiros de "
-"áudio atuais."
+"Pode abrir este ficheiro num editor de texto e transferir os ficheiros de áudio atuais."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro Windows Media Audio. \n"
@@ -10719,26 +11768,24 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro AAC (Advanced Audio Coding).\n"
-"Sem a biblioteca FFmpeg opcional, o Tenacity não pode abrir este tipo de "
-"ficheiro.\n"
-"Caso contrário, terá de convertê-lo num formato de áudio suportado, como WAV "
-"ou AIFF."
+"Sem a biblioteca FFmpeg opcional, o Tenacity não pode abrir este tipo de ficheiro.\n"
+"Caso contrário, terá de convertê-lo num formato de áudio suportado, como WAV ou AIFF."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro de áudio encriptado. \n"
@@ -10749,10 +11796,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro Real Player. \n"
@@ -10761,12 +11808,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" é um ficheiro de notas e não de áudio. \n"
 "O Tenacity não abre este tipo de ficheiro. \n"
@@ -10775,10 +11822,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10791,10 +11838,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro Wavpack. \n"
@@ -10803,10 +11850,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro Dolby Digital. \n"
@@ -10815,10 +11862,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro Ogg Speex. \n"
@@ -10827,10 +11874,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" é um ficheiro de vídeo. \n"
@@ -10844,16 +11891,15 @@ msgstr "Ficheiro \"%s\" não encontrado."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "O Tenacity não reconhece o tipo de ficheiro '%s'.\n"
 "\n"
-"%sPara ficheiros descomprimidos, tente também Ficheiro > Importar > Dados "
-"Raw."
+"%sPara ficheiros descomprimidos, tente também Ficheiro > Importar > Dados Raw."
 
 #: src/import/Import.cpp
 msgid ""
@@ -10863,11 +11909,16 @@ msgstr ""
 "Tente instalar o FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, testagem do Audacity"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10876,6 +11927,11 @@ msgstr ""
 "Os importadores que suportam tais ficheiros são: \n"
 "%s,\n"
 "mas nenhum deles reconheceu o formato."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Ficheiros de projeto AUP3"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10893,19 +11949,18 @@ msgid "Import Project"
 msgstr "Importar Projeto"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
-"Este projeto foi guardado pela versão 1.0 do Tenacity ou posterior. O "
-"formato\n"
+"Este projeto foi guardado pela versão 1.0 do Tenacity ou posterior. O formato\n"
 "mudou e esta versão do Tenacity não consegue importar o projeto.\n"
 "\n"
-"Utilize uma versão do Tenacity anterior ao v3.0.0 para atualizar o projeto e "
-"depois\n"
+"Utilize uma versão do Tenacity anterior ao v3.0.0 para atualizar o projeto e depois\n"
 "poderá importá-lo com esta versão do Tenacity."
 
 #: src/import/ImportAUP.cpp
@@ -10951,10 +12006,9 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Não foi possível encontrar a pasta de dados do projeto: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
-msgstr ""
-"Foram encontradas faixas MIDI no ficheiro do projeto, mas esta compilação do "
-"Tenacity não inclui suporte MIDI. A ignorar a faixa."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr "Foram encontradas faixas MIDI no ficheiro do projeto, mas esta compilação do Tenacity não inclui suporte MIDI. A ignorar a faixa."
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
@@ -11058,40 +12112,6 @@ msgstr "Índice[%02x] Codec[%s], Idioma[%s], Taxa de Bits[%s], Canais[%d], Dura�
 msgid "FLAC files"
 msgstr "Ficheiros FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Ficheiros compatíveis GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Incapaz de adicionar descodificador para conduto"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importador GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Não foi possível colocar o estado do fluxo em pausa."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Índice[%02d], Tipo[%s], Canais[%d], Taxa[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "O ficheiro não contém nenhuns fluxos de áudio."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Incapaz de importar ficheiro, mudança de estado falhou."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Erro GStreamer: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Lista de ficheiros em formato de texto básico"
@@ -11194,6 +12214,100 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, e outros ficheiros sem-compressão"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAVEX (Microsoft)"
+msgstr "WAV (Microsoft) 16 bit PCM com sinal"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
 msgstr "8 bit PCM Assinado"
 
@@ -11212,6 +12326,74 @@ msgstr "32 bit PCM Assinado"
 #: src/import/ImportPCM.cpp
 msgid "Unsigned 8 bit PCM"
 msgstr "8 bit PCM Não-Assinado"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "32 bit float"
+msgstr "32-bit flutuante"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "64 bit float"
+msgstr "32-bit flutuante"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DPCM"
+msgstr "16 bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "16 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11261,6 +12443,19 @@ msgstr "Importar Dados Raw"
 msgid "No endianness"
 msgstr "Sem endianess"
 
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Médiano"
+
 #  i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #  know the correct technical word.
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
@@ -11294,6 +12489,10 @@ msgstr "Canais:"
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
 msgstr "Iniciar compensação:"
+
+#: src/import/ImportRaw.cpp
+msgid "bytes"
+msgstr ""
 
 #: src/import/ImportRaw.cpp
 msgid "Amount to import:"
@@ -11332,6 +12531,7 @@ msgstr "%s direita"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11355,6 +12555,7 @@ msgstr "fim"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11381,7 +12582,8 @@ msgstr "Faixas movidas no tempo para a direita"
 msgid "Time shifted clips to the left"
 msgstr "Faixas movidas no tempo para a esquerda"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Movimento-Tempo"
 
@@ -11519,7 +12721,8 @@ msgstr "Aparar as faixas selecionadas entre o segundo %.2f e o segundo %.2f"
 msgid "Trim Audio"
 msgstr "Aparar Áudio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Separar"
 
@@ -11640,32 +12843,8 @@ msgid "Delete Key&2"
 msgstr "Tecla Apaga&r2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Barra de M&istura"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "A&justar o volume de reprodução…"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Aumentar Volume Reprodução"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Diminuir Volume Reprodução"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Aju&star o volume de gravação…"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "A&umentar Volume Gravação"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "D&iminuir Volume Gravação"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -11841,6 +13020,11 @@ msgid "&Labels..."
 msgstr "&Rótulos..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Exportar MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Dados &Raw…"
 
@@ -11929,8 +13113,17 @@ msgid "&Getting Started"
 msgstr "&Como Iniciar"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Manual"
+msgstr "&Gerir"
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&Ajuda Rápida…"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -11948,11 +13141,8 @@ msgstr "Informação do Dispositivo &MIDI…"
 msgid "Show &Log..."
 msgstr "Mostrar &Relatório..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Sobre o Tenacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Rótulo adicionado"
 
@@ -12256,6 +13446,11 @@ msgid "Repeat Last Tool"
 msgstr "Repetir a Última Ferramenta"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Macros..."
+msgstr "Macro"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Apply Macro"
 msgstr "&Aplicar Macro"
 
@@ -12282,6 +13477,12 @@ msgstr "Simular Erros de Gravação"
 #: src/menus/PluginMenus.cpp
 msgid "Detect Upstream Dropouts"
 msgstr "Detetar quebras de fluxo de entrada"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Script&ables I"
+msgstr "Todos os scriptables"
 
 #: src/menus/PluginMenus.cpp
 msgid "Select Time..."
@@ -12330,6 +13531,12 @@ msgstr "Definir Rótulo…"
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Definir Projeto…"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Todos os scriptables"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -12598,6 +13805,11 @@ msgid "Cursor to Project End"
 msgstr "Cursor para Projeto Final"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Cursor"
+msgstr "Cursor:"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor &Left"
 msgstr "Cursor à &Esquerda"
 
@@ -12624,6 +13836,7 @@ msgstr "Salto longo do Curs&or à Direita"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Pro&curar"
@@ -12835,20 +14048,21 @@ msgid "Created new label track"
 msgstr "Criada nova faixa de rótulos"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
-msgstr ""
-"Esta versão do Tenacity permite apenas uma pista de tempo por cada janela de "
-"projeto."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr "Esta versão do Tenacity permite apenas uma pista de tempo por cada janela de projeto."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Criada nova faixa de tempo"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nova taxa de sample (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "O valor digitado não é válido"
 
@@ -12860,6 +14074,11 @@ msgstr "Resampling faixa %d"
 #: src/menus/TrackMenus.cpp
 msgid "Resampled audio track(s)"
 msgstr "Faixa(s) de áudio resampled"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "Remover Faixa"
 
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
@@ -13102,7 +14321,9 @@ msgstr "Reproduzindo"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Gravação"
 
@@ -13253,10 +14474,6 @@ msgstr "&Sobrepor (ligado/desligado)"
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Reprodução via &Software (ligado/desligado)"
 
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Ajuste A&utomático do Nível de Gravação (ligado/desligado)"
-
 # nao tenho certeza desta tradução.  CT
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13309,6 +14526,22 @@ msgid "Play C&ut Preview"
 msgstr "Antever o C&orte"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Play-at-Speed"
+msgstr "Reproduzir na velocidade ajustada"
+
+#. i18n-hint: 'Normal Play-at-Speed' doesn't loop or cut preview.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Normal Pl&ay-at-Speed"
+msgstr "Reproduzir na velocidade ajustada"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play-at-Speed"
+msgstr "Reproduzir-na-Velocidade-Repetindo"
+
+#: src/menus/TransportMenus.cpp
 msgid "Play C&ut Preview-at-Speed"
 msgstr "Reproduzir C&ut Preview-at-Speed"
 
@@ -13335,6 +14568,13 @@ msgstr "Mover para o Rótulo Se&guinte"
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Ver"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "Ampliação"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
@@ -13452,7 +14692,8 @@ msgid "Preferences for Application"
 msgstr "Preferências para Qualidade"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "Atualizar o Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13484,6 +14725,13 @@ msgstr "Dispositivos"
 msgid "Preferences for Device"
 msgstr "Preferências para Dispositivo"
 
+#. i18n-hint Software interface to audio devices
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgctxt "device"
+msgid "Interface"
+msgstr "Interface de Utilizador"
+
 #. i18n-hint: (noun)
 #: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
 msgid "&Host:"
@@ -13493,7 +14741,8 @@ msgstr "&Anfitrião:"
 msgid "Using:"
 msgstr "A Utilizar:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Reprodução"
 
@@ -13513,7 +14762,8 @@ msgstr "Ca&nais:"
 msgid "Latency"
 msgstr "Latência"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milissegundos"
 
@@ -13534,11 +14784,17 @@ msgid "No devices found"
 msgstr "Nenhum dispositivo encontrado"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 Canal (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "2 (Stereo)"
 msgstr "2 (Estéreo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Pastas"
 
@@ -13589,6 +14845,11 @@ msgstr "&Exportar:"
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Bro&wse..."
 msgstr "Pesqu&isar…"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Macro output:"
+msgstr "Mostrar saída"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory"
@@ -13642,9 +14903,9 @@ msgid "Directory %s is not writable"
 msgstr "A pasta %s não tem permissão de escrita"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
-msgstr ""
-"As alterações na pasta temporária só terão efeito quando reiniciar o Tenacity"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr "As alterações na pasta temporária só terão efeito quando reiniciar o Tenacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -13674,6 +14935,40 @@ msgstr "Agrupado por Publicador"
 msgid "Grouped by Type"
 msgstr "Agrupado por Tipo"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Erro Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Ativar Efeitos"
@@ -13695,11 +14990,13 @@ msgid "Plugin Options"
 msgstr "Configurações do Plugin"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Verificar se existem atualizações dos plug-ins ao iniciar o Tenacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Tornar a detetar plug-ins da próxima vez que o Tenacity iniciar"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13770,11 +15067,7 @@ msgstr "Filtros não utilizados:"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"Há caracteres de espaçamento (espaços, quebras de linha ou tabulações) num "
-"dos itens. Estes podem quebrar a pesquisa de padrões. A não ser que seja "
-"intencional, é recomendado eliminar estes caracteres. Pretende que o "
-"Tenacity os elimine?"
+msgstr "Há caracteres de espaçamento (espaços, quebras de linha ou tabulações) num dos itens. Estes podem quebrar a pesquisa de padrões. A não ser que seja intencional, é recomendado eliminar estes caracteres. Pretende que o Tenacity os elimine?"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -13791,6 +15084,13 @@ msgstr "Confirmação de eliminação da regra"
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
 msgstr "Ext Importar"
+
+#. i18n-hint: refers to Audacity's user interface settings
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgctxt "GUI"
+msgid "Interface"
+msgstr "Interface de Utilizador"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Preferences for GUI"
@@ -13827,6 +15127,11 @@ msgstr "-120 dB (limite aproximado da audição humana)"
 #: src/prefs/GUIPrefs.cpp
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (alcance PCM para samples de 24 bit)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Voz I"
 
 #: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
@@ -13873,7 +15178,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Manter &rótulos se seleção chegar ao limite de outro"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "&Misturar temas do sistema e do Tenacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -13897,6 +15203,10 @@ msgstr "Mostrar Régua de Percorrer"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "Idioma \"%s\" é desconhecido"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14047,9 +15357,9 @@ msgstr ""
 "   *   \"%s\"  (porque o atalho '%s' é utilizado por \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
-msgstr ""
-"Selecionar um ficheiro XML que contenha atalhos do teclado para o Tenacity…"
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
+msgstr "Selecionar um ficheiro XML que contenha atalhos do teclado para o Tenacity…"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Error Importing Keyboard Shortcuts"
@@ -14135,6 +15445,11 @@ msgstr ""
 "\n"
 "ao invés. Caso contrário, clique Cancelar."
 
+#: src/prefs/KeyConfigPrefs.h
+#, fuzzy
+msgid "Key Config"
+msgstr "Atalhos do Teclado"
+
 #: src/prefs/LibraryPrefs.cpp
 msgid "Preferences for Library"
 msgstr "Preferências para Biblioteca"
@@ -14176,8 +15491,9 @@ msgid "Dow&nload"
 msgstr "&Transferir"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "O Tenacity detetou automaticamente bibliotecas FFmpeg válidas.\n"
@@ -14204,6 +15520,13 @@ msgstr "Preferências para MidiIO"
 msgid "No MIDI interfaces"
 msgstr "Sem interfaces MIDI"
 
+#. i18n-hint Software interface to MIDI
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgctxt "MIDI"
+msgid "Interface"
+msgstr "Interface de Utilizador"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Using: PortMidi"
 msgstr "A Usar: PortMidi"
@@ -14216,6 +15539,10 @@ msgstr "Latênci&a do sintetizador MIDI (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "A latência do sintetizador MIDI deve ser um número inteiro"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -14226,27 +15553,25 @@ msgid "Preferences for Module"
 msgstr "Preferências para Modulo"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
-"Isto são módulos experimentais. Ative apenas se tiver lido o manual do "
-"Tenacity\n"
+"Isto são módulos experimentais. Ative apenas se tiver lido o manual do Tenacity\n"
 "e souber o que está a fazer."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
-msgstr ""
-"  'Perguntar' significa que o Tenacity perguntará sempre se quer carregar o "
-"módulo sempre que o iniciar."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr "  'Perguntar' significa que o Tenacity perguntará sempre se quer carregar o módulo sempre que o iniciar."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
-msgstr ""
-"  'Falhou' significa que o Tenacity pensa que o módulo está corrompido e não "
-"o vai executar."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr "  'Falhou' significa que o Tenacity pensa que o módulo está corrompido e não o vai executar."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
@@ -14254,10 +15579,9 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Novo' significa sem escolha ainda feita."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
-msgstr ""
-"As alterações na pasta temporária só terão efeito quando reiniciar o "
-"Tenacity."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "As alterações na pasta temporária só terão efeito quando reiniciar o Tenacity."
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -14274,6 +15598,10 @@ msgstr "Nenhum módulo encontrado"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modulo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14316,7 +15644,10 @@ msgstr "Arrastar à Esquerda"
 msgid "Set Selection Range"
 msgstr "Definir o Intervalo da seleção"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-Clique-Esquerdo"
 
@@ -14404,6 +15735,15 @@ msgstr "-Arrastar-Esquerdo"
 msgid "Move clip up/down between tracks"
 msgstr "Mover clipe para cima/baixo entre faixas"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Arrastar-Esquerdo"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -14432,6 +15772,11 @@ msgstr "Alterar Vários Samples"
 #: src/prefs/MousePrefs.cpp
 msgid "Change ONE Sample only"
 msgstr "Alterar apenas UM Sample"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Multi"
+msgstr "Multi-Ferramenta"
 
 #: src/prefs/MousePrefs.cpp
 msgid "same as select tool"
@@ -14515,11 +15860,16 @@ msgid "&Vari-Speed Play"
 msgstr "Reproduzir &Vari-Speed"
 
 #: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "Always scrub un&pinned"
 msgstr "Sempre percorrer &soltos"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferências do Tenacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14535,8 +15885,18 @@ msgid "Preferences for Quality"
 msgstr "Preferências para Qualidade"
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Outro…"
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "A amplificar"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Rate:"
@@ -14571,6 +15931,16 @@ msgstr "Conversor da &Taxa de Sample:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Pon&tilhar:"
+
+#: src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "16-bit"
+msgstr "16 bit PCM"
+
+#: src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "24-bit"
+msgstr "24 bit PCM"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14640,48 +16010,34 @@ msgstr "&Data do Sistema"
 msgid "System T&ime"
 msgstr "T&empo Sistema"
 
-#: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Ajuste Automático do Nível de Gravação"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Ativar o Ajuste Automático do Nível de Gravação."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Pico Alvo:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Entre:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Tempo de Análise:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milissegundos (tempo de uma análise)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Número de análises consecutivas:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 significa infinitas"
-
 # smart rec = grav programada! (igual aos VCR)
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Gravação Punch and Roll"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Clipes Crossfade"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
 #. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Bark"
 msgstr "Ladrar"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14792,6 +16148,10 @@ msgid "&Range (dB):"
 msgstr "&Intervalo (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
 msgstr "Algoritmo"
 
@@ -14810,6 +16170,10 @@ msgstr "8 - banda mais larga"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "1024 - definição"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
@@ -14905,28 +16269,31 @@ msgid "Preferences for Theme"
 msgstr "Preferências para Tema"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Info"
+msgstr "Obter Info"
+
+#: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
 msgstr ""
 "O uso de temas é uma funcionalidade experimental. \n"
 "\n"
-"Para experimentar, prima em \"Carregar ficheiros temporários de temas\" e "
-"depois encontre e altera as \n"
+"Para experimentar, prima em \"Carregar ficheiros temporários de temas\" e depois encontre e altera as \n"
 "imagens e cores em ImageCacheVxx.png com um editor de imagens como o Gimp. \n"
 "\n"
-"Prima em \"Carregar ficheiros temporários de temas\" para carregar as "
-"imagens e cores alteradas para o Tenacity. \n"
+"Prima em \"Carregar ficheiros temporários de temas\" para carregar as imagens e cores alteradas para o Tenacity. \n"
 "\n"
-"(De momento, apenas a barra dos controlos e as cores das faixas de formas da "
-"onda serão alteradas, \n"
+"(De momento, apenas a barra dos controlos e as cores das faixas de formas da onda serão alteradas, \n"
 "mesmo que o ficheiro apresente outros ícones.)"
 
 #: src/prefs/ThemePrefs.cpp
@@ -15090,10 +16457,16 @@ msgid "MilliSeconds"
 msgstr "Milisegundos"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Samples"
+msgstr "Simples"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "4 Pixels per Sample"
 msgstr "4 Pixéis por Sample"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom Max"
 
@@ -15215,16 +16588,24 @@ msgid "Stopped"
 msgstr "Parado"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Ir para o Início"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Ir para o Fim"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Selecionar para o Início"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Selecionar para o Fim"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15238,20 +16619,17 @@ msgstr "Nova Faixa Gravada"
 msgid "Append Record"
 msgstr "Anexar Registo"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Selecionar para o Fim"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Selecionar para o Início"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s Pausado."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15331,11 +16709,17 @@ msgstr "Silenciar o áudio da seleção"
 msgid "Sync-Lock Tracks"
 msgstr "Trancar Sincronização"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Ampliar"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Reduzir"
 
@@ -15402,43 +16786,6 @@ msgstr "&Barras Metro de Gravação"
 msgid "&Playback Meter Toolbar"
 msgstr "&Barras Metro de Reprodução"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Volume de Gravação"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volume de Reprodução"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Volume de Gravação: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Volume de Gravação (Indisponível; use o misturador do sistema.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volume de Reprodução: %.2f (emulado)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volume de Reprodução: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Volume de Reprodução (Indisponível; use o misturador do sistema.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Barra de M&istura"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Procurar"
@@ -15454,6 +16801,7 @@ msgstr "Percorrendo"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Parar Percorrer"
@@ -15461,6 +16809,7 @@ msgstr "Parar Percorrer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Iniciar Percorrer"
@@ -15468,6 +16817,7 @@ msgstr "Iniciar Percorrer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Parar Procurar"
@@ -15475,6 +16825,7 @@ msgstr "Parar Procurar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Iniciar Procurar"
@@ -15529,7 +16880,9 @@ msgstr "Ajustar a"
 msgid "Length"
 msgstr "Tamanho"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centro"
 
@@ -15595,8 +16948,8 @@ msgstr "Barra de &Tempo"
 # audacity'
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Barra de ferramentas %s do Tenacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15623,7 +16976,8 @@ msgstr "Ferramenta Mover"
 msgid "Zoom Tool"
 msgstr "Ferramenta Zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Ferramenta Desenho"
 
@@ -15699,11 +17053,13 @@ msgstr "Arraste um ou mais limites de rótulo."
 msgid "Drag label boundary."
 msgstr "Arraste o limite de rótulo."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Rótulo Modificado"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Editar Rótulo"
 
@@ -15758,31 +17114,42 @@ msgstr "Rótulos editados"
 msgid "New label"
 msgstr "Novo rótulo"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Subir &Oitava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Descer Oita&va"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Prima o Botão do Rato para ampliar na vertical. Shift-clique para diminuir. Arraste para indicar uma área a ampliar."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Clique direito para menu."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Repor Zoom"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-Clique-Direito"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Clique-Esquerdo/Arrastar-Esquerdo"
 
@@ -15824,7 +17191,8 @@ msgstr "Fundir"
 msgid "Expanded Cut Line"
 msgstr "Linha de Corte Expandida"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expandir"
 
@@ -15847,6 +17215,11 @@ msgstr "Samples Movidos"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Editar Sample"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15892,7 +17265,8 @@ msgstr "Processar…   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Alterado '%s' para %s"
@@ -15904,6 +17278,54 @@ msgstr "Alterar Formato"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Taxa"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15923,7 +17345,8 @@ msgstr "Alterar Taxa"
 msgid "Set Rate"
 msgstr "Definir Taxa"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Vista-múlti&pla"
 
@@ -15942,6 +17365,10 @@ msgstr "&Separar Faixa Estéreo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Separar Estéreo para Mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -15997,6 +17424,11 @@ msgid "Stereo, %dHz"
 msgstr "Estéreo, %dHz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Estéreo, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Esquerdo, %dHz"
@@ -16006,14 +17438,23 @@ msgstr "Esquerdo, %dHz"
 msgid "Right, %dHz"
 msgstr "Direito, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Esquerdo"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Direito"
@@ -16033,6 +17474,16 @@ msgstr "Reorganizar sub-visualizações"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Close sub-view"
 msgstr "Fechar sub-visualização"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Ampliar"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Ampliação"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
@@ -16123,9 +17574,8 @@ msgstr "&Interpolação Logarítmica"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Prima e arraste para mover uma faixa no tempo"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16176,6 +17626,7 @@ msgstr "Envelope ajustado."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Percorrer"
@@ -16187,6 +17638,7 @@ msgstr "Procurando"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Régua de &Percorrer"
@@ -16262,6 +17714,11 @@ msgstr "Prima e arraste para selecionar banda larga de frequência."
 msgid "Click and drag to select audio"
 msgstr "Prima e arraste para selecionar áudio"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Prima e arraste para mover uma faixa no tempo"
@@ -16303,6 +17760,18 @@ msgstr "Ctrl+Click para desmarcar"
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Open menu..."
 msgstr "Abrir menu…"
+
+#. i18n-hint: Command names a modifier key on Macintosh keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Command+Click"
+msgstr "Comando"
+
+#. i18n-hint: Ctrl names a modifier key on Windows or Linux keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Ctrl+Click"
+msgstr "Prima o Botão Esquerdo"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -16367,6 +17836,12 @@ msgstr "E"
 msgid "R"
 msgstr "D"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16400,13 +17875,28 @@ msgstr "Vazio"
 msgid "Backwards"
 msgstr "Retroceder"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Avançar"
 
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Ajuda na Internet"
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Menu Árvore"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -16484,6 +17974,16 @@ msgid "Automatic"
 msgstr "Automático"
 
 #: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Horizontal"
+msgstr "Dividir &horizontalmente"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "Régua Vertical"
+
+#: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr " Monitorização "
 
@@ -16501,6 +18001,10 @@ msgstr " Pico %2.f dB"
 msgid " Peak %.2f "
 msgstr " Pico %.2f "
 
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
 #: src/widgets/MultiDialog.cpp
 msgid "Show Log for Details"
 msgstr "Mostrar Relatório para Detalhes"
@@ -16515,6 +18019,28 @@ msgstr "Por favor, selecione uma ação"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000,01000 seconds"
 msgstr "01000,01000 segundos"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "099 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -16531,11 +18057,72 @@ msgstr "0100 dias 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + centésimos"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "099 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + milissegundos"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "099 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + samples"
+msgstr "hh:mm:ss + milissegundos"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+># samples"
+msgstr "099 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "dados sample"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000,01000,01000 samples|#"
+msgstr "01000,01000 segundos"
 
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at 24 frames per second (commonly used for films)
@@ -16543,11 +18130,32 @@ msgstr "hh:mm:ss + milissegundos"
 msgid "hh:mm:ss + film frames (24 fps)"
 msgstr "hh:mm:ss + frames de vídeo (24 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr "099 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in frames (lots of
 #. * frames) at 24 frames per second (commonly used for films)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "film frames (24 fps)"
 msgstr "frames de filme (24 fps)"
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000,01000 frames|24"
+msgstr "01000,01000 segundos"
 
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at NTSC TV drop-frame rate (used for American /
@@ -16556,6 +18164,17 @@ msgstr "frames de filme (24 fps)"
 msgid "hh:mm:ss + NTSC drop frames"
 msgstr "hh:mm:ss + frames NTSC perdidos"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr "099 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
 #. * Japanese TV, and doesn't quite match wall time
@@ -16563,11 +18182,31 @@ msgstr "hh:mm:ss + frames NTSC perdidos"
 msgid "hh:mm:ss + NTSC non-drop frames"
 msgstr "hh:mm:ss + frames NTSC não-perdidos"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
 #. i18n-hint: Name of time display format that shows time in frames at NTSC
 #. * TV frame rate (used for American / Japanese TV
 #: src/widgets/NumericTextCtrl.cpp
 msgid "NTSC frames"
 msgstr "Frames NTSC"
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
 
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at PAL TV frame rate (used for European TV)
@@ -16575,11 +18214,31 @@ msgstr "Frames NTSC"
 msgid "hh:mm:ss + PAL frames (25 fps)"
 msgstr "hh:mm:ss + frames PAL (25 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr "099 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in frames at PAL
 #. * TV frame rate (used for European TV)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "PAL frames (25 fps)"
 msgstr "Frames PAL (25 fps)"
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000,01000 frames|25"
+msgstr "01000,01000 segundos"
 
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at CD Audio frame rate (75 frames per second)
@@ -16587,11 +18246,61 @@ msgstr "Frames PAL (25 fps)"
 msgid "hh:mm:ss + CDDA frames (75 fps)"
 msgstr "hh:mm:ss + frames CDDA (75 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr "099 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in frames at CD
 #. * Audio frame rate (75 frames per second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "CDDA frames (75 fps)"
 msgstr "Frames CDDA (75 fps)"
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000,01000 frames|75"
+msgstr "01000,01000 segundos"
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "kHz"
+msgstr "Hz"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -16657,6 +18366,11 @@ msgstr "(Use o menu de contexto para alterar o formato.)"
 msgid "centiseconds"
 msgstr "centésimos de segundo"
 
+#: src/widgets/PopupMenuTable.h
+#, fuzzy, c-format
+msgid "%s (%s)"
+msgstr "(%s)"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Tempo Decorrido:"
@@ -16699,6 +18413,11 @@ msgstr "Confirmar Fecho"
 msgid "Unable to write files to directory: %s."
 msgstr "Não foi possível inicializar o ficheiro do projeto"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -16715,6 +18434,10 @@ msgstr "Preferências para Directórios"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Não mostrar este aviso novamente"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -16798,15 +18521,27 @@ msgstr "Não conseguiu analisar XML"
 msgid "Spectral edit multi tool"
 msgstr "Edição espectral multi ferramenta"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtragem…"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Lançado sob os termos da GNU General Public License version 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aPor favor selecione frequências."
@@ -16833,7 +18568,8 @@ msgstr ""
 "                      Tente aumentar o limite baixo de frequência~%~\n"
 "                      ou reduzir o filtro 'Width'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Erro.~%"
@@ -16895,6 +18631,25 @@ msgstr "Fade Out Estúdio"
 msgid "Applying Fade..."
 msgstr "A Aplicar Fade…"
 
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "De&finir como padrão"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Distribuído sob os termos da GNU General Public License versão 2 ou posterior."
+
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
 msgid "Selection too short.~%It must be more than 2 samples."
@@ -16907,6 +18662,16 @@ msgstr "Fade Ajustável"
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
 msgstr "Tipo do Filtro"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Fade Up"
+msgstr "Tipo do Filtro"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Fade Down"
+msgstr "Mover para Baixo"
 
 #: plug-ins/adjustable-fade.ny
 msgid "S-Curve Up"
@@ -17023,8 +18788,17 @@ msgstr ""
 "                                 -6 dB divide a meio a amplitude."
 
 #: plug-ins/beat.ny
+#, fuzzy
+msgid "Beat Finder"
+msgstr "Sons de batida"
+
+#: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Encontrando batimentos…"
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17037,6 +18811,10 @@ msgstr "Fixar Clipe"
 #: plug-ins/clipfix.ny
 msgid "Reconstructing clips..."
 msgstr "A reconstruir clipes…"
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
 
 #: plug-ins/clipfix.ny
 msgid "Licensing confirmed under terms of the GNU General Public License version 2"
@@ -17130,6 +18908,11 @@ msgstr "A aplicar Efeito de Atraso…"
 #: plug-ins/delay.ny
 msgid "Delay type"
 msgstr "Tempo de atraso"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Regular"
+msgstr "Retangular"
 
 #: plug-ins/delay.ny
 msgid "Bouncing Ball"
@@ -17342,13 +19125,38 @@ msgstr "Filtro High-Pass"
 msgid "Performing High-Pass Filter..."
 msgstr "Realizando Filtro High-Pass…"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frequência (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB por oitava)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17369,10 +19177,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Sons de Rótulo"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Distribuído sob os termos da GNU General Public License versão 2 ou posterior."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17433,6 +19237,12 @@ msgstr "Silêncio final máximo"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Som ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -17521,8 +19331,17 @@ msgid "Performing Low-Pass Filter..."
 msgstr "Realizando Filtro Low-Pass…"
 
 #: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Noise Gate"
+msgstr "Tipo de &ruído:"
+
+#: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Selecionar Função"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
@@ -17539,6 +19358,11 @@ msgstr "Ligar Faixas Estéreo"
 #: plug-ins/noisegate.ny
 msgid "Don't Link Stereo"
 msgstr "Não Ligar Estéreo"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Gate threshold (dB)"
+msgstr "Nível de limite (dB)"
 
 #: plug-ins/noisegate.ny
 msgid "Gate frequencies above (kHz)"
@@ -17600,9 +19424,24 @@ msgstr ""
 "Pico baseado nos primeiros ~a segundos ~a dB~%\n"
 "Configuração de limite sugerida ~a dB."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, fuzzy
+msgid "Notch Filter"
+msgstr "Aplicar Notch Filter…"
+
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "Aplicar Notch Filter…"
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
 
 #: plug-ins/notch.ny
 msgid "Q (higher value reduces width)"
@@ -17629,6 +19468,11 @@ msgid "Select file(s) to install"
 msgstr "Selecionar ficheiro(s) para instalar"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Plug-in"
+msgstr "Suporte a plug-in"
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Lisp file"
 msgstr "Ficheiro Lisp"
 
@@ -17636,7 +19480,8 @@ msgstr "Ficheiro Lisp"
 msgid "HTML file"
 msgstr "Ficheiro HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Ficheiro de texto"
 
@@ -17701,6 +19546,10 @@ msgid "Error.~%No file selected."
 msgstr "Erro.~%Nenhum ficheiro selecionado."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "A gerar som pluck…"
 
@@ -17709,12 +19558,24 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Valores MIDI para notas C: 36, 48, 60 [meio C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Tipo de desaparecer"
 
 #: plug-ins/pluck.ny
 msgid "Abrupt"
 msgstr "Abrupto"
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -17727,6 +19588,10 @@ msgstr "Faixa de Ritmo"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "A Gerar Ritmo…"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -17743,6 +19608,10 @@ msgstr "1 - 20 batimentos/medida"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Quantidade de Swing"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -17777,6 +19646,10 @@ msgid "Beat sound"
 msgstr "Sons de batida"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Ping (short)"
 msgstr "Ping (curto)"
 
@@ -17785,8 +19658,17 @@ msgid "Ping (long)"
 msgstr "Ping (longo)"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Ruído Ressonante"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Noise Click"
+msgstr "Ruído"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Drip (short)"
@@ -17801,6 +19683,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Tom MIDI para batimento forte"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Tom MIDI para batimento fraco"
 
@@ -17813,8 +19699,17 @@ msgstr ""
 "'Duração da faixa de ritmo' para maior do que zero."
 
 #: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Risset Drum"
+msgstr "A gerar Risset Drum…"
+
+#: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "A gerar Risset Drum…"
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -17831,6 +19726,11 @@ msgstr "Largura da banda de ruído (Hz)"
 #: plug-ins/rissetdrum.ny
 msgid "Amount of noise in mix (percent)"
 msgstr "Quantidade de ruído na mixagem (percentagem)"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amplitude (0 - 1)"
+msgstr "Amplitude Final"
 
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
@@ -17877,6 +19777,11 @@ msgid "Include header information"
 msgstr "Incluir cabeçalho de informação"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Minimal"
+msgstr "&Minimizar"
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Todos"
 
@@ -17909,6 +19814,11 @@ msgstr "Mostrar mensagens"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Apenas Erros"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -17957,8 +19867,18 @@ msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
 msgstr "Esquerdo: ~a lin, ~a dB | Direito: ~a lin, ~a dB."
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~a samples."
+msgstr "Exibir &samples:"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -17986,6 +19906,17 @@ msgstr "<b>Amplitude de Pico:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
 msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
 msgstr "<b>RMS</b> (sem peso): &nbsp;&nbsp;~a dB."
 
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr "<b>Taxa de Sample:</b> &nbsp;&nbsp;~a Hz."
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr "Esquerdo: ~a lin, ~a dB | Direito: ~a linear, &nbsp;&nbsp;~a dB."
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
@@ -17994,6 +19925,11 @@ msgstr "Esquerdo: ~a lin, ~a dB | Direito: ~a linear, &nbsp;&nbsp;~a dB."
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
 msgstr "dados sample"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample #"
+msgstr "Editar Sample"
 
 #: plug-ins/sample-data-export.ny
 msgid "Value (linear)"
@@ -18033,6 +19969,11 @@ msgstr ""
 "Produzido com <span>Exportação de dados Sample</span> para o\n"
 "<a href=\"~a\">Tenacity</a> por Steve\n"
 "Daulton"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "linear"
+msgstr "Linear Dentro"
 
 #: plug-ins/sample-data-export.ny
 msgid "2 channels (stereo)"
@@ -18148,6 +20089,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Erro.~%Faixa de taxa de sample abaixo de 100 Hz não é suportada."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Aplicar Tremolo…"
 
@@ -18174,6 +20119,10 @@ msgstr "Redução e Isolação Vocal"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Aplicar Ação…"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18316,8 +20265,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Este plug-in funciona apenas com faixas estéreo."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Processar Vocoder…"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18359,6 +20316,222 @@ msgstr "Frequência de Agulhas de Radar (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Erro.~%Requer faixa estéreo."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Atualizar o Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Ignorar"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Instalar atualização"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Ler mais no GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Erro ao verificar a atualização"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Não foi possível ligar ao servidor de atualização do Tenacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Os dados de atualização estavam corrompidos."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Erro ao descarregar atualização."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Não foi possível abrir a hiperligação de atualização do Tenacity."
+
+# Diz assim 'barra de dispositivo do audacity' 'barra de transcrição do
+# audacity'
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Está disponível o Tenacity %s !"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Gravação"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Biblioteca GUI multi-plataforma"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importar via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "O ajuste automático do volume de gravação terminou. Não foi possível otimizar mais. Ainda está muito elevado."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "O ajuste automático do volume de gravação diminuiu o volume para %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "O ajuste automático do volume de gravação terminou. Não foi possível otimizar mais. Ainda está muito baixo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "O ajuste automático do volume de gravação aumentou o volume para %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "O ajuste automático de volume de gravação terminou. O número total de análises foi excedido sem encontrar um volume aceitável. Ainda está muito alto."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "O ajuste automático de volume de gravação terminou. O número total de análises foi excedido sem encontrar um volume aceitável. O volume ainda está muito baixo."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "O Ajuste automático de volume de gravação terminou. %.2f parece um volume aceitável."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Recebido %d ao abrir os dispositivos\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Não foi possível abrir o Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Misturadores disponíveis:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Fontes de gravação disponíveis:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volumes de reprodução disponíveis:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "O volume de gravação é emulado\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "O volume de gravação é nativo\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "O volume de reprodução é emulado\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "O volume de reprodução é nativo\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Data e hora desconhecidos"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Ficheiros compatíveis GStreamer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Incapaz de adicionar descodificador para conduto"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importador GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Não foi possível colocar o estado do fluxo em pausa."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Índice[%02d], Tipo[%s], Canais[%d], Taxa[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "O ficheiro não contém nenhuns fluxos de áudio."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Incapaz de importar ficheiro, mudança de estado falhou."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Erro GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Barra de M&istura"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "A&justar o volume de reprodução…"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Aumentar Volume Reprodução"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Diminuir Volume Reprodução"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Aju&star o volume de gravação…"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "A&umentar Volume Gravação"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "D&iminuir Volume Gravação"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Sobre o Tenacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Ajuste A&utomático do Nível de Gravação (ligado/desligado)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Ajuste Automático do Nível de Gravação"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Ativar o Ajuste Automático do Nível de Gravação."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Pico Alvo:"
+
+#~ msgid "Within:"
+#~ msgstr "Entre:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Tempo de Análise:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milissegundos (tempo de uma análise)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Número de análises consecutivas:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 significa infinitas"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Volume de Gravação"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volume de Reprodução"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Volume de Gravação: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume de Gravação (Indisponível; use o misturador do sistema.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volume de Reprodução: %.2f (emulado)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volume de Reprodução: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Volume de Reprodução (Indisponível; use o misturador do sistema.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Barra de M&istura"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Prima e arraste para mover uma faixa no tempo"
 
 #~ msgid "Program build date:"
 #~ msgstr "Data de compilação do programa:"
@@ -18433,9 +20606,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 
 #~ msgid "Gray Scale"
 #~ msgstr "Escala de Cinzentos"
-
-#~ msgid "Menu Tree"
-#~ msgstr "Menu Árvore"
 
 #~ msgid "&Generate Support Data..."
 #~ msgstr "&Gerar Dados de Suporte…"
@@ -18714,9 +20884,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 
 #~ msgid "Import complete. Running an on-demand waveform calculation. %2.0f%% complete."
 #~ msgstr "Importação completa. A executar cálculo a pedido, da forma da onda. %2.0f%% completo."
-
-#~ msgid "Compress"
-#~ msgstr "Comprimir"
 
 #~ msgid "Waiting for waveform to finish computing..."
 #~ msgstr "Em espera para a forma de onda a acabar de processar..."
@@ -19186,9 +21353,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "AIFF (Apple) signed 16-bit PCM"
 #~ msgstr "AIFF (Apple) 16 bit PCM com sinal"
 
-#~ msgid "WAV (Microsoft) signed 16-bit PCM"
-#~ msgstr "WAV (Microsoft) 16 bit PCM com sinal"
-
 #~ msgid "WAV (Microsoft) signed 24-bit PCM"
 #~ msgstr "WAV (Microsoft) 24-bit PCM com sinal"
 
@@ -19474,9 +21638,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "Transcri&ption"
 #~ msgstr "Transcri&ção"
 
-#~ msgid "All Menus"
-#~ msgstr "Todos os Menus"
-
 #~ msgid "Transcription"
 #~ msgstr "Transcrição"
 
@@ -19712,9 +21873,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "Recording Exported:\n"
 #~ msgstr "Gravação Exportada:\n"
 
-#~ msgid "Stereo, "
-#~ msgstr "Estéreo, "
-
 #~ msgid "Left, "
 #~ msgstr "Esquerdo, "
 
@@ -19778,12 +21936,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ "              O ficheiro não pode ser escrito pois o caminho é necessário para restaurar o áudio original do projecto. \n"
 #~ "              Vá a Ficheiro > Verificar Dependências para ver a localização dos ficheiros em falta. \n"
 #~ "              Se ainda assim desejar exportar, por favor indique uma nova pasta ou nome de ficheiro."
-
-#~ msgid " - L"
-#~ msgstr " - E"
-
-#~ msgid " - R"
-#~ msgstr " - D"
 
 #~ msgid "Exporting the entire project using command-line encoder"
 #~ msgstr "A exportar o projecto com o codificador da linha de comandos"
@@ -19964,10 +22116,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgstr "Percentagem a Alterar"
 
 #, fuzzy
-#~ msgid "NoiseFloor"
-#~ msgstr "Limite Base do Ruído"
-
-#, fuzzy
 #~ msgid "AttackTime"
 #~ msgstr "Tempo de Ataque"
 
@@ -19986,10 +22134,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #, fuzzy
 #~ msgid "Duty Cycle"
 #~ msgstr "Ciclo de trabalho:"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Amplitude Final"
 
 #, fuzzy
 #~ msgid "Decay"
@@ -20161,9 +22305,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "Independent"
 #~ msgstr "Independente"
 
-#~ msgid "Version"
-#~ msgstr "Versão"
-
 #~ msgid "C&ategory:"
 #~ msgstr "C&ategoria:"
 
@@ -20227,10 +22368,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "Para Desenhar, vá a 'Forma da Onda' no Menu da Faixa."
-
-#, fuzzy
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "%.1f dB Valor médio da potência (RMS)"
 
 #, fuzzy
 #~ msgid "Average RMS = %.2f dB."
@@ -20748,14 +22885,8 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "Amplify..."
 #~ msgstr "Amplificador ..."
 
-#~ msgid "Amplifying"
-#~ msgstr "A amplificar"
-
 #~ msgid "Please enter valid values."
 #~ msgstr "Por favor, digite valores válidos."
-
-#~ msgid "Auto Duck..."
-#~ msgstr "Auto Duck ..."
 
 #~ msgid "Processing Auto Duck..."
 #~ msgstr "A processar o Auto Duck ..."
@@ -20888,9 +23019,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "Fading In"
 #~ msgstr "A Executar Fade In"
 
-#~ msgid "Fading Out"
-#~ msgstr "A Executar Fade Out"
-
 #~ msgid "Detect clipping"
 #~ msgstr "Detectar picos"
 
@@ -21007,9 +23135,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 
 #~ msgid "Change name to:"
 #~ msgstr "Mudar o nome para:"
-
-#~ msgid "Reverb..."
-#~ msgstr "Reverberar ..."
 
 #~ msgid "Applying Reverb"
 #~ msgstr "A Aplicar Reverberação ..."
@@ -21166,9 +23291,6 @@ msgstr "Erro.~%Requer faixa estéreo."
 
 #~ msgid "Automated Recording Level Adjustment stopped as requested by user."
 #~ msgstr "Ajuste Automático do Nível de Gravação parado a pedido do utilizador."
-
-#~ msgid "Vertical Ruler"
-#~ msgstr "Régua Vertical"
 
 #~ msgid "&Quick Help (in web browser)"
 #~ msgstr "&Ajuda Rápida (no navegador de Internet)"
@@ -21430,381 +23552,16 @@ msgstr "Erro.~%Requer faixa estéreo."
 #~ msgid "From Pitch"
 #~ msgstr "Do Tom"
 
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Registo de alterações"
+
 #, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"A marca Audacity%s é usada neste software unicamente por motivos "
-"informativos e de descrição."
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"
 
-#: src/AboutDialog.cpp
-msgid "Emeritus:"
-msgstr "Eméritos do Audacity:"
+#~ msgid "Commit Id:"
+#~ msgstr "Id. do commit:"
 
-#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s, web developer"
-msgstr "%s, desenvolvimento web do Audacity"
-
-#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s, tester"
-msgstr "%s, testagem do Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Registo de alterações"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
-msgstr "Karaoke do Tenacity%s"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/BatchCommands.cpp
-msgid "Fade Ends"
-msgstr "Suavização na saída (fade-end)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"O Tenacity não é produzido ou endossado pela empresa MuseCY SM Ltd. nem "
-"Dominic M Mazzoni."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s colaboradores"
-
-#. i18n-hint: The program's name substitutes for %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s website: "
-msgstr "%s sítio na web: "
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Note que os nomes estão ordenados alfabeticamente e não por ordem de "
-"importância."
-
-#: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Id. do commit:"
-
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "OK"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Tango Icon Gallery (toolbar icons)"
-msgstr "Tango Icon Gallery (ícones da barra de ferramentas)"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
-msgstr ""
-"Scripts Nyquist (*.ny)|*.ny|Scripts Lisp (*.lsp)|*.lsp|Todos os ficheiros|*"
-
-#: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manual do Tenacity"
-
-#. i18n-hint: This is the heading for a column in the edit macros dialog
-#: src/BatchProcessDialog.cpp
-msgid "Macro"
-msgstr "Macro"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "Lá♯/Si♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "Sol♯/Lá♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "Fá♯/Sol♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "Ré♯/Mi♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "Dó♯/Ré♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "Si♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "Lá♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "Sol♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "Mi♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "Ré♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "Si"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "Lá♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "Lá"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "Sol♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "Sol"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "Fá♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "Fá"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "Mi"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "Ré♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "Ré"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "Dó♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "Dó"
-
-#. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Solo"
-msgstr "Solo"
-
-#: src/LyricsWindow.cpp
-msgid "&Karaoke..."
-msgstr "&Karaoke..."
-
-#: src/FreqWindow.cpp
-msgid "spectrum.txt"
-msgstr "espectro.txt"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%.4f sec (%d Hz) (%s) = %.3f"
-msgstr "%.4f seg (%d Hz) (%s) = %.3f"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%.4f sec (%d Hz) (%s) = %f"
-msgstr "%.4f seg (%d Hz) (%s) = %f"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
-
-#: src/FreqWindow.cpp
-msgid "Cursor:"
-msgstr "Cursor:"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
-msgid "Zoom"
-msgstr "Ampliação"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#: src/FileNames.cpp
-msgid ", "
-msgstr ", "
-
-#: src/FileNames.cpp
-msgid "Dynamically Linked Libraries"
-msgstr "Bibliotecas dinâmicas do sistema"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=4.5)"
-msgstr "Gaussiano(a=4.5)"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=3.5)"
-msgstr "Gaussiano(a=3.5)"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=2.5)"
-msgstr "Gaussiano(a=2.5)"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "Checkpointing %s"
-msgstr "A criar o ponto de restauração %s"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#: src/BuildInfo.h
-msgid ", 64 bits"
-msgstr ", 64 bits"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "testedesempenho.txt"
-
-#. i18n-hint: Benchmark means a software speed test
-#: src/Benchmark.cpp
-msgid "Benchmark"
-msgstr "Teste de desempenho"
-
-#. i18n-hint: This is the number of the command in the list
-#: src/BatchProcessDialog.cpp
-msgid "Num"
-msgstr "Número"
-
-#. i18n-hint:  A name given to a track, appearing as its menu button.
-#. The translation should be short or else it will not display well.
-#. At most, about 11 Latin characters.
-#. Dropout is a loss of a short sequence of audio sample data from the
-#. recording
-#: src/ProjectAudioManager.cpp
-msgid "Dropouts"
-msgstr "Perdas"
-
-#. i18n-hint a format string for hours, minutes, and seconds
-#: src/TimerRecordDialog.cpp
-msgid "099 h 060 m 060 s"
-msgstr "099 h 060 m 060 s"
-
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
-msgid "Play-at-Speed"
-msgstr "Reproduzir na velocidade ajustada"
-
-#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
-#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
-msgid "32-bit float"
-msgstr "32-bit flutuante"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Projeto %02i] "
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manual do Tenacity"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -9,54 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:31+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Romanian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/ro/>\n"
+"Language-Team: Romanian <https://hosted.weblate.org/projects/tenacity/tenacity/ro/>\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
-"20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Canal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Eroare la deschiderea fișierului"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Eroare la încărcarea metadatelor"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Bara de instrumente %s Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Înregistrare"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -67,9 +29,31 @@ msgstr "Nu s-a putut determina"
 msgid "%s bytes"
 msgstr "%ld octeți"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Simplu"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -80,12 +64,68 @@ msgid "2nd Experimental Command"
 msgstr "Selectați comanda"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Efecte Nyquist"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "Li&pește"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "Li&pește"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "Li&pește"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "Li&pește"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "&Selectează"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -100,28 +140,129 @@ msgid "Split &Horizontally"
 msgstr "Orizontal"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Show S&cript"
+msgstr "Salvat %s"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Show &Output"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "Bare de instrumen&te"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Stop"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Salvat %s"
+
+#. i18n-hint noun
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
+msgid "Output"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Load Nyquist script"
+msgstr "Efecte Nyquist"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Avertisment"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Save Nyquist script"
+msgstr "Efecte Nyquist"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Efecte Nyquist"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "No matches found"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Efecte Nyquist"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nou"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Deschide fișiere recente"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -155,7 +296,8 @@ msgstr "Copiază"
 msgid "Copy to clipboard"
 msgstr "Taie și copiază în clipboard"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Taie"
 
@@ -163,7 +305,8 @@ msgstr "Taie"
 msgid "Cut to clipboard"
 msgstr "Taie și copiază în clipboard"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Lipește"
 
@@ -188,7 +331,8 @@ msgstr "&Selectează"
 msgid "Select all text"
 msgstr "&Selectează"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Anulează"
 
@@ -196,20 +340,69 @@ msgstr "Anulează"
 msgid "Undo last change"
 msgstr "Schimbare de format"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Refă"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Schimbare de format"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Match"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Nicio etichetă de exportat."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Instrumentul precedent"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Lipește textul într-o etichetă nouă"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Instrumentul următor"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Început"
 
@@ -217,15 +410,40 @@ msgstr "Început"
 msgid "Start script"
 msgstr "Timpul de început"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Stop"
+msgstr "Oprit"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Stop script"
+msgstr "Timpul de început"
+
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informații despre compilare"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Activat"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Dezactivat"
 
@@ -235,8 +453,9 @@ msgid "The Build"
 msgstr "Compilare pentru testare și depanare"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "ID-ul de comitere:"
+#, fuzzy
+msgid "Version:"
+msgstr "Versiune"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -246,13 +465,23 @@ msgstr "Tipul de compilare:"
 msgid "Compiler:"
 msgstr "Compresor"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Prefix de instalare:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Dosar pentru setări:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Dosar pentru setări:"
 
 #: src/AboutDialog.cpp
@@ -272,7 +501,6 @@ msgstr "Conversie a ratei de eșantionare"
 msgid "MP3 Importing"
 msgstr "Import MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Import și export Ogg Vorbis"
@@ -281,7 +509,6 @@ msgstr "Import și export Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Suport pentru etichetă ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Import și export FLAC"
@@ -291,12 +518,12 @@ msgid "MP2 export"
 msgstr "Export MP2"
 
 #: src/AboutDialog.cpp
-msgid "FFmpeg Import/Export"
-msgstr "Import sau export FFmpeg"
+msgid "Import via QuickTime"
+msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Caracteristici"
+msgid "FFmpeg Import/Export"
+msgstr "Import sau export FFmpeg"
 
 #: src/AboutDialog.cpp
 msgid "Plug-in support"
@@ -313,6 +540,10 @@ msgstr "Suport pentru modificarea înălțimii și tempoului sunetului"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Suport pentru modificarea extremă a înălțimii și tempoului sunetului"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Caracteristici"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -339,6 +570,18 @@ msgstr "Nivel"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Nivel"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Nivel"
 
@@ -346,6 +589,54 @@ msgstr "Nivel"
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer and support"
+msgstr "Nivel"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Nivel"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Nivel"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Nivel"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Nivel"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
 msgstr "Nivel"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
@@ -360,6 +651,21 @@ msgstr "Nyquist"
 msgid "%s, web developer"
 msgstr "Nivel"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -369,6 +675,10 @@ msgstr "software gratuit, cu sursă deschisă, multiplatformă, pentru editarea 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Credite"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -403,14 +713,23 @@ msgid "%s Team Members"
 msgstr " Membri emeriți ai echipei"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Alți contribuitori"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "<b>Traducere în limba română</b><br><a href=\"mailto:gale@audacityteam.org\">Gale</a> (20??-2012)<br><a href=\"mailto:cristi@secarica.ro\">Cristian Secară</a> (2014-2015)"
@@ -429,6 +748,26 @@ msgstr "Mulțumiri speciale:"
 msgid "%s website: "
 msgstr "Prima rulare a programului Audacity"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Alți contribuitori"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Clic și trageți pentru a ajusta dimensiunea relativă a pistelor stereo."
@@ -439,9 +778,15 @@ msgstr "Clic și trageți pentru a ajusta dimensiunea relativă a pistelor stere
 msgid "Record/Play head"
 msgstr "Înregistrare"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Acțiune"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Clic și trageți pentru a redimensiona pista."
@@ -449,12 +794,57 @@ msgstr "Clic și trageți pentru a redimensiona pista."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Clic și trageți pentru a redimensiona pista."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Lipește textul într-o etichetă nouă"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Mută pista jos de &tot"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Mută pista sus de &tot"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr " (dezactivat)"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr " (dezactivat)"
 
 #: src/AdornedRulerPanel.cpp
@@ -462,8 +852,16 @@ msgid "Timeline Options"
 msgstr "Acțiune"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "Liniște în locul selecției audi&o"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Lock Play Region"
@@ -473,9 +871,47 @@ msgstr "Zona de re&dare"
 msgid "Pinned Play Head"
 msgstr "Înregistrare"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Eroare"
+
+#: src/AudacityApp.cpp
+#, fuzzy, c-format
+msgid "Failed to remove %s"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Failed!"
+msgstr "Eșuat"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
+msgstr "Preferințe Audacity"
 
 #: src/AudacityApp.cpp
 #, c-format
@@ -487,6 +923,14 @@ msgstr ""
 "%s nu a putut fi găsit.\n"
 "\n"
 "A fost eliminat din lista fișierelor recente."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -507,7 +951,7 @@ msgstr "&Deschide..."
 msgid "Open &Recent..."
 msgstr "Deschide &recente..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "Despre &Audacity..."
@@ -521,37 +965,136 @@ msgid "&File"
 msgstr "&Fișier"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nu a putut găsi un loc unde să stocheze fișierele temporare.\n"
 "Introduceți un director adecvat în dialogul de preferințe."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nu a putut găsi un loc unde să stocheze fișierele temporare.\n"
 "Introduceți un director adecvat în dialogul de preferințe."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity este pe cale de a se închide. Reporniți Audacity pentru a folosi noul director pentru fișiere temporare."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+msgid ""
+"Running two copies of Tenacity simultaneously may cause\n"
+"data loss or cause your system to crash.\n"
+"\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Do you still want to start Tenacity?"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Eroare la deschiderea fișierului"
+
+#: src/AudacityApp.cpp
+msgid "The system has detected that another copy of Tenacity is running.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Use the New or Open commands in the currently running Tenacity\n"
+"process to open multiple projects simultaneously.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity rulează deja"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Fișiere de proiect Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
+
+#. i18n-hint: This displays a list of available options
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "this help message"
+msgstr "Activat"
+
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+msgid "run self diagnostics"
+msgstr ""
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "afișează versiunea Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -561,9 +1104,10 @@ msgid "audio or project file name"
 msgstr "numele de fișier audio sau al proiectului"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -576,16 +1120,50 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Fișiere de proiect Audacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&Reeșantionează..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Canale de înregistrare"
 
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Help"
+msgstr "&Ajutor"
+
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Jurnal Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -597,9 +1175,14 @@ msgstr "&Salvează..."
 msgid "Cl&ear"
 msgstr "Șt&erge"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "În&chide"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -610,6 +1193,10 @@ msgstr "Salvează jurnalul în:"
 #, c-format
 msgid "Couldn't save log to file: %s"
 msgstr "Nu s-a putut scrie în fișier:"
+
+#: src/AudioIO.cpp
+msgid "Could not find any audio devices.\n"
+msgstr ""
 
 #: src/AudioIO.cpp
 msgid ""
@@ -629,13 +1216,56 @@ msgid "Error Initializing Audio"
 msgstr "Eroare la inițializarea audio"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"Nu veți putea să ascultați sau să înregistrați audio.\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "Eroare la inițializarea audio"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Jurnal Audacity"
+
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
+#, c-format
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "Selectați dispozitivul de înregistrare\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Selectați dispozitivul de înregistrare\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -650,6 +1280,11 @@ msgstr "Dispozitiv:\n"
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Device name: %s\n"
+msgstr "Dispozitive\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Host name: %s\n"
 msgstr "Dispozitive\n"
 
 #: src/AudioIOBase.cpp
@@ -668,8 +1303,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Înregistrare\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Înregistrare\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Înregistrare\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Înregistrare\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -683,37 +1328,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Selectați dispozitivul de înregistrare\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Selectați dispozitivul de înregistrare\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Selectați dispozitivul de redare\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Nu s-a putut deschide fișierul de genuri muzicale.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Selectați dispozitivul de redare\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Înregistrare\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Importat '%s'\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Volum de redare\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Volum de redare\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Dispozitiv de înregistrare\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Volum de redare\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Volum de redare\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -721,17 +1369,44 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Selectați dispozitivul de înregistrare\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Selectați dispozitivul de înregistrare\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
 msgstr "Selectați dispozitivul de redare\n"
 
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
+msgstr "Selectați dispozitivul de redare\n"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Automatic Crash Recovery"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
+"\n"
+"After recovery, save the projects to ensure changes are written to disk."
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
+msgid "Recoverable &projects"
+msgstr ""
+
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Selectare"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Nume"
 
@@ -744,8 +1419,19 @@ msgid "&Recover Selected"
 msgstr "Selectare"
 
 #: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "Nu sunt selectate suficiente date."
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -768,12 +1454,22 @@ msgid "&Parameters"
 msgstr "&Parametri"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Detașează"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "Ale&geți comanda"
 
 #: src/BatchCommands.cpp
 msgid "MP3 Conversion"
 msgstr "Conversie în timp real"
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Fade Ends"
+msgstr "Mută mai jos"
 
 # hm ? sau import brut ?
 #: src/BatchCommands.cpp
@@ -797,6 +1493,33 @@ msgstr "Efe&ct"
 msgid "Menu Command (With Parameters)"
 msgstr "&Editare parametri"
 
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Editare parametri"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Your batch command of %s was not recognized."
+msgstr ""
+
+#. i18n-hint: active verb in past tense
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Applied Macro"
+msgstr "Efectul aplicat: %s"
+
 #: src/BatchCommands.cpp
 msgid "Apply Macro"
 msgstr "Se aplică"
@@ -813,8 +1536,29 @@ msgid "Apply '%s'"
 msgstr "Se aplică"
 
 #: src/BatchCommands.cpp
+#, c-format
+msgid ""
+"Apply %s with parameter(s)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/BatchCommands.cpp
 msgid "Test Mode"
 msgstr "Mod de test"
+
+#: src/BatchCommands.cpp
+#, fuzzy, c-format
+msgid "Apply %s"
+msgstr "Se aplică"
+
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
 
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
@@ -822,17 +1566,73 @@ msgstr "Mod de test"
 msgid "Select Macro"
 msgstr "Presetări de fabrică"
 
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Etichete..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Se aplică"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to project"
+msgstr "Se aplică"
+
 #: src/BatchProcessDialog.cpp
 msgid "&Project"
 msgstr "Proiecte"
 
 #: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply macro to files..."
+msgstr "Se aplică efectul Nyquist..."
+
+#: src/BatchProcessDialog.cpp
 msgid "&Files..."
 msgstr "&Fișier"
+
+#. i18n-hint: The Expand button makes the dialog bigger, with more in it
+#: src/BatchProcessDialog.cpp
+msgid "&Expand"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "No macro selected"
 msgstr "Nu sunt selectate suficiente date."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "Applying '%s' to current project"
+msgstr "&Salvează proiectul"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Please save and close the current project first."
+msgstr "&Salvează proiectul"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Select file(s) for batch processing..."
+msgstr "Sfârșitul selecției:"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Applying..."
+msgstr "Se aplică"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "File"
+msgstr "&Fișier"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "&Cancel"
+msgstr "Renunță"
 
 #: src/BatchProcessDialog.cpp
 msgid "Remo&ve"
@@ -850,9 +1650,30 @@ msgstr "Restaurează zo&na"
 msgid "I&mport..."
 msgstr "I&mportă..."
 
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "Exportă..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Editare etichete"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Command  "
+msgstr "&Comandă"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#, fuzzy
+msgid "Parameters"
+msgstr "&Parametri"
 
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp
 msgid "&Insert"
@@ -874,17 +1695,94 @@ msgstr "Mută mai s&us"
 msgid "Move &Down"
 msgstr "Mută mai j&os"
 
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Save"
+msgstr "&Salvează..."
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
+
+#. i18n-hint: This is the last item in a list.
+#: src/BatchProcessDialog.cpp
+msgid "- END -"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "%s changed"
+msgstr "Schimbare de format"
+
+#: src/BatchProcessDialog.cpp
+msgid "Do you want to save the changes?"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Enter name of new macro"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Name of new macro"
+msgstr "De câte ori să se repete:"
+
+#: src/BatchProcessDialog.cpp
+msgid "Name must not be blank"
+msgstr ""
+
+#. i18n-hint: The %c will be replaced with 'forbidden characters', like '/' and '\'.
+#: src/BatchProcessDialog.cpp
+#, c-format
+msgid "Names may not contain '%c' and '%c'"
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of a file.
+#: src/BatchProcessDialog.cpp
+#, fuzzy, c-format
+msgid "Are you sure you want to delete %s?"
+msgstr "Sigur vreți să ștergeți „%s” ?"
+
 #. i18n-hint: Benchmark means a software speed test
 #: src/Benchmark.cpp
 msgid "Benchmark"
 msgstr "&Rulează un test de performanță..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "De câte ori să se repete:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Închide"
 
@@ -899,22 +1797,137 @@ msgid "Export Benchmark Data as:"
 msgstr "Exportă etichetele ca:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "Preparing...\n"
+msgstr "Lungime"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, fuzzy, c-format
+msgid "Performing %d edits...\n"
+msgstr "Încarcă fișiere"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 #, c-format
 msgid "Paste: %lld\n"
 msgstr "Lipește\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Canale de înregistrare\n"
 
 #: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Benchmark completed successfully.\n"
 msgstr "Fișierul a fost decodat cu succes\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Necunoscut"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "Compilare pentru publicare"
 
 #: src/BuildInfo.h
 #, c-format
@@ -935,9 +1948,58 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Trebuie să selectați audio în fereastra proiectului."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Nu sunt selectate suficiente date."
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr "Trebuie să selectați audio în fereastra proiectului."
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr "Trebuie să selectați audio în fereastra proiectului."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -953,11 +2015,28 @@ msgstr "Nu s-a putut citi fișierul de setări predefinite."
 msgid "Checkpointing project"
 msgstr "Directorul curent:"
 
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "Directorul curent:"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 # hm ? urmează numele fișierului sau al unei erori ?
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Nu s-a putut scrie în fișier:\n"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
 
 # hm ? urmează numele fișierului sau al unei erori ?
 #: src/DBConnection.cpp
@@ -967,6 +2046,47 @@ msgid ""
 "\n"
 "%s"
 msgstr "Nu s-a putut scrie în fișier:"
+
+# hm ? urmează numele fișierului sau al unei erori ?
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to release savepoint:\n"
+"\n"
+"%s"
+msgstr "Nu s-a putut scrie în fișier:"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Removing Dependencies"
+msgstr "Dependințele proiectului"
+
+#: src/Dependencies.cpp
+msgid "Copying audio data into project..."
+msgstr ""
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "Dependințele proiectului"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1000,6 +2120,10 @@ msgstr "Nu copia"
 msgid "Copy All Files (Safer)"
 msgstr "Copiază toate fișierele (mai sigur)"
 
+#: src/Dependencies.cpp
+msgid "Whenever a project depends on other files:"
+msgstr ""
+
 #. i18n-hint: One of the choices of what you want Audacity to do when
 #. * Audacity finds a project depends on another file.
 #: src/Dependencies.cpp
@@ -1019,6 +2143,11 @@ msgid "Never copy any files"
 msgstr "Nu copia niciodată niciun fișier"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Taie și copiază în clipboard"
 
@@ -1031,7 +2160,27 @@ msgstr "„%s”, „%s”, „%s”\n"
 msgid "Missing"
 msgstr "Lipsesc fișierele"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dependencies.cpp
+msgid "If you proceed, your project will not be saved to disk. Is this what you want?"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Dependency Check"
+msgstr ""
+
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Nimic"
 
@@ -1039,19 +2188,113 @@ msgstr "Nimic"
 msgid "Rectangle"
 msgstr "Dreptunghi"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triunghi"
+
+#: src/Dither.cpp
+msgid "Shaped"
+msgstr ""
+
+#: src/FFT.cpp
+#, fuzzy
+msgid "Rectangular"
+msgstr "Dreptunghi"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
 msgid "Welch"
 msgstr "Bun venit !"
 
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg library not found"
+msgstr "FFmpeg nu a fost găsit"
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Locație"
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "To find '%s', click here -->"
+msgstr ""
+
 # hm ? sau răsfoiește ?
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Navighează..."
+
+#: src/FFmpeg.cpp
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr ""
 
 #. i18n-hint: (verb)
 #: src/FFmpeg.cpp src/export/ExportMP3.cpp
@@ -1071,8 +2314,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg nu a fost găsit"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1088,10 +2332,41 @@ msgstr ""
 msgid "Do not show this warning again"
 msgstr "Nu mai arăta din nou acest avertisment"
 
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr "Audacity se bazează pe codul din următoarele proiecte:"
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr "Audacity se bazează pe codul din următoarele proiecte:"
+
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
-msgstr "Audacity se bazează pe codul din următoarele proiecte:"
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
+"Perhaps %s is not writable or the disk is full.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
 
 #: src/FileException.h
 msgid "File Error"
@@ -1104,10 +2379,28 @@ msgid "Error (file may not have been written): %s"
 msgstr "Eroare (este posibil ca fișierul să nu fi fost scris): %s"
 
 #: src/FileFormats.cpp
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "&Copy all audio into project (safest)"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "As&k"
 msgstr "Întreabă utili&zatorul"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Toate Fișierele|*"
 
@@ -1116,6 +2409,11 @@ msgstr "Toate Fișierele|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Fișiere de proiect Audacity"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Biblioteci"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1128,6 +2426,10 @@ msgstr "Selectați un fișier MIDI..."
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Încarcă fișiere"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1154,6 +2456,30 @@ msgstr "Directorul %s nu există. Doriți să fie creat ?"
 msgid "Frequency Analysis"
 msgstr "Analiza frecvenței"
 
+#: src/FreqWindow.cpp src/prefs/SpectrumPrefs.h
+#, fuzzy
+msgid "Spectrum"
+msgstr "Spectrogramă"
+
+#: src/FreqWindow.cpp
+msgid "Standard Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Cuberoot Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Enhanced Autocorrelation"
+msgstr ""
+
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+msgid "Cepstrum"
+msgstr ""
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -1163,8 +2489,43 @@ msgid "%s window"
 msgstr "&Potrivește în fereastră"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "Linear frequency"
+msgstr "Frecvența de jurnalizare"
+
+#: src/FreqWindow.cpp
 msgid "Log frequency"
 msgstr "Frecvența de jurnalizare"
+
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoom"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1181,6 +2542,14 @@ msgid "Cursor:"
 msgstr "&Mută cursorul"
 
 #: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Algorithm:"
 msgstr "L&ogaritmic"
 
@@ -1188,13 +2557,26 @@ msgstr "L&ogaritmic"
 msgid "&Size:"
 msgstr "Dimensiune"
 
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Export..."
+msgstr "Exportă..."
+
 #: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "Acțiune"
 
 #: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Replot..."
 msgstr "Repetă..."
+
+#: src/FreqWindow.cpp
+msgid "To plot the spectrum, all selected tracks must be the same sample rate."
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, c-format
@@ -1205,8 +2587,49 @@ msgstr "A fost selectat prea mult audio. Numai primele %.1f secunde de audio vor
 msgid "Not enough data selected."
 msgstr "Nu sunt selectate suficiente date."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "spectrum.txt"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Export Spectral Data As:"
+msgstr "Exportă etichetele ca:"
+
 # hm ? urmează numele fișierului sau al unei erori ?
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Nu s-a putut scrie în fișier:"
@@ -1215,9 +2638,97 @@ msgstr "Nu s-a putut scrie în fișier:"
 msgid "Frequency (Hz)\tLevel (dB)"
 msgstr "Frecvență (Hz)\tNivel (dB)"
 
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Lag (seconds)\tFrequency (Hz)\tLevel"
+msgstr "Frecvență (Hz)\tNivel (dB)"
+
+#: src/FreqWindow.cpp
+msgid "Plot Spectrum..."
+msgstr ""
+
 #: src/HelpText.cpp
 msgid "Welcome!"
 msgstr "Bun venit !"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "În redare"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording Audio"
+msgstr "Sunete înregistrate"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording - Choosing the Recording Device"
+msgstr "Schimbă dispozitivul de înregistrare"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Recording - Choosing the Recording Source"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Recording - Setting the Recording Level"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Export audio"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Se deschide proiectul Audacity"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
 
 #: src/HelpText.cpp
 msgid "These are our support methods:"
@@ -1240,6 +2751,22 @@ msgstr " <a href=\"http://forum.audacityteam.org/\">Forum</a> (formulați între
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
 msgstr " [[http://wiki.audacityteam.org/index.php|Wiki]] (cele mai recente sfaturi utile și tutoriale, pe internet)"
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1286,11 +2813,35 @@ msgstr "&Suprimă"
 msgid "&Compact"
 msgstr "&Comandă"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Istoric..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.h
+#, fuzzy
+msgid "Internal Error"
+msgstr "Eroare LOF"
 
 #: src/LabelDialog.cpp
 msgid "Edit Labels"
@@ -1302,7 +2853,9 @@ msgid "Track"
 msgstr "Pistă"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etichetă"
 
@@ -1362,18 +2915,25 @@ msgstr "Introduceți numele pistei"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Pistă de etichete"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Prima rulare a programului Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Alegeți limba care să fie folosită de Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -1383,7 +2943,8 @@ msgstr "Alegeți limba care să fie folosită de Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Limba pe care ați ales-o, %s (%s), nu este aceeași cu limba sistemului, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Confirmă"
 
@@ -1401,8 +2962,20 @@ msgstr ""
 "Fișierul vechi a fost salvat ca '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Se deschide proiectul Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Mulțumiri speciale:"
+
+# hm ? sau răsfoiește ?
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Navighează..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1422,22 +2995,106 @@ msgstr "&Refă %s"
 msgid "&Redo"
 msgstr "&Refă"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "Dezactivat"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
 msgstr "Mixează"
 
+#: src/Mix.cpp src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mix and Render"
+msgstr "Mi&xează și randează"
+
+#: src/Mix.cpp
+#, fuzzy
+msgid "Mixing and rendering tracks"
+msgstr "Mixează și randează într-o nouă &pistă"
+
+#: src/MixerBoard.cpp
+#, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr ""
+
 # hm ? sau Amplificare ?
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Câștig"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
+#. i18n-hint: Title of the Pan slider, used to move the sound left or right
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Pan"
+msgstr "Sfârșit"
+
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Mut"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
+
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved gain slider"
+msgstr "Modifică eșantionul"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Moved velocity slider"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved pan slider"
+msgstr "Modifică eșantionul"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "Î&ncarcă..."
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1447,21 +3104,115 @@ msgid ""
 "Error: %s"
 msgstr "Nu s-a putut încărca fișierul de setări predefinite."
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Activează"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, fuzzy, c-format
+msgid "Module \"%s\" found."
+msgstr "FFmpeg nu a fost găsit"
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Da"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nu"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Încărcător de module Audacity"
 
 #: src/ModuleManager.cpp
 msgid "Try and load this module?"
 msgstr "Încercați și încărcați acest modul ?"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Note track.
+#: src/NoteTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Note Track"
+msgstr "Pistă nouă"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
@@ -1470,13 +3221,94 @@ msgstr "GiB"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Suprascrie fișierele existente"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
+
+# hm ? urmează numele fișierului sau al unei erori ?
+#: src/PluginManager.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to register:\n"
+"%s"
+msgstr "Nu s-a putut scrie în fișier:"
 
 #. i18n-hint A plug-in is an optional added program for a sound
 #. effect, or generator, or analyzer
@@ -1492,9 +3324,18 @@ msgstr[2] "Nu s-a putut determina\n"
 msgid "Enable new plug-ins"
 msgstr "Nu s-a putut determina"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Efecte Nyquist"
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Nu s-a putut determina"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
 
 #. i18n-hint: This is before radio buttons selecting which effects to show
 #: src/PluginRegistrationDialog.cpp
@@ -1531,6 +3372,25 @@ msgstr "Activat"
 msgid "E&nabled"
 msgstr "Activat"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Activat"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "&Selectează"
@@ -1539,7 +3399,8 @@ msgstr "&Selectează"
 msgid "C&lear All"
 msgstr "&Curăță"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Activ&ează"
 
@@ -1563,6 +3424,13 @@ msgid ""
 "%s"
 msgstr "Efectul aplicat: %s"
 
+#: src/PluginRegistrationDialog.cpp
+#, c-format
+msgid ""
+"Effect or Command at %s failed to register:\n"
+"%s"
+msgstr ""
+
 #: src/Printing.cpp
 msgid "There was a problem printing."
 msgstr "A apărut o problemă la tipărire."
@@ -1571,10 +3439,43 @@ msgstr "A apărut o problemă la tipărire."
 msgid "Print"
 msgstr "Tipărire"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgid "Actual Rate: %d"
 msgstr "Rata de biți actuală: %d"
+
+#: src/ProjectAudioManager.cpp src/effects/Effect.cpp
+msgid ""
+"Error opening sound device.\n"
+"Try changing the audio host, playback device and the project sample rate."
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "The tracks selected for recording must all have the same sampling rate"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
 
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
@@ -1584,11 +3485,187 @@ msgstr "Sunete înregistrate"
 msgid "Record"
 msgstr "Înregistrează"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Nu se poate deschide fișierul de proiect"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Treat missing audio as silence (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Fill in silence for missing display data (this session only)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Close project immediately with no further changes"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Progres"
+
+#: src/ProjectFSCK.cpp
+msgid "Cleaning up unused directories in project data"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Proiecte"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1611,6 +3688,14 @@ msgid "Failed to restore connection"
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
 #: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to execute a project file command:\n"
+"\n"
+"%s"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/ProjectFileIO.cpp
 #, c-format
 msgid ""
 "Unable to prepare project file command:\n"
@@ -1619,11 +3704,96 @@ msgid ""
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Nu s-a putut încărca fișierul de setări predefinite."
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Nu s-a putut salva fișierul de genuri muzicale."
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1632,12 +3802,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Nu s-a putut salva fișierul de genuri muzicale."
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1648,15 +3844,42 @@ msgid "Error Writing to File"
 msgstr "Eroare la scrierea fișierului: „%s”"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Tenacity failed to write file %s.\n"
+"Perhaps disk is full or not writable.\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Compacting project"
 msgstr "A fost creat un nou proiect"
 
-#. i18n-hint: %s will be replaced by the version number.
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
 #, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Despre &Audacity..."
+
+#. i18n-hint: E.g this is recovered audio that had been lost.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "(Recovered)"
+msgstr "Înregistrează"
+
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Fișierul a fost salvat folosind Audacity %s.\n"
 "În prezent folosiți Audacity %s. Pentru a putea deschide acest fișier trebuie să treceți la versiunea mai nouă."
@@ -1664,6 +3887,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Nu se poate deschide fișierul de proiect"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -1678,16 +3905,78 @@ msgid "Unable to parse project information."
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Salvează proiectul"
+
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Avertisment - proiect gol"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Proiecte"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Warning - Empty Project"
@@ -1697,15 +3986,51 @@ msgstr "Avertisment - proiect gol"
 msgid "Insufficient Disk Space"
 msgstr "Spațiu pe disc"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
 msgstr "Salvat %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Salvează proiectul „%s” ca..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -1713,9 +4038,21 @@ msgid "Overwrite Project Warning"
 msgstr "Suprascrie fișierele existente"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Salvează proiectul „%s” ca..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -1738,6 +4075,23 @@ msgstr "Instrument de selecție"
 msgid "%s is already open in another window."
 msgstr "%s este deja deschis în altă fereastră."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Eroare la deschiderea fișierului"
@@ -1747,8 +4101,31 @@ msgid "Error opening file"
 msgstr "Eroare la deschiderea fișierului"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"File may be invalid or corrupted: \n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Error Opening File or Project"
 msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Project was recovered"
+msgstr "Proiecte"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Recover"
+msgstr "Înregistrează"
 
 #: src/ProjectFileManager.cpp
 #, c-format
@@ -1768,20 +4145,45 @@ msgid "Error Importing"
 msgstr "Eroare la import"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Salvează proiectul"
+
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Nu se poate deschide fișierul de proiect"
 
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Comandă"
+
 #: src/ProjectHistory.cpp
 msgid "Created new project"
 msgstr "A fost creat un nou proiect"
 
+#: src/ProjectHistory.cpp
+msgid "Automatic database backup failed."
+msgstr ""
+
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Bun venit la Audacity versiunea %s"
 
 # titlu
@@ -1796,9 +4198,23 @@ msgid "Save project before closing?"
 msgstr "Doriți salvarea modificărilor înainte închidere ?"
 
 #: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "Disk space remaining for recording: %s"
 msgstr "Pe disc mai este spațiu pentru %d minute de înregistrare."
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -1814,6 +4230,25 @@ msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
+#. i18n-hint: This is an experimental feature where the main panel in
+#. Audacity is put on a notebook tab, and this is the name on that tab.
+#. Other tabs in that notebook may have instruments, patch panels etc.
+#: src/ProjectWindow.cpp
+msgid "Main Mix"
+msgstr ""
+
 #: src/ProjectWindow.cpp
 msgid "Horizontal Scrollbar"
 msgstr "Orizontal"
@@ -1822,6 +4257,26 @@ msgstr "Orizontal"
 msgid "Vertical Scrollbar"
 msgstr "Vertical"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "Calitate"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Calitate"
@@ -1829,6 +4284,10 @@ msgstr "Calitate"
 #: src/Resample.cpp
 msgid "High Quality"
 msgstr "Calitate"
+
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
 
 #. i18n-hint: Audio data bit depth (precision): 16-bit integers
 #: src/SampleFormat.cpp
@@ -1849,9 +4308,82 @@ msgstr "32 de biți flotant"
 msgid "Unknown format"
 msgstr "Necunoscut"
 
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "Alegeți o locație pentru salvarea fișierelor exportate"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "Salvează jurnalul în:"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Alegeți..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "Dimensiune"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "Dimensiune"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+msgid "White Bkgnd"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr "&Potrivește în fereastră"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "Dimensiune &fereastră"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Screen"
+msgstr "Ecran întreg pornit/oprit"
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "Directorul curent:"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "Bare de instrumen&te"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -1865,7 +4397,13 @@ msgstr "Toate Fișierele|*"
 msgid "All Preferences"
 msgstr "Preferințe:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Selecție"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Potrivește selecția"
 
@@ -1873,35 +4411,200 @@ msgstr "Potrivește selecția"
 msgid "Timer"
 msgstr "Timpul de sfârșit"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Tools"
+msgstr "Bare de instrumen&te"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "T&ransport"
+
+#: src/Screenshot.cpp
+msgid "Mixer"
+msgstr ""
+
+#. i18n-hint: Noun (the meter is used for playback or record level monitoring)
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+msgid "Meter"
+msgstr ""
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Play Meter"
+msgstr "Nivel de redare"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Record Meter"
+msgstr "Dispozitiv de înregistrare"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&Editare"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device"
+msgstr "Dispozitive"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Redă-cu-viteza"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "Bare de instrumen&te"
+
+#: src/Screenshot.cpp src/TrackPanel.cpp
+#, fuzzy
+msgid "Track Panel"
+msgstr "Nume pistă"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
 
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Piste"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "&Ordonează pistele"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "Pistă nouă"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "Redă o secundă"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "&Ordonează pistele"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "Pune toate pistele pe &mut"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "&Aliniază pistele"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "Alegeți o locație pentru salvarea fișierelor exportate"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "Activat"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
 msgstr "Pre&vizualizare"
 
 #: src/ShuttleGui.cpp
+#, fuzzy
+msgid "Dry Previe&w"
+msgstr "Pre&vizualizare"
+
+#: src/ShuttleGui.cpp
 msgid "&Settings"
 msgstr "S&etări"
+
+#: src/ShuttleGui.cpp
+msgid "Debu&g"
+msgstr ""
 
 #: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
 msgid "Off"
 msgstr "Nimic"
+
+#: src/Snap.cpp
+#, fuzzy
+msgid "Nearest"
+msgstr "Acroșare la cel mai apropiat"
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+msgid "Sound Activated Record"
+msgstr ""
 
 #: src/SoundActivatedRecord.cpp
 msgid "Activation level (dB):"
 msgstr "Nivel de activare (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Bun venit la Audacity !"
 
 #: src/SplashDialog.cpp
@@ -1953,6 +4656,15 @@ msgid "Value"
 msgstr "Valoare"
 
 #: src/Tags.cpp
+msgid "&Add"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "&Remove"
+msgstr "Elimină"
+
+#: src/Tags.cpp
 msgid "Genres"
 msgstr "Genuri muzicale"
 
@@ -2001,8 +4713,18 @@ msgid "Unable to open genre file."
 msgstr "Nu s-a putut deschide fișierul de genuri muzicale."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Load Metadata As:"
+msgstr "Editare etichete metadate"
+
+#: src/Tags.cpp
 msgid "Error Loading Metadata"
 msgstr "Eroare la încărcarea metadatelor"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Save Metadata As:"
+msgstr "Editare etichete metadate"
 
 #: src/Tags.cpp
 msgid "Error Saving Tags File"
@@ -2012,19 +4734,231 @@ msgstr "Eroare la salvarea fișierului de etichete"
 msgid "Unsuitable"
 msgstr "Activează"
 
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+# hm ? urmează numele fișierului sau al unei erori ?
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
+"  %s."
+msgstr "Nu s-a putut scrie în fișier:"
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
+"  %s\n"
+"for writing."
+msgstr "Fișierul țintă nu a putut fi deschis pentru scriere"
+
+# hm ? urmează numele fișierului sau al unei erori ?
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write images to file:\n"
+"  %s."
+msgstr "Nu s-a putut scrie în fișier:"
+
+#. i18n-hint "Cee" means the C computer programming language
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Tenacity could not load file:\n"
+"  %s.\n"
+"Bad png format perhaps?"
+msgstr ""
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
+
+# hm ? urmează numele fișierului sau al unei erori ?
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Could not create directory:\n"
+"  %s"
+msgstr "Nu s-a putut scrie în fișier:\n"
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"Some required files in:\n"
+"  %s\n"
+"were already present. Overwrite?"
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not save file:\n"
+"  %s"
+msgstr "Nu s-a putut deschide fișierul: „%s”"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
+#. i18n-hint: Light meaning opposite of dark
+#: src/Theme.cpp
+#, fuzzy
+msgid "Light"
+msgstr "Dreapta"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Contrast..."
 
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Nume pistă"
+
+#. i18n-hint: This string is used to configure the controls which shows the recording
+#. * duration. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The string 'days' indicates that the first number in the control will be the number of days,
+#. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
+#. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
+#. * seconds.
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Duration"
+msgstr "&Durată:"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "Pistă de &timp"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record"
+msgstr "Înregistrare"
+
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
 msgstr "Înregistrare"
 
 #: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
 msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "Canale de înregistrare"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "NU s-a putut exporta"
+
+#: src/TimerRecordDialog.cpp
+msgid "Error in Automatic Save"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "NU s-a putut exporta"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "NU s-a putut exporta"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "Dispozitiv de înregistrare"
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -2034,13 +4968,34 @@ msgstr "Directorul curent:"
 msgid "Recording start:"
 msgstr "Dispozitiv de înregistrare"
 
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "&Durată:"
+
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
 msgstr "Înregistrare"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save enabled:"
+msgstr "NU s-a putut exporta"
+
+#: src/TimerRecordDialog.cpp
 msgid "Automatic Export enabled:"
 msgstr "NU s-a putut exporta"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Action after Timer Recording:"
+msgstr "Înregistrare"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
+msgstr "Eroare la deschiderea fișierului sau a proiectului"
 
 #: src/TimerRecordDialog.cpp
 msgid "Timer Recording stopped."
@@ -2074,9 +5029,79 @@ msgid ""
 "Recording exported: %s"
 msgstr "Dispozitiv de înregistrare"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Înregistrare"
+
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint a format string for days, hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+msgid "099 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: This string is used to configure the controls for times when the recording is
+#. * started and stopped. As such it is important that only the alphabetic parts of the string
+#. * are translated, with the numbers left exactly as they are.
+#. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
+#. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date and Time"
+msgstr "Timpul de început"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "Timpul de început"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date and Time"
+msgstr "Necunoscut"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date"
+msgstr "Timpul de sfârșit"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save"
+msgstr "NU s-a putut exporta"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
+msgstr "NU s-a putut exporta"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Project As:"
@@ -2087,6 +5112,11 @@ msgid "Select..."
 msgstr "Selectare"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export"
+msgstr "NU s-a putut exporta"
+
+#: src/TimerRecordDialog.cpp
 msgid "Enable Automatic &Export?"
 msgstr "NU s-a putut exporta"
 
@@ -2094,7 +5124,8 @@ msgstr "NU s-a putut exporta"
 msgid "Export Project As:"
 msgstr "Exportă etichetele ca:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opțiuni..."
 
@@ -2103,8 +5134,25 @@ msgid "After Recording completes:"
 msgstr "Dispozitiv de înregistrare"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -2114,11 +5162,23 @@ msgstr "Canale de înregistrare"
 msgid "Scheduled to stop at:"
 msgstr "Începutul selecției:"
 
+#: src/TimerRecordDialog.cpp
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr ""
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Dispozitiv de înregistrare"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -2127,6 +5187,33 @@ msgstr "Nivel de înregistrare"
 #: src/TimerRecordDialog.cpp
 msgid "Recording Exported:"
 msgstr "Dispozitiv de înregistrare"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
+msgstr "Înregistrare"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo,"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "TrackView"
+msgstr "Pistă"
+
+#. i18n-hint: The %d is replaced by the number of the track.
+#. i18n-hint: compose a name identifying an unnamed track by number
+#: src/TrackPanelAx.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "Track %d"
+msgstr "Pistă"
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this track is muted. (The mute button is on.)
@@ -2145,6 +5232,29 @@ msgstr "Solo"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Selectare"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Mute On"
+msgstr "Mut"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Solo On"
+msgstr "Solo"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "Selecție"
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
@@ -2211,37 +5321,167 @@ msgstr "Mută pista mai s&us"
 msgid "Move Track Down"
 msgstr "Mută pista mai &jos"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
+#. i18n-hint: Voice key is an experimental/incomplete feature that
+#. is used to navigate in vocal recordings, to move forwards and
+#. backwards by words.  So 'key' is being used in the sense of an index.
+#. This error message means that you've selected too short
+#. a region of audio to be able to use this feature.
+#: src/VoiceKey.cpp
+msgid "Selection is too small to use voice key."
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Results\n"
+msgstr ""
+
+#. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Energy                  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Sign Changes        -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+#, c-format
+msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
+msgstr ""
+
+#: src/VoiceKey.cpp
+msgid "Calibration Complete"
+msgstr ""
+
 #: src/WaveClip.cpp
 msgid "Resampling failed."
 msgstr "Dispozitiv de înregistrare"
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to paste the selection"
+msgstr ""
+
+#: src/WaveTrack.cpp
+msgid "There is not enough room available to expand the cut line"
+msgstr ""
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
 
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Se aplică"
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Selectați comanda"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "&Comandă"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Repetă %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
 msgstr "Sunete înregistrate"
 
+#: src/commands/CompareAudioCommand.cpp
+#, fuzzy
+msgid "Threshold:"
+msgstr "Liniște în locul audio"
+
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "A fost creată o nouă pistă audio"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Timpul de întârziere (secunde):"
 
+#: src/commands/Demo.cpp
+msgid "Decay factor:"
+msgstr ""
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Drag"
 msgstr "Tragere spre stânga"
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+msgid "Panel"
+msgstr ""
 
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
@@ -2255,9 +5495,38 @@ msgstr "Pistă"
 msgid "Track 1"
 msgstr "Pistă"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Dimensiune &fereastră"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -2275,17 +5544,51 @@ msgstr "Meniu"
 msgid "Preferences"
 msgstr "Preferințe:"
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Instrumentul următor"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Instrument de anvelopă"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etichete"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Tip"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Schimbare de format"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -2295,9 +5598,30 @@ msgstr "Mută pista mai &jos"
 msgid "Types:"
 msgstr "Tip"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Comentarii"
+
+#: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command:"
+msgstr "&Comandă"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -2316,6 +5640,11 @@ msgid "Number of Channels:"
 msgstr "De câte ori să se repete:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Exportă &multiplu..."
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Exportă &multiplu..."
 
@@ -2323,9 +5652,31 @@ msgstr "Exportă &multiplu..."
 msgid "Builtin Commands"
 msgstr "Selectați comanda"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Echipa de suport Audacity"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Necunoscut"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "Activat"
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Open Project2"
@@ -2363,11 +5714,22 @@ msgstr "&Salvează proiectul"
 msgid "Saves a copy of current project."
 msgstr "&Salvează proiectul"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Preferințe:"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Nume"
 
@@ -2378,6 +5740,23 @@ msgstr "Preferințe:"
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Valoare"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "Ti&părește..."
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Window"
@@ -2398,6 +5777,17 @@ msgstr "Ecran întreg pornit/oprit"
 #: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "Bare de instrumen&te"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "Efe&ct"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Toate Fișierele|*"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -2436,13 +5826,40 @@ msgid "All Tracks Plus"
 msgstr "Pune toate pistele pe &mut"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
+#. i18n-hint:  This really means the color, not as in "white noise"
+#: src/commands/ScreenshotCommand.cpp
+msgctxt "color"
+msgid "White"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "Înapoi"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Eroare la scrierea fișierului: „%s”"
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "Ti&părește..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -2485,6 +5902,14 @@ msgid "Select Frequencies"
 msgstr "Liniște"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&Ordonează pistele"
 
@@ -2493,7 +5918,12 @@ msgstr "&Ordonează pistele"
 msgid "Set"
 msgstr "Stabilește"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp
+msgid "Add"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Elimină"
 
@@ -2505,8 +5935,17 @@ msgstr "&Ordonează pistele"
 msgid "Track Count:"
 msgstr "Pistă de etichete"
 
+#: src/commands/SelectCommand.cpp
+msgid "Mode:"
+msgstr ""
+
 #: src/commands/SelectCommand.h
 msgid "Selects a time range."
+msgstr "Selectați un fișier MIDI..."
+
+#: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
 msgstr "Selectați un fișier MIDI..."
 
 #: src/commands/SelectCommand.h
@@ -2521,9 +5960,37 @@ msgstr "Selectați gazda audio"
 msgid "Set Clip"
 msgstr "Instrumentul următor"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Început"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -2541,6 +6008,17 @@ msgstr "Șterge"
 msgid "Edited Envelope"
 msgstr "Nivel"
 
+#. i18n-hint: The envelope is a curve that controls the audio loudness.
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Envelope"
+msgstr "Instrument de anvelopă"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
 msgstr "Șterge etic&heta"
@@ -2549,6 +6027,10 @@ msgstr "Șterge etic&heta"
 msgid "Label Index"
 msgstr "Editare etichetă"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Selectare"
@@ -2556,6 +6038,10 @@ msgstr "Selectare"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Editare etichete"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -2570,12 +6056,25 @@ msgid "Resize:"
 msgstr "Dimensiune"
 
 #: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
 msgid "Width:"
 msgstr "Lățime de bandă:"
 
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Dreapta"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Salvează proiectul"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -2588,6 +6087,10 @@ msgstr "Canal"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Status"
 msgstr "la începutul pi&stei"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
@@ -2603,12 +6106,41 @@ msgid "Gain:"
 msgstr "Câștig"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&Ordonează pistele"
+
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Linear"
+msgstr "&Liniar"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "R&eset"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Timpul de sfârșit"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Display:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -2630,16 +6162,36 @@ msgstr "Presetări de utilizatori"
 msgid "Spectral Select"
 msgstr "Potrivește selecția"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Pistă nouă"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "A fost creată o nouă pistă audio"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Amplifică"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "Amplificare (dB):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "Amplificare (dB):"
 
 #: src/effects/Amplify.cpp
@@ -2651,16 +6203,86 @@ msgid "Allo&w clipping"
 msgstr "Arată li&mitarea"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Pistă de etichete"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#. i18n-hint: Name of time display format that shows time in seconds
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "seconds"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/AutoDuck.cpp
+msgid "Ma&ximum pause:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Liniște în locul audio"
+
+#: src/effects/AutoDuck.cpp
+#, fuzzy
+msgid "Preview not available"
+msgstr "Informațiile despre dispozitiv nu sunt disponibile\n"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass and Treble"
 msgstr "Bași și înalte"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Simple tone control effect"
+msgstr "câtre începu&tul selecției"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Liniște în locul audio"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -2690,6 +6312,10 @@ msgstr "Înal&te (dB):"
 msgid "Level"
 msgstr "Nivel"
 
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "Modifică înălțimea sunetului"
@@ -2699,8 +6325,24 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Modifică înălțimea sunetului fără a schimba tempoul"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Suport pentru modificarea înălțimii și tempoului sunetului"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Modifică înălțimea sunetului fără a schimba tempoul"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
+
+#. i18n-hint: (noun) Musical pitch.
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "Pitch"
+msgstr "Înălțime sunet (EAC)"
 
 #. i18n-hint: changing musical pitch "from" one value "to" another
 #: src/effects/ChangePitch.cpp
@@ -2713,6 +6355,11 @@ msgstr "de la"
 msgctxt "change pitch"
 msgid "&from"
 msgstr "de la"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "from Octave"
+msgstr "Mai jos o octa&vă"
 
 #. i18n-hint: changing musical pitch "from" one value "to" another
 #: src/effects/ChangePitch.cpp
@@ -2727,8 +6374,30 @@ msgid "&to"
 msgstr "către"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "to Octave"
+msgstr "Mai jos o octa&vă"
+
+#: src/effects/ChangePitch.cpp
+msgid "Semitones (half-steps)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "&Semitones (half-steps):"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "Frequency"
+msgstr "Frecvență joasă:"
+
+#: src/effects/ChangePitch.cpp
 msgid "from (Hz)"
 msgstr "de la (Hz)"
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
@@ -2739,9 +6408,25 @@ msgid "t&o"
 msgstr "către"
 
 # hm ?
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Schimbare în procente:"
+
+# hm ?
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "Schimbare în procente:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -2750,6 +6435,14 @@ msgstr "4"
 #: src/effects/ChangeSpeed.cpp
 msgid "78"
 msgstr "8"
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -2763,11 +6456,35 @@ msgstr "Modifică înălțimea sunetului fără a schimba tempoul"
 msgid "Change Speed, affecting both Tempo and Pitch"
 msgstr "Modifică viteza afectând atât tempoul cât și înălțimea sunetului"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "&Speed Multiplier:"
+msgstr ""
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
 msgctxt "change speed"
 msgid "&from"
 msgstr "de la"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -2819,11 +6536,25 @@ msgstr "Suport pentru modificarea înălțimii și tempoului sunetului"
 msgid "Change Tempo without Changing Pitch"
 msgstr "Modifică tempoul fără a schimba înălțimea sunetului"
 
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
 msgid "&from"
 msgstr "de la"
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -2852,16 +6583,105 @@ msgstr "către"
 msgid "Length in seconds from %s, to"
 msgstr "Timpul de întârziere (secunde):"
 
+#: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Eliminare zgomot"
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, c-format
+msgid "Selection must be larger than %d samples."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "Liniște în locul audio"
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 msgid "Compressor"
 msgstr "Compresor"
 
 #: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "%.1f dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
 msgid "&Noise Floor:"
+msgstr "Zgomot:"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
 msgstr "Zgomot:"
 
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "&Durată:"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "&Durată:"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -2872,24 +6692,147 @@ msgid "&Attack Time:"
 msgstr "Timpul de întârziere (secunde):"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Timpul de întârziere (secunde):"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Repetat de %d ori"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "Repetat de %d ori"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Threshold %d dB"
+msgstr "Liniște în locul audio"
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Noise Floor %d dB"
+msgstr "Zgomot:"
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Attack Time %.2f secs"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Release Time %.1f secs"
+msgstr "Repetat de %d ori"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "A fost creată o nouă pistă audio"
+
 #: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "A fost creată o nouă pistă audio"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "A fost creată o nouă pistă audio"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Sfârșit"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "Înal&te (dB):"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Foreground:"
+msgstr "Înapoi"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Measure selection"
+msgstr "Taie selecția"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Background:"
+msgstr "Înapoi"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background start time"
+msgstr "Înapoi"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "Înapoi"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Mea&sure selection"
+msgstr "Taie selecția"
+
+#: src/effects/Contrast.cpp
 msgid "Result"
 msgstr "Rezultat"
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "R&eset"
 
 #: src/effects/Contrast.cpp
 msgid "&Difference:"
@@ -2899,6 +6842,27 @@ msgstr "&Diferență:"
 msgid "&Help"
 msgstr "&Ajutor"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Nu s-a putut determina"
+
 #. i18n-hint: dB abbreviates decibels
 #. * RMS abbreviates root mean square, a certain averaging method
 #: src/effects/Contrast.cpp
@@ -2906,11 +6870,151 @@ msgstr "&Ajutor"
 msgid "%.2f dB RMS"
 msgstr "%.1f dB"
 
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr "Directorul curent:"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
 #. i18n-hint: short form of 'decibels'
 #: src/effects/Contrast.cpp
 #, c-format
 msgid "%.2f dB"
 msgstr "%.1f dB"
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Exportă etichetele ca:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "'%s' a fost redenumit în '%s'"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "Înapoi"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "Rezultat"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Contrast..."
 
 #: src/effects/Distortion.cpp
 msgid "Hard Clipping"
@@ -2921,8 +7025,124 @@ msgid "Soft Clipping"
 msgstr "Arată li&mitarea"
 
 #: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Expand and Compress"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "Nivel"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "&Durată:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Arată li&mitarea"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -2945,8 +7165,16 @@ msgid "Distortion"
 msgstr "&Durată:"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Interfață"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -2957,20 +7185,153 @@ msgid "Parameter controls"
 msgstr "&Parametri"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Clipping level"
+msgstr "Liniște în locul audio"
+
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Liniște în locul audio"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "&Durată:"
+
+#: src/effects/Distortion.cpp
+msgid "Output level"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Repeat processing"
 msgstr "Repetă %s"
 
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "Arată li&mitarea"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Nivel de redare"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Nivel de redare"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "DTMF Tones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "Liniște"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
+#, fuzzy
+msgid "&Amplitude (0-1):"
+msgstr "Amplificator"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Durată:"
+
+#: src/effects/DtmfGen.cpp
+msgid "&Tone/silence ratio:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f dB"
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Tone duration:"
+msgstr "Canale de înregistrare"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "Silence duration:"
+msgstr "Liniște în locul audi&o"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -2980,9 +7341,18 @@ msgstr "Ecou"
 msgid "Repeats the selected audio again and again"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/Echo.cpp
+msgid "D&ecay factor:"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Built-in"
@@ -2996,7 +7366,8 @@ msgstr "Apăsați"
 msgid "Export Effect Parameters"
 msgstr "&Editare parametri"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Nu s-a putut deschide fișierul: „%s”"
@@ -3019,6 +7390,31 @@ msgstr "&Editare parametri"
 #, c-format
 msgid "%s: is not a valid presets file.\n"
 msgstr "Nu s-a putut încărca fișierul de setări predefinite.\n"
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Preparing preview"
+msgstr "&Lungimea previzualizării:"
+
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Previewing"
+msgstr "Pre&vizualizare"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -3054,6 +7450,35 @@ msgstr "Lungimea curentă"
 msgid "Factory Defaults"
 msgstr "Stabilește ca &implicit"
 
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "Sfârșitul selecției:"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
+
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
 msgstr "Rack de efecte"
@@ -3065,6 +7490,27 @@ msgstr "&Aplică"
 #: src/effects/EffectUI.cpp
 msgid "Latency: 0"
 msgstr "Latență: 0"
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Clic pentru a începe"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Move Up"
@@ -3091,6 +7537,15 @@ msgid "Mark effect as a favorite"
 msgstr "Marchează efectul ca favorit"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Mută efectul mai jos în rack"
+
+#: src/effects/EffectUI.cpp
+msgid "Name of the effect"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Latență: %4d"
@@ -3098,6 +7553,20 @@ msgstr "Latență: %4d"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Selectați comanda"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "&Gestionare istoric"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "&Pornește redarea"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3114,6 +7583,16 @@ msgid "&Preview effect"
 msgstr "Pre&vizualizare"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Sari peste îna&poi"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Sari peste î&nainte"
+
+#: src/effects/EffectUI.cpp
 msgid "Skip forward"
 msgstr "Sari peste îna&poi"
 
@@ -3128,6 +7607,11 @@ msgstr "Activează"
 #: src/effects/EffectUI.cpp
 msgid "Save Preset..."
 msgstr "Salvează proiectul c&a..."
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "Presetări de fabrică"
 
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
@@ -3146,13 +7630,59 @@ msgid "Options..."
 msgstr "Opțiuni..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Tip"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Name: %s"
+msgstr "Nume"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Versiune"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Eroare:"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Description: %s"
+msgstr "&Editează bara de unelte"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "Sigur vreți să ștergeți „%s” ?"
 
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "Salvează proiectul c&a..."
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Preset name:"
+msgstr "Apăsați"
+
 #: src/effects/EffectUI.cpp
 msgid "You must specify a name"
 msgstr "Mai întâi trebuie să selectați o pistă."
+
+#: src/effects/EffectUI.cpp
+msgid ""
+"Preset already exists.\n"
+"\n"
+"Replace?"
+msgstr ""
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3164,9 +7694,44 @@ msgstr "O&prește redarea"
 msgid "Play"
 msgstr "Redă"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cosine"
+msgstr "&Liniar"
+
+#: src/effects/Equalization.cpp
+msgid "Cubic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Equalization"
+msgstr "Se aplică"
+
 #: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
 msgid "Filter Curve EQ"
 msgstr "Presetări de fabrică"
+
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
@@ -3177,6 +7742,18 @@ msgid "Bass Cut"
 msgstr "Bași"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Treble Boost"
 msgstr "Înalte"
 
@@ -3185,20 +7762,121 @@ msgid "Treble Cut"
 msgstr "Înalte"
 
 #: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "To apply Equalization, all selected tracks must have the same sample rate."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Track sample rate is too low for this effect."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Previzualizare efecte"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "Tip"
 
 #: src/effects/Equalization.cpp
+msgid "Draw Curves"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Instrument de desenare"
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Interpolation type"
 msgstr "Interfață"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Frecvență centrală:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Frecvență centrală:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "&Lungimea previzualizării:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "&Lungimea previzualizării:"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Presetări de fabrică"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Presetări de fabrică"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Invert"
@@ -3213,12 +7891,116 @@ msgid "Show g&rid lines"
 msgstr "Arată fișierele ascunse"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Processing: "
+msgstr "&Restrânge toate pistele"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&efault"
+msgstr "Implicite"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Rulează un test de performanță..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Eroare la încărcarea metadatelor"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve not found"
+msgstr "FFmpeg nu a fost găsit"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "&Gestionare istoric"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Nu s-a putut determina"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "&Mută cursorul"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "NumeNou"
+
+#: src/effects/Equalization.cpp
 msgid "D&elete..."
 msgstr "Șt&erge..."
 
 #: src/effects/Equalization.cpp
 msgid "&Get More..."
 msgstr "&Obține mai multe..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "De&faults"
+msgstr "Implicite"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3235,6 +8017,10 @@ msgid "Rename '%s'"
 msgstr "'%s' a fost redenumit în '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Same name"
 msgstr "Același nume"
 
@@ -3248,44 +8034,348 @@ msgid "Curve exists"
 msgstr "Curba există"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Can't delete 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Șterge '"
+
+#: src/effects/Equalization.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Deletion"
+msgstr "Confirmă"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "Delete %d items?"
+msgstr "Șterge '"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Choose an EQ curve file"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Exportă etichete&le..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cannot Export 'unnamed'"
+msgstr "Nu se poate exporta audioul către %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Dispozitiv de înregistrare"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "Curba există"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "Nicio etichetă de exportat."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade In"
+msgstr "Mută mai jos"
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade Out"
+msgstr "Tipul de compilare:"
 
 #: src/effects/Fade.cpp
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Clic și trageți pentru a redimensiona pista."
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Clic și trageți pentru a redimensiona pista."
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "Arată li&mitarea"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Arată li&mitarea"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "Liniște în locul audio"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "Liniște în locul audio"
+
+#: src/effects/Generator.cpp
+msgid "There is not enough room available to generate the audio"
+msgstr ""
+
+#: src/effects/Invert.cpp
+#, fuzzy
+msgid "Invert"
+msgstr "&Inversează"
+
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Efecte Nyquist"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "perceived loudness"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalizing Loudness...\n"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Analyzing: %s"
+msgstr "&Analizare"
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing: %s"
+msgstr "&Restrânge toate pistele"
+
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Zoom &normal"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
+
+#. i18n-hint: not a color, but "white noise" having a uniform spectrum
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "White"
+msgstr ""
+
+#. i18n-hint: not a color, but "pink noise" having a spectrum with more power
+#. in low frequencies
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Pink"
+msgstr ""
+
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
 
 #: src/effects/Noise.cpp
 msgid "Noise"
 msgstr "Zgomot:"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Tipul de compilare:"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Median"
+msgstr "Calitate"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Second greatest"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Zoom implicit"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Zoom implicit"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Reducere de zgomot"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "All noise profile data must have the same sample rate."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Selected noise profile is too short."
+msgstr "Nu s-a putut deschide fișierul:"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Noise reduction (dB):"
+msgstr "Re&ducere de zgomot (dB):"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Noise reduction"
 msgstr "Reducere de zgomot"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Sensitivity:"
+msgstr "&Sensibilitate (dB):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Sensitivity"
+msgstr "&Sensibilitate (dB):"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Attac&k time (secs):"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Attack time"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "R&elease time (secs):"
 msgstr "Timpul de întârziere (secunde):"
 
 #: src/effects/NoiseReduction.cpp
@@ -3297,8 +8387,29 @@ msgid "&Frequency smoothing (bands):"
 msgstr "N&etezire de frecvență (Hz):"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "N&etezire de frecvență (Hz):"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "&Sensibilitate (dB):"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Old Sensitivity"
+msgstr "&Sensibilitate (dB):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 1"
 msgstr "Pasul 1"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid ""
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
+"then click Get Noise Profile:"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Get Noise Profile"
@@ -3308,9 +8419,31 @@ msgstr "Obține profilul de z&gomot"
 msgid "Step 2"
 msgstr "Pasul 2"
 
+#: src/effects/NoiseReduction.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Noise:"
 msgstr "Zgomot:"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "&Elimină special"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Dimensiune"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -3324,9 +8457,63 @@ msgstr "Dimensiune &fereastră"
 msgid "Window si&ze:"
 msgstr "Dimensiune &fereastră"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - implicit"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -3341,6 +8528,16 @@ msgid "Noise Removal"
 msgstr "Eliminare zgomot"
 
 #: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to remove noise.\n"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Noise re&duction (dB):"
 msgstr "Re&ducere de zgomot (dB):"
 
@@ -3353,36 +8550,249 @@ msgid "Fr&equency smoothing (Hz):"
 msgstr "N&etezire de frecvență (Hz):"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Re&move"
 msgstr "Eli&mină"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalize"
+msgstr "Zoom &normal"
+
+#: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Removing DC offset and Normalizing...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset...\n"
+msgstr "Elimină"
+
+#: src/effects/Normalize.cpp
+msgid "Normalizing without removing DC offset...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "&Normalize peak amplitude to   "
+msgstr "Amplificator"
 
 #: src/effects/Normalize.cpp
 msgid "Peak amplitude dB"
 msgstr "Amplificator"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
+#. i18n-hint: This is how many times longer the sound will be, e.g. applying
+#. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
+#. * will give an (approximately) 10 second sound
+#.
+#: src/effects/Paulstretch.cpp
+msgid "&Stretch Factor:"
+msgstr ""
+
 #: src/effects/Paulstretch.cpp
 msgid "&Time Resolution (seconds):"
 msgstr "Reducere de zgomot"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Phaser"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Etape:"
 
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Etape:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
+
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "N&etezire de frecvență (Hz):"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "N&etezire de frecvență (Hz):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO Sta&rt Phase (deg.):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO start phase in degrees"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Profunzime:"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Feedbac&k (%):"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "&Output gain (dB):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Output gain (dB)"
+msgstr "Bași (dB):"
+
+#: src/effects/Repair.cpp
+msgid "Repair"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
+"\n"
+"Zoom in and select a tiny fraction of a second to repair."
+msgstr ""
+
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Repetă"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "De câte ori să se repete:"
+
+#: src/effects/Repeat.cpp
+#, fuzzy
+msgid "Current selection length: dd:hh:mm:ss"
+msgstr "Lungimea curentă"
+
+#: src/effects/Repeat.cpp
+#, fuzzy
+msgid "New selection length: dd:hh:mm:ss"
+msgstr "Lungimea curentă"
 
 #: src/effects/Repeat.cpp
 #, c-format
@@ -3394,6 +8804,104 @@ msgstr "Lungimea curentă"
 msgid "New selection length: %s"
 msgstr "Lungimea curentă"
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Eliminare pistă"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "Calitate"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Inversează"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Dimensiune"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Rever&berance (%):"
+msgstr "Inversează"
+
+#: src/effects/Reverb.cpp
+msgid "Da&mping (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Profunzime (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Bași (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Bași (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Stereo,"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
+
 #: src/effects/Reverb.cpp
 #, c-format
 msgid "Reverb: %s"
@@ -3403,13 +8911,128 @@ msgstr "Inversează"
 msgid "Reverse"
 msgstr "Inversează"
 
+#: src/effects/Reverse.cpp
+#, fuzzy
+msgid "Reverses the selected audio"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Încarcă fișiere"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "To apply a filter, all selected tracks must have the same sample rate."
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Tipul de compilare:"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Subtype:"
+msgstr "Tipul de compilare:"
+
 #: src/effects/ScienFilter.cpp
 msgid "Cutoff (Hz)"
 msgstr "la (Hz)"
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "C&utoff:"
+msgstr "la (Hz)"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Align MIDI to Audio"
+msgstr "&Aliniază sfârșit la sfârșit"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "&Durată:"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "&Durată:"
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
 msgstr "Dimensiune &fereastră"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size"
+msgstr "Dimensiune &fereastră"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Silence Threshold:"
+msgstr "Liniște în locul audio"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold"
@@ -3421,6 +9044,15 @@ msgstr "Liniște în locul audio"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "Ordonează după timp"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "Ordonează după timp"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -3459,11 +9091,20 @@ msgstr "Stabilește ca &implicit"
 msgid "Restore Defaults"
 msgstr "Stabilește ca &implicit"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Liniște"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -3489,9 +9130,76 @@ msgstr "Divizează stereo în mono „%s”"
 msgid "Sliding Stretch"
 msgstr "Liniște în locul audio"
 
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Tempo Change (%)"
+msgstr "Suport pentru modificarea înălțimii și tempoului sunetului"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Tempo Change (%)"
+msgstr "Suport pentru modificarea înălțimii și tempoului sunetului"
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "L&ogaritmic"
+
+#: src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Sine"
+msgstr ""
+
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Square"
 msgstr "Pătrat"
+
+#: src/effects/ToneGen.cpp plug-ins/tremolo.ny
+msgid "Sawtooth"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Square, no alias"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
 
 #: src/effects/ToneGen.cpp
 msgid "&Waveform:"
@@ -3502,8 +9210,50 @@ msgid "&Frequency (Hz):"
 msgstr "N&etezire de frecvență (Hz):"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "N&etezire de frecvență (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "N&etezire de frecvență (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Începutul selecției:"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Amplificator"
+
+#: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
 msgstr "Interfață"
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Detected Silence"
+msgstr "Detectează liniștea"
+
+#: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Liniște"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -3513,11 +9263,38 @@ msgstr "Detectează liniștea"
 msgid "Tr&uncate to:"
 msgstr "Trunchiază la:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Compresor"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "Efecte Vamp"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Nu s-a putut deschide biblioteca de codare MP3 !"
 
@@ -3525,29 +9302,127 @@ msgstr "Nu s-a putut deschide biblioteca de codare MP3 !"
 msgid "VST Effect Options"
 msgstr "Setările efectului"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Lungime nouă"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Combinație de taste"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "Combinație de taste"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Save VST Preset As:"
+msgstr "Salvează proiectul c&a..."
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Standard VST bank file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Standard VST program file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Fișiere de proiect Audacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Load VST Preset:"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Selectați un fișier MIDI..."
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "Eroare la deschiderea fișierului sau a proiectului"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Nu s-a putut încărca fișierul de setări predefinite."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Setările efectului"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Nu s-a putut încărca fișierul de setări predefinite."
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -3558,24 +9433,85 @@ msgid "Reso&nance:"
 msgstr "Rezonanța:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Rezonanța:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "N&etezire de frecvență (Hz):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "N&etezire de frecvență (Hz):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Efecte Nyquist"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "Nu s-a putut deschide fișierul:"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Could not initialize component"
+msgstr "Nu s-a putut deschide fișierul:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effect Options"
+msgstr "Setările efectului"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Interfață"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Selectează clipul sau întreaga pistă"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "&Potrivește în fereastră"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Generare"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Preset"
+msgstr "Apăsați"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Location"
@@ -3589,6 +9525,11 @@ msgstr "Nu s-a putut deschide fișierul: „%s”"
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Unable to read the preset from \"%s\""
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to encode preset from \"%s\""
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -3609,6 +9550,11 @@ msgid "Export Audio Unit Preset As %s:"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Standard Audio Unit preset file"
+msgstr "Fișiere de proiect Audacity"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid ""
 "Could not export \"%s\" preset\n"
@@ -3617,24 +9563,164 @@ msgid ""
 msgstr "Nu s-a putut deschide fișierul: „%s”"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Export Audio Unit Presets"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Import Audio Unit Preset As %s:"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Failed to set preset name"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to retrieve preset content"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Conversie a ratei de eșantionare"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to write XML preset to \"%s\""
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+# hm ? urmează numele fișierului sau al unei erori ?
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Nu s-a putut scrie în fișier:"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Fișier audio"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "LADSPA Effects"
+msgstr "Efecte Vamp"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Provides LADSPA Effects"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "LADSPA Effect Options"
+msgstr "Setările efectului"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Effect Output"
+msgstr "Setările efectului"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr ""
+
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
 msgstr "Setările efectului"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Generare"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
 
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efecte Vamp"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Efecte Nyquist"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -3650,6 +9736,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Nu sunt selectate suficiente date."
 
@@ -3662,8 +9766,75 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Nu se pot aplica efecte pe piste stereo în care pistele nu se potrivesc."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Debug Output: "
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr "Dispozitiv de înregistrare"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
 msgstr "Nyquist"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned a list."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "Nyquist returned the value: %f"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "Nyquist returned the value: %d"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned too many audio channels.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned one audio channel as an array.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned an empty array.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Nyquist returned nil audio.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -3674,10 +9845,37 @@ msgstr "Aceasră versiune Audacity nu a fost compilată cu suport pentru %s."
 msgid "Could not open file"
 msgstr "Nu s-a putut deschide fișierul:"
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Nu s-a putut deschide fișierul:"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Nu s-a putut încărca fișierul de setări predefinite.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -3696,6 +9894,21 @@ msgstr "Efecte Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Deschide fișiere recente"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Nu s-a putut deschide fișierul:"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
 
 # titlu
 #: src/effects/nyquist/Nyquist.cpp
@@ -3717,9 +9930,52 @@ msgstr "Selectați un fișier MIDI..."
 msgid "Save file as"
 msgstr "Salvează fișierele"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Efecte Vamp"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "Nu se pot aplica efecte pe piste stereo în care pistele nu se potrivesc."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "Acțiune"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spectrogramă"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Setările efectului"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -3747,12 +10003,70 @@ msgid "Are you sure you want to export the file as \"%s\"?\n"
 msgstr "Sigur vreți să exportați fișierul ca \"\n"
 
 #: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
 msgstr "Numele de cale mai lungi de 256 caractere nu sunt suportate."
 
 #: src/export/Export.cpp
+#, c-format
+msgid "A file named \"%s\" already exists. Replace?"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one mono file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one stereo file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down to one exported file according to the encoder settings."
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Advanced Mixing Options"
+msgstr "Setările efectului"
+
+#: src/export/Export.cpp
 msgid "Format Options"
 msgstr "Setările efectului"
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Channel: %2d"
+msgstr "Canal"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Output Channels: %2d"
+msgstr "%d canale"
+
+#: src/export/Export.cpp
+msgid "Mixer Panel"
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -3761,10 +10075,43 @@ msgid ""
 "Error %s"
 msgstr "NU s-a putut exporta"
 
+#: src/export/ExportCL.cpp
+msgid "Show output"
+msgstr ""
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+msgid "Executables"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Selectați comanda"
+
+#: src/export/ExportCL.cpp
+msgid "(external program)"
+msgstr ""
+
 #: src/export/ExportCL.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Cannot export audio to %s"
 msgstr "Nu se poate exporta audioul către %s"
+
+#: src/export/ExportCL.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export"
+msgstr "Exportă..."
 
 #: src/export/ExportCL.cpp
 msgid "Exporting the selected audio using command-line encoder"
@@ -3775,24 +10122,185 @@ msgid "Exporting the audio using command-line encoder"
 msgstr "Se exportă audio selectat folosind un codor în linie de comandă"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Command Output"
+msgstr "Acțiunea comenzii"
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
 "Ați selectat un nume de fișier cu o extensie de fișier nerecunoascută.\n"
 "Vreți să continuați ?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "FFmpeg nu a fost găsit"
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Nu s-a putut încărca fișierul de setări predefinite."
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Eroare FFmpeg"
 
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Exporting the audio as %s"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Modifică eșantionul"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample"
+msgstr "&Reeșantionează..."
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "Simplu"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -3801,6 +10309,49 @@ msgstr "Rată de biți:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Calitate"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.1f dB"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -3811,12 +10362,61 @@ msgid "On"
 msgstr "&Deschide..."
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Constrained"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Audio..."
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Tipul de compilare:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mediumband"
+msgstr "Calitate"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -3831,8 +10431,21 @@ msgid "Frame Duration:"
 msgstr "&Durată:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Vbr Mode:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Application:"
 msgstr "Se aplică"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Cutoff:"
+msgstr "la (Hz)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
@@ -3847,17 +10460,427 @@ msgid "Error Saving FFmpeg Presets"
 msgstr "Eroare la deschiderea fișierului sau a proiectului"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Suprascrie curba existentă '"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "Confirmă"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "A fost creată o nouă pistă audio"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Directorul %s nu există. Doriți să fie creat ?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "'%s' a fost redenumit în '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Main"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "Import sau export FFmpeg"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Nivel"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Nivel"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Nivel"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "Apăsați"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Apăsați"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Exportă etichetele ca:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Exportă etichetele ca:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Directorul curent:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Show All Codecs"
+msgstr "Arată tot"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Acțiune"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Limbă:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Quality:"
+msgstr "Calitate"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "&Rata de eșantionare implicită:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Toate Fișierele|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Opțiuni..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Compresor"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Nume"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Instrument de selecție"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Stabilește rata"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "Titlu pistă"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "'%s' a fost redenumit în '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "Nicio etichetă de exportat."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file to export presets into"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -3880,8 +10903,44 @@ msgid "Level:"
 msgstr "Nivel:"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Bit depth:"
+msgstr "Rată de biți:"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "FLAC Files"
+msgstr "Încarcă fișiere"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Nu s-a putut deschide fișierul: „%s”"
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the selected audio as FLAC"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/export/ExportFLAC.cpp
 msgid "Exporting the audio as FLAC"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/export/ExportMP2.cpp
+#, fuzzy
+msgid "MP2 Files"
+msgstr "Încarcă fișiere"
+
+#: src/export/ExportMP2.cpp
+msgid "Cannot export MP2 with this sample rate and bit rate"
+msgstr ""
 
 #: src/export/ExportMP2.cpp src/export/ExportMP3.cpp src/export/ExportOGG.cpp
 msgid "Unable to open target file for writing"
@@ -3898,13 +10957,148 @@ msgid "Exporting the audio at %ld kbps"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
 
 #: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+msgid "Standard"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "Medium"
 msgstr "Calitate"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Variable"
+msgstr "Previzualizare efecte"
+
+#: src/export/ExportMP3.cpp
+msgid "Average"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Constant"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "2 (stereo)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Bit Rate Mode:"
+msgstr "Rată de biți:"
 
 #. i18n-hint: meaning accuracy in reproduction of sounds
 #: src/export/ExportMP3.cpp src/prefs/QualityPrefs.cpp src/prefs/QualityPrefs.h
 msgid "Quality"
 msgstr "Calitate"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Channel Mode:"
+msgstr "Canal"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Elimină pista"
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Tenacity needs the file %s to create MP3s."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Location of %s:"
+msgstr "Locație"
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "To find %s, click here -->"
+msgstr ""
+
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+msgid "To get a free copy of LAME, click here -->"
+msgstr ""
 
 #. i18n-hint: It's asking for the location of a file, for
 #. * example, "Where is lame_enc.dll?" - you could translate
@@ -3915,11 +11109,49 @@ msgid "Where is %s?"
 msgstr "Unde se află %s?"
 
 #: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Fișiere de proiect Audacity"
+
+#: src/export/ExportMP3.cpp
 msgid "Extended libraries"
 msgstr "Biblioteci principale"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 Files"
+msgstr "Încarcă fișiere"
+
+#: src/export/ExportMP3.cpp
 msgid "Could not open MP3 encoding library!"
+msgstr "Nu s-a putut deschide biblioteca de codare MP3 !"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Could not initialize MP3 encoding library!"
 msgstr "Nu s-a putut deschide biblioteca de codare MP3 !"
 
 #: src/export/ExportMP3.cpp
@@ -3927,8 +11159,23 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "Bibliotecă de codare MP3 nevalidă sau nesuportată !"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
 
 #: src/export/ExportMP3.cpp
@@ -3937,17 +11184,65 @@ msgid "Exporting the audio with VBR quality %s"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "(Built-in)"
 msgstr "Efecte Nyquist"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export Multiple"
+msgstr "Exportă &multiplu..."
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Cannot Export Multiple"
+msgstr "Exportă &multiplu..."
+
+#: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Locația pentru export:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -3962,19 +11257,151 @@ msgid "Split files based on:"
 msgstr "Divizează fișierele pe baza:"
 
 #: src/export/ExportMultiple.cpp
+msgid "Include audio before first label"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name:"
+msgstr "Tipul de compilare:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Tipul de compilare:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Name files:"
+msgstr "Salvează fișierele"
+
+#: src/export/ExportMultiple.cpp
 msgid "Using Label/Track Name"
 msgstr "Se folosește eticheta sau numele pistei"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Se folosește eticheta sau numele pistei"
+
+#: src/export/ExportMultiple.cpp
+msgid "Numbering after File name prefix"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix:"
+msgstr "Tipul de compilare:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
+msgstr "Tipul de compilare:"
 
 #: src/export/ExportMultiple.cpp
 msgid "Overwrite existing files"
 msgstr "Suprascrie fișierele existente"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "\"%s\" successfully created."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Choose a location to save the exported files"
 msgstr "Alegeți o locație pentru salvarea fișierelor exportate"
 
 #: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr "Fișierul „%s” există deja, sigur vreți să fie suprascris ?"
+
+#: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
+msgstr "Nu s-a putut încărca fișierul de setări predefinite."
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Save As..."
+msgstr "Salvat %s"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis Files"
+msgstr "Nu este un fișier Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Nu s-a putut încărca fișierul de setări predefinite."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Nu s-a putut încărca fișierul de setări predefinite."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Nu s-a putut încărca fișierul de setări predefinite."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Nu s-a putut încărca fișierul de setări predefinite."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
 msgstr "Nu s-a putut încărca fișierul de setări predefinite."
 
 #: src/export/ExportOGG.cpp
@@ -3989,6 +11416,14 @@ msgstr "Se exportă audio selectat ca Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Se exportă audio selectat ca Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Antet:"
@@ -4002,12 +11437,47 @@ msgid "Other uncompressed files"
 msgstr "Alte fișiere necomprimate"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Eroare la import"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
 msgstr "Nu se poate exporta audio în acest format."
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "Se exportă audio selectat ca Ogg Vorbis"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -4015,13 +11485,184 @@ msgstr "Importat '%s'"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Sfârșitul selecției:"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Aceasră versiune Audacity nu a fost compilată cu suport pentru %s."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
 
 #: src/import/Import.cpp
 #, c-format
 msgid "File \"%s\" not found."
 msgstr "FFmpeg nu a fost găsit"
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Fișiere de proiect Audacity"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -4036,13 +11677,123 @@ msgid "Import Project"
 msgstr "Exportă etichetele ca:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Nu s-a putut găsi dosarul cu datele proiectului: „%s”"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Proiecte"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -4059,18 +11810,48 @@ msgstr "Nu s-a putut citi fișierul de setări predefinite."
 msgid "Unable to read %lld samples from %s"
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Nu s-a putut citi fișierul de setări predefinite."
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "Toate Fișierele|*"
+
+#: src/import/ImportLOF.cpp
+msgid "List of Files in basic text format"
+msgstr ""
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+msgid "Invalid window offset in LOF file."
+msgstr ""
 
 #. i18n-hint: You do not need to translate "LOF"
 #: src/import/ImportLOF.cpp
 msgid "LOF Error"
 msgstr "Eroare LOF"
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+msgid "Invalid duration in LOF file."
+msgstr ""
+
+#: src/import/ImportLOF.cpp
+msgid "MIDI tracks cannot be offset individually, only audio files can be."
+msgstr ""
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+msgid "Invalid track offset in LOF file."
+msgstr ""
 
 #: src/import/ImportMIDI.cpp
 #, c-format
@@ -4096,9 +11877,151 @@ msgstr "Nu s-a putut deschide fișierul:"
 msgid "Could not open file %s."
 msgstr "Nu s-a putut deschide fișierul: „%s”"
 
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "Încarcă fișiere"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis files"
+msgstr "Nu este un fișier Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Media read error"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Not an Ogg Vorbis file"
 msgstr "Nu este un fișier Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+msgid "Vorbis version mismatch"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Invalid Vorbis bitstream header"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Internal logic fault"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr "Alte fișiere necomprimate"
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16 biți PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -4109,12 +12032,55 @@ msgid "Signed 24 bit PCM"
 msgstr "24 biți PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24 biți PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16 biți PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32 de biți flotant"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32 de biți flotant"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 biți"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -4125,12 +12091,58 @@ msgid "24 bit DWVW"
 msgstr "24 de biți"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16 biți PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16 biți PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+# hm ?
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "Import MP3"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "Selectați un fișier MIDI..."
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "Nu s-a putut citi fișierul de setări predefinite."
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Nu s-a putut salva fișierul de genuri muzicale."
 
 # hm ? sau import brut ?
 #. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
@@ -4141,6 +12153,31 @@ msgstr "Importă brut"
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
 msgstr "Importă date brute"
+
+#. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "No endianness"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Big-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Default endianness"
+msgstr "Directoare"
 
 #: src/import/ImportRaw.cpp
 msgid "1 Channel (Mono)"
@@ -4156,6 +12193,21 @@ msgid "%d Channels"
 msgstr "%d canale"
 
 #: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Ca&nale:"
+
+#. i18n-hint: (noun)
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Start offset:"
+msgstr "Timpul de început"
+
+#: src/import/ImportRaw.cpp
 msgid "bytes"
 msgstr "baiți"
 
@@ -4163,9 +12215,19 @@ msgstr "baiți"
 msgid "Amount to import:"
 msgstr "Cantitate de importat:"
 
+#. i18n-hint: (noun)
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Sample rate:"
+msgstr "Simplu"
+
 #: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
 msgid "&Import"
 msgstr "&Importă"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -4187,6 +12249,7 @@ msgstr "dreapta"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -4210,6 +12273,7 @@ msgstr "Sfârșit"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -4228,12 +12292,37 @@ msgid_plural "%d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Suprimă audio de la %.2f secunde la %.2f secunde din pistele audio selectate"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the left"
+msgstr "Suprimă audio de la %.2f secunde la %.2f secunde din pistele audio selectate"
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Decalaj temporal"
 
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "Limitele &clipului"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Limitele &clipului"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "Limitele &clipului"
 
 #: src/menus/ClipMenus.cpp
@@ -4278,6 +12367,11 @@ msgstr "Instrument de decalaj temporal"
 msgid "Time Shift &Right"
 msgstr "Instrument de decalaj temporal"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasted text from the clipboard"
+msgstr "Lipit din clipboard"
+
 #: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
 msgid "Pasted from the clipboard"
 msgstr "Lipit din clipboard"
@@ -4300,8 +12394,46 @@ msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Au fost șterse %.2f secunde la t=%.2f"
 
 #: src/menus/EditMenus.cpp
+msgid "Pasting one type of track into another is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+msgid "Copying stereo audio into a mono track is not allowed."
+msgstr ""
+
+#: src/menus/EditMenus.cpp
 msgid "Duplicated"
 msgstr "Duplicat"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Duplicate"
+msgstr "Duplicat"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split-cut to the clipboard"
+msgstr "Taie și copiază în clipboard"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Cut"
+msgstr "Divi&zează și taie"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Split-deleted %.2f seconds at t=%.2f"
+msgstr "Au fost șterse %.2f secunde la t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split Delete"
+msgstr "Divize&ază și șterge"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Silenced selected tracks for %.2f seconds at %.2f"
+msgstr "Suprimă audio de la %.2f secunde la %.2f secunde din pistele audio selectate"
 
 #. i18n-hint: verb
 #: src/menus/EditMenus.cpp
@@ -4321,9 +12453,35 @@ msgid "Trim Audio"
 msgstr "Suprimă audio în afara selecției"
 
 # hm ? sau divizare ?
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Divizează"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split to new track"
+msgstr "Pistă stereo"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Split New"
+msgstr "Divizează no&u"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Joined %.2f seconds at t=%.2f"
+msgstr "Au fost șterse %.2f secunde la t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Join"
+msgstr "&Unește"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Au fost șterse %.2f secunde la t=%.2f"
 
 #: src/menus/EditMenus.cpp
 msgid "Detach"
@@ -4421,28 +12579,8 @@ msgid "Delete Key&2"
 msgstr "Tasta de ștergere2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Ajustează volumul de redare"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Mărește volumul de redare"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Scade volumul de redare"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Ajustează volumul de înregistrare"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Mărește volumul de înregistrare"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Scade volumul de înregistrare"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -4467,6 +12605,13 @@ msgstr "Schimbă canalele de înregistrare"
 #: src/menus/ExtraMenus.cpp
 msgid "&Full Screen (on/off)"
 msgstr "Ecran întreg pornit/oprit"
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -4525,6 +12670,11 @@ msgstr "Importă etichetele"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Selectați un fișier MIDI..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Toate Fișierele|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -4597,8 +12747,18 @@ msgid "Export MI&DI..."
 msgstr "Exportă MIDI..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "&Exportă audio..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Labels..."
 msgstr "&Etichete..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Exportă MIDI..."
 
 #: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
@@ -4619,6 +12779,10 @@ msgid "E&xit"
 msgstr "&Ieșire"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "Exportă etichetele ca:"
 
@@ -4633,12 +12797,25 @@ msgid "Unable to save %s"
 msgstr "Nu s-a putut salva fișierul de genuri muzicale."
 
 #: src/menus/HelpMenus.cpp
+msgid "Do you have these problems?"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Fix"
 msgstr "Mixează"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "&Ajutor rapid"
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "Nu există nimic de anulat"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -4653,6 +12830,18 @@ msgid "Recording stops and starts"
 msgstr "Dispozitiv de înregistrare"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "&Ajutor rapid"
 
@@ -4661,8 +12850,9 @@ msgid "&Getting Started"
 msgstr "Începutul selecției:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manual"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -4673,16 +12863,136 @@ msgid "&Manual..."
 msgstr "&Manual"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Despre &Audacity..."
+msgid "&Diagnostics"
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etichetă adaugată"
 
 #: src/menus/LabelMenus.cpp
 msgid "Paste Text to New Label"
 msgstr "Lipește textul într-o etichetă nouă"
+
+#. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
+#. regions.
+#: src/menus/LabelMenus.cpp
+msgid "Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Cut Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#. i18n-hint: (verb) Audacity has just deleted the labeled audio regions
+#: src/menus/LabelMenus.cpp
+msgid "Deleted labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Delete Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#. i18n-hint: (verb) Audacity has just split cut the labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Cut labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of cut on the labels
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Cut Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#. i18n-hint: (verb) Audacity has just done a special kind of DELETE on
+#. the labeled audio regions
+#: src/menus/LabelMenus.cpp
+msgid "Split Deleted labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb) Do a special kind of DELETE on labeled audio
+#. regions
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Delete Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silenced labeled audio regions"
+msgstr "Liniște în locul selecției audi&o"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#: src/menus/LabelMenus.cpp
+msgid "Copied labeled audio regions to clipboard"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Copy Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#. i18n-hint: (verb) past tense.  Audacity has just split the labeled
+#. audio (a point or a region)
+#: src/menus/LabelMenus.cpp
+msgid "Split labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Split Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+msgid "Joined labeled audio (points or regions)"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Join Labeled Audio"
+msgstr "Audio etic&hetat"
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+msgid "Detached labeled audio regions"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detach Labeled Audio"
+msgstr "Audio etic&hetat"
 
 #: src/menus/LabelMenus.cpp
 msgid "&Labels"
@@ -4703,6 +13013,10 @@ msgstr "Potrivește selecția"
 #: src/menus/LabelMenus.cpp
 msgid "Paste Te&xt to New Label"
 msgstr "Lipește te&xtul într-o nouă etichetă"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
 
 #: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
@@ -4769,6 +13083,23 @@ msgid "Label Join"
 msgstr "Editare etichetă"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "Mută efectul mai sus în rack"
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
 msgstr "Mută efectul mai sus în rack"
 
@@ -4831,6 +13162,10 @@ msgid "&Generate"
 msgstr "&Generare"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
 msgstr "Repetă ultimul efect"
 
@@ -4886,6 +13221,10 @@ msgstr "&Rulează un test de performanță..."
 msgid "Simulate Recording Errors"
 msgstr "Înregistrare"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -4908,6 +13247,16 @@ msgid "Set Track Status..."
 msgstr "la începutul pi&stei"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Liniște în locul audio"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&Ordonează pistele"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Preferințe..."
 
@@ -4920,12 +13269,23 @@ msgid "Set Clip..."
 msgstr "Instrumentul următor"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Envelope..."
+msgstr "Nivel"
+
+#: src/menus/PluginMenus.cpp
 msgid "Set Label..."
 msgstr "&Editare etichete..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Salvează proiectul c&a..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Toate Fișierele|*"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -4959,6 +13319,12 @@ msgstr "&Obține mai multe..."
 msgid "Compare Audio..."
 msgstr "&Exportă audio..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "Ti&părește..."
+
 #: src/menus/SelectMenus.cpp
 msgid "Set Left Selection Boundary"
 msgstr "Stabilește limita de selecție din stânga"
@@ -4989,24 +13355,54 @@ msgid "&Tracks"
 msgstr "Pis&te"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "&Aliniază pistele"
+
+#: src/menus/SelectMenus.cpp
 msgid "In All &Sync-Locked Tracks"
 msgstr "Blochează sincronizarea pistelor"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Selecție"
 
 #: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "Zona de re&dare"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Left at Playback Position"
+msgstr "Potrivește selecția"
+
+#: src/menus/SelectMenus.cpp
 msgid "Set Selection Left at Play Position"
 msgstr "Stabilește punctul de selecție"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Right at Playback Position"
+msgstr "Potrivește selecția"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Selection Right at Play Position"
 msgstr "Stabilește punctul de selecție"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "Începutul selecției:"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "Începutul selecției:"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "Nume pistă"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -5029,6 +13425,11 @@ msgid "Retrieve Selectio&n"
 msgstr "Potrivește selecția"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "S&pectral"
+msgstr "Spectrogramă"
+
+#: src/menus/SelectMenus.cpp
 msgid "To&ggle Spectral Selection"
 msgstr "Comută selecția &spectrală"
 
@@ -5041,8 +13442,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Frecvență joasă:"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Începutul selecției:"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Poziție audio:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -5156,6 +13566,56 @@ msgstr "Directorul curent:"
 msgid "&Cursor"
 msgstr "&Mută cursorul"
 
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Left"
+msgstr "&Mută cursorul"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Right"
+msgstr "&Mută cursorul"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Sh&ort Jump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Shor&t Jump Right"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long J&ump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long Ju&mp Right"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
 #: src/menus/ToolbarMenus.cpp
 msgid "&Toolbars"
 msgstr "Bare de instrumen&te"
@@ -5170,6 +13630,27 @@ msgstr "B&lochează sincronizarea pistelor"
 msgid "Reset Toolb&ars"
 msgstr "Bare de instrumen&te"
 
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Rendered all audio in track '%s'"
+msgstr "Piste audio eliminate"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+msgid "Render"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Mixed and rendered %d tracks into one new stereo track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Mixed and rendered %d tracks into one new mono track"
+msgstr "Mixează și randează într-o nouă &pistă"
+
 #. i18n-hint: One or more audio tracks have been panned
 #: src/menus/TrackMenus.cpp
 msgid "Panned audio track(s)"
@@ -5178,6 +13659,46 @@ msgstr "Piste audio eliminate"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Track"
 msgstr "Pistă"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Zero"
+msgstr "Început"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Cursor/Selection Start"
+msgstr "Du-&te la începutul selecției"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to Selection &End"
+msgstr "către s&fârșitul selecției"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "End to Cu&rsor/Selection Start"
+msgstr "Du-&te la începutul selecției"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "End to Selection En&d"
+msgstr "către s&fârșitul selecției"
+
+#. i18n-hint: In this and similar messages describing editing actions,
+#. the starting or ending points of tracks are re-"aligned" to other
+#. times, and the time selection may be "moved" too.  The first
+#. noun -- "start" in this example -- is the object of a verb (not of
+#. an implied preposition "from").
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to zero"
+msgstr "&Aliniază sfârșit la sfârșit"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to zero"
+msgstr "Taie selecția"
 
 #. i18n-hint: This and similar messages give shorter descriptions of
 #. the aligning and moving editing actions
@@ -5190,8 +13711,33 @@ msgid "Align Start"
 msgstr "Începutul selecției:"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to cursor/selection start"
+msgstr "Taie selecția"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to cursor/selection start"
+msgstr "Taie selecția"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to selection end"
+msgstr "Taie selecția"
+
+#: src/menus/TrackMenus.cpp
 msgid "Aligned start to selection end"
 msgstr "Taie selecția"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to cursor/selection start"
+msgstr "&Du-te la sfârșitul selecției"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to cursor/selection start"
+msgstr "Liniște în locul selecției audi&o"
 
 #: src/menus/TrackMenus.cpp
 msgid "Align/Move End"
@@ -5242,6 +13788,22 @@ msgid "Align Together"
 msgstr "A&liniază împreună"
 
 #: src/menus/TrackMenus.cpp
+msgid "Synchronize MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Adjusted gain"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Adjusted Pan"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
 msgstr "A fost creată o nouă pistă audio"
 
@@ -5258,8 +13820,61 @@ msgid "Created new label track"
 msgstr "A fost creată o nouă pistă de etichete"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Created new time track"
+msgstr "A fost creată o nouă pistă audio"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Amplificator"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "The entered value is invalid"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Resampling track %d"
+msgstr "Dispozitiv de înregistrare"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resampled audio track(s)"
+msgstr "Piste audio eliminate"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Resample Track"
+msgstr "Elimină pista"
+
+#: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "A fost creată o nouă pistă audio"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -5276,6 +13891,10 @@ msgstr "Piste ordonate după nume"
 #: src/menus/TrackMenus.cpp
 msgid "Sort by Name"
 msgstr "Ordonează după nume"
+
+#: src/menus/TrackMenus.cpp
+msgid "Can't delete track with active audio"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Add &New"
@@ -5296,6 +13915,10 @@ msgstr "Pistă de etic&hete"
 #: src/menus/TrackMenus.cpp
 msgid "&Time Track"
 msgstr "Pistă de &timp"
+
+#: src/menus/TrackMenus.cpp
+msgid "Mi&x"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
@@ -5336,6 +13959,10 @@ msgstr "Pune toate pistele pe &mut"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "Activează sunet&ul pe toate pistele"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -5468,7 +14095,9 @@ msgstr "În redare"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Înregistrare"
 
@@ -5477,8 +14106,32 @@ msgid "no label track"
 msgstr "Pistă de etichete"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track at or below focused track"
+msgstr "A fost creată o nouă pistă de etichete"
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "A fost creată o nouă pistă de etichete"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -5543,6 +14196,15 @@ msgid "Record &New Track"
 msgstr "Elimină &pistele"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Înregistrare"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "Zona de re&dare"
 
@@ -5555,13 +14217,52 @@ msgid "&Unlock"
 msgstr "Debloc&hează"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Dispozitiv de înregistrare"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "Setările efectului"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Sound Activation Le&vel..."
+msgstr "Nivel de activare (dB):"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Înregistrare"
+
+# hm ?
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Overdub (on/off)"
+msgstr "B&lochează sincronizarea pistelor"
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "T&ransport"
 
 #. i18n-hint: (verb) Start playing audio
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "Red&are/Stop"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -5679,6 +14380,11 @@ msgid "&Fit to Width"
 msgstr "&Potrivește în fereastră"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&Potrivește în fereastră"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Restrânge toate pistele"
 
@@ -5704,6 +14410,12 @@ msgstr "către s&fârșitul selecției"
 
 # hm ?
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Extra Menus (on/off)"
+msgstr "B&lochează sincronizarea pistelor"
+
+# hm ?
+#: src/menus/ViewMenus.cpp
 msgid "Track &Name (on/off)"
 msgstr "B&lochează sincronizarea pistelor"
 
@@ -5711,9 +14423,46 @@ msgstr "B&lochează sincronizarea pistelor"
 msgid "&Show Clipping (on/off)"
 msgstr "Arată li&mitarea"
 
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "Rack de efecte"
+
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr "&Potrivește în fereastră"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Nivel de înregistrare"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -5721,7 +14470,7 @@ msgstr "Preferințe:"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -5729,9 +14478,21 @@ msgstr "Audacity"
 msgid "&Check for Updates"
 msgstr "&Caută actualizări..."
 
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+msgid "Batch"
+msgstr ""
+
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
 msgstr "Preferințe:"
+
+#: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Behaviors"
+msgstr ""
+
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
 
 #: src/prefs/DevicePrefs.cpp
 msgid "Devices"
@@ -5752,7 +14513,13 @@ msgstr "Interfață"
 msgid "&Host:"
 msgstr "&Gazdă:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Using:"
+msgstr "Lipsesc fișierele"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Redare"
 
@@ -5772,6 +14539,12 @@ msgstr "Ca&nale:"
 msgid "Latency"
 msgstr "Latență"
 
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "milliseconds"
+msgstr "hh:mm:ss + milisecunde"
+
 #: src/prefs/DevicePrefs.cpp
 msgid "&Buffer length:"
 msgstr "Lungime nouă"
@@ -5779,6 +14552,15 @@ msgstr "Lungime nouă"
 #: src/prefs/DevicePrefs.cpp
 msgid "&Latency compensation:"
 msgstr "Combinație de taste"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Piste audio eliminate"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
 
 #: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
@@ -5789,7 +14571,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Directoare"
 
@@ -5801,10 +14584,24 @@ msgstr "Preferințe:"
 msgid "Default directories"
 msgstr "Directoare"
 
+#: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
 # hm ? sau răsfoiește ?
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Navighează..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 # hm ? sau răsfoiește ?
 #: src/prefs/DirectoriesPrefs.cpp
@@ -5829,6 +14626,24 @@ msgstr "Exportă..."
 msgid "Bro&wse..."
 msgstr "Navighează..."
 
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "&Macro output:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "Director temporar nou"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Locație"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
+
 # hm ? sau răsfoiește ?
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
@@ -5843,8 +14658,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Alegeți o locație pentru amplasarea directorului temporar"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "Ale&geți comanda"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -5861,8 +14685,14 @@ msgid "Directory %s is not writable"
 msgstr "Directorul %s nu este scriibil"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Schimbările asupra directorului temporar vor avea efect numai după repornirea Audacity"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Director temporar nou"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -5872,6 +14702,37 @@ msgstr "Preferințe:"
 msgid "Sorted by Effect Name"
 msgstr "Ordonează după nume"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Ordonează după nume"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Ordonează după nume"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
 #. In the translations of this and other strings, you may transliterate the
@@ -5880,21 +14741,140 @@ msgstr "Ordonează după nume"
 msgid "N&yquist"
 msgstr "Nyquist"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "Efecte Vamp"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Setările efectului"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Acțiune"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Interfață"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Importă"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Preferințe:"
 
 #: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Tipul de compilare:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Exportă etichetele ca:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Mută mai s&us"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Mută mai j&os"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "Mută mai s&us"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Mută mai j&os"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Redă la viteza selectată"
+
+#: src/prefs/ExtImportPrefs.cpp
 msgid "Unused filters:"
 msgstr "Filtre neutilizate:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Selectare"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "Sigur vreți să ștergeți „%s” ?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Canale de înregistrare"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -5911,28 +14891,179 @@ msgid "Preferences for GUI"
 msgstr "Preferințe:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "-36 dB (shallow range for high-amplitude editing)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-48 dB (PCM range of 8 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-72 dB (PCM range of 12 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-84 dB (PCM range of 14 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "-96 dB (PCM range of 16 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-120 dB (approximate limit of human hearing)"
 msgstr "-120 dB (limita aproximativă a auzului uman)"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "-145 dB (PCM range of 24 bit samples)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Locație"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "Display"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Limbă:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Location of &Manual:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Nive&l (dB):"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Show e&xtra menus"
 msgstr "Arată fișierele ascunse"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Acțiune"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Bare de instrumen&te"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "Import sau export FFmpeg"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Preferințe:"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
 msgstr "Divizează stereo în mono „%s”"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "&Use Advanced Mixing Options"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&tandard"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Seconds"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Beats"
 msgstr "Repetă"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&how Metadata Tags editor before export"
 msgstr "Editare etichete metadate"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Exportă etichetele ca:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -5944,16 +15075,164 @@ msgid "Preferences for KeyConfig"
 msgstr "Preferințe:"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Key Bindings"
+msgstr "Combinație de taste"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by:"
+msgstr "&Vizualizare"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Name"
+msgstr "Nume"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by name"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "View by key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Bindings"
+msgstr "Avertismente"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "S&etări"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Import..."
 msgstr "&Importă..."
 
+#: src/prefs/KeyConfigPrefs.cpp src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "&Defaults"
+msgstr "Implicite"
+
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Selectați un fișier XML care conține scurtăturile din tastatură Audacity..."
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Error Importing Keyboard Shortcuts"
+msgstr "Exportă scurtăturile de tastatură ca:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy, c-format
+msgid "Loaded %d keyboard shortcuts\n"
+msgstr "Exportă scurtăturile de tastatură ca:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Loading Keyboard Shortcuts"
+msgstr "Exportă scurtăturile de tastatură ca:"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Export Keyboard Shortcuts As:"
 msgstr "Exportă scurtăturile de tastatură ca:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Error Exporting Keyboard Shortcuts"
+msgstr "Exportă scurtăturile de tastatură ca:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
@@ -5964,22 +15243,97 @@ msgid "Preferences for Library"
 msgstr "Preferințe:"
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "Versiunea bibliotecilor MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export Library"
+msgstr "Import sau export FFmpeg"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "Versiunea bibliotecilor MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "Eroare FFmpeg"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "Șt&erge..."
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Dow&nload"
+msgstr "Descarcă"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
 msgstr "Biblioteci"
 
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "Dispozitive"
+
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "Preferințe:"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Interfață"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
 msgctxt "MIDI"
 msgid "Interface"
 msgstr "Interfață"
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
 
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
@@ -5991,7 +15345,29 @@ msgid "Preferences for Module"
 msgstr "Preferințe:"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Schimbările asupra directorului temporar vor avea efect numai după repornirea Audacity"
 
 #: src/prefs/ModulePrefs.cpp
@@ -6001,6 +15377,19 @@ msgstr "Întreabă"
 #: src/prefs/ModulePrefs.cpp
 msgid "Failed"
 msgstr "Eșuat"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+#, fuzzy
+msgid "Module"
+msgstr "Module"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -6042,7 +15431,10 @@ msgstr "Tragere spre stânga"
 msgid "Set Selection Range"
 msgstr "Stabilește intervalul de selecție"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift + clic stânga"
 
@@ -6130,6 +15522,15 @@ msgstr "Tragere spre stânga"
 msgid "Move clip up/down between tracks"
 msgstr "Mută clipul mai sus sau mai jos între piste"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Tragere spre stânga"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -6199,6 +15600,11 @@ msgstr "Mărește pe punct"
 msgid "-Shift-Wheel-Rotate"
 msgstr "Shift + învârtire de rotiță"
 
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Vertical Scale Waveform (dB) range"
+msgstr "Nive&l (dB):"
+
 #: src/prefs/PlaybackPrefs.cpp
 msgid "Preferences for Playback"
 msgstr "Preferințe:"
@@ -6216,8 +15622,41 @@ msgstr "Lungime"
 msgid "Cut Preview"
 msgstr "Taie previzualizarea"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Preferințe Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -6231,6 +15670,11 @@ msgstr "Preferințe:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Preferințe:"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -6256,9 +15700,24 @@ msgstr "Conversie în timp real"
 msgid "Sample Rate Con&verter:"
 msgstr "Con&vertor al ratei de eșantionare:"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Conversie în timp real"
+
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "Conver&tor al ratei de eșantionare:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -6273,8 +15732,30 @@ msgid "Preferences for Recording"
 msgstr "Preferințe:"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Pistă nouă"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Înregistrare"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -6285,9 +15766,19 @@ msgstr "Nive&l (dB):"
 msgid "Name newly recorded tracks"
 msgstr "A fost creată o nouă pistă audio stereo"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Nume pistă"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Editare etichetă"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -6297,11 +15788,67 @@ msgstr "Sunete înregistrate"
 msgid "&Track Number"
 msgstr "Număr pistă"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "System &Date"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Preferințe:"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "&Restrânge toate pistele"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "Zoom implicit"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "Zoom implicit"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "&Liniar"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -6313,6 +15860,11 @@ msgstr "&Liniar"
 msgid "Frequencies"
 msgstr "Liniște"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
@@ -6321,6 +15873,29 @@ msgstr "Înălțime sunet (EAC)"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Maximum frequency must be 100 Hz or above"
 msgstr "Frecvența maximă trebuie să fie 100 Hz sau peste"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be at least 0 Hz"
+msgstr "Frecvența maximă trebuie să fie 100 Hz sau peste"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "Frecvența maximă trebuie să fie 100 Hz sau peste"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -6339,6 +15914,10 @@ msgstr "Preferințe:"
 msgid "&Use Preferences"
 msgstr "Preferințe:"
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "N&etezire de frecvență (Hz):"
@@ -6346,6 +15925,24 @@ msgstr "N&etezire de frecvență (Hz):"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "N&etezire de frecvență (Hz):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Bași (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "&Bași (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -6356,12 +15953,69 @@ msgid "A&lgorithm:"
 msgstr "L&ogaritmic"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &size:"
+msgstr "Dimensiune &fereastră"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "256 - implicit"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Window &type:"
+msgstr "Dimensiune &fereastră"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Zero padding factor:"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Potrivește selecția"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Show a grid along the &Y-axis"
+msgstr "Arată fișierele ascunse"
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "Amplificator"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Global settings"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble spectral selection"
@@ -6369,6 +16023,41 @@ msgstr "Comută selecția &spectrală"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "The maximum frequency must be an integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum frequency must be an integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Frecvența maximă trebuie să fie un număr întreg"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
 msgstr "Frecvența maximă trebuie să fie un număr întreg"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
@@ -6388,12 +16077,59 @@ msgid "Info"
 msgstr "Informații"
 
 #: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
 msgid "Save Files"
 msgstr "Salvează fișierele"
 
 #: src/prefs/ThemePrefs.cpp
 msgid "Load Files"
 msgstr "Încarcă fișiere"
+
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+msgid "Tracks Behaviors"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "Preferințe:"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Simple"
@@ -6417,16 +16153,54 @@ msgid "Enable &dragging selection edges"
 msgstr "Liniște în locul selecției audi&o"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Setările efectului"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Buton"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
 msgstr "L&ogaritmic"
 
+#: src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.h
+#, fuzzy
+msgid "Waveform"
+msgstr "Nive&l (dB):"
+
 #: src/prefs/TracksPrefs.cpp
 msgid "Spectrogram"
 msgstr "Spectrogramă"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
@@ -6441,10 +16215,52 @@ msgid "Zoom Default"
 msgstr "Zoom implicit"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Seconds"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "5ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "10ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "20ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "50ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "100ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "500ths of Seconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "MilliSeconds"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Samples"
 msgstr "Simplu"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom"
 
@@ -6453,12 +16269,42 @@ msgid "Preferences for Tracks"
 msgstr "Preferințe:"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Înregistrare"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "&Rata de eșantionare implicită:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "&Formatul implicit al eșantionării:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "Simplu"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -6489,6 +16335,44 @@ msgstr "Avertismente"
 msgid "Preferences for Warnings"
 msgstr "Preferințe:"
 
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&Salvează proiectul"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&Salvează proiectul"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "Divizează stereo în mono „%s”"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "Divizează stereo în mono „%s”"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
+
+#. i18n-hint: A waveform is a visual representation of vibration
+#: src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "Waveforms"
+msgstr "Nive&l (dB):"
+
 #: src/prefs/WaveformPrefs.cpp
 msgid "Preferences for Waveforms"
 msgstr "Preferințe:"
@@ -6505,16 +16389,24 @@ msgid "Stopped"
 msgstr "Oprit"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pauză"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Sari la început"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Sari la sfârșit"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pauză"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Începutul selecției:"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Sfârșitul selecției:"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -6528,20 +16420,24 @@ msgstr "Pistă nouă"
 msgid "Append Record"
 msgstr ") / Adaugă înregistrarea ("
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Sfârșitul selecției:"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Începutul selecției:"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "În pauză"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "&Editează bara de unelte"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -6589,6 +16485,13 @@ msgstr "Selectați canalele de înregistrare"
 msgid "Device information is not available."
 msgstr "Informațiile despre dispozitiv nu sunt disponibile"
 
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. that manages devices
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "&Device Toolbar"
+msgstr "&Editează bara de unelte"
+
 #: src/toolbars/EditToolBar.cpp
 msgid "Cut selection"
 msgstr "Taie selecția"
@@ -6609,11 +16512,17 @@ msgstr "Liniște în locul selecției audi&o"
 msgid "Sync-Lock Tracks"
 msgstr "Blochează sincronizarea pistelor"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Mărește"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Micșorează"
 
@@ -6624,6 +16533,11 @@ msgstr "Potrivește selecția la fereastră"
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "Potrivește proiectul la fereastră"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "Rack de efecte"
 
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
@@ -6641,6 +16555,21 @@ msgstr "Dispozitiv de înregistrare"
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Meter"
 msgstr "Nivel de redare"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Meter-Record"
+msgstr "Înregistrează"
+
+#. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
+#. This is the name used in screen reader software, where having 'Meter' first
+#. apparently is helpful to partially sighted people.
+#: src/toolbars/MeterToolBar.cpp
+msgid "Meter-Play"
+msgstr ""
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Playback Level"
@@ -6662,23 +16591,24 @@ msgstr "Bară de unelte pentru în&registrare"
 msgid "&Playback Meter Toolbar"
 msgstr "Bară de unelte &pentru înregistrare"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Volum de redare"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Volum de redare"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Bare de instrumen&te"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Volum de redare"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Oprește monitorizarea"
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Oprește monitorizarea"
@@ -6686,6 +16616,7 @@ msgstr "Oprește monitorizarea"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Timpul de început"
@@ -6693,9 +16624,24 @@ msgstr "Timpul de început"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Pornește monitorizarea"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Pornește monitorizarea"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Bare de instrumen&te"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -6743,7 +16689,9 @@ msgstr "Acroșează la"
 msgid "Length"
 msgstr "Lungime"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centrează"
 
@@ -6752,12 +16700,32 @@ msgstr "Centrează"
 msgid "Snap Clicks/Selections to %s"
 msgstr "Acroșează clicurile sau selecțiile la %s"
 
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
+
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
 #: src/toolbars/SelectionBar.cpp
 #, c-format
 msgid "Selection %s. %s won't change."
 msgstr "Selectați un fișier MIDI..."
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. for selecting a time range of audio
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "&Selection Toolbar"
+msgstr "Instrument de selecție"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Center frequency and Width"
+msgstr "Frecvență centrală:"
 
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Low and High Frequencies"
@@ -6789,13 +16757,18 @@ msgstr "&Editează bara de unelte"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Bara de instrumente %s Audacity"
 
 #: src/toolbars/ToolBar.cpp
 msgid "Click and drag to resize toolbar"
 msgstr "Clic și trageți pentru a redimensiona pista."
+
+#: src/toolbars/ToolDock.cpp
+#, fuzzy
+msgid "ToolDock"
+msgstr "Instrument"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Selection Tool"
@@ -6814,7 +16787,8 @@ msgstr "Instrument de decalaj temporal"
 msgid "Zoom Tool"
 msgstr "Instrument de zoom"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Instrument de desenare"
 
@@ -6822,6 +16796,18 @@ msgstr "Instrument de desenare"
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Multi-Tool"
 msgstr "Instrument multiplu"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Slide Tool"
+msgstr "Instrument de selecție"
+
+#. i18n-hint: Clicking this menu item shows a toolbar
+#. that has some tools in it
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools Toolbar"
+msgstr "Bare de instrumen&te"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "&Selection Tool"
@@ -6875,13 +16861,33 @@ msgstr "Redă în buclă la viteza"
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "Redă-cu-viteza"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Modified Label"
+msgstr "Editare etichete"
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Editare etichetă"
 
 #: src/tracks/labeltrack/ui/LabelTextHandle.cpp
 msgid "Click to edit label text"
 msgstr "Clic pentru a începe"
+
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "&Font..."
+msgstr "Ti&părește..."
 
 #. i18n-hint: (noun) This is the font for the label track.
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
@@ -6891,6 +16897,12 @@ msgstr "Pistă de etichete"
 #. i18n-hint: (noun) The name of the typeface
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Face name"
+msgstr "Același nume"
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
 msgstr "Același nume"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -6910,30 +16922,55 @@ msgid "&Edit Label..."
 msgstr "&Editare etichete..."
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Deleted Label"
+msgstr "Șterge etic&heta"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#, fuzzy
+msgid "Edited labels"
+msgstr "Editare etichete"
+
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "New label"
 msgstr "Etichetă adaugată"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Mai sus o &octavă"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Mai jos o octa&vă"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Click dreapta"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Micșorează"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift + clic stânga"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift + clic stânga"
 
@@ -6947,9 +16984,53 @@ msgstr "Clic și trageți pentru a redimensiona pista."
 msgid "Stretch Note Track"
 msgstr "Pistă stereo"
 
+#. i18n-hint: In the history list, indicates a MIDI note has
+#. been dragged to change its duration (stretch it). Using either past
+#. or present tense is fine here.  If unsure, go for whichever is
+#. shorter.
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+#, fuzzy
+msgid "Stretch"
+msgstr "Lungime"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "Arată li&mitarea"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Expanded Cut Line"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Expand"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Removed Cut Line"
+msgstr "Elimină pista"
+
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Click and drag to edit the samples"
 msgstr "Clic și trageți pentru a redimensiona pista."
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
@@ -6959,6 +17040,11 @@ msgstr "Modifică eșantionul"
 msgid "Sample Edit"
 msgstr "Editare eșantion"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Mărește pe punct"
@@ -6966,6 +17052,16 @@ msgstr "Mărește pe punct"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Spectrogramă"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -6984,9 +17080,15 @@ msgstr "Modifică eșantionul"
 msgid "Processing...   0%%"
 msgstr "&Restrânge toate pistele"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   %i%%"
+msgstr "&Restrânge toate pistele"
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' a fost schimbat în %s"
@@ -6998,6 +17100,54 @@ msgstr "Schimbare de format"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "Stabileșt&e rata"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -7017,7 +17167,8 @@ msgstr "Schimbare de rată"
 msgid "Set Rate"
 msgstr "Stabilește rata"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Multiplu"
 
@@ -7038,6 +17189,11 @@ msgid "Split Stereo to Mo&no"
 msgstr "Divizează stereo în mono „%s”"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
 msgstr "Canalul stâng"
 
@@ -7049,9 +17205,21 @@ msgstr "Canalul drept"
 msgid "Channel"
 msgstr "Canal"
 
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Made '%s' a stereo track"
+msgstr "Pistă stereo"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Make Stereo"
 msgstr "Transformă în stereo"
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Swapped Channels in '%s'"
+msgstr "%d canale"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Swap Channels"
@@ -7094,10 +17262,25 @@ msgid "Right, %dHz"
 msgstr "Dreapta, "
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "dreapta"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -7107,6 +17290,15 @@ msgstr "Clic și trageți pentru a ajusta dimensiunea relativă a pistelor stere
 msgid "Click and drag to rearrange sub-views"
 msgstr "Click and Drag pentru a muta o piesă în timp"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Click and Drag pentru a muta o piesă în timp"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Mărește"
@@ -7114,6 +17306,25 @@ msgstr "Mărește"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Zoom"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "Wa&veform"
+msgstr "Nive&l (dB):"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "&Wave Color"
+msgstr "Schimbare de rată"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -7135,14 +17346,40 @@ msgstr "Schimbă limita vitezei superioare (%) la:"
 msgid "Upper speed limit"
 msgstr "Limita superioară de viteză"
 
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, c-format
+msgid "Set range to '%ld' - '%ld'"
+msgstr ""
+
 #. i18n-hint: (verb)
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Range"
 msgstr "Stabilește rata"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Display"
+msgstr "Instrumentul următor"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Interfață"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
@@ -7162,9 +17399,8 @@ msgstr "Interfață"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Click and Drag pentru a muta o piesă în timp"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -7207,9 +17443,30 @@ msgstr "Click and Drag pentru a muta o piesă în timp"
 msgid "Click and drag to edit the amplitude envelope"
 msgstr "Clic și trageți pentru a redimensiona pista."
 
+#. i18n-hint: (verb) Audacity has just adjusted the envelope .
+#: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Adjusted envelope."
+msgstr "Nivel"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Bare de instrumen&te"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Pornește monitorizarea"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Bare de instrumen&te"
@@ -7225,6 +17482,11 @@ msgstr "Mută pista sus de &tot"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Mută pista jos de &tot"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Oprește monitorizarea"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -7267,6 +17529,12 @@ msgstr "Clic și trageți pentru a ajusta dimensiunea relativă a pistelor stere
 msgid "Edit, Preferences..."
 msgstr "Editare, Preferințe..."
 
+#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac
+#: src/tracks/ui/SelectHandle.cpp
+#, c-format
+msgid "Multi-Tool Mode: %s for Mouse and Keyboard Preferences."
+msgstr ""
+
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to set frequency bandwidth."
 msgstr "Clic și trageți pentru a modifica limita stângă a selecției."
@@ -7274,6 +17542,11 @@ msgstr "Clic și trageți pentru a modifica limita stângă a selecției."
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to select audio"
 msgstr "Clic și trageți pentru a redimensiona pista."
+
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
@@ -7296,6 +17569,10 @@ msgstr "Suprimă audio de la %.2f secunde la %.2f secunde din pistele audio sele
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Suprimă audio de la %.2f secunde la %.2f secunde din pistele audio selectate"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -7325,6 +17602,12 @@ msgstr "Ctrl + clic stânga"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "A fost creată o nouă pistă audio"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track."
 msgstr "A fost creată o nouă pistă audio"
@@ -7340,6 +17623,11 @@ msgstr "'%s' a fost schimbat în %s"
 msgid "Moved '%s' down"
 msgstr "'%s' a fost schimbat în %s"
 
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Move Track"
+msgstr "Mută pista mai s&us"
+
 #: src/tracks/ui/ZoomHandle.cpp
 msgid "Click to Zoom In, Shift-Click to Zoom Out"
 msgstr "Click pentru Zoom In, Shift-Click pentru Zoom Out"
@@ -7347,6 +17635,10 @@ msgstr "Click pentru Zoom In, Shift-Click pentru Zoom Out"
 #: src/tracks/ui/ZoomHandle.cpp
 msgid "Drag to Zoom Into Region, Right-Click to Zoom Out"
 msgstr "Clic pentru a mări zona, Shift-Clic pentru a o micșora"
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Left=Zoom In, Right=Zoom Out, Middle=Normal"
+msgstr ""
 
 #: src/widgets/AButton.cpp
 msgid "(disabled)"
@@ -7359,6 +17651,18 @@ msgstr "Apăsați"
 #: src/widgets/AButton.cpp
 msgid "Button"
 msgstr "Buton"
+
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
 
 #. i18n-hint: "x" suggests a multiplicative factor
 #: src/widgets/ASlider.cpp
@@ -7400,9 +17704,23 @@ msgstr "Gol"
 msgid "Backwards"
 msgstr "Înapoi"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Înainte"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
 
 #: src/widgets/KeyView.cpp
 msgid "Menu"
@@ -7445,12 +17763,135 @@ msgid "Refresh Rate"
 msgstr "Rată de reîmprospătare"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter refresh rate per second [1-100]: "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Meter Style"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Meter Type"
+msgstr "Tip"
+
+#: src/widgets/Meter.cpp
+msgid "Orientation"
+msgstr ""
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+msgid "Automatic"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Horizontal"
 msgstr "Orizontal"
 
 #: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "Potrivește &vertical"
+
+#: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr " Monitorizare "
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %2.f dB"
+msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "A fost creată o nouă pistă audio"
+
+#. i18n-hint: Format string for displaying time in seconds. Change the comma
+#. * in the middle to the 1000s separator for your locale, and the 'seconds'
+#. * on the end to the word for seconds. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 seconds"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in days, hours, minutes and
+#. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes and 's' to the
+#. * abbreviation for seconds. Don't change the numbers unless there aren't
+#. * 24 hours in a day in your locale
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 days 024 h 060 m 060 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "hh:mm:ss + milisecunde"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>0100 s"
+msgstr ""
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
@@ -7458,9 +17899,291 @@ msgstr " Monitorizare "
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + milisecunde"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060>01000 s"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + samples"
+msgstr "hh:mm:ss + milisecunde"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+># samples"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in samples (at the
+#. * current project sample rate).  For example the number of a sample at 1
+#. * second into a recording at 44.1KHz would be 44,100.
+#.
+#: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "samples"
+msgstr "Simplu"
+
+#. i18n-hint: Format string for displaying time in samples (lots of samples).
+#. * Change the ',' to the 1000s separator for your locale, and translate
+#. * samples. If 1000s aren't a base multiple for your number system, then you
+#. * can change the numbers to an appropriate one, and put a 0 on the front
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000,01000 samples|#"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames (lots of
+#. * frames) at 24 frames per second (commonly used for films)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "film frames (24 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames at 24 frames per
+#. * second. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|24"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV drop-frame rate (used for American /
+#. * Japanese TV, and very odd)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
+#. * Japanese TV, and doesn't quite match wall time
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + NTSC non-drop frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at NTSC
+#. * TV frame rate (used for American / Japanese TV
+#: src/widgets/NumericTextCtrl.cpp
+msgid "NTSC frames"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone. That really is the frame
+#. * rate!
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|29.97002997"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at PAL TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at PAL
+#. * TV frame rate (used for European TV)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "PAL frames (25 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with NTSC frames.
+#. * Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|25"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes,
+#. * seconds and frames at CD Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss + CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr ""
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "CDDA frames (75 fps)"
+msgstr ""
+
+#. i18n-hint: Format string for displaying time in frames with CD Audio
+#. * frames. Change the comma
+#. * in the middle to the 1000s separator for your locale,
+#. * translate 'frames' and leave the rest alone
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000,01000 frames|75"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "010,01000>0100 Hz"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in octaves
+#: src/widgets/NumericTextCtrl.cpp
+msgid "octaves"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "100>01000 octaves|1.442695041"
+msgstr ""
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "(Folosiți meniul contextual pentru a modifica formatul)"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "Timpul de întârziere (secunde):"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -7504,6 +18227,11 @@ msgstr "Confirmă"
 msgid "Unable to write files to directory: %s."
 msgstr "Nu s-a putut citi fișierul de setări predefinite."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 # hm ? urmează numele fișierului sau al unei erori ?
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -7520,14 +18248,64 @@ msgstr "Preferințe:"
 msgid "Don't show this warning again"
 msgstr "Nu mai arăta acest avertisment"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
 #: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Valoare goală"
 
 #: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr ") / Adaugă înregistrarea ("
+
+#: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "În afara intervalului"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Eroare LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
+
+# titlu
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Value not in range: %s to %s"
+msgstr "Salvarea modificărilor"
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be less than %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value must not be greater than %s"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
@@ -7535,6 +18313,11 @@ msgstr "Crează un director nou"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Directoare"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Directoare"
 
 #: src/xml/XMLFileReader.cpp
@@ -7555,16 +18338,49 @@ msgstr "Nu s-a putut deschide fișierul:"
 msgid "Spectral edit multi tool"
 msgstr "Potrivește selecția"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Lungime"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Liniște"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Eroare"
@@ -7579,20 +18395,72 @@ msgstr "Bași (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Frecvența maximă trebuie să fie 100 Hz sau peste"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "Potrivește selecția"
 
+#: plug-ins/StudioFadeOut.ny
+msgid "Studio Fade Out"
+msgstr ""
+
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Se aplică"
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Stabilește ca &implicit"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -7615,8 +18483,16 @@ msgid "S-Curve Down"
 msgstr "Mută mai jos"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Început"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 # hm ? sau Amplificare ?
 #: plug-ins/adjustable-fade.ny
@@ -7626,6 +18502,14 @@ msgstr "Câștig"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Început"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -7640,12 +18524,25 @@ msgid "Linear Out"
 msgstr "&Liniar"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
 msgstr "L&ogaritmic"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic Out"
 msgstr "L&ogaritmic"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Rounded In"
+msgstr "&Liniar"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Rounded Out"
@@ -7672,13 +18569,65 @@ msgstr "Curba există"
 msgid "Error~%~%"
 msgstr "Eroare"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Repetă"
 
 #: plug-ins/beat.ny
+msgid "Finding beats..."
+msgstr ""
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Jurnal Audacity"
+
+#: plug-ins/beat.ny
 msgid "Threshold Percentage"
 msgstr "Liniște în locul audio"
+
+#: plug-ins/clipfix.ny
+msgid "Clip Fix"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Reconstructing clips..."
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Liniște în locul audio"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
 
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
@@ -7688,6 +18637,21 @@ msgstr "&Restrânge toate pistele"
 msgid "Crossfading..."
 msgstr "&Restrânge toate pistele"
 
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
 msgstr "&Restrânge toate pistele"
@@ -7695,6 +18659,18 @@ msgstr "&Restrânge toate pistele"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade type"
 msgstr "Tipul de compilare:"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Gain"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 1"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Constant Power 2"
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Custom Curve"
@@ -7707,6 +18683,19 @@ msgstr "Nume pistă"
 #: plug-ins/crossfadetracks.ny
 msgid "Fade direction"
 msgstr "Reducere de zgomot"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Delay"
@@ -7721,12 +18710,37 @@ msgid "Delay type"
 msgstr "Tipul de compilare:"
 
 #: plug-ins/delay.ny
+msgid "Regular"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Re&ducere de zgomot (dB):"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Timpul de întârziere (secunde):"
 
 #: plug-ins/delay.ny
 msgid "Pitch change effect"
 msgstr "Pre&vizualizare"
+
+#: plug-ins/delay.ny
+msgid "Pitch/Tempo"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
 
 #: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
@@ -7736,27 +18750,61 @@ msgstr "Pre&vizualizare"
 msgid "Number of echoes"
 msgstr "De câte ori să se repete:"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Repetă ultimul efect"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Equalization XML file"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "Încarcă fișiere"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr ") / Adaugă înregistrarea ("
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Nu s-a putut deschide fișierul de genuri muzicale."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Eroare (este posibil ca fișierul să nu fi fost scris): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Eroare (este posibil ca fișierul să nu fi fost scris): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -7787,10 +18835,50 @@ msgstr "Timpul de întârziere (secunde):"
 msgid "Length of label region (seconds)"
 msgstr "Timpul de întârziere (secunde):"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Editare etichetă"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -7804,6 +18892,11 @@ msgstr "Detașează"
 msgid "Warnings only"
 msgstr "Avertismente"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -7813,6 +18906,17 @@ msgstr "Sal&vează zona"
 msgid "point labels"
 msgstr "Importă etichetele"
 
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
 msgstr "Încarcă fișiere"
@@ -7821,13 +18925,50 @@ msgstr "Încarcă fișiere"
 msgid "Performing High-Pass Filter..."
 msgstr "Încarcă fișiere"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "N&etezire de frecvență (Hz):"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Frecvența maximă trebuie să fie 100 Hz sau peste"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -7847,12 +18988,86 @@ msgid "Peak level"
 msgstr "Nivel de redare"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "Nivel de redare"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "Nivel de redare"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Minimum silence duration"
+msgstr "Editare etichetă"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum label interval"
 msgstr "Editare etichetă"
 
 #: plug-ins/label-sounds.ny
 msgid "Label type"
 msgstr "Editare etichetă"
+
+#: plug-ins/label-sounds.ny
+msgid "Point before sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Point after sound"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum leading silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum trailing silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
+#. i18n-hint: '~a' will be replaced by a time duration
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Error.~%Selection must be less than ~a."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -7880,8 +19095,29 @@ msgid "Hard Clip"
 msgstr "Arată li&mitarea"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Canalul drept"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Nive&l (dB):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
 
 #: plug-ins/lowpass.ny
 msgid "Low-Pass Filter"
@@ -7900,7 +19136,24 @@ msgid "Select Function"
 msgstr "Selecție"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Stereo Linking"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Link Stereo Tracks"
+msgstr "Pistă stereo"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
 msgstr "Pistă stereo"
 
 #: plug-ins/noisegate.ny
@@ -7923,6 +19176,44 @@ msgstr "Timpul de întârziere (secunde):"
 msgid "Decay (ms)"
 msgstr "Timpul de întârziere (secunde):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Se aplică efectul Nyquist..."
@@ -7934,6 +19225,18 @@ msgstr "Se aplică efectul Nyquist..."
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Stabilește ca &implicit"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -7956,7 +19259,8 @@ msgstr "Toate Fișierele|*"
 msgid "HTML file"
 msgstr "Încarcă fișiere"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Selectați un fișier MIDI..."
 
@@ -7965,13 +19269,33 @@ msgid "All supported"
 msgstr "Importat '%s'"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow overwriting"
+msgstr "Arată li&mitarea"
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Disallow"
 msgstr "Dezactivat"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Dezactivat"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -7982,20 +19306,107 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Selectați un fișier MIDI..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Filtre neutilizate:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Selectați un fișier MIDI..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Generating pluck sound..."
+msgstr "Schimbă gazda audio"
+
+#: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Tipul de compilare:"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Duration (60s max)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm Track"
 msgstr "Elimină pista"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Generating Rhythm..."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "De câte ori să se repete:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -8010,8 +19421,28 @@ msgid "Start time offset"
 msgstr "Timpul de început"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Silence before first beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Beat sound"
 msgstr "Repetă"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
@@ -8020,6 +19451,40 @@ msgstr "Rezonanța:"
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Zgomot:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Risset Drum"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Generating Risset Drum..."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Steven Jones"
@@ -8033,6 +19498,19 @@ msgstr "Timpul de întârziere (secunde):"
 msgid "Center frequency of noise (Hz)"
 msgstr "Frecvență centrală:"
 
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "N&etezire de frecvență (Hz):"
+
+#: plug-ins/rissetdrum.ny
+msgid "Amplitude (0 - 1)"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 msgid "Sample Data Export"
 msgstr "NU s-a putut exporta"
@@ -8040,6 +19518,10 @@ msgstr "NU s-a putut exporta"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "&Analizare"
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -8058,6 +19540,10 @@ msgid "HTML files"
 msgstr "Încarcă fișiere"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Editare eșantion"
 
@@ -8070,8 +19556,29 @@ msgid "Include header information"
 msgstr "Informații despre compilare"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Tot"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -8086,6 +19593,11 @@ msgstr "Activat"
 msgid "Errors Only"
 msgstr "Eroare:"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -8098,6 +19610,46 @@ msgstr "Canalul drept"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "Simplu"
 
@@ -8105,6 +19657,43 @@ msgstr "Simplu"
 #, lisp-format
 msgid "~a seconds."
 msgstr "Timpul de întârziere (secunde):"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -8123,6 +19712,10 @@ msgid "Value (dB)"
 msgstr "Înal&te (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Nive&l (dB):"
 
@@ -8139,6 +19732,14 @@ msgid "Right (dB)"
 msgstr "Dreapta, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "&Liniar"
 
@@ -8150,17 +19751,87 @@ msgstr "2 canale (stereo)"
 msgid "1 channel (mono)"
 msgstr "1 canal (mono)"
 
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Eroare (este posibil ca fișierul să nu fi fost scris): %s"
+
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
 msgstr "Con&vertor al ratei de eșantionare:"
+
+#: plug-ins/sample-data-import.ny
+msgid "Reading and rendering samples..."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Select file"
 msgstr "Selectați un fișier MIDI..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Eroare"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -8171,6 +19842,15 @@ msgstr "Nu s-a putut deschide fișierul de genuri muzicale."
 msgid "Spectral Delete"
 msgstr "Potrivește selecția"
 
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Se aplică"
@@ -8179,9 +19859,29 @@ msgstr "Se aplică"
 msgid "Waveform type"
 msgstr "Nive&l (dB):"
 
+#: plug-ins/tremolo.ny
+msgid "Inverse Sawtooth"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Starting phase (degrees)"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Se aplică"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -8223,6 +19923,102 @@ msgstr "&Analizare"
 msgid "Strength"
 msgstr "Lungime"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Processing Vocoder..."
+msgstr "&Restrânge toate pistele"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Output choice"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Both Channels"
 msgstr "%d canale"
@@ -8251,6 +20047,99 @@ msgstr "N&etezire de frecvență (Hz):"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "N&etezire de frecvență (Hz):"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Canal"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Eroare la încărcarea metadatelor"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Bara de instrumente %s Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Înregistrare"
+
+#~ msgid "Commit Id:"
+#~ msgstr "ID-ul de comitere:"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Nu s-a putut deschide fișierul de genuri muzicale.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Înregistrare\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Volum de redare\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Volum de redare\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Dispozitiv de înregistrare\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Volum de redare\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Volum de redare\n"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Nu s-a putut salva fișierul de genuri muzicale."
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Ajustează volumul de redare"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Mărește volumul de redare"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Scade volumul de redare"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Ajustează volumul de înregistrare"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Mărește volumul de înregistrare"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Scade volumul de înregistrare"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Despre &Audacity..."
+
+#~ msgid "Playback Volume"
+#~ msgstr "Volum de redare"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Volum de redare"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Volum de redare"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Click and Drag pentru a muta o piesă în timp"
+
 #~ msgid "Program build date:"
 #~ msgstr "Data compilării programului:"
 
@@ -8266,16 +20155,8 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgstr "Necunoscut"
 
 #, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Nu s-a putut citi fișierul de setări predefinite."
-
-#, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
 #~ msgstr "Audacity este un program gratuit, scris de o echipă de <a href=\"http://audacity.sourceforge.net/community/developers\">dezvoltatoril</a> voluntari din toată lumea. Mulțumim <a href=\"http://code.google.com\">Google Code</a> și <a href=\"http://sourceforge.net\">SourceForge</a> pentru găzduirea proiectului nostru. Audacity este <a href=\"http://audacity.sourceforge.net/download/\">disponibil</a> pentru Windows, Mac și GNU/Linux (precum și alte sisteme de tip Unix)."
-
-#, fuzzy
-#~ msgid "available"
-#~ msgstr "Previzualizare efecte"
 
 #, fuzzy
 #~ msgid "If you find a bug or have a suggestion for us, please write, in English, to our %s. For help, view the tips and tricks on our %s or visit our %s."
@@ -8437,10 +20318,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgstr "Liniște"
 
 #, fuzzy
-#~ msgid "Gating audio..."
-#~ msgstr "Schimbă gazda audio"
-
-#, fuzzy
 #~ msgid "Apply Low-Cut filter"
 #~ msgstr "Se aplică efectul Nyquist..."
 
@@ -8554,10 +20431,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgstr "Nu s-a putut deschide fișierul:"
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "Eliminare pistă"
-
-#, fuzzy
 #~ msgid "Remove vocals or view Help"
 #~ msgstr "&Elimină special"
 
@@ -8582,18 +20455,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgstr "N&etezire de frecvență (Hz):"
 
 #, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "Fișier audio"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Efecte Nyquist"
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "Nu s-a putut salva fișierul de genuri muzicale."
-
-#, fuzzy
 #~ msgid "Unable to save MIDI device info"
 #~ msgstr "Nu s-a putut salva fișierul de genuri muzicale."
 
@@ -8604,10 +20465,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #, fuzzy
 #~ msgid "Left"
 #~ msgstr "Stânga"
-
-#, fuzzy
-#~ msgid "Right"
-#~ msgstr "Dreapta"
 
 #~ msgid "Insert &After"
 #~ msgstr "Insere&ază după"
@@ -8624,18 +20481,6 @@ msgstr "N&etezire de frecvență (Hz):"
 
 #~ msgid "Edit C&hains..."
 #~ msgstr "Editare lanț de comenz&i..."
-
-#, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "&Editează bara de unelte"
-
-#, fuzzy
-#~ msgid "&Tools"
-#~ msgstr "Bare de instrumen&te"
-
-#, fuzzy
-#~ msgid "Transcri&ption"
-#~ msgstr "&Editează bara de unelte"
 
 #, fuzzy
 #~ msgid "All Menus"
@@ -8659,16 +20504,8 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgstr "Schimbă numele pistei în:"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "Bare de instrumen&te"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "&Comandă"
-
-#, fuzzy
-#~ msgid "and"
-#~ msgstr "Sfârșit"
 
 #, fuzzy
 #~ msgid "Duration:\n"
@@ -8702,10 +20539,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgstr "Lungime"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Instrument de selecție"
-
-#, fuzzy
 #~ msgid "S-E"
 #~ msgstr "SSE"
 
@@ -8729,24 +20562,8 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgstr "Liniște"
 
 #, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "NumeNou"
-
-#, fuzzy
-#~ msgid "RemoveDcOffset"
-#~ msgstr "Elimină"
-
-#, fuzzy
 #~ msgid "Depth"
 #~ msgstr "Profunzime:"
-
-#, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Dimensiune"
-
-#, fuzzy
-#~ msgid "Reverberance"
-#~ msgstr "Inversează"
 
 # hm ? sau Amplificare ?
 #, fuzzy
@@ -8757,10 +20574,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Câștig"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Stereo,"
 
 # hm ?
 #, fuzzy
@@ -8794,9 +20607,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #~ msgid "Truncate"
 #~ msgstr "Trunchiază la:"
 
-#~ msgid "Version"
-#~ msgstr "Versiune"
-
 #~ msgid "C&ategory:"
 #~ msgstr "C&ategorie:"
 
@@ -8806,9 +20616,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #, fuzzy
 #~ msgid "Edit Me&tadata Tags..."
 #~ msgstr "Editare etichete metadate"
-
-#~ msgid "Fit &Vertically"
-#~ msgstr "Potrivește &vertical"
 
 #, fuzzy
 #~ msgid "Co&mbined Meter Toolbar"
@@ -8838,9 +20645,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #, fuzzy
 #~ msgid "Host:"
 #~ msgstr "&Gazdă:"
-
-#~ msgid "&Length of preview:"
-#~ msgstr "&Lungimea previzualizării:"
 
 #, fuzzy
 #~ msgid "Add &Track Number"
@@ -8913,9 +20717,6 @@ msgstr "N&etezire de frecvență (Hz):"
 #, fuzzy
 #~ msgid "R&ight Channel"
 #~ msgstr "Canalul drept"
-
-#~ msgid "&Bass (dB):"
-#~ msgstr "&Bași (dB):"
 
 #~ msgid "&Enable level control"
 #~ msgstr "Activ&ează controlul de nivel"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -18,84 +18,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-21 19:01+0000\n"
 "Last-Translator: Konstantin Kobzar <kobzar.ka@ya.ru>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/tenacity/tenacity/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Обновить  Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Пропустить"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Установить обновления"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Журнал изменений"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Узнать больше на GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Ошибка проверки обновлений"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Невозможно подключиться к серверу обновлений Audacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Данные обновления повреждены."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Ошибка получения обновления."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Не удаётся открыть ссылку для загрузки Audacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Доступно Audacity %s!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Запись"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -249,7 +181,8 @@ msgid "Script"
 msgstr "Скрипт"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Вывод"
 
@@ -265,7 +198,12 @@ msgstr "Скрипты Найквиста (*.ny)|*.ny|Скрипты Lisp (*.lsp
 msgid "Script was not saved."
 msgstr "Скрипт не сохранён."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Предупреждение"
 
@@ -286,11 +224,17 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Галерея значков Tango (для панелей)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009, Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009, Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Внешний модуль Audacity, предоставляющий среду создания новых эффектов."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -313,7 +257,8 @@ msgstr "Без названия"
 msgid "Nyquist Effect Workbench - "
 msgstr "Редактор эффектов Найквиста - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Новый"
 
@@ -353,7 +298,8 @@ msgstr "Копировать"
 msgid "Copy to clipboard"
 msgstr "Копировать в буфер обмена"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Вырезать"
 
@@ -361,7 +307,8 @@ msgstr "Вырезать"
 msgid "Cut to clipboard"
 msgstr "Вырезать в буфер обмена"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Вставить"
 
@@ -386,7 +333,8 @@ msgstr "Выбрать всё"
 msgid "Select all text"
 msgstr "Выбрать весь текст"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Отменить"
 
@@ -394,7 +342,8 @@ msgstr "Отменить"
 msgid "Undo last change"
 msgstr "Отменить последние изменения"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Вернуть"
 
@@ -451,7 +400,8 @@ msgid "Go to next S-expr"
 msgstr "Перейти к следующему S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Начало"
 
@@ -459,7 +409,8 @@ msgstr "Начало"
 msgid "Start script"
 msgstr "Запустить скрипт"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Стоп"
 
@@ -473,15 +424,23 @@ msgstr "Остановить скрипт"
 msgid "About %s"
 msgstr "&Об %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "Ок"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Информация о сборке"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Включено"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Выключено"
 
@@ -491,8 +450,9 @@ msgid "The Build"
 msgstr "Сборка"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Id фиксации:"
+#, fuzzy
+msgid "Version:"
+msgstr "Версия: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -502,22 +462,28 @@ msgstr "Тип сборки:"
 msgid "Compiler:"
 msgstr "Компилятор:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Префикс установки:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Папка настроек:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Папка настроек:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Поддержка форматов файлов"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Кросс-платформенная библиотека GUI"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -531,7 +497,6 @@ msgstr "Преобразование частоты дискретизации"
 msgid "MP3 Importing"
 msgstr "Импорт MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Импорт и экспорт Ogg Vorbis"
@@ -540,7 +505,6 @@ msgstr "Импорт и экспорт Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Поддержка ID3-тегов"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Импорт и экспорт FLAC"
@@ -558,14 +522,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Импорт/экспорт FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Импорт через GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Функции"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Поддержка плагинов"
 
@@ -580,6 +536,10 @@ msgstr "Поддержка изменения темпа и высоты тон�
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Поддержка значительного изменения темпа и высоты тона"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Функции"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -698,16 +658,22 @@ msgstr "%s, графика Audacity"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (включая %s, %s, %s, %s и %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Бесплатное, открытое, кросс-платформенное программное обеспечение для записи "
-"и редактирования звука."
+msgstr "Бесплатное, открытое, кросс-платформенное программное обеспечение для записи и редактирования звука."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Об авторах"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Обратите внимание, что имена расположены в алфавитном порядке, а не в порядке важности."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -756,6 +722,7 @@ msgstr "Веб-сайт и графика Audacity"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -778,6 +745,22 @@ msgstr "Особая благодарность проекта Audacity:"
 msgid "%s website: "
 msgstr "Веб-сайт %s: "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s участники проекта %s"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Товарный знак Audacity%s используется в данном програмном обеспечении только в описательных и информационных целях."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity не производится и не поддерживается MuseCY SM Ltd. или Домиником М Маццони."
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "Во время записи действия со шкалой времени запрещены"
@@ -799,6 +782,7 @@ msgstr "Шкала времени"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Щёлкните или перетащите для поиска"
@@ -806,6 +790,7 @@ msgstr "Щёлкните или перетащите для поиска"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Щёлкните или перетащите для старта скраббинга"
@@ -813,6 +798,7 @@ msgstr "Щёлкните или перетащите для старта скр�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Щёлкните и перемещайте для скраббинга. Щёлкните и перетащите для поиска."
@@ -820,6 +806,7 @@ msgstr "Щёлкните и перемещайте для скраббинга. 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Перемещайте для поиска"
@@ -827,6 +814,7 @@ msgstr "Перемещайте для поиска"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Перемещайте для скраббинга"
@@ -883,7 +871,17 @@ msgstr ""
 "Не удалось заблокировать область за\n"
 "пределами конца проекта."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Ошибка"
 
@@ -907,7 +905,8 @@ msgstr ""
 "Этот вопрос задаётся один раз после 'установки' при получении запроса на сброс настроек."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Сбросить настройки Audacity"
 
 #: src/AudacityApp.cpp
@@ -922,7 +921,8 @@ msgstr ""
 "Файл удалён из списка недавно открытых файлов."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Не удалось инициализировать библиотеку SQLite. Audacity не может продолжить."
 
 #: src/AudacityApp.cpp
@@ -947,7 +947,7 @@ msgstr "&Открыть..."
 msgid "Open &Recent..."
 msgstr "Открыть &недавние..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&О Tenacity..."
 
@@ -960,9 +960,10 @@ msgid "&File"
 msgstr "&Файл"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity не удалось найти безопасное место для хранения временных файлов.\n"
@@ -970,20 +971,23 @@ msgstr ""
 "Укажите соответствующий каталог в диалоге настроек."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity не удалось найти каталог временных файлов.\n"
 "Задайте соответствующий каталог в диалоге настроек."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity завершает работу. Для использования нового каталога временных файлов запустите программу повторно."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -992,15 +996,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity не удалось заблокировать каталог временных файлов.\n"
 "Возможно, он используется другой копией Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Всё равно запустить Audacity?"
 
 #: src/AudacityApp.cpp
@@ -1008,19 +1014,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Ошибка блокировки каталога временных файлов"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Система обнаружила другую запущенную копию Audacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Чтобы одновременно открыть несколько проектов, воспользуйтесь\n"
 "командами 'Новый проект' или 'Открыть' в уже запущенной копии Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity уже запущен"
 
 #: src/AudacityApp.cpp
@@ -1036,7 +1045,8 @@ msgstr ""
 "и может потребоваться перезагрузка."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Не удалось запустить Audacity"
 
 #: src/AudacityApp.cpp
@@ -1076,8 +1086,9 @@ msgstr ""
 "и может потребоваться перезагрузка."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1109,7 +1120,8 @@ msgstr "запустить самодиагностику"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "отобразить версию Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1119,9 +1131,10 @@ msgid "audio or project file name"
 msgstr "имя файла аудиоданных или проекта"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1134,16 +1147,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Файлы проектов Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Сообщение"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Ошибка конфигурации Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1153,7 +1168,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Не удалось получить доступ к следующему файлу конфигурации:\n"
 "\n"
@@ -1162,12 +1177,15 @@ msgstr ""
 "\n"
 "Это может быть вызвано многими причинами. Вероятно, диск заполнен или у вас нет прав на запись в файл. Более подробно можно узнать, нажав кнопку справки ниже."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Справка"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Выйти из Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1175,7 +1193,8 @@ msgid "&Retry"
 msgstr "&Повторить"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Журнал Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1187,9 +1206,14 @@ msgstr "&Сохранить..."
 msgid "Cl&ear"
 msgstr "О&чистить"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Закрыть"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1237,6 +1261,11 @@ msgstr ""
 msgid "Error Initializing Midi"
 msgstr "Ошибка инициализации MIDI"
 
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
+msgstr "Обрезка аудио"
+
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
 #, c-format
 msgid ""
@@ -1249,37 +1278,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Недостаточно памяти!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Авторегулировка уровня записи остановлена. Дальнейшая оптимизация невозможна. Уровень всё ещё слишком высокий."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Авторегулировка уровня записи снизила громкость до %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Авторегулировка уровня записи остановлена. Дальнейшая оптимизация невозможна. Уровень всё ещё слишком низкий."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Авторегулировка уровня записи увеличила громкость до %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Авторегулировка уровня записи остановлена. Превышено количество точек анализа, но приемлемая громкость не найдена и остаётся слишком высокой."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Авторегулировка уровня записи остановлена. Превышено количество точек анализа, но приемлемая громкость не найдена и остаётся слишком низкой."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Авторегулировка уровня записи остановлена. Похоже, что %.2f является приемлемой громкостью."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1378,43 +1376,6 @@ msgstr "Не найдено устройство проигрывания '%s'.\
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Невозможно проверить взаимные частоты дискретизации без обоих устройств\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "При открытии устройств получено %d\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Невозможно открыть Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Доступные микшеры:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Доступные источники записи:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Доступные каналы микшера:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Уровень записи эмулирован\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Уровень записи естественный\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Громкость проигрывания эмулирована\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Громкость проигрывания естественна\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1457,8 +1418,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Автовосстановление после сбоя"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1471,12 +1433,14 @@ msgid "Recoverable &projects"
 msgstr "Восстановимые &проекты"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Выделить"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Имя"
 
@@ -1562,6 +1526,11 @@ msgstr "Эффект"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Команда меню (с параметрами)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1707,7 +1676,8 @@ msgstr "Во&сстановить"
 msgid "I&mport..."
 msgstr "И&мпорт..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Экспорт..."
 
@@ -1748,7 +1718,8 @@ msgstr "Переместить &вверх"
 msgid "Move &Down"
 msgstr "Переместить в&низ"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Сохранить"
 
@@ -1831,9 +1802,17 @@ msgid "Run"
 msgstr "Пуск"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Закрыть"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "Тест производительности"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1969,11 +1948,6 @@ msgstr "Тест завершён успешно.\n"
 #: src/BuildInfo.h
 msgid "No revision identifier was provided"
 msgstr "Не предоставлен идентификатор ревизии"
-
-#: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Дата и время завершения"
 
 #: src/BuildInfo.h
 #, c-format
@@ -2226,6 +2200,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Копировать имена в буфер обмена"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Отсутствует"
 
@@ -2234,10 +2213,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Если продолжить, ваш проект не будет сохранён на диск. Всё равно продолжить?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2251,7 +2231,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Проверка зависимостей"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "(Нет)"
 
@@ -2259,7 +2242,7 @@ msgstr "(Нет)"
 msgid "Rectangle"
 msgstr "Прямоугольный"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Треугольный"
 
@@ -2321,9 +2304,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Программа собрана без поддержки FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2345,8 +2329,8 @@ msgid "Locate FFmpeg"
 msgstr "Найти FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity нужен файл %s для импорта и экспорта аудиоданных с помощью FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2359,7 +2343,8 @@ msgstr "Расположение '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Чтобы найти '%s', щёлкните здесь -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Обзор..."
 
@@ -2385,8 +2370,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg не найден"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2416,24 +2402,24 @@ msgid "Only libavformat.so"
 msgstr "Только libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity не удалось открыть файл в %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity не удалось прочесть данные из файла в %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity удалось успешно записать файл в %s, но не удалось переименовать его в %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2471,7 +2457,9 @@ msgstr "&Не копировать никаких аудиоданных"
 msgid "As&k"
 msgstr "&Спросить"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Все файлы"
 
@@ -2496,6 +2484,10 @@ msgstr "Текст-файлы"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML-файлы"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2562,7 +2554,12 @@ msgstr "Логарифмический масштаб"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "дБ"
 
@@ -2577,7 +2574,9 @@ msgstr "Масштаб"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "Гц"
 
@@ -2679,7 +2678,8 @@ msgstr "спектр.txt"
 msgid "Export Spectral Data As:"
 msgstr "Экспорт данных о частотах в:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Не удалось записать в файл: %s"
@@ -2869,19 +2869,19 @@ msgid "&History..."
 msgstr "&История..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Внутренняя ошибка в %s в строке %s %d.\n"
 "Пожалуйста, сообщите команде Audacity на https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Внутренняя ошибка в %s в строке %d.\n"
 "Пожалуйста, сообщите Audacity на https://forum.audacityteam.org/."
@@ -2900,7 +2900,9 @@ msgid "Track"
 msgstr "Трек"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Метка"
 
@@ -2960,7 +2962,8 @@ msgstr "Введите имя трека"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Трек меток"
 
@@ -2971,11 +2974,13 @@ msgstr "Не удалось прочесть одну или несколько 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Первый запуск Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Выберите язык интерфейса Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2985,7 +2990,8 @@ msgstr "Выберите язык интерфейса Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Выбранный вами язык %s (%s) отличается от языка системы, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Подтвердить"
 
@@ -3003,12 +3009,13 @@ msgstr ""
 "Старый файл сохранён как '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Открытие проекта Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Караоке в Audacity%s"
 
 #: src/LyricsWindow.cpp
@@ -3059,19 +3066,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Микширование и сведение треков"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Пульт микшера Audacity %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Усиление"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Скорость"
 
@@ -3080,17 +3091,23 @@ msgid "Musical Instrument"
 msgstr "Музыкальный инструмент"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Баланс"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Тихо"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Соло"
 
@@ -3098,15 +3115,18 @@ msgstr "Соло"
 msgid "Signal Level Meter"
 msgstr "Индикатор уровня сигнала"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Регулятор усиления смещён"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Регулятор velocity смещён"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Регулятор баланса смещён"
 
@@ -3140,9 +3160,9 @@ msgstr ""
 "Он не будет загружен."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3176,16 +3196,19 @@ msgstr ""
 "\n"
 "Использовать модули только из надёжных источников"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Да"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Нет"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Загрузчик модулей Audacity"
 
 #: src/ModuleManager.cpp
@@ -3208,6 +3231,117 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Трек нот"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+#, fuzzy
+msgid "B"
+msgstr "дБ"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3318,7 +3452,8 @@ msgstr "&Выбрать всё"
 msgid "C&lear All"
 msgstr "О&чистить всё"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Включить"
 
@@ -3398,9 +3533,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Несовпадающие частоты дискретизации"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Слишком мало треков выбрано для записи с такой частотой дискретизации.\n"
@@ -3429,10 +3565,11 @@ msgid "Dropouts"
 msgstr "Пропуски"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3472,11 +3609,11 @@ msgid "Inspecting project file data"
 msgstr "Выполняется проверка данных проекта"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3519,11 +3656,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Внимание - отсутствуют файлы-ссылки"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "При проверке папки проекта '%s' \n"
@@ -3548,12 +3685,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Внимание - отсутствуют сводные файлы-ссылок"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3611,7 +3748,8 @@ msgstr "Внимание - несвязанные файлы блока"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Выполнение"
 
@@ -3636,6 +3774,11 @@ msgstr "Внимание: проблемы автовосстановления"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<без названия>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Проект %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3705,12 +3848,14 @@ msgstr ""
 "(Невозможно создать требуемые временные файлы)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Это не файл проекта Audacit"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3842,9 +3987,9 @@ msgid "Error Writing to File"
 msgstr "Ошибка записи в файл"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3858,9 +4003,16 @@ msgstr "Сжатие проекта"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Проект %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Скорость"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3869,10 +4021,10 @@ msgstr "(Восстановлен)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Этот файл был сохранён с использованием Audacity %s.\n"
 "Вы используете Audacity %s. Чтобы открыть этот файл, надо обновить версию программы."
@@ -3944,8 +4096,9 @@ msgid "Backing up project"
 msgstr "Backup проекта"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3954,8 +4107,9 @@ msgstr ""
 "Он был восстановлен до последнего снимка."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4034,8 +4188,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sСохранить проект '%s' как..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "Пункт 'Сохранить проект' сохраняет проект Audacity, а не аудиофайл.\n"
@@ -4112,11 +4267,12 @@ msgid "Error Opening Project"
 msgstr "Ошибка открытия проекта"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Вы пытаетесь открыть автоматически созданный файл\n"
 "резервной копии. Это может привести к потере данных.\n"
@@ -4225,8 +4381,8 @@ msgid "Automatic database backup failed."
 msgstr "Ошибка автоматического резервного копирования базы данных."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Добро пожаловать в Audacity версии %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4443,7 +4599,8 @@ msgstr "Все настройки"
 msgid "SelectionBar"
 msgstr "Панель выбора"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Выбор спектра"
 
@@ -4451,46 +4608,55 @@ msgstr "Выбор спектра"
 msgid "Timer"
 msgstr "Таймер"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Инструменты"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Транспорт"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Микшер"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Индикатор"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Индикатор проигрывания"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Индикатор записи"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Правка"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Устройство"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Проигрывание на скорости"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Скраббинг"
 
@@ -4505,7 +4671,10 @@ msgstr "Линейка"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Треки"
 
@@ -4615,7 +4784,8 @@ msgid "Activation level (dB):"
 msgstr "Уровень активации (дБ):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Добро пожаловать в Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4762,9 +4932,9 @@ msgstr ""
 "Чтобы получить советы по подходящим дискам, нажмите кнопку справки."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity не удалось записать файл:\n"
@@ -4784,9 +4954,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4795,9 +4965,9 @@ msgstr ""
 "на запись."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity не удалось записать данные изображения в файл:\n"
@@ -4814,9 +4984,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4826,9 +4996,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4837,8 +5007,9 @@ msgstr ""
 "Возможно, неправильный формат PNG?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity не смог прочитать свою исходную тему.\n"
@@ -4876,9 +5047,9 @@ msgstr ""
 "уже присутствуют. Перезаписать?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity не удалось сохранить файл:\n"
@@ -4917,7 +5088,11 @@ msgstr "Задать"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Длительность"
 
@@ -4928,7 +5103,8 @@ msgid "Time Track"
 msgstr "Трек времени"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Запись по таймеру Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5002,7 +5178,8 @@ msgstr "Текущий проект"
 msgid "Recording start:"
 msgstr "Начало записи:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Длительность:"
 
@@ -5023,7 +5200,8 @@ msgid "Action after Timer Recording:"
 msgstr "Действие после записи по таймеру:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Ход выполнения записи по таймеру"
 
 #: src/TimerRecordDialog.cpp
@@ -5119,6 +5297,7 @@ msgstr "099 дней 024 ч 060 м 060 с"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Дата и время начала"
@@ -5163,7 +5342,8 @@ msgstr "Включить авто&экспорт?"
 msgid "Export Project As:"
 msgstr "Экспорт проекта как:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Опции"
 
@@ -5176,7 +5356,8 @@ msgid "Do nothing"
 msgstr "Ничего не делать"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Закрыть Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5200,7 +5381,8 @@ msgid "Scheduled to stop at:"
 msgstr "Запланирована остановка на:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Таймер записи Audacity - ожидание запуска"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5226,7 +5408,8 @@ msgid "Recording Exported:"
 msgstr "Запись экспортирована:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Запись по таймеру Audacity - ожидание"
 
 #: src/TrackInfo.cpp
@@ -5423,7 +5606,11 @@ msgid "Applying %s..."
 msgstr "Применяется %s..."
 
 #. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%s: %s"
 msgstr "%s - %s"
@@ -5446,13 +5633,15 @@ msgstr "%s не является параметром принятым %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Недопустимое значение параметра '%s': должно быть %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Команда"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Повторить %s"
@@ -5522,6 +5711,11 @@ msgstr "Трек 0"
 msgid "Track 1"
 msgstr "Трек 1"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Имя окна:"
@@ -5574,13 +5768,24 @@ msgstr "Фрагменты"
 msgid "Envelopes"
 msgstr "Огибающие"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Метки"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Боксы"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5590,7 +5795,8 @@ msgstr "Краткий"
 msgid "Type:"
 msgstr "Тип:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Формат:"
 
@@ -5617,6 +5823,10 @@ msgstr "Комментарий"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Команда:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5654,12 +5864,17 @@ msgstr "Экспорт в файл."
 msgid "Builtin Commands"
 msgstr "Встроенные команды"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Команда Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Обеспечивает для Audacity встроенные команды"
 
 #: src/commands/LoadCommands.cpp
@@ -5722,7 +5937,10 @@ msgstr "Очищает содержимое журнала"
 msgid "Get Preference"
 msgstr "Получить настройку"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Имя:"
 
@@ -5770,7 +5988,8 @@ msgstr "Весь экран"
 msgid "Toolbars"
 msgstr "Панели инструментов"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Эффекты"
 
@@ -5912,7 +6131,8 @@ msgstr "Задать"
 msgid "Add"
 msgstr "Добавить"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Удалить"
 
@@ -5997,7 +6217,8 @@ msgid "Edited Envelope"
 msgstr "Редактируемая огибающая"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Огибающая"
 
@@ -6040,6 +6261,14 @@ msgstr "Частота:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Изменить размер:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -6089,7 +6318,10 @@ msgstr "Баланс:"
 msgid "Set Track Visuals"
 msgstr "Задать визуальные эффекты трека"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Линейная"
 
@@ -6202,7 +6434,9 @@ msgid "Duck &amount:"
 msgstr "&Значение приглушения:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "сек."
 
@@ -6226,7 +6460,8 @@ msgstr "Длина в&нутреннего затухания:"
 msgid "Inner &fade up length:"
 msgstr "Длина &внутреннего нарастания:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Порог:"
 
@@ -6364,11 +6599,13 @@ msgstr "до (Гц)"
 msgid "t&o"
 msgstr "д&о"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "&Процент изменения:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Процент изменения"
 
@@ -6376,9 +6613,23 @@ msgstr "Процент изменения"
 msgid "&Use high quality stretching (slow)"
 msgstr "И&спользовать растяжение высокого качества (медленно)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "н/д"
 
@@ -6406,6 +6657,7 @@ msgstr "Стандартное число об/мин пластинок:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "От об/мин"
@@ -6418,6 +6670,7 @@ msgstr "&от"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "До об/мин"
@@ -6576,6 +6829,20 @@ msgstr "%.2f сек."
 msgid "%.1f secs"
 msgstr "%.1f сек."
 
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f мс"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
@@ -6691,7 +6958,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Анализатор контраста позволяет измерять разность громкости RMS между двумя выделенными фрагментами."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Конец"
 
@@ -6750,6 +7018,18 @@ msgstr "&Отклонение:"
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&Справка"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "zero"
@@ -7177,7 +7457,9 @@ msgstr "DTMF-&последовательность:"
 msgid "&Amplitude (0-1):"
 msgstr "А&мплитуда (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Д&лительность:"
 
@@ -7188,6 +7470,11 @@ msgstr "Отно&шение сигнал/тишина:"
 #: src/effects/DtmfGen.cpp
 msgid "Duty cycle:"
 msgstr "Цикл активности:"
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f дБ"
 
 #: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
@@ -7217,7 +7504,8 @@ msgstr "Эхо"
 msgid "Repeats the selected audio again and again"
 msgstr "Циклично повторяет выделенные аудиоданные"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "\"Указанное значение превышает объём доступной памяти."
 
@@ -7241,7 +7529,8 @@ msgstr "Пресеты"
 msgid "Export Effect Parameters"
 msgstr "Экспорт параметров эффекта"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Не удалось открыть файл: '%s'"
@@ -7618,6 +7907,10 @@ msgid "Low rolloff for speech"
 msgstr "Спад НЧ для речи"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Телефон"
 
@@ -7682,6 +7975,12 @@ msgstr "%d Гц"
 #: src/effects/Equalization.cpp
 #, c-format
 msgid "%g kHz"
+msgstr "%g кГц"
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%gk"
 msgstr "%g кГц"
 
 #: src/effects/Equalization.cpp
@@ -7757,8 +8056,16 @@ msgid "D&efault"
 msgstr "По &умолчанию"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &потоковый"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -8003,7 +8310,8 @@ msgid "Builtin Effects"
 msgstr "Встроенные эффекты"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Обеспечивает для Audacity  встроенные эффекты"
 
 #: src/effects/LoadEffects.cpp
@@ -8013,6 +8321,11 @@ msgstr "Неизвестное имя встроенного эффекта"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "воспринимаемая громкость"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+#, fuzzy
+msgid "RMS"
+msgstr "RMS дБ."
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -8044,6 +8357,10 @@ msgstr "&Нормализация"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Громкость LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "RMS dB"
@@ -8225,8 +8542,9 @@ msgid "Step 1"
 msgstr "Этап 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Выделите несколько секунд только шума, чтобы программа знала\n"
@@ -8278,13 +8596,62 @@ msgstr "Т&ип окна:"
 msgid "Window si&ze:"
 msgstr "Размер &окна:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (по-умолчанию)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Шагов на окно:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8400,12 +8767,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Нормализовать &стереоканалы раздельно"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Растянуть"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch - только для экстремального растяжения времени или эффекта 'стазиса'"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Ко&эффициент растяжения:"
@@ -8848,6 +9221,11 @@ msgstr "Использовать умолчания"
 msgid "Restore Defaults"
 msgstr "Сброс в умолчание"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -9006,6 +9384,10 @@ msgstr "Обнаружение тишины"
 msgid "Tr&uncate to:"
 msgstr "&Усечь до:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "С&жать до:"
@@ -9019,7 +9401,8 @@ msgid "VST Effects"
 msgstr "VST-эффекты"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Добавляет возможность использовать VST-эффекты в Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9031,7 +9414,8 @@ msgstr "Поиск Shell-VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Регистрация %d из %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Не удалось загрузить библиотеку"
 
@@ -9051,7 +9435,8 @@ msgstr "Размер буфера определяет количество сэ
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Размер буфера (8 - 1048576 сэмплов):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Компенсация задержки"
 
@@ -9059,7 +9444,8 @@ msgstr "Компенсация задержки"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Некоторые VST-эффекты в рамках процедуры обработки должны задерживать возврат данных в Audacity. Если эту задержку не компенсировать, вы заметите, что в начале звука появились небольшие фрагменты тишины. Включение этой опции позволит компенсировать задержку, но это работает не для всех VST-эффектов"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Включить &компенсацию"
 
@@ -9093,7 +9479,8 @@ msgid "Standard VST program file"
 msgstr "Стандартный файл программы VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Файл пресета VST для Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9120,7 +9507,8 @@ msgstr "Ошибка загрузки пресетов VST"
 msgid "Unable to load presets file."
 msgstr "Невозможно загрузить файл пресетов."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Настройки эффекта"
 
@@ -9136,6 +9524,12 @@ msgstr "Невозможно прочесть файл пресетов."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Этот файл параметров был сохранён из %s. Продолжить?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -9171,7 +9565,8 @@ msgid "Audio Unit Effects"
 msgstr "Эффекты Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Обеспечивает поддержку эффектов Audio Unit для Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9187,7 +9582,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Параметры эффектов Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Некоторые эффекты Audio Unit в рамках обработки должны задерживать возврат звука в Audacity. Если эту задержку не компенсировать, то к звуку добавляются небольшие фрагменты тишины. Включение этой опции обеспечит такую компенсацию, но она работает не для всех эффектов Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9323,8 +9719,16 @@ msgstr "Не удалось создать список свойств прес�
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "Не удалось задать класс для пресета '%s'"
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Эффекты Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA-эффекты"
@@ -9334,7 +9738,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Обеспечивает LADSPA-эффекты"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity больше не использует vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9342,12 +9747,30 @@ msgid "LADSPA Effect Options"
 msgstr "Параметры LADSPA-эффекта"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Некоторые эффекты LADSPA в рамках своей работы должны задерживать возврат звука в Audacity. Если эту задержку не компенсировать, то к звуку добавляются небольшие фрагменты тишины. Включение этой опции обеспечит такую компенсацию, но она работает не для всех эффектов LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Вывод эффекта"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA-эффекты"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9359,7 +9782,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Размер буфера (8 - %d) сэмплов:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Некоторые эффекты LV2 в рамках своей работы должны задерживать возврат звука в Audacity. Если эту задержку не компенсировать, то к звуку добавляются небольшие фрагменты тишины. Включение этой опции обеспечит такую компенсацию, но она работает не для всех эффектов LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9384,12 +9808,19 @@ msgstr "'%s' требует неподдерживаемый параметр %s
 msgid "Generator"
 msgstr "Генераторы"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-эффекты"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Обеспечивает поддержку для Audacity LV2-эффектов"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9397,7 +9828,8 @@ msgid "Nyquist Effects"
 msgstr "Эффекты Найквиста"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Обеспечивает поддержку для Audacity эффектов Найквиста"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9625,7 +10057,8 @@ msgstr "Выберите файл"
 msgid "Save file as"
 msgstr "Сохранить файл как"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "без названия"
 
@@ -9634,7 +10067,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-эффекты"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Обеспечивает поддержку Vamp-эффектов для Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9656,6 +10090,12 @@ msgstr "Настройки плагина"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Программа"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9814,6 +10254,11 @@ msgid "Command Output"
 msgstr "Вывод команды"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "&OK"
+msgstr "Ок"
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "Указано имя файла без расширения. Вы уверены?"
 
@@ -9952,7 +10397,8 @@ msgstr "Экспорт аудиоданных в %s"
 msgid "Invalid sample rate"
 msgstr "Неверная частота дискретизации"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Изменение частоты дискретизации"
 
@@ -9984,7 +10430,8 @@ msgstr "Частоты дискретизации"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d кб/с"
@@ -10004,12 +10451,52 @@ msgid "%.2f kbps"
 msgstr "%.2f кб/с"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Включено"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Constrained"
 msgstr "Ограничено"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -10128,8 +10615,17 @@ msgid "Replace preset '%s'?"
 msgstr "Заменить пресет '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Л"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Основной"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10237,6 +10733,10 @@ msgstr "Язык:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Бит-буфер"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10370,6 +10870,11 @@ msgstr ""
 "0 - по умолчанию\n"
 "min - 1\n"
 "max - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Использовать LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10687,7 +11192,8 @@ msgstr "Ненормальный"
 msgid "Extreme"
 msgstr "Экстремальный"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Стандарт"
 
@@ -10738,8 +11244,8 @@ msgid "Locate LAME"
 msgstr "Найти LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity требуется файл %s для записи файлов MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10767,10 +11273,10 @@ msgid "Where is %s?"
 msgstr "Где находится %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Вы ссылаетесь на lame_enc.dll v%d.%d. Эта версия несовместима с Audacity %d.%d.%d.\n"
 "Скачайте последнюю версию библиотеки 'LAME для Audacity'."
@@ -11075,6 +11581,14 @@ msgstr "Экспорт выделенного аудио как Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Экспорт аудиоданных в Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Заголовок:"
@@ -11088,9 +11602,10 @@ msgid "Other uncompressed files"
 msgstr "Прочие несжатые файлы"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Попытка экспорта файла WAV или AIFF размером более 4 ГБ.\n"
 "Audacity не может этого сделать, экспорт был прекращён."
@@ -11100,8 +11615,9 @@ msgid "Error Exporting"
 msgstr "Ошибка экспорта"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Экспортированный WAV-файл был усечён - Audacity не может экспортировать\n"
@@ -11141,11 +11657,11 @@ msgid "All supported files"
 msgstr "Все поддерживаемые файлы"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "'%s' \n"
@@ -11155,11 +11671,11 @@ msgstr ""
 "меню: Файл > Импорт > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\"\n"
 "это не аудиофайл.\n"
@@ -11170,18 +11686,18 @@ msgid "Select stream(s) to import"
 msgstr "Выберите потоки для импорта"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Эта версия Audacity была скомпилирована без поддержки %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "'%s' - это трек компакт-диска. \n"
 "Audacity не может открыть её напрямую. \n"
@@ -11190,10 +11706,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "'%s' - это плей-лист.\n"
@@ -11202,10 +11718,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "'%s' - файл Windows Media Audio. \n"
@@ -11215,10 +11731,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" - файл Advanced Audio Coding.\n"
@@ -11227,12 +11743,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "'%s' - зашифрованный аудиофайл.\n"
@@ -11243,10 +11759,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "'%s' - медиафайл RealPlayer. \n"
@@ -11255,12 +11771,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "'%s' - файл нотной записи, а не звуковой файл.\n"
 "Audacity не может открыть файл этого формата.\n"
@@ -11269,10 +11785,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11285,10 +11801,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "'%s' - это аудиофайл Wavpack. \n"
@@ -11297,10 +11813,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "'%s' - файл Dolby Digutal. \n"
@@ -11309,10 +11825,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "'%s' - файл Ogg Speex.\n"
@@ -11321,10 +11837,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "'%s' - видеофайл.\n"
@@ -11338,9 +11854,9 @@ msgstr "Не найден файл '%s'."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11355,11 +11871,16 @@ msgstr ""
 "Попробуйте установить FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, тестировщик Audacity"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11389,12 +11910,13 @@ msgid "Import Project"
 msgstr "Импорт проекта"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Этот проект был сохранён Audacity версии 1.0 или более ранней. Формат\n"
 "изменён, и эта версия Audacity не может импортировать проект.\n"
@@ -11445,7 +11967,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Не удалось найти папку с данными проекта: '%s'"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "В файле проекта найдены MIDI-треки, но эта сборка Audacity не включает поддержку MIDI в обход трека."
 
 #: src/import/ImportAUP.cpp
@@ -11550,40 +12073,6 @@ msgstr "Индекс[%02x] Кодек[%s], Язык[%s], Битрейт[%s], К�
 msgid "FLAC files"
 msgstr "Файлы FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Совместимые с GStreamer файлы"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Невозможно добавить декодер в конвейер"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Мастер импорта GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Не удалось перевести состояние потока в состояние паузы."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Индекс[%02d], тип[%s], каналы[%d], частота[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Файл не содержит аудиопотоков."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Импорт файла невозможен - не удалось изменить состояние."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Ошибка GStreamer: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Список файлов в обычном текстовом формате"
@@ -11684,22 +12173,98 @@ msgstr "Внутренняя логическая ошибка"
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF и другие типы несжатых данных"
 
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/import/ImportPCM.cpp
 msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (FLAC, аудиокодек без потерь)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG-контейнер)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (без заголовка)"
 
 #: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAV (NIST Sphere)"
 msgstr "WAV (NIST Sphere"
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11730,6 +12295,26 @@ msgid "64 bit float"
 msgstr "64-бит с пл. точкой"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "32kbs G721 ADPCM"
 msgstr "32 кб/сек G721 ADPCM"
 
@@ -11750,12 +12335,20 @@ msgid "24 bit DWVW"
 msgstr "DWVW 24-бит"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "DPCM 16-бит"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "DPCM 8-бит"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11804,6 +12397,19 @@ msgstr "Импорт необработанных данных"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Без перестановки"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Среднее"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -11878,6 +12484,7 @@ msgstr "%s правый"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11902,6 +12509,7 @@ msgstr "конец"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11930,7 +12538,8 @@ msgstr "Клипы со сдвигом по времени вправо"
 msgid "Time shifted clips to the left"
 msgstr "Клипы со сдвигом по времени влево"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Сдвиг по времени"
 
@@ -12068,7 +12677,8 @@ msgstr "Обрезать выделенные треки с %.2f сек. до %.
 msgid "Trim Audio"
 msgstr "Обрезка аудио"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Разделить"
 
@@ -12191,34 +12801,6 @@ msgstr "Клавиша Удалить&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "Экс&тра-меню"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "&Микшер"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Ре&гулировка громкости проигрывания..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "У&величить громкость проигрывания"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "У&меньшить громкость проигрывания"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Ре&гулировка громкости записи..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Уве&личить громкость записи"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "У&меньшить громкость записи"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12394,6 +12976,11 @@ msgid "&Labels..."
 msgstr "&Меток..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "Необработанных &данных (RAW)..."
 
@@ -12482,8 +13069,9 @@ msgid "&Getting Started"
 msgstr "Начало работы"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Ру&ководство Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Руководство..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12509,11 +13097,8 @@ msgstr "Информация о &MIDI-устройствах..."
 msgid "Show &Log..."
 msgstr "Показать &журнал..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Об Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Метка добавлена"
 
@@ -12761,6 +13346,11 @@ msgstr "Переключение &активного трека"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Без категории"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Новая..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -13199,6 +13789,7 @@ msgstr "Длинный пе&реход курсора вправо"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Поиск"
@@ -13410,18 +14001,21 @@ msgid "Created new label track"
 msgstr "Создан новый трек меток"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "В этой версии Audacity в каждом из окон проекта можно использовать только 1 трек времени."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Создан новый трек времени"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Новая частота дискретизации (Гц):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Введённое значение недопустимо"
 
@@ -13678,7 +14272,9 @@ msgstr "Играет"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Запись"
 
@@ -13827,10 +14423,6 @@ msgstr "Наложение записи"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Про&граммное проигрывание"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "А&вторегулировка уровня записи"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -14046,7 +14638,7 @@ msgstr "Настройки для качества"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Обновить  Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -14093,7 +14685,8 @@ msgstr "Метод &вывода звука:"
 msgid "Using:"
 msgstr "Используется:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Проигрывание"
 
@@ -14113,7 +14706,8 @@ msgstr "Ка&налы:"
 msgid "Latency"
 msgstr "Задержка"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "миллисек."
 
@@ -14142,7 +14736,8 @@ msgid "2 (Stereo)"
 msgstr "2 (стерео)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Каталоги"
 
@@ -14250,7 +14845,8 @@ msgid "Directory %s is not writable"
 msgstr "У вас нет прав на запись в каталог %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Изменения во временном каталоге вступят в силу только после перезапуска Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14281,6 +14877,19 @@ msgstr "по разработчикам"
 msgid "Grouped by Type"
 msgstr "по типу"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
 #. In the translations of this and other strings, you may transliterate the
@@ -14288,6 +14897,18 @@ msgstr "по типу"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "На&йквист"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -14310,11 +14931,13 @@ msgid "Plugin Options"
 msgstr "Опции плагина"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Проверять наличие обновлений плагинов при старте"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Пересканировать плагины при следующем старте"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14494,7 +15117,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Со&хранять метки, если выделение привязано к метке"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "О&бъединить системную тему и тему Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14518,6 +15142,10 @@ msgstr "Показать скраб-линейку"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "Язык '%s' не определён"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14668,7 +15296,8 @@ msgstr ""
 "* ' %s' ( потому что сочетание клавиш '%s' назначено для \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Выберите XML-файл с сочетаниями клавиш Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14800,8 +15429,9 @@ msgid "Dow&nload"
 msgstr "За&грузить"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Программа уже обнаружила библиотеки FFMpeg автоматически.\n"
@@ -14860,19 +15490,22 @@ msgid "Preferences for Module"
 msgstr "Настройки для модуля"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr "Здесь показаны экспериментальные модули. Включите их только после изучения руководства Audacity и если вы уверены в своих действиях."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "'Запрос' - Audacity будет запрашивать каждый раз при загрузке модуля."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "'Неудачно' - Audacity посчитает модуль нерабочим и не запустит его."
 
 #. i18n-hint preserve the leading spaces
@@ -14881,7 +15514,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "'Новый' - не выбран ещё ни один вариант."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Изменения этих параметров вступят в силу только после перезапуска."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14899,6 +15533,10 @@ msgstr "Модули не найдены"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Модуль"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14940,7 +15578,10 @@ msgstr "Перетаскивание с нажатой левой кнопкой
 msgid "Set Selection Range"
 msgstr "Задать область выделения"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift+щелчок левой"
 
@@ -15027,6 +15668,15 @@ msgstr "-перетаскивание с нажатой левой кнопко�
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Переместить фрагмент вверх/вниз между треками"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-перетаскивание с нажатой левой кнопкой"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -15151,7 +15801,8 @@ msgid "Always scrub un&pinned"
 msgstr "&Прокрутка всегда разблокирована"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Параметры Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -15289,39 +15940,6 @@ msgid "System T&ime"
 msgstr " Системное &время"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Авторегулировка уровня записи"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Включить авторегулировку уровня записи."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Целевой пик:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "В границах:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Время анализа:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "мсек. (время одного анализа)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Число последовательных анализов:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 - бесконечность"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Запись с перезаписью"
 
@@ -15332,6 +15950,21 @@ msgstr "&Опережение:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Кро&ссфейд:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15466,6 +16099,10 @@ msgid "1024 - default"
 msgstr "1024 - по умолчанию"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - самый узкополосный"
 
@@ -15563,13 +16200,14 @@ msgid "Info"
 msgstr "Информация"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15752,7 +16390,8 @@ msgstr "Сэмплы"
 msgid "4 Pixels per Sample"
 msgstr "4 пикселя на сэмпл"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Макс. масштаб"
 
@@ -15874,16 +16513,24 @@ msgid "Stopped"
 msgstr "Остановлено"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Пауза"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Перейти в начало трека"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Перейти в конец трека"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Пауза"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Выделить до начала"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Выделить до конца"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15896,14 +16543,6 @@ msgstr "Записать новый трек"
 #: src/toolbars/ControlToolBar.cpp
 msgid "Append Record"
 msgstr "Дописать в конец"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Выделить до конца"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Выделить до начала"
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
@@ -15995,11 +16634,17 @@ msgstr "Заполнить выделенную область тишиной"
 msgid "Sync-Lock Tracks"
 msgstr "Синхронизация треков"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Увеличить"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Уменьшить"
 
@@ -16066,43 +16711,6 @@ msgstr "Ин&дикатор уровня записи"
 msgid "&Playback Meter Toolbar"
 msgstr "Инд&икатор уровня проигрывания"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Громкость записи"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Громкость проигрывания"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Уровень записи: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Уровень записи (недоступно; используйте системный микшер.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Громкость проигрывания: %.2f (эмуляция)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Громкость проигрывания: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Громкость проигрывания (недоступно; используйте системный микшер.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "&Микшер"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Поиск"
@@ -16118,6 +16726,7 @@ msgstr "Скраббинг"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Остановить скраббинг"
@@ -16125,6 +16734,7 @@ msgstr "Остановить скраббинг"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Начать скраббинг"
@@ -16132,6 +16742,7 @@ msgstr "Начать скраббинг"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Остановить поиск"
@@ -16139,6 +16750,7 @@ msgstr "Остановить поиск"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Начать поиск"
@@ -16193,7 +16805,9 @@ msgstr "Прилипать к линейке"
 msgid "Length"
 msgstr "Длина"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "центр"
 
@@ -16257,8 +16871,8 @@ msgstr "Панель &времени"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Панель: %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -16285,7 +16899,8 @@ msgstr "Сдвиг по времени"
 msgid "Zoom Tool"
 msgstr "Масштаб"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Отрисовка"
 
@@ -16361,11 +16976,13 @@ msgstr "Перетащите одну или несколько меток."
 msgid "Drag label boundary."
 msgstr "Перетащите метку."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Изменённая метка"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Правка метки"
 
@@ -16420,31 +17037,42 @@ msgstr "Отредактированные метки"
 msgid "New label"
 msgstr "Новая метка"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Верхняя &октава"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Нижняя окта&ва"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Щелчок увеличивает по вертикали, Shift+щелчок уменьшает. Перетащите, указав область изменения."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Щелчок правой вызывает меню."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Сбросить масштаб"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift+щелчок правой"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "щелчок левой/перетаскивание влево"
 
@@ -16486,7 +17114,8 @@ msgstr "Объединить"
 msgid "Expanded Cut Line"
 msgstr "Расширенная линия выреза"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Расширить"
 
@@ -16509,6 +17138,11 @@ msgstr "Перемещёные сэмплы"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Правка сэмпла"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16554,7 +17188,8 @@ msgstr "Обработка...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' изменено на %s"
@@ -16633,7 +17268,8 @@ msgstr "Изменить частоту"
 msgid "Set Rate"
 msgstr "Задать рейтинг"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Мульти-вид"
 
@@ -16726,19 +17362,22 @@ msgid "Right, %dHz"
 msgstr "Правый, %dГц"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f дБ"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% левый"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% правый"
@@ -16856,9 +17495,8 @@ msgstr "Логарифмическая &интерполяция"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Щёлкните и перетащите для перемещения трека во времени"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16909,6 +17547,7 @@ msgstr "Огибающая с коррекцией."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Ск&раббинг"
@@ -16920,6 +17559,7 @@ msgstr "Поиск"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Скраб-&линейка"
@@ -17115,6 +17755,12 @@ msgstr "Л"
 msgid "R"
 msgstr "П"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.2fx"
+msgstr "%.2f дБ"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -17148,9 +17794,19 @@ msgstr "Пусто"
 msgid "Backwards"
 msgstr "Назад"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Вперёд"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -17363,6 +18019,7 @@ msgstr "0100 ч 060 м 060 с+># сэмплов"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "сэмплы"
@@ -17609,6 +18266,11 @@ msgstr "(Для изменения формата используйте кон�
 msgid "centiseconds"
 msgstr "сотые секунды"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Затрачено времени:"
@@ -17651,6 +18313,11 @@ msgstr "Подтверждение закрытия"
 msgid "Unable to write files to directory: %s."
 msgstr "Не удалось прочесть пресет из %s."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -17667,6 +18334,10 @@ msgstr "Настройки для каталогов"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "Больше не показывать"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17750,15 +18421,27 @@ msgstr "Не удался парсинг XML"
 msgid "Spectral edit multi tool"
 msgstr "Мульти-инструмент правки спектра"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Фильтрация..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Опубликовано на условиях GNU General Public License версии 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aВыберите частоты."
@@ -17785,7 +18468,8 @@ msgstr ""
 "                      Попробуйте увеличить граничную низкую частоту~%~\n"
 "                      или уменьшить значение фильтра 'Ширина'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Ошибка.~%"
@@ -17846,6 +18530,25 @@ msgstr "Студийный фейд-спад"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Применение фейдинга..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Назна&чить по умолчанию"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Опубликовано на условиях GNU General Public License версии 2 или позднее"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17989,6 +18692,11 @@ msgstr "Поиск долей"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Найденные доли..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Журнал Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18313,7 +19021,12 @@ msgstr "ФВЧ"
 msgid "Performing High-Pass Filter..."
 msgstr "Выполнение ФВЧ..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Частота (Гц)"
 
@@ -18360,10 +19073,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Метка Звуки"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Опубликовано на условиях GNU General Public License версии 2 или позднее"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18424,6 +19133,12 @@ msgstr "Максимальная тишина в конце"
 #: plug-ins/label-sounds.ny
 msgid "Sound ##1"
 msgstr "Звук ##1"
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 #, lisp-format
@@ -18602,6 +19317,12 @@ msgstr ""
 "Пик на основе первых ~a секунд ~a дБ~%\n"
 "Рекомендуемый порог ~a дБ."
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Режекторный фильтр"
@@ -18650,7 +19371,8 @@ msgstr "LISP-файл"
 msgid "HTML file"
 msgstr "HTML-файл"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Текст-файл"
 
@@ -18727,6 +19449,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI-значения для нот C : 36, 48, 60 [среднее C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Тон MIDI для пиццикато"
 
@@ -18773,6 +19499,10 @@ msgstr "1 - 20 ударов/такт"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Значение свинга"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18843,6 +19573,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI-тон сильной доли"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI-тон слабой доли"
 
@@ -18861,6 +19595,10 @@ msgstr "Барабан Риссета"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Создание Барабана Риссета..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18963,6 +19701,11 @@ msgstr "Показывать сообщения"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Только ошибки"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -19263,6 +20006,10 @@ msgid "Applying Action..."
 msgstr "Применяется действие..."
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "Удалить вокал: моно"
 
@@ -19411,6 +20158,10 @@ msgid "Processing Vocoder..."
 msgstr "Обработка вокодера..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "Расстояние: (1 - 120, умолчание = 20)"
 
@@ -19450,6 +20201,232 @@ msgstr "Частота игл радара (Гц)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Ошибка.~%Требуется стереотрек."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Обновить  Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Пропустить"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Установить обновления"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Журнал изменений"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Узнать больше на GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Ошибка проверки обновлений"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Невозможно подключиться к серверу обновлений Audacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Данные обновления повреждены."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Ошибка получения обновления."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Не удаётся открыть ссылку для загрузки Audacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Доступно Audacity %s!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Запись"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Id фиксации:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Кросс-платформенная библиотека GUI"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Импорт через GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Авторегулировка уровня записи остановлена. Дальнейшая оптимизация невозможна. Уровень всё ещё слишком высокий."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Авторегулировка уровня записи снизила громкость до %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Авторегулировка уровня записи остановлена. Дальнейшая оптимизация невозможна. Уровень всё ещё слишком низкий."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Авторегулировка уровня записи увеличила громкость до %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Авторегулировка уровня записи остановлена. Превышено количество точек анализа, но приемлемая громкость не найдена и остаётся слишком высокой."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Авторегулировка уровня записи остановлена. Превышено количество точек анализа, но приемлемая громкость не найдена и остаётся слишком низкой."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Авторегулировка уровня записи остановлена. Похоже, что %.2f является приемлемой громкостью."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "При открытии устройств получено %d\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Невозможно открыть Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Доступные микшеры:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Доступные источники записи:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Доступные каналы микшера:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Уровень записи эмулирован\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Уровень записи естественный\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Громкость проигрывания эмулирована\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Громкость проигрывания естественна\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Дата и время завершения"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Совместимые с GStreamer файлы"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Невозможно добавить декодер в конвейер"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Мастер импорта GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Не удалось перевести состояние потока в состояние паузы."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Индекс[%02d], тип[%s], каналы[%d], частота[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Файл не содержит аудиопотоков."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Импорт файла невозможен - не удалось изменить состояние."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Ошибка GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "&Микшер"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Ре&гулировка громкости проигрывания..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "У&величить громкость проигрывания"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "У&меньшить громкость проигрывания"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Ре&гулировка громкости записи..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Уве&личить громкость записи"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "У&меньшить громкость записи"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Ру&ководство Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Об Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "А&вторегулировка уровня записи"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Авторегулировка уровня записи"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Включить авторегулировку уровня записи."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Целевой пик:"
+
+#~ msgid "Within:"
+#~ msgstr "В границах:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Время анализа:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "мсек. (время одного анализа)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Число последовательных анализов:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 - бесконечность"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Громкость записи"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Громкость проигрывания"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Уровень записи: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Уровень записи (недоступно; используйте системный микшер.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Громкость проигрывания: %.2f (эмуляция)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Громкость проигрывания: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Громкость проигрывания (недоступно; используйте системный микшер.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "&Микшер"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Щёлкните и перетащите для перемещения трека во времени"
 
 #~ msgid "Program build date:"
 #~ msgstr "Дата сборки:"
@@ -19544,38 +20521,3 @@ msgstr "Ошибка.~%Требуется стереотрек."
 
 #~ msgid "Gra&yscale"
 #~ msgstr "Оттенки &серого"
-
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "Ок"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Обратите внимание, что имена расположены в алфавитном порядке, а не в "
-"порядке важности."
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity не производится и не поддерживается MuseCY SM Ltd. или Домиником М "
-"Маццони."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Товарный знак Audacity%s используется в данном програмном обеспечении только "
-"в описательных и информационных целях."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s участники проекта %s"

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -8,11 +8,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-12 13:54+0000\n"
 "Last-Translator: Marek Ľach <graweeld@googlemail.com>\n"
-"Language-Team: Slovak <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"sk/>\n"
+"Language-Team: Slovak <https://hosted.weblate.org/projects/tenacity/tenacity/sk/>\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,71 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.8-dev\n"
 "X-Poedit-Bookmarks: -1,3893,-1,-1,-1,-1,-1,-1,-1,-1\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Aktualizovať Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Preskočiť"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Nainštalovať aktualizáciu"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Súbor zmien"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Prečítať si viac na GitHube"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Chyba pokusu o aktualizáciu"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Nemožno sa pripojiť ku serveru poskytujúcemu aktualizácie."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Dáta aktualizácie neboli v poriadku."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Chyba pri sťahovaní aktualizácie."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Nemožno otvoriť link na stiahnutie novej verzie."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s je k dispozícií"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Nahrávať"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -100,6 +34,18 @@ msgstr "%s bajtov"
 #, c-format
 msgid "%s KB"
 msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -226,7 +172,8 @@ msgid "Script"
 msgstr "Skript"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Výstup"
 
@@ -242,7 +189,12 @@ msgstr "Nyquist skripty (*.ny)|*.ny|Lisp skripty (*.lsp)|*.lsp|Všetky súbory|*
 msgid "Script was not saved."
 msgstr "Skript nebol uložený."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Upozornenie"
 
@@ -255,15 +207,25 @@ msgid "Find dialog"
 msgstr "Nájsť dialóg"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galéria ikon Tango (ikony panela nástrojov)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 od Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 od Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Externý modul Audacity, ktorý ponúka jednoduché prostredie (IDE) pre písanie efektov."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -286,7 +248,8 @@ msgstr "Nepomenovaný"
 msgid "Nyquist Effect Workbench - "
 msgstr "Pracovná plocha efektu Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nový"
 
@@ -326,7 +289,8 @@ msgstr "Kopírovať"
 msgid "Copy to clipboard"
 msgstr "Kopíruje do schránky"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Vystrihnúť"
 
@@ -334,7 +298,8 @@ msgstr "Vystrihnúť"
 msgid "Cut to clipboard"
 msgstr "Vystrihne do schránky"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Prilepiť"
 
@@ -359,7 +324,8 @@ msgstr "Vybrať všetko"
 msgid "Select all text"
 msgstr "Vyberie celý text"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Späť"
 
@@ -367,7 +333,8 @@ msgstr "Späť"
 msgid "Undo last change"
 msgstr "Vráti poslednú zmenu"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Vpred"
 
@@ -424,7 +391,8 @@ msgid "Go to next S-expr"
 msgstr "Prejde na ďalší S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Štart"
 
@@ -432,7 +400,8 @@ msgstr "Štart"
 msgid "Start script"
 msgstr "Spustí skript"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Zastaviť"
 
@@ -446,15 +415,23 @@ msgstr "Zastaví skript"
 msgid "About %s"
 msgstr "O programe %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Informácie o zostave"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Povolené"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Zakázané"
 
@@ -464,8 +441,9 @@ msgid "The Build"
 msgstr "Testovacia zostava"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Id záväzku:"
+#, fuzzy
+msgid "Version:"
+msgstr "Vykonáva sa obracanie"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -475,22 +453,28 @@ msgstr "Typ zostavy:"
 msgid "Compiler:"
 msgstr "Kompilátor:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Predčíslie inštalácie:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Nastavenia priečinka:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Nastavenia priečinka:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Podpora formátov súborov"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Viac platformová GUI knižnica"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -504,7 +488,6 @@ msgstr "Prevod vzorkovacej rýchlosti"
 msgid "MP3 Importing"
 msgstr "Import MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Import a export Ogg Vorbis"
@@ -513,7 +496,6 @@ msgstr "Import a export Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Podpora príznakov ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Import a export FLAC"
@@ -531,14 +513,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Import/export FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Import cez GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Vzhľad"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Podporné rozšírenie"
 
@@ -553,6 +527,10 @@ msgstr "Podpora zmeny výšky tónu a tempa"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Podpora zmeny extrémnych výšok a tempa"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Vzhľad"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -644,6 +622,12 @@ msgstr "%s, skladateľ"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "%s, skladateľ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, Nyquist plug-ins"
 msgstr "%s, rozšírenia Nyquist"
@@ -665,6 +649,10 @@ msgstr "%s, grafik"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (vrátane %s, %s, %s, %s a %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -674,6 +662,10 @@ msgstr "%s bezplatný viacplatformový softvér s otvoreným zdrojom na nahráva
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Spolupracovali"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -724,6 +716,7 @@ msgstr "Webová stránka a grafika"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "slovenský preklad pripravil Jozef Matta"
@@ -741,6 +734,22 @@ msgstr "Špeciálne poďakovanie:"
 #, c-format
 msgid "%s website: "
 msgstr "%s webstránka: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Prispievatelia"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -763,6 +772,7 @@ msgstr "Časová os"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kliknite alebo ťahajte pre začatie vyhľadávania"
@@ -770,6 +780,7 @@ msgstr "Kliknite alebo ťahajte pre začatie vyhľadávania"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Kliknite alebo ťahajte pre začatie snímania"
@@ -777,6 +788,7 @@ msgstr "Kliknite alebo ťahajte pre začatie snímania"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Kliknite a posúvajte pre snímanie. Kliknite a ťahajte pre vyhľadávanie."
@@ -784,6 +796,7 @@ msgstr "Kliknite a posúvajte pre snímanie. Kliknite a ťahajte pre vyhľadáva
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Posúvajte pre vyhľadávanie"
@@ -791,6 +804,7 @@ msgstr "Posúvajte pre vyhľadávanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Posúvajte pre snímanie"
@@ -847,7 +861,17 @@ msgstr ""
 "Nemožno zamknúť oblasť\n"
 "za koncom projektu."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Chyba"
 
@@ -871,7 +895,8 @@ msgstr ""
 "Toto je jednorázová otázka, po 'inštalácii' kde sa žiada súhlas s vynulovaní predvolieb."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Vynulovať predvoľby Audacity"
 
 #: src/AudacityApp.cpp
@@ -884,6 +909,10 @@ msgstr ""
 "%s nenájdený.\n"
 "\n"
 "Záznam bol odstránený zo zoznamu nedávnych súborov."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -908,7 +937,7 @@ msgstr "&Otvoriť..."
 msgid "Open &Recent..."
 msgstr "Otvoriť &nedávne..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&O programe Audacity..."
@@ -922,9 +951,10 @@ msgid "&File"
 msgstr "&Súbor"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nenašlo bezpečné miesto pre umiestnenie dočasných súborov.\n"
@@ -932,20 +962,23 @@ msgstr ""
 "Prosím zadajte správny priečinok v dialógu predvolieb."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity nenašlo umiestnenie pre uloženie dočasných súborov.\n"
 "Prosím zadajte správny priečinok v dialógu predvolieb."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity sa teraz vypne. Spustite, prosím, Audacity znovu pre použitie nového dočasného priečinka."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -954,15 +987,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity nemôže zamknúť priečinok pre dočasné súbory.\n"
 "Je možné, že tento priečinok práve používa iná kópia Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Stále ešte chcete spustiť Audacity?"
 
 #: src/AudacityApp.cpp
@@ -970,24 +1005,68 @@ msgid "Error Locking Temporary Folder"
 msgstr "Chyba uzamykania dočasného priečinka"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Systém rozpoznal ďalšiu spustenú kópiu Audacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Použite príkazy Nový alebo Otvoriť v aktuálne spustenom Audacity\n"
 "procese pre otvorenie viacero projektov súčasne.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity je už spustené"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Zlyhanie pri spustení Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
 
 #: src/AudacityApp.cpp
 msgid "An unrecoverable error has occurred during startup"
@@ -1011,7 +1090,8 @@ msgstr "spustí vlastnú diagnostiku"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "zobrazí verziu Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1021,9 +1101,10 @@ msgid "audio or project file name"
 msgstr "audio alebo súbor názvu projektu"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1036,24 +1117,48 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Projektové súbory Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Správa"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Prispôsobenie tmavého Audacity"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Nápoveda"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Ukončiť Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Záznamy Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1065,7 +1170,8 @@ msgstr "&Uložiť..."
 msgid "Cl&ear"
 msgstr "&Zmazať"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Zavrieť"
 
@@ -1119,6 +1225,11 @@ msgstr ""
 msgid "Error Initializing Midi"
 msgstr "Chyba pri inicializácii Midi"
 
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
+msgstr "Orezať audio"
+
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
 #, c-format
 msgid ""
@@ -1131,37 +1242,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Nedostatok pamäte!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automatické nastavenie úrovne nahrávania zastavené. Ďalšia optimalizácia už nebola možná. Úroveň je stále príliš vysoká."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automatické nastavenie úrovne nahrávania znížilo hlasitosť na %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatické nastavenie úrovne nahrávania zastavené. Ďalšia optimalizácia už nebola možná. Úroveň je stále príliš nízka."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automatické nastavenie úrovne nahrávania zvýšilo hlasitosť na %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automatické nastavenie úrovne nahrávania zastavené. Celkový počet analýz bol prekročený bez nájdenia prijateľnej hlasitosti. Úroveň je stále príliš vysoká."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automatické nastavenie úrovne nahrávania zastavené. Celkový počet analýz bol prekročený bez nájdenia prijateľnej hlasitosti. Úroveň je stále príliš nízka."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatické nastavenie úrovne nahrávania zastavené. %.2f vyzerá byť prijateľná hlasitosť."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1260,43 +1340,6 @@ msgstr "Nenájdené žiadne prehrávacie zariadenie pre '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Nemožno skontrolovať vzájomné vzorkové rýchlosti bez oboch zariadení.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Prijatých %d počas otvárania zariadenia\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Nemožno otvoriť Portmixér\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Dostupné zmiešavače:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Dostupné zdroje nahrávania:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Dostupná hlasitosť prehrávania:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Nahrávacia hlasitosť je emulovaná\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Nahrávacia hlasitosť je skutočná\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Prehrávacia hlasitosť je emulovaná\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Prehrávacia hlasitosť je skutočná\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1339,8 +1382,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatická oprava pádu"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1352,12 +1396,14 @@ msgid "Recoverable &projects"
 msgstr "Obnoviteľné projekty"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Výber"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Názov"
 
@@ -1368,6 +1414,11 @@ msgstr " Vybrané"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Žiadny výber"
+
+#: src/AutoRecoveryDialog.cpp
+#, fuzzy
+msgid "&Skip"
+msgstr "&Preskočiť"
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1442,6 +1493,11 @@ msgstr "Efekt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Ponuka Príkaz (s parametrami)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1587,13 +1643,19 @@ msgstr "Obnoviť výbe&r"
 msgid "I&mport..."
 msgstr "I&mportovať..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xportovať..."
 
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "Upraviť kroky"
+
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
 
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
@@ -1623,7 +1685,8 @@ msgstr "Posunúť &hore"
 msgid "Move &Down"
 msgstr "Posunúť &dole"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Uložiť"
 
@@ -1706,7 +1769,8 @@ msgid "Run"
 msgstr "Spustiť"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Zavrieť"
 
@@ -1854,11 +1918,6 @@ msgid "No revision identifier was provided"
 msgstr "Nebol poskytnutý žiadny identifikátor revízie"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Dátum a čas ukončenia"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Ladenie zostavy (úroveň ladenia %d)"
@@ -1967,10 +2026,24 @@ msgstr "Súčasný projekt"
 msgid "Checkpointing %s"
 msgstr "Importovanie %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Nemožno zapisovať do súboru: %s\n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity nedokázalo zapísať súbor %s.\n"
+"Disk je možno plný alebo nezapisovateľný."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1991,6 +2064,10 @@ msgid ""
 msgstr ""
 "Zlyhala registrácia:\n"
 "%s"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -2088,6 +2165,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopírovať názvy do schránky"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Chýbajúce"
 
@@ -2096,10 +2178,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ak budete pokračovať, váš projekt nebude uložený na disk. To je to, čo chcete?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2111,7 +2194,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Kontrola závislostí"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Žiadne"
 
@@ -2119,7 +2205,7 @@ msgstr "Žiadne"
 msgid "Rectangle"
 msgstr "Obdĺžnikové"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trojuholníkové"
 
@@ -2130,6 +2216,32 @@ msgstr "Tvarované"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Obdĺžnikový"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, žiadny"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
@@ -2156,9 +2268,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Podpora FFmpeg nebola skompilovaná do"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2180,8 +2293,8 @@ msgid "Locate FFmpeg"
 msgstr "Vyhľadať FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity potrebuje súbor '%s' pre import a export audia cez FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2194,7 +2307,8 @@ msgstr "Umiestnenie '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Pre nájdenie '%s', kliknite tu -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Prehľadávať..."
 
@@ -2220,8 +2334,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg nenájdené"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2251,24 +2366,24 @@ msgid "Only libavformat.so"
 msgstr "Len libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity zlyhalo pri otváraní súboru v %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity zlyhalo pri načítaní súboru z %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity úspešne zapísalo súbor v %s ale zlyhalo pri jeho premenovať na %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2305,7 +2420,9 @@ msgstr "&Nekopírovať žiadne audio"
 msgid "As&k"
 msgstr "Sp&ýtať sa"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Všetky súbory"
 
@@ -2330,6 +2447,10 @@ msgstr "Textové súbory"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Súbory XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2371,6 +2492,14 @@ msgstr "Cuberoot automatická korelácia"
 msgid "Enhanced Autocorrelation"
 msgstr "Vylepšená automatická korelácia"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spektrum"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2387,6 +2516,17 @@ msgstr "Lineárna frekvencia"
 msgid "Log frequency"
 msgstr "Logaritmická frekvencia"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Posúvanie"
@@ -2394,6 +2534,15 @@ msgstr "Posúvanie"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Priblíženie"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2454,6 +2603,23 @@ msgstr "Vybraných príliš veľká dĺžka audia. Bude analyzovaných len prvý
 msgid "Not enough data selected."
 msgstr "Nie je vybraných dostatok údajov."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f sek (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f sek (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2476,7 +2642,8 @@ msgstr "spektrum.txt"
 msgid "Export Spectral Data As:"
 msgstr "Exportovať spektrálne údaje ako:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Nemožno zapisovať do súboru: %s"
@@ -2654,6 +2821,11 @@ msgstr "Zahodiť"
 msgid "&Compact"
 msgstr "&Príkaz"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
@@ -2661,19 +2833,19 @@ msgid "&History..."
 msgstr "&História..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Vnútorná chyba v %s pri %s riadok %d.\n"
 "Informujte, prosím, Audacity tím na https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Vnútorná chyba v %s riadok %d.\n"
 "Informujte, prosím, Audacity tím na https://forum.audacityteam.org/."
@@ -2692,7 +2864,9 @@ msgid "Track"
 msgstr "Stopa"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Návesť"
 
@@ -2752,7 +2926,8 @@ msgstr "Vložte názov stopy"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Návesť stopy"
 
@@ -2763,11 +2938,13 @@ msgstr "Jeden alebo viac uložených nápisov nemožno prečítať."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Prvé spustenie Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Zvoľte jazyk pre Audacity na použitie:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2777,7 +2954,8 @@ msgstr "Zvoľte jazyk pre Audacity na použitie:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Jazyk, ktorý ste zvolili, %s (%s), sa odlišuje od jazyka systému, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Potvrdiť"
 
@@ -2795,13 +2973,19 @@ msgstr ""
 "Starý súbor bol uložený ako '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Otváranie projektu Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke Audacity %s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Prehľadávať..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2847,19 +3031,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Stopy zmiešavania a prevodu"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Panel zmiešavača Audacity %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Zisk"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Rýchlosť"
 
@@ -2868,17 +3056,23 @@ msgid "Musical Instrument"
 msgstr "Hudobný nástroj"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Vyvážiť"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Stlmiť"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Sólo"
 
@@ -2886,15 +3080,18 @@ msgstr "Sólo"
 msgid "Signal Level Meter"
 msgstr "Merač úrovne signálu"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Posunutý posuvník zisku"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Posunutý posuvník rýchlosti"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Posunutý posuvník vyváženia"
 
@@ -2928,9 +3125,9 @@ msgstr ""
 "Nebude načítaný."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2964,16 +3161,19 @@ msgstr ""
 "\n"
 "Použiť iba moduly z dôveryhodných zdrojov"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Áno"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nie"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Zavádzač modulov Audacity"
 
 #: src/ModuleManager.cpp
@@ -2996,6 +3196,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Notová stopa"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3106,7 +3416,8 @@ msgstr "&Vybrať všetko"
 msgid "C&lear All"
 msgstr "&Zmazať všetko"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Povoliť"
 
@@ -3185,9 +3496,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Zmätočné vzorkovacie frekvencie"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Na nahrávanie pri tejto vzorkovacej frekvencii je vybratých príliš málo stôp.\n"
@@ -3216,10 +3528,11 @@ msgid "Dropouts"
 msgstr "Výpadky"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3259,11 +3572,11 @@ msgid "Inspecting project file data"
 msgstr "Kontrolujú sa údaje súborov projektu"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3306,11 +3619,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Upozornenie - chýbajúci súbor(y) 'aliasu'"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Kontrola projektu priečinku \"%s\" \n"
@@ -3335,12 +3648,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Upozornenie - chýba sumárny 'alias' súbor(y)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3398,7 +3711,8 @@ msgstr "Upozornenie - súbor(y) osirelého bloku"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Priebeh"
 
@@ -3423,6 +3737,11 @@ msgstr "Upozornenie: problémy pri automatickej obnove"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<nepomenovaný>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity „%s“"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3461,11 +3780,96 @@ msgid ""
 msgstr "Nemožno čítať súbor predvolieb."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Nepodarilo sa zakódovať predvoľbu z \"%s“"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Ukladanie projektu Audacity"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Nemožno inicializovať MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nemožno inicializovať MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nemožno inicializovať MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nemožno inicializovať MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nemožno inicializovať MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nemožno inicializovať MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Nemožno inicializovať MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Nemožno inicializovať MP3 tok"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3479,12 +3883,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Osirelý súbor bloku: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Nemožno nastaviť tok na pozastavený stav."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Nepodarilo sa nájsť kodek"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Nepodarilo sa zakódovať predvoľbu z \"%s“"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -3495,9 +3920,9 @@ msgid "Error Writing to File"
 msgstr "Chyba pri zápise do súboru"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3510,9 +3935,16 @@ msgstr "Uložení &projektov"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekt %02i] Audacity „%s“"
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Rýchlosť"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3521,10 +3953,10 @@ msgstr "(Obnovené)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Súbor bol uložený použitím Audacity %s.\n"
 "Používate Audacity %s. Pokiaľ tento súbor chcete otvoriť, mali by ste prejsť na novšiu verziu programu."
@@ -3532,6 +3964,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Nemožno otvoriť súbor projektu"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3546,6 +3982,10 @@ msgid "Unable to parse project information."
 msgstr "Nemožno čítať súbor predvolieb."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Uložení &projektov"
 
@@ -3554,12 +3994,35 @@ msgid "Error Saving Project"
 msgstr "Chyba uloženia projektu"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Uložení &prázdneho projektu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3567,8 +4030,24 @@ msgstr ""
 "Našťastie sa dajú automaticky obnoviť tieto projekty:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Niektoré projekty pri poslednom spustení Audacity neboli správne uložené.\n"
+"Našťastie sa dajú automaticky obnoviť tieto projekty:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Projekt bol obnovený"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Priečinok dočasných súborov"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3598,6 +4077,17 @@ msgstr "Upozornenie - prázdny projekt"
 msgid "Insufficient Disk Space"
 msgstr "Miesto na disku"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3617,8 +4107,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sUložiť projekt \"%s\" ako..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Uložiť Projekt' je pre projekt Audacity, nie pre audio súbor.\n"
@@ -3695,11 +4186,12 @@ msgid "Error Opening Project"
 msgstr "Chyba pri otváraní projektu"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Pokúšate sa otvoriť automaticky vytvorený záložný súbor,\n"
 "čo môže spôsobiť stratu viacerých údajov.\n"
@@ -3732,6 +4224,12 @@ msgid "Error Opening File or Project"
 msgstr "Chyba otvárania súboru alebo projektu"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Projekt bol obnovený"
 
@@ -3757,12 +4255,33 @@ msgid "Error Importing"
 msgstr "Chyba importovania"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Nastaviť projekt"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Nemožno otvoriť súbor projektu"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Príkaz"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3773,8 +4292,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatické ukladanie zapnuté:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Vitajte v Audacity verzia %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3888,6 +4407,18 @@ msgstr "Vysoká kvalita"
 msgid "Best Quality (Slowest)"
 msgstr "Najlepšia kvalita (najpomalšie)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "Podpísané 16-bitové PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "Podpísaná 24 bitová PCM"
+
 #. i18n-hint: Audio data bit depth (precision): 32-bit floating point
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
@@ -3983,7 +4514,8 @@ msgstr "Všetky preferencie"
 msgid "SelectionBar"
 msgstr "Pás výberu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektrálny výber"
 
@@ -3991,42 +4523,56 @@ msgstr "Spektrálny výber"
 msgid "Timer"
 msgstr "Časovač"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Nástroje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "&Transport"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Zmiešavač"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Merač"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Merač prehrávania"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Merač nahrávania"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Upraviť"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Zariadenie"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Zrýchlené prehrávanie"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Zosnímať"
 
@@ -4041,7 +4587,10 @@ msgstr "Pravítko"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Stopy"
 
@@ -4151,7 +4700,8 @@ msgid "Activation level (dB):"
 msgstr "Aktivačná úroveň (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Vitajte v Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4278,10 +4828,25 @@ msgstr "Chyba ukladania súboru príznakov"
 msgid "Unsuitable"
 msgstr "Modul je nevhodný"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Priečinok dočasných súborov"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity nemôže zapísať súbor:\n"
@@ -4301,9 +4866,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4312,9 +4877,9 @@ msgstr ""
 "pre zápis."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity nemôže zapísať obrázky do súboru:\n"
@@ -4331,9 +4896,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4343,9 +4908,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4354,8 +4919,9 @@ msgstr ""
 "Pravdepodobne zlý png formát?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity nemôže prečítať svoju predvolený motív.\n"
@@ -4393,9 +4959,9 @@ msgstr ""
 "už existujú. Prepísať?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity nemôže uložiť súbor:\n"
@@ -4434,7 +5000,11 @@ msgstr "Vlastná"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Trvanie"
 
@@ -4445,7 +5015,8 @@ msgid "Time Track"
 msgstr "Časová stopa"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Časový záznam Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4519,7 +5090,8 @@ msgstr "Súčasný projekt"
 msgid "Recording start:"
 msgstr "Začiatok záznamu:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Trvanie:"
 
@@ -4540,7 +5112,8 @@ msgid "Action after Timer Recording:"
 msgstr "Akcia po časovom zázname:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Priebeh časového záznamu Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4636,6 +5209,7 @@ msgstr "099 dní 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Dátum a čas začiatku"
@@ -4680,7 +5254,8 @@ msgstr "Zapnúť automatický &export?"
 msgid "Export Project As:"
 msgstr "Exportovať projekt ako:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Možnosti"
 
@@ -4693,7 +5268,8 @@ msgid "Do nothing"
 msgstr "Neurobiť nič"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Ukončiť Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4717,7 +5293,8 @@ msgid "Scheduled to stop at:"
 msgstr "Plánované zastavenie na:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Časový záznam Audacity - čakanie na štart"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4743,8 +5320,13 @@ msgid "Recording Exported:"
 msgstr "Záznam exportovaný:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Časový záznam Audacity - čakanie"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -4865,6 +5447,10 @@ msgstr "Presunúť stopu nahor"
 msgid "Move Track Down"
 msgstr "Posunúť stopu nadol"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -4931,6 +5517,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Aplikácia %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "Zlyhanie"
@@ -4949,13 +5545,15 @@ msgstr "%s nie je akceptovaný parameter od %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Nesprávna hodnota pre parameter '%s': mala by byť %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Príkaz"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Opakovať %s"
@@ -4990,6 +5588,10 @@ msgid "Compares a range on two tracks."
 msgstr "Porovnáva rozsah dvoch skladieb."
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Čas oneskorenia (sekundy):"
 
@@ -5005,6 +5607,11 @@ msgstr "Spustí ukážkovú akciu."
 msgid "Drag"
 msgstr "Ťahať"
 
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Panel"
+msgstr "Panel stopy"
+
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
 msgstr "Aplikácia"
@@ -5016,6 +5623,11 @@ msgstr "Stopa 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Stopa 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5069,13 +5681,24 @@ msgstr "Klipy"
 msgid "Envelopes"
 msgstr "Obálky"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Nápisy"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Schránky"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5085,7 +5708,8 @@ msgstr "Krátky"
 msgid "Type:"
 msgstr "Typ:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Formát:"
 
@@ -5113,13 +5737,31 @@ msgstr "Komentáre"
 msgid "Command:"
 msgstr "Príkaz:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Ponúkne pomoc pri príkaze."
 
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Import2"
+msgstr "Importovať"
+
 #: src/commands/ImportExportCommands.cpp src/commands/OpenSaveCommands.cpp
 msgid "File Name:"
 msgstr "Názov súboru:"
+
+#: src/commands/ImportExportCommands.cpp
+#, fuzzy
+msgid "Export2"
+msgstr "Exportovať"
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Number of Channels:"
@@ -5137,17 +5779,26 @@ msgstr "Export do súboru."
 msgid "Builtin Commands"
 msgstr "Vstavané príkazy"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tím Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Poskytuje vstavané príkazy pre Audacity"
 
 #: src/commands/LoadCommands.cpp
 msgid "Unknown built-in command name"
 msgstr "Neznámy zabudovaný názov príkazu"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -5189,11 +5840,22 @@ msgstr "Uloží projekt."
 msgid "Saves a copy of current project."
 msgstr "Uloží projekt."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Získať predvoľby"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Názov:"
 
@@ -5241,7 +5903,8 @@ msgstr "Celá obrazovka"
 msgid "Toolbars"
 msgstr "Panely nástrojov"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efekty"
 
@@ -5381,7 +6044,8 @@ msgstr "Nastaviť"
 msgid "Add"
 msgstr "Pridať"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Odstrániť"
 
@@ -5466,7 +6130,8 @@ msgid "Edited Envelope"
 msgstr "Nastaviť obálku"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Obal"
 
@@ -5509,6 +6174,14 @@ msgstr "Intenzita:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Zmeniť veľkosť:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5558,7 +6231,10 @@ msgstr "Vyváženie:"
 msgid "Set Track Visuals"
 msgstr "Nastaviť vizualizáciu stopy"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Lineárny"
 
@@ -5671,7 +6347,9 @@ msgid "Duck &amount:"
 msgstr "&Množstvo vnorenia:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekúnd"
 
@@ -5695,7 +6373,8 @@ msgstr "Vnútorná dĺžka zosl&abovania:"
 msgid "Inner &fade up length:"
 msgstr "Vnútorná dĺžka zo&silňovania:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Prah:"
 
@@ -5833,11 +6512,13 @@ msgstr "na (Hz)"
 msgid "t&o"
 msgstr "d&o"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "&Percentuálna zmena:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Percentuálna zmena"
 
@@ -5845,9 +6526,23 @@ msgstr "Percentuálna zmena"
 msgid "&Use high quality stretching (slow)"
 msgstr "Použiť &napínanie vysokej kvality (pomalé)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "nie je"
 
@@ -5875,6 +6570,7 @@ msgstr "Štandardné otáčky vinylovej pásky:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Z otáčok"
@@ -5887,6 +6583,7 @@ msgstr "&z"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Na otáčky"
@@ -6029,6 +6726,12 @@ msgstr "Kompresor"
 msgid "Compresses the dynamic range of audio"
 msgstr "Komprimuje dynamický rozsah audia"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6038,6 +6741,20 @@ msgstr "%.2f sekúnd"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f sekúnd"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6154,7 +6871,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analyzátor kontrastu, pre meranie rozdielov hlasitosti RMS medzi dvoma výbermi audia."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Koniec"
 
@@ -6214,6 +6932,18 @@ msgstr "&Rozdiel:"
 msgid "&Help"
 msgstr "Nápove&da"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nula"
@@ -6221,6 +6951,13 @@ msgstr "nula"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "neurčitý"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "Priemerná efektívna hodnota rozdielu %.1f dB"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6274,6 +7011,12 @@ msgstr "Aktuálny rozdiel"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Meraná úroveň popredia"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f sekúnd"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6342,6 +7085,12 @@ msgstr "Kritériá úspešnosti 1.4.7 podľa WCAG 2.0: neúspešné"
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
 msgstr "Zhromaždené údaje"
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
@@ -6482,6 +7231,16 @@ msgid "Upper Threshold"
 msgstr "Horný prah"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Parametre"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Parametre"
+
+#: src/effects/Distortion.cpp
 msgid "Number of repeats"
 msgstr "Počet opakovaní"
 
@@ -6613,7 +7372,9 @@ msgstr "Sekvencia &DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Amplitúda (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Trvanie:"
 
@@ -6626,18 +7387,40 @@ msgid "Duty cycle:"
 msgstr "Pracovný cyklus:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f sekúnd"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Trvanie tónu:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Trvanie ticha:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
+
+#: src/effects/Echo.cpp
+msgid "Echo"
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Opakuje vybrané audio znova a znova"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Požadovaná hodnota presahuje kapacitu pamäte."
 
@@ -6661,7 +7444,8 @@ msgstr "Predvoľby"
 msgid "Export Effect Parameters"
 msgstr "Exportovať parametre efektu"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Nemožno otvoriť súbor: \"%s\""
@@ -6698,6 +7482,15 @@ msgstr "Pripravuje sa ukážka"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Predvádzanie ukážky"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Chyba Nyquistu"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -6902,6 +7695,16 @@ msgstr "Odstrániť predvoľby"
 msgid "Defaults"
 msgstr "Predvolené"
 
+#: src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Import..."
+msgstr "&Importovať..."
+
+#: src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Export..."
+msgstr "&Exportovať..."
+
 #: src/effects/EffectUI.cpp src/widgets/Meter.cpp
 msgid "Options..."
 msgstr "Možnosti..."
@@ -7022,6 +7825,10 @@ msgid "Low rolloff for speech"
 msgstr "Nízke rozvinutie frekvencií (roll-off) pre reč"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefón"
 
@@ -7056,6 +7863,43 @@ msgstr "Vzorkovacia rýchlosť stopy je príliš nízka pre tento efekt."
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Efekt nedostupný"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7130,8 +7974,16 @@ msgid "D&efault"
 msgstr "P&redvolené"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "Vláknové SS&E"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7376,7 +8228,8 @@ msgid "Builtin Effects"
 msgstr "Vstavané efekty"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Poskytuje vstavané efekty v Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7386,6 +8239,10 @@ msgstr "Neznámy názov vstavaného efektu"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "vnímaná hlasitosť"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7419,12 +8276,25 @@ msgid "Loudness LUFS"
 msgstr "Hlasitosť LUFS"
 
 #: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Nezávisle normalizovať &stereo kanály"
 
 #: src/effects/Loudness.cpp
 msgid "&Treat mono as dual-mono (recommended)"
 msgstr "&Zaobchádzať s mono ako s dvojitým mono (odporúčané)"
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+#, fuzzy
+msgid "(Maximum 0dB)"
+msgstr ".  Maximum 0dB."
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -7482,7 +8352,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (predvolené)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, žiadny"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, žiadny"
 
 #: src/effects/NoiseReduction.cpp
@@ -7582,8 +8461,9 @@ msgid "Step 1"
 msgstr "Krok 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Vyberte niekoľko sekúnd samotného šumu, aby Audacity vedel čo sa má odfiltrovať,\n"
@@ -7635,13 +8515,62 @@ msgstr "Typy &okna:"
 msgid "Window si&ze:"
 msgstr "Veľ&kosť okna:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (predvolené)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "K&rokov na okno:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7757,12 +8686,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "&Nezávisle normalizovať stereo kanály"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Roztiahnuť"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch je iba pre extrémne napínanie času alebo efektu \"hromadenia\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Faktor na&pnutia:"
@@ -8205,6 +9140,11 @@ msgstr "Použiť predvolené"
 msgid "Restore Defaults"
 msgstr "Obnoviť predvolené"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8363,6 +9303,10 @@ msgstr "Zistiť ticho"
 msgid "Tr&uncate to:"
 msgstr "S&krátiť na:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Ko&mprimovať na:"
@@ -8376,7 +9320,8 @@ msgid "VST Effects"
 msgstr "Efekty VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Pridá možnosť použiť efekty VST v Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8388,7 +9333,8 @@ msgstr "Prostredie skenovania VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registrovanie %d z %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Nemožno načítať knižnicu"
 
@@ -8408,7 +9354,8 @@ msgstr "Veľkosť zásobníka riadi počet snímok odoslaných s efektom na kaž
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Veľkosť &zásobníka (8 do 1 048 576 vzoriek):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Kompenzácia odozvy"
 
@@ -8416,7 +9363,8 @@ msgstr "Kompenzácia odozvy"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "V rámci spracovania musia niektoré efekty VST oneskoriť návrat zvuku do Audacity. Ak toto oneskorenie nevykompenzujete, všimnite si, že do audia bude vložené krátke ticho. Povolenie tejto možnosti zabezpečí túto kompenzáciu, ale nemusí fungovať pre všetky efekty VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Povoliť &kompenzáciu"
 
@@ -8450,7 +9398,8 @@ msgid "Standard VST program file"
 msgstr "Štandardný programový súbor VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Súbor predvolieb Audacity VST"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8477,7 +9426,8 @@ msgstr "Chyba načítania predvolieb VST"
 msgid "Unable to load presets file."
 msgstr "Nemožno načítať súbor predvolieb."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Nastavenia efektu"
 
@@ -8493,6 +9443,12 @@ msgstr "Nemožno čítať súbor predvolieb."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Tento súbor s parametrami bol uložený od %s. Pokračovať?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -8528,7 +9484,8 @@ msgid "Audio Unit Effects"
 msgstr "Efekty zvukových jednotiek"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Poskytuje podporu Audacity pre efekty zvukových jednotiek"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8544,7 +9501,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Možnosti efektov zvukových jednotiek"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "V rámci spracovania musia niektoré efekty audio zariadení oneskoriť návrat zvuku do Audacity. Ak toto oneskorenie nevykompenzujete, všimnite si, že do audia bolo vložené krátke ticho. Povolenie tejto možnosti zabezpečí túto kompenzáciu, ale nemusí fungovať pre všetky efekty audio zariadení."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8688,6 +9646,7 @@ msgstr "Audio jednotka"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Efekty LADSPA"
@@ -8697,7 +9656,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Poskytuje efekty LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity už nepoužíva most VST"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -8705,12 +9665,30 @@ msgid "LADSPA Effect Options"
 msgstr "Možnosti efektu LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "V rámci spracovania musia niektoré efekty LADSPA oneskoriť návrat audia do Audacity. Ak toto oneskorenie nevykompenzujete, všimnete si, že do audia bude vložené krátke ticho. Povolenie tejto možnosti zabezpečí túto kompenzáciu, ale nemusí fungovať pre všetky efekty LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s v:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Výstup efektov"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Efekty LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8722,7 +9700,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Veľkosť zásobníka (8 až %d) snímok):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "V rámci spracovania musia niektoré efekty LV2 oneskoriť návrat audia do Audacity. Ak toto oneskorenie nevykompenzujete, všimnete si, že do zvuku bude vložené krátke ticho. Povolenie tohto nastavenia poskytne túto kompenzáciu, ale nemusí fungovať pre všetky efekty LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -8747,12 +9726,19 @@ msgstr "%s vyžaduje nepodporovanú voľbu %s\n"
 msgid "Generator"
 msgstr "Generátor"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Efekty LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Poskytuje podporu Audacity pre efekty LV2"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8760,7 +9746,8 @@ msgid "Nyquist Effects"
 msgstr "Efekty Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Poskytuje podporu Audacity pre efekty Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8775,6 +9762,12 @@ msgstr "Pracovník Nyquistu"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "III-formovaná hlavička rozšírenia Nyquist"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -8979,7 +9972,8 @@ msgstr "Vybrať súbor"
 msgid "Save file as"
 msgstr "Uložiť súbor ako"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "nepomenovaný"
 
@@ -8988,7 +9982,8 @@ msgid "Vamp Effects"
 msgstr "Efekty Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Poskytuje podporu efektov Vamp pre Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9006,6 +10001,17 @@ msgstr "Prepáčte, nepodarilo sa inicializovať rozšírenie Vamp."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Nastavenia rozšírení"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9162,6 +10168,10 @@ msgid "Command Output"
 msgstr "Výstupný príkaz"
 
 #: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr "Zadali ste názov súboru bez prípony. Si si istý?"
 
@@ -9300,7 +10310,8 @@ msgstr "Exportovanie audia ako %s"
 msgid "Invalid sample rate"
 msgstr "Neplatná vzorkovacia frekvencia"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Prevzorkovať"
 
@@ -9332,7 +10343,8 @@ msgstr "Vzorkovacie frekvencie"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kbit/s"
@@ -9352,6 +10364,42 @@ msgid "%.2f kbps"
 msgstr "%.2f kbit/s"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Zapnúť"
 
@@ -9360,12 +10408,42 @@ msgid "Constrained"
 msgstr "Vynútené"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Audio"
+msgstr "AudioJednotka"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Nízke oneskorenie"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9452,8 +10530,17 @@ msgid "Replace preset '%s'?"
 msgstr "Nahradiť predvoľbu '%s'?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Hlavný"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9561,6 +10648,10 @@ msgstr "Jazyk:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bitový zásobník"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9694,6 +10785,11 @@ msgstr ""
 "0 - predvolené \n"
 "min - 1 \n"
 "max - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9874,6 +10970,16 @@ msgid "Failed to find the codec"
 msgstr "Nepodarilo sa nájsť kodek"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr "%s, 64 bitov"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr "%s, 64 bitov"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (najrýchlejšie)"
 
@@ -10003,7 +11109,8 @@ msgstr "Nezmyselný"
 msgid "Extreme"
 msgstr "Extrémny"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Štandardná"
 
@@ -10028,6 +11135,11 @@ msgid "Joint Stereo"
 msgstr "Spojené stereo"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Vytvoriť stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Režim bitovej rýchlosti:"
 
@@ -10050,8 +11162,8 @@ msgid "Locate LAME"
 msgstr "Vyhladať LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity potrebuje súbor %s na vytvorenie MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10079,10 +11191,10 @@ msgid "Where is %s?"
 msgstr "Kde je %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Pripájate knižnicu lame_enc.dll v%d.%d. Táto verzia nie je kompatibilná s Audacity %d.%d.%d.\n"
 "Stiahnite si, prosím, poslednú verziu knižnice 'LAME for Audacity'."
@@ -10382,6 +11494,15 @@ msgstr "Exportovanie vybraného audia ako Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Exportovanie audia ako Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAV (Microsoft)"
+msgstr "WAV (Microsoft) podpísané 16-bit PCM"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Hlavička:"
@@ -10395,9 +11516,10 @@ msgid "Other uncompressed files"
 msgstr "Ďalšie nekomprimované súbory"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Pokúsili ste sa exportovať súbor WAV alebo AIFF, ktorý by bol väčší ako 4 GB.\n"
 "Audacity to nedokáže, export nebol uskutočnený."
@@ -10407,8 +11529,9 @@ msgid "Error Exporting"
 msgstr "Chyba exportu"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Váš exportovaný WAV súbor bol orezaný, pretože Audacity nemôže exportovať\n"
@@ -10448,11 +11571,11 @@ msgid "All supported files"
 msgstr "Všetky podporované súbory"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10461,11 +11584,11 @@ msgstr ""
 "ho upraviť kliknutím na Súbor/Importovať/MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "je MIDI súbor, nie audio súbor. \n"
@@ -10477,18 +11600,18 @@ msgid "Select stream(s) to import"
 msgstr "Vybrať tok(y) na importovanie"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Táto verzia Audacity nebola kompilovaná s podporou %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je audio CD stopa. \n"
 "Audacity nedokáže priamo otvoriť audio CD. \n"
@@ -10497,10 +11620,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" je zoznam súborov na prehrávanie.\n"
@@ -10509,10 +11632,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je Windows Media Audio súbor.\n"
@@ -10521,10 +11644,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je súbor Advanced Audio Coding (rozšírené audio kódovanie).\n"
@@ -10533,12 +11656,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zašifrovaný audio súbor. \n"
@@ -10549,10 +11672,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je súbor pre RealPlayer.\n"
@@ -10561,12 +11684,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" je súbor základných nôt, nie audio súbor. \n"
 "Audacity tento typ súboru nevie otvoriť. \n"
@@ -10575,10 +11698,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10591,10 +11714,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvukový súbor Wavpack.\n"
@@ -10603,10 +11726,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvukový súbor Dolby Digital.\n"
@@ -10615,10 +11738,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je zvukový súbor Ogg Speex. \n"
@@ -10627,10 +11750,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" je video súbor. \n"
@@ -10644,20 +11767,31 @@ msgstr "Súbor \"%s\" nenájdený."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity nerozpoznal typ súboru '%s'.\n"
 "Skúste nainštalovať FFmpeg. Pre nekomprimované súbory, taktiež skúste Súbor/Importovať/Surové údaje."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10687,11 +11821,55 @@ msgid "Import Project"
 msgstr "Importovať predvoľby"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Interná chyba oznámená procesom zarovnávania."
 
 #: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Chybná rýchlosť."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Chybná rýchlosť."
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid project 'h' attribute."
+msgstr "Chybná rýchlosť."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Chybná rýchlosť."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Chybná rýchlosť."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Chybná rýchlosť."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Chybná rýchlosť."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
 msgstr "Chybná rýchlosť."
 
 #: src/import/ImportAUP.cpp
@@ -10700,16 +11878,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Nemožno nájsť priečinok s údajmi projektu: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Začiatok projektu"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Neplatná vzorkovacia frekvencia"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Neplatná vzorkovacia frekvencia"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Neplatná vzorkovacia frekvencia"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Neplatná vzorkovacia frekvencia"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10739,40 +11975,6 @@ msgstr "Index[%02x] kodek[%s], jazyk[%s], bitová rýchlosť[%s], kanály[%d], t
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Súbory FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Súbory kompatibilné s GStreamerom"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Nemožno pridať dekódovač do radu"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Importér GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Nemožno nastaviť tok na pozastavený stav."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index [%02d], typ [%s], kanály [%d], rýchlosť [%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Súbor neobsahuje žiadne audio toky."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Nemožno importovať súbor, zmena stavu zlyhala."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Chyba GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10830,6 +12032,14 @@ msgstr "Nemožno otvoriť súbor %s."
 msgid "MP3 files"
 msgstr "Súbory MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Súbory Ogg Vorbis"
@@ -10864,6 +12074,100 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF a ďalšie nekomprimované typy"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "WAVEX (Microsoft)"
+msgstr "WAV (Microsoft) podpísané 16-bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
 msgstr "Podpísaná 8 bitová PCM"
 
@@ -10890,6 +12194,64 @@ msgstr "32 bitové na pohyblivej čiarke"
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "64 bitové na pohyblivej čiarke"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DPCM"
+msgstr "Podpísané 16-bitové PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "Podpísaná 8 bitová PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11000,6 +12362,10 @@ msgstr "Vzorkovacia frekvencia:"
 msgid "&Import"
 msgstr "&Importovať"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -11020,6 +12386,7 @@ msgstr "%s pravý"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11044,6 +12411,7 @@ msgstr "koniec"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11072,7 +12440,8 @@ msgstr "Časovo obrátené strihy doprava"
 msgid "Time shifted clips to the left"
 msgstr "Časovo obrátené strihy doľava"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Časový posun"
 
@@ -11210,7 +12579,8 @@ msgstr "Orezať vybrané audio stopy od %.2f sekúnd do %.2f sekúnd"
 msgid "Trim Audio"
 msgstr "Orezať audio"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Oddeliť"
 
@@ -11333,34 +12703,6 @@ msgstr "Odstrániť kľúč&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "Š&peciálne"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "&Zmiešavač"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Up&raviť hlasitosť prehrávania..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Z&výšiť hlasitosť prehrávania"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Z&nížiť hlasitosť prehrávania"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Up&raviť hlasitosť nahrávania..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Z&výšiť hlasitosť nahrávania"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Z&nížiť hlasitosť nahrávania"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -11528,8 +12870,18 @@ msgid "Export MI&DI..."
 msgstr "Exportovať MI&DI..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Audio..."
+msgstr "&Exportovať audio..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Labels..."
 msgstr "&Návesti..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Exportovať MI&DI..."
 
 #: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
@@ -11548,6 +12900,10 @@ msgstr "&Tlačiť..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Koniec"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -11616,8 +12972,9 @@ msgid "&Getting Started"
 msgstr "&Začíname"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Manuál Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Manuál..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -11643,11 +13000,8 @@ msgstr "Informácie o zariadení &MIDI..."
 msgid "Show &Log..."
 msgstr "Zobraziť &záznamy..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&O programe Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Pridaná návesť"
 
@@ -11895,6 +13249,11 @@ msgstr "Prepnúť zamer&anú stopu"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Nekategorizované"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Nový..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12333,6 +13692,7 @@ msgstr "&Dlhý skok kurzoru doprava"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Vy&hľadať"
@@ -12544,18 +13904,21 @@ msgid "Created new label track"
 msgstr "Vytvorená nová návesť stopy"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Táto verzia Audacity povoľuje len jednu časovú stopu pre každé okno projektu."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Vytvorená nová časová stopa"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nová vzorkovacia rýchlosť (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Zadaná hodnota nie je platná"
 
@@ -12812,7 +14175,9 @@ msgstr "Prehrávanie"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Nahrávanie"
 
@@ -12823,6 +14188,11 @@ msgstr "stopa bez návesti"
 #: src/menus/TransportMenus.cpp
 msgid "no label track at or below focused track"
 msgstr "žiadna stopa s návesťou tu alebo nižšie pod zameranou stopou"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy, c-format
+msgid "%s %d of %d"
+msgstr "%s %d z %d strihu %s"
 
 #: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
@@ -12958,8 +14328,9 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr "Softv&érové celoprehrávanie (zap/vyp)"
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomatické nastavenie nahrávacej úrovne (zap/vyp)"
+#, fuzzy
+msgid "T&ransport"
+msgstr "&Transport"
 
 #. i18n-hint: (verb) Start playing audio
 #: src/menus/TransportMenus.cpp
@@ -13171,7 +14542,7 @@ msgstr "Predvoľby kvality"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Aktualizovať Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13218,7 +14589,8 @@ msgstr "&Hostiteľ:"
 msgid "Using:"
 msgstr "Použitý:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Prehrávanie"
 
@@ -13238,7 +14610,8 @@ msgstr "Ka&nály:"
 msgid "Latency"
 msgstr "Odozva"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisekúnd"
 
@@ -13258,8 +14631,19 @@ msgstr "Žiadne audio rozhrania"
 msgid "No devices found"
 msgstr "Žiadne zariadenia neboli nájdené"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "1 kanál (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "2 kanály (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Priečinky"
 
@@ -13272,8 +14656,22 @@ msgid "Default directories"
 msgstr "Priečinky"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Prehľadávať..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -13351,7 +14749,8 @@ msgid "Directory %s is not writable"
 msgstr "Priečinok %s nie je zapisovateľný"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Zmeny dočasného priečinka sa neprejavia až po reštarte Audacity"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13382,6 +14781,40 @@ msgstr "Zoskupené podľa vydavateľa"
 msgid "Grouped by Type"
 msgstr "Zoskupené podľa typu"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Chyba Nyquistu"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Povoliť efekty"
@@ -13403,11 +14836,13 @@ msgid "Plugin Options"
 msgstr "Nastavenie rozšírení"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Skontrolovať aktualizácie rozšírení pri spustení Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Znovu preskenovať rozšírenia pri budúcom štarte Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13587,13 +15022,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Za&chovať návesti ak výber pripadne po návesť"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "&Zmiešať systémovú a tému Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Používať väčšinou rozloženia zľava doprava v jazykoch RTL"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13664,6 +15104,10 @@ msgstr "Exportovať návesti ako:"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "Čas uloženia exportovaných Allegro (.gro) súborov v:"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13757,7 +15201,8 @@ msgstr ""
 "   *   \"%s\"  (pretože skratku '%s' používa \"%s\")\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Zvoľte XML súbor obsahujúci klávesové skratky pre Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13890,8 +15335,9 @@ msgid "Dow&nload"
 msgstr "Stia&hnuť"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity automaticky našiel vhodné knižnice FFmpeg.\n"
@@ -13936,6 +15382,10 @@ msgstr "&Odozva MIDI syntetizátora (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "Odozva syntetizátora MIDI musí byť celé číslo"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -13946,8 +15396,9 @@ msgid "Preferences for Module"
 msgstr "Predvoľby modulov"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Toto sú experimentálne moduly. Povoľte ich, iba ak ste prečítali manuál Audacity\n"
@@ -13955,12 +15406,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  'Spýtať sa' znamená, že sa Audacity spýta, či chcete načítať modul vždy pri štarte."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  'Zlyhal' znamená, že si Audacity myslí, že modul je poškodený a nebude bežať."
 
 #. i18n-hint preserve the leading spaces
@@ -13969,7 +15422,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  'Nový' znamená, že žiadny výber zatiaľ nebol vykonaný."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Zmena týchto nastavení sa prejaví až po reštarte Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14032,7 +15486,10 @@ msgstr "ťahať ľavým"
 msgid "Set Selection Range"
 msgstr "Nastaviť rozsah výberu"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift+kliknúť ľavým"
 
@@ -14119,6 +15576,15 @@ msgstr "ťahať ľavým"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Presunúť strih nahor/nadol medzi stopami"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "ťahať ľavým"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14243,7 +15709,8 @@ msgid "Always scrub un&pinned"
 msgstr "Vždy snímať ne&pripnuté"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Predvoľby Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14257,6 +15724,11 @@ msgstr "Predvoľby:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Predvoľby kvality"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14299,6 +15771,14 @@ msgstr "Prevo&dník vzorkovacej frekvencie:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Chv&enie:"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14352,6 +15832,11 @@ msgid "Custom name text"
 msgstr "Vlastný text názvu"
 
 #: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Recorded_Audio"
+msgstr "Nahraté audio"
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Track Number"
 msgstr "Číslo &stopy"
 
@@ -14364,39 +15849,6 @@ msgid "System T&ime"
 msgstr "Systémový č&as"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatické nastavenie úrovne nahrávania"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Povoliť automatické nastavenie úrovne nahrávania."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Cieľová špička:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Vnútri:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Čas analýzy:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisekundy (čas jednej analýzy)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Počet po sebe nasledujúcich analýz:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 znamená nekonečno"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Nahrávanie Punch and Roll"
 
@@ -14407,6 +15859,21 @@ msgstr "Pred pre&točenie:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Krížové &zoslabenie:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -14541,6 +16008,10 @@ msgid "1024 - default"
 msgstr "1024 - predvolené"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - najužšie pásmo"
 
@@ -14638,13 +16109,14 @@ msgid "Info"
 msgstr "Informácie"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14828,7 +16300,8 @@ msgstr "Vzorky"
 msgid "4 Pixels per Sample"
 msgstr "4 pixely za vzorku"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Maximálne priblíženie"
 
@@ -14950,16 +16423,24 @@ msgid "Stopped"
 msgstr "Zastavené"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pozastaviť"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Skočiť na začiatok"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Skočiť na koniec"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pozastaviť"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Vybrať po začiatok"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Vybrať po koniec"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -14973,20 +16454,17 @@ msgstr "Nahrať novú stopu"
 msgid "Append Record"
 msgstr "Pripojiť nahrávku"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Vybrať po koniec"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Vybrať po začiatok"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s pozastavené."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15066,11 +16544,17 @@ msgstr "Stlmiť výber audio"
 msgid "Sync-Lock Tracks"
 msgstr "Synchronizovane zamknuté stopy"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Priblížiť"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Oddialiť"
 
@@ -15137,43 +16621,6 @@ msgstr "Panel nástrojov merača &nahrávania"
 msgid "&Playback Meter Toolbar"
 msgstr "Panel nástrojov merača &prehrávania"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Hlasitosť nahrávania"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Hlasitosť prehrávania"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Hlasitosť nahrávania: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Hlasitosť nahrávania (nedostupná; použite systémový zmiešavač.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Hlasitosť prehrávania: %.2f (emulovaná)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Hlasitosť prehrávania : %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Hlasitosť nahrávania (nedostupná; použite systémový zmiešavač.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Panel nástrojov &zmiešavača"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Vyhľadať"
@@ -15189,6 +16636,7 @@ msgstr "Snímanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Zastaviť snímanie"
@@ -15196,6 +16644,7 @@ msgstr "Zastaviť snímanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Začať snímanie"
@@ -15203,6 +16652,7 @@ msgstr "Začať snímanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Zastaviť hľadanie"
@@ -15210,6 +16660,7 @@ msgstr "Zastaviť hľadanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Spustiť hľadanie"
@@ -15264,7 +16715,9 @@ msgstr "Prichytiť na"
 msgid "Length"
 msgstr "Dĺžka"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Stred"
 
@@ -15328,8 +16781,8 @@ msgstr "Č&asová lišta"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "%s - panel nástrojov Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -15356,7 +16809,8 @@ msgstr "Nástroj časového posunu"
 msgid "Zoom Tool"
 msgstr "Nástroj priblíženia"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Nástroj kreslenia"
 
@@ -15432,11 +16886,13 @@ msgstr "Ťahajte jeden alebo viac okrajov návesti."
 msgid "Drag label boundary."
 msgstr "Ťahať okraj návesti."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Zmenená návesť"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Upraviť návesť"
 
@@ -15491,31 +16947,42 @@ msgstr "Upravené návesti"
 msgid "New label"
 msgstr "Nová návesť"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Horná &oktáva"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Dolná oktá&va"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Kliknite pre vertikálne priblíženie. Shift+kliknúť pre oddialenie. Ťahajte pre určenie oblasti priblíženia."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Kliknúť pravým pre ponuku."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Vynulovať priblíženie"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift+kliknúť pravým"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Kliknúť ľavým/ťahať ľavým"
 
@@ -15557,7 +17024,8 @@ msgstr "Zlúčiť"
 msgid "Expanded Cut Line"
 msgstr "Rozšírená čiara strihu"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Rozšíriť"
 
@@ -15580,6 +17048,11 @@ msgstr "Posunuté vzorky"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Úprava vzoriek"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15625,7 +17098,8 @@ msgstr "Spracovávanie: %s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Zmenené '%s' na %s"
@@ -15637,6 +17111,54 @@ msgstr "Zmeniť formát"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Frekvencia"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15656,7 +17178,8 @@ msgstr "Zmena frekvencie"
 msgid "Set Rate"
 msgstr "Nastaviť frekvenciu"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Viacnásobné zobrazenie"
 
@@ -15675,6 +17198,11 @@ msgstr "Roz&deliť stereo stopu"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Rozdeliť stereo na mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -15725,6 +17253,16 @@ msgid "Split to Mono"
 msgstr "Rozdeliť na mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Ľavý, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Ľavý, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Ľavý, %dHz"
@@ -15734,14 +17272,23 @@ msgstr "Ľavý, %dHz"
 msgid "Right, %dHz"
 msgstr "Pravý, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% ľavé"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% pravé"
@@ -15859,9 +17406,8 @@ msgstr "Logaritmická &interpolácia"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Kliknite a ťahajte pre posunutie stopy v čase"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15912,6 +17458,7 @@ msgstr "Úprava obalu."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Snímanie"
@@ -15923,6 +17470,7 @@ msgstr "Vyhľadávanie"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Pravítko snímania"
@@ -16118,6 +17666,12 @@ msgstr "Ľ"
 msgid "R"
 msgstr "P"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16151,9 +17705,19 @@ msgstr "Prázdny"
 msgid "Backwards"
 msgstr "Dozadu"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Dopredu"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16282,6 +17846,29 @@ msgstr "Vyberte, prosím, akciu"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 sekúnd"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + vzorky"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "000 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -16297,11 +17884,35 @@ msgstr "0100 dni 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + stotiny"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "000 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + milisekundy"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "000 h 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16323,6 +17934,7 @@ msgstr "0100 h 060 m 060 s+># vzorky"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "vzorky"
@@ -16484,6 +18096,28 @@ msgstr "01000,01000 snímky|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000>0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000>01000 kHz|0.001"
+msgstr "0100000>0100 Hz"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
@@ -16548,6 +18182,11 @@ msgstr "(Použite kontextovú ponuku pre zmenu formátu.)"
 msgid "centiseconds"
 msgstr "stotiny sekundy"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Uplynulý čas:"
@@ -16589,6 +18228,11 @@ msgstr "Potvrdiť zatvorenie"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Nemožno čítať súbor predvolieb z \"%s\""
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -16693,15 +18337,27 @@ msgstr "Nemožno otvoriť súbor"
 msgid "Spectral edit multi tool"
 msgstr "Viacúčelový nástroj spektrálnej úpravy"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrovanie..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Vydané pod podmienkami GNU Všeobecná verejná licencia verzia 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aVyberte, prosím, frekvencie."
@@ -16728,7 +18384,8 @@ msgstr ""
 "                      Skúste zvýšiť okraj nízkej frekvencie~%~\n"
 "                      alebo znížte filter 'Šírka'."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Chyba.~%"
@@ -16789,6 +18446,25 @@ msgstr "Štúdio zoslabovania"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Aplikácia zoslabovania..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Nastaviť pred&volené"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Vydané pod podmienkami GNU Všeobecná verejná licencia verzia 2"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16932,6 +18608,11 @@ msgstr "Hľadač úderov"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Hľadám údery..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Záznamy Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17256,13 +18937,39 @@ msgstr "Hornopriepustný filter"
 msgid "Performing High-Pass Filter..."
 msgstr "Vykonávanie hornopriepustného filtra..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Dominic Mazzoni"
+msgstr "Normalizácia  od Dominica Mazzoniho"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvencia (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Rolovať (dB za oktávu)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17283,10 +18990,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Návesť spojenia"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Vydané pod podmienkami GNU Všeobecná verejná licencia verzia 2"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17329,12 +19032,37 @@ msgid "Point after sound"
 msgstr "Spojené stereo"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "~aDĺžka oblasti = ~a sekúnd."
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "~aDĺžka oblasti = ~a sekúnd."
 
 #: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Vyhľadávanie ticha..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Vyhľadávanie ticha..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, fuzzy, lisp-format
+msgid "~ah ~am ~as"
+msgstr "~ah ~am ~as"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -17346,6 +19074,11 @@ msgstr "Výber musí byť väčší ako %d vzorky."
 #, lisp-format
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "Žiadny zvuk nebol nájdený. Skúste znížiť úroveň~%ticha a minimálnu dĺžku ticha."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -17474,6 +19207,14 @@ msgstr ""
 "Nastavte ovládač nižšie ~a kHz."
 
 #: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Výber musí byť väčší ako %d vzorky."
+
+#: plug-ins/noisegate.ny
 #, lisp-format
 msgid ""
 "Error.\n"
@@ -17546,7 +19287,8 @@ msgstr "Súbor Lisp"
 msgid "HTML file"
 msgstr "Súbor HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Textový súbor"
 
@@ -17623,6 +19365,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Hodnoty MIDI pre noty C: 36, 48, 60 [stredné C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "Výška tónu brnknutia MIDI"
 
@@ -17669,6 +19415,10 @@ msgstr "1 - 20 úderov/meranie"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Množstvo švihu"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -17739,6 +19489,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Výška tónu silného úderu MIDI"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Výška tónu slabého úderu MIDI"
 
@@ -17757,6 +19511,10 @@ msgstr "Rissetov bubon"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Generovanie Rissetovho bubna..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -17859,6 +19617,11 @@ msgstr "Zobraziť správy"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Len chyby"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18127,6 +19890,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Chyba.~%Snímková frekvencia stopy pod 100 Hz nie je podporovaná."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Aplikácia tremola..."
 
@@ -18153,6 +19920,10 @@ msgstr "Redukcia a izolácia spevu"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Aplikácia akcie..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18303,6 +20074,10 @@ msgid "Processing Vocoder..."
 msgstr "Spracovávanie vokodéra..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "Vzdialenosť: (1 do 120, predvolené = 20)"
 
@@ -18342,6 +20117,227 @@ msgstr "Frekvencia radarových ihlíc (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Chyba.~%Požadovaná stereo stopa."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Aktualizovať Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Nainštalovať aktualizáciu"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Súbor zmien"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Prečítať si viac na GitHube"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Chyba pokusu o aktualizáciu"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Nemožno sa pripojiť ku serveru poskytujúcemu aktualizácie."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Dáta aktualizácie neboli v poriadku."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Chyba pri sťahovaní aktualizácie."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Nemožno otvoriť link na stiahnutie novej verzie."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s je k dispozícií"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Nahrávať"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Id záväzku:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Viac platformová GUI knižnica"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Import cez GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automatické nastavenie úrovne nahrávania zastavené. Ďalšia optimalizácia už nebola možná. Úroveň je stále príliš vysoká."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automatické nastavenie úrovne nahrávania znížilo hlasitosť na %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatické nastavenie úrovne nahrávania zastavené. Ďalšia optimalizácia už nebola možná. Úroveň je stále príliš nízka."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automatické nastavenie úrovne nahrávania zvýšilo hlasitosť na %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automatické nastavenie úrovne nahrávania zastavené. Celkový počet analýz bol prekročený bez nájdenia prijateľnej hlasitosti. Úroveň je stále príliš vysoká."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automatické nastavenie úrovne nahrávania zastavené. Celkový počet analýz bol prekročený bez nájdenia prijateľnej hlasitosti. Úroveň je stále príliš nízka."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatické nastavenie úrovne nahrávania zastavené. %.2f vyzerá byť prijateľná hlasitosť."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Prijatých %d počas otvárania zariadenia\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Nemožno otvoriť Portmixér\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Dostupné zmiešavače:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Dostupné zdroje nahrávania:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Dostupná hlasitosť prehrávania:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Nahrávacia hlasitosť je emulovaná\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Nahrávacia hlasitosť je skutočná\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Prehrávacia hlasitosť je emulovaná\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Prehrávacia hlasitosť je skutočná\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Dátum a čas ukončenia"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Súbory kompatibilné s GStreamerom"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Nemožno pridať dekódovač do radu"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Importér GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Nemožno nastaviť tok na pozastavený stav."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index [%02d], typ [%s], kanály [%d], rýchlosť [%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Súbor neobsahuje žiadne audio toky."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Nemožno importovať súbor, zmena stavu zlyhala."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Chyba GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "&Zmiešavač"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Up&raviť hlasitosť prehrávania..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Z&výšiť hlasitosť prehrávania"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Z&nížiť hlasitosť prehrávania"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Up&raviť hlasitosť nahrávania..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Z&výšiť hlasitosť nahrávania"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Z&nížiť hlasitosť nahrávania"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Manuál Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&O programe Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomatické nastavenie nahrávacej úrovne (zap/vyp)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatické nastavenie úrovne nahrávania"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Povoliť automatické nastavenie úrovne nahrávania."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Cieľová špička:"
+
+#~ msgid "Within:"
+#~ msgstr "Vnútri:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Čas analýzy:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisekundy (čas jednej analýzy)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Počet po sebe nasledujúcich analýz:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 znamená nekonečno"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Hlasitosť nahrávania"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Hlasitosť prehrávania"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Hlasitosť nahrávania: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Hlasitosť nahrávania (nedostupná; použite systémový zmiešavač.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Hlasitosť prehrávania: %.2f (emulovaná)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Hlasitosť prehrávania : %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Hlasitosť nahrávania (nedostupná; použite systémový zmiešavač.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Panel nástrojov &zmiešavača"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Kliknite a ťahajte pre posunutie stopy v čase"
 
 #~ msgid "Program build date:"
 #~ msgstr "Dátum zostavy programu:"
@@ -19139,9 +21135,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #~ msgid "AIFF (Apple) signed 16-bit PCM"
 #~ msgstr "AIFF (Apple) podpísané 16-bit PCM"
 
-#~ msgid "WAV (Microsoft) signed 16-bit PCM"
-#~ msgstr "WAV (Microsoft) podpísané 16-bit PCM"
-
 #~ msgid "WAV (Microsoft) signed 24-bit PCM"
 #~ msgstr "WAV (Microsoft) podpísané 24-bit PCM"
 
@@ -19315,9 +21308,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 
 #~ msgid "false"
 #~ msgstr "nepravda"
-
-#~ msgid "AudioUnit"
-#~ msgstr "AudioJednotka"
 
 #~ msgid "Nyquist Effects Prompt"
 #~ msgstr "Hlásenie Nyquist Efektu"
@@ -19621,10 +21611,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #~ msgstr "na &koniec výberu"
 
 #, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
-
-#, fuzzy
 #~ msgid "Show start time and end time"
 #~ msgstr "Dátum a čas začiatku"
 
@@ -19840,10 +21826,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #~ msgid "Truncate"
 #~ msgstr "Orezať ticho"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Vykonáva sa obracanie"
-
 #~ msgid "C&ategory:"
 #~ msgstr "&Kategória:"
 
@@ -19893,10 +21875,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #~ msgstr "Stereo &stopa na mono"
 
 #, fuzzy
-#~ msgid "&Mono"
-#~ msgstr "Mono"
-
-#, fuzzy
 #~ msgid "&Left Channel"
 #~ msgstr "Ľavý kanál"
 
@@ -19913,10 +21891,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "Ak chcete použiť Kreslenie, zvoľte 'Časový priebeh' z rozbaľovacieho menu stopy."
-
-#, fuzzy
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "Priemerná efektívna hodnota rozdielu %.1f dB"
 
 #, fuzzy
 #~ msgid "Average RMS = %.2f dB."
@@ -20128,10 +22102,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 #, fuzzy
 #~ msgid "&Enable level control"
 #~ msgstr "Zapnúť indikátor"
-
-#, fuzzy
-#~ msgid ":   Maximum 0 dB."
-#~ msgstr ".  Maximum 0dB."
 
 #~ msgid "From beats per minute"
 #~ msgstr "Z úderov za minútu"
@@ -21866,9 +23836,6 @@ msgstr "Chyba.~%Požadovaná stereo stopa."
 
 #~ msgid "Equalize soft and loud sections"
 #~ msgstr "Vyrovnať tiché a hlasité časti"
-
-#~ msgid "Normalize by Dominic Mazzoni"
-#~ msgstr "Normalizácia  od Dominica Mazzoniho"
 
 #~ msgid "Phaser by Nasca Octavian Paul"
 #~ msgstr "Fázer od Nasca Octavian Paul"

--- a/locale/sl.po
+++ b/locale/sl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/tenacity/tenacity/sl/>\n"
@@ -19,72 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Posodobi Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Preskoči"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Namesti posodobitev"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Zapisnik sprememb"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Preberi več na GitHubu"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Napaka pri preverjanju obstoja posodobitev"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Povezovanje s strežnikom posodobitev Audacity ni uspelo."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Podatki posodobitve so okvarjeni."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Napaka pri prenašanju posodobitve."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Povezave za prenos Audacity ni moč odpreti."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Na voljo je Audacity %s!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Snemanje"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Nemogoče določiti"
@@ -93,6 +27,24 @@ msgstr "Nemogoče določiti"
 #, c-format
 msgid "%s bytes"
 msgstr "%s bajtov"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -219,7 +171,8 @@ msgid "Script"
 msgstr "Skript"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Izhod"
 
@@ -235,7 +188,12 @@ msgstr "Skripti Nyquist (*.ny)|*.ny|Skripti Lisp (*.lsp)|*.lsp|Vse datoteke|*"
 msgid "Script was not saved."
 msgstr "Skript ni bil shranjen."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Opozorilo"
 
@@ -256,11 +214,17 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Galerija ikon Tango (ikone orodne vrstice)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(c) 2009 Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(c) 2009 Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Zunanji modul Audacity, ki ponuja enostavni IDE za pisanje učinkov."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -283,7 +247,8 @@ msgstr "Neimenovano"
 msgid "Nyquist Effect Workbench - "
 msgstr "Delovni pult učinkov Nyquist - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nov"
 
@@ -323,7 +288,8 @@ msgstr "Kopiraj"
 msgid "Copy to clipboard"
 msgstr "Kopiraj na odložišče"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Izreži"
 
@@ -331,7 +297,8 @@ msgstr "Izreži"
 msgid "Cut to clipboard"
 msgstr "Izreži v odložišče"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Prilepi"
 
@@ -356,7 +323,8 @@ msgstr "Izberi vse"
 msgid "Select all text"
 msgstr "Izberi vse besedilo"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Razveljavi"
 
@@ -364,7 +332,8 @@ msgstr "Razveljavi"
 msgid "Undo last change"
 msgstr "Razveljavi zadnjo spremembo"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Ponovi"
 
@@ -421,7 +390,8 @@ msgid "Go to next S-expr"
 msgstr "Pojdi na naslednji S-izraz"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Začetek"
 
@@ -429,7 +399,8 @@ msgstr "Začetek"
 msgid "Start script"
 msgstr "Zaženi skript"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Ustavi"
 
@@ -444,7 +415,8 @@ msgid "About %s"
 msgstr "O programu %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "V redu"
 
@@ -452,11 +424,13 @@ msgstr "V redu"
 msgid "Build Information"
 msgstr "Informacije o gradnji"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Omogočeno"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Onemogočeno"
 
@@ -466,8 +440,9 @@ msgid "The Build"
 msgstr "Gradnja"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Id objave:"
+#, fuzzy
+msgid "Version:"
+msgstr "Različica: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -477,22 +452,28 @@ msgstr "Vrsta gradnje:"
 msgid "Compiler:"
 msgstr "Prevajalnik:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Namestitvena predpona poti:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Mapa z nastavitvami:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Mapa z nastavitvami:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Podpora vrstam datotek"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Čezplatformna knjižnica GUI"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -506,7 +487,6 @@ msgstr "Pretvorba frekvence vzorčenja"
 msgid "MP3 Importing"
 msgstr "Uvažanje MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Uvoz in izvoz Ogg Vorbis"
@@ -515,7 +495,6 @@ msgstr "Uvoz in izvoz Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Podpora značkam ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Uvoz in izvoz FLAC"
@@ -533,14 +512,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Uvoz/izvoz FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Uvozi prek GStreamerja"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Odlike"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Podpora za vstavke"
 
@@ -555,6 +526,10 @@ msgstr "Podpora spremembi višine tona in tempa"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Podpora izjemni spremembi višine tona in tempa"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Odlike"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -673,6 +648,10 @@ msgstr "%s, grafično oblikovanje"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (vključuje %s, %s, %s, %s in %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -682,6 +661,10 @@ msgstr "%s je brezplačno, odprto-kodno, več platformno programje za snemanje i
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Zasluge"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -732,6 +715,7 @@ msgstr "Spletišče in grafika"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Slovenski prevod: Martin Srebotnjak"
@@ -749,6 +733,22 @@ msgstr "Posebna zahvala:"
 #, c-format
 msgid "%s website: "
 msgstr "Spletišče %s: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Avtorji prispevkov"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -771,6 +771,7 @@ msgstr "Časovnica"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "S klikom ali povlekom začnite iskati"
@@ -778,6 +779,7 @@ msgstr "S klikom ali povlekom začnite iskati"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "S klikom ali povlekom začnite drseti"
@@ -785,6 +787,7 @@ msgstr "S klikom ali povlekom začnite drseti"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Kliknite in premaknite za drsenje. Kliknite in povlecite za iskanje."
@@ -792,6 +795,7 @@ msgstr "Kliknite in premaknite za drsenje. Kliknite in povlecite za iskanje."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Premaknite za iskanje"
@@ -799,6 +803,7 @@ msgstr "Premaknite za iskanje"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Premaknite za drsenje"
@@ -853,7 +858,17 @@ msgid ""
 "end of project."
 msgstr "Regije ni mogoče zakleniti pred koncem projekta."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Napaka"
 
@@ -877,7 +892,8 @@ msgstr ""
 "To je enkratno vprašanje po 'namestitvi', kjer ste zahtevali ponastavitev možnosti."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Ponastavi nastavitve Audacity"
 
 #: src/AudacityApp.cpp
@@ -892,7 +908,8 @@ msgstr ""
 "Odstranjeno s seznama nedavnih datotek."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Knjižnica SQLite se ni uspela inicializirati. Audacity ne more nadaljevati z delom."
 
 #: src/AudacityApp.cpp
@@ -918,7 +935,7 @@ msgstr "&Odpri ..."
 msgid "Open &Recent..."
 msgstr "Odpri ne&davne ..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&O programu Audacity ..."
@@ -932,9 +949,10 @@ msgid "&File"
 msgstr "&Datoteka"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity ni našel prostora za začasne datoteke.\n"
@@ -942,20 +960,23 @@ msgstr ""
 "Prosimo, da vnesete primerno pot do mape v dialogu nastavitev."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity ni našel prostora za začasne datoteke.\n"
 "Prosimo, da vnesete primerno pot do mape v dialogu nastavitev."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity se zapira. Prosimo, znova zaženite Audacity, da boste lahko uporabljali novo začasno mapo."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -964,15 +985,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity ne more zakleniti mape začasnih datotek.\n"
 "To mapo morda uporablja drugi Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Želite vseeno zagnati Audacity?"
 
 #: src/AudacityApp.cpp
@@ -980,19 +1003,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Napaka pri zaklepu začasne mape"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Sistem je zaznal, da Audacity že teče.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Uporabite ukaza Nov ali Odpri v trenutno zagnanem procesu Audacity,\n"
 "da odprete več projektov hkrati.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity je že zagnan."
 
 #: src/AudacityApp.cpp
@@ -1008,7 +1034,8 @@ msgstr ""
 "in morda je potreben ponovne zagon."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Spodletel zagon Audacity"
 
 #: src/AudacityApp.cpp
@@ -1048,8 +1075,9 @@ msgstr ""
 "in morda je potreben ponovne zagon."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1081,7 +1109,8 @@ msgstr "izvedi samodiagnostiko"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "pokaži različico Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1091,9 +1120,10 @@ msgid "audio or project file name"
 msgstr "ime datoteke zvoka ali projekta"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1106,16 +1136,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Projektne datoteke Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Sporočilo"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Prilagoditvena napaka Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1125,7 +1157,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Do naslednje prilagoditvene datoteke ni mogoče dostopati:\n"
 "\n"
@@ -1137,12 +1169,15 @@ msgstr ""
 "\n"
 "Če izberete »Izhod iz Audacity«, lahko vaš projekt ostane v neshranjenem stanju, ki bo obnovljeno ob naslednjem odpiranju programa."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Pomoč"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Zapri Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1150,7 +1185,8 @@ msgid "&Retry"
 msgstr "Poskusi &znova"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Zapisnik Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1162,7 +1198,8 @@ msgstr "&Shrani ..."
 msgid "Cl&ear"
 msgstr "Po&čisti"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Zapri"
 
@@ -1217,7 +1254,8 @@ msgid "Error Initializing Midi"
 msgstr "Napaka pri inicializaciji za MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Zvok Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1232,37 +1270,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Pomanjkanje pomnilnika!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Bolj je ni bilo mogoče optimizirati. Še vedno je previsoka."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Samodejna prilagoditev ravni vhoda je znižala jakost na %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Bolj je ni bilo mogoče optimizirati. Še vedno je prenizka."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Samodejna prilagoditev ravni vhoda je zvišala jakost na %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Skupno število analiz je preseglo mejo brez določitve sprejemljive jakosti. Še vedno je previsoka."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Skupno število analiz je preseglo mejo brez določitve sprejemljive jakosti. Še vedno je prenizka."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. %.2f se zdi sprejemljiva jakost."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1361,48 +1368,6 @@ msgstr "Predvajalne naprave za »%s« ni mogoče najti.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Brez obeh naprav ni mogoče preveriti medsebojnih mer vzorčenja.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Prejeto %d med odpiranjem naprav\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Portmixer ni mogoče odpreti.\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Mešalniki na voljo:\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d – %s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Viri snemanja na voljo:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Glasnosti predvajanja na voljo:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Glasnost snemanja je emulirana\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Glasnost snemanja je domorodna\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Glasnost predvajanja je emulirana\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Glasnost predvajanja je domorodna\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1445,8 +1410,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Samodejna obnovitev po sesutju"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1459,12 +1425,14 @@ msgid "Recoverable &projects"
 msgstr "O&bnovljivi projekti"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Izberi"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Ime"
 
@@ -1550,6 +1518,11 @@ msgstr "Učinek"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menijski ukaz (s parametri)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1695,7 +1668,8 @@ msgstr "O&bnovi"
 msgid "I&mport..."
 msgstr "U&vozi ..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "I&zvozi ..."
 
@@ -1736,7 +1710,8 @@ msgstr "Premakni &gor"
 msgid "Move &Down"
 msgstr "Premakni &dol"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Shrani"
 
@@ -1819,7 +1794,8 @@ msgid "Run"
 msgstr "Zaženi"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Zapri"
 
@@ -1965,11 +1941,6 @@ msgid "No revision identifier was provided"
 msgstr "Identifikator različice ni podan"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Datum in čas zaključka"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Gradnja za razhroščevanje (raven razhroščevanja %d)"
@@ -2053,6 +2024,11 @@ msgid ""
 msgstr ""
 "Za to morate najprej izbrati kak zvok\n"
 " (izbiranje drugih vrst stez ne bo delovalo)."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2228,10 +2204,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Če nadaljujete, vaš projekt ne bo shranjen na disk. Res to želite storiti?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2244,7 +2221,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Preverjanje odvisnosti"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Prazno"
 
@@ -2252,7 +2232,7 @@ msgstr "Prazno"
 msgid "Rectangle"
 msgstr "Pravokotnik"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trikotnik"
 
@@ -2263,6 +2243,38 @@ msgstr "Oblikovano"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Pravokotno"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Hamming"
+msgstr "Hamming, brez"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Dobrodošli!"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2284,9 +2296,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Podpora za FFmpeg ni prevedena v"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2308,8 +2321,8 @@ msgid "Locate FFmpeg"
 msgstr "Najdi FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity potrebuje datoteko %s za uvoz in izvoz zvoka prek FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2322,7 +2335,8 @@ msgstr "Mesto '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Če želite poiskati »%s«, kliknite sem -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Prebrskaj ..."
 
@@ -2348,8 +2362,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg ni mogoče najti"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2379,24 +2394,24 @@ msgid "Only libavformat.so"
 msgstr "Samo libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Z Audacity ni mogoče odpreti datoteke v %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Z Audacity ni mogoče brati iz datoteke v %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity je uspešno zapisal datoteko v %s, vendar ni uspel preimenovati v %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2434,7 +2449,9 @@ msgstr "&Ne kopiraj nobenega zvoka"
 msgid "As&k"
 msgstr "Vpra&šaj"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Vse datoteke"
 
@@ -2459,6 +2476,10 @@ msgstr "Besedilne datoteke"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Datoteke XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2500,6 +2521,14 @@ msgstr "Samodejna korelacija Cuberoot"
 msgid "Enhanced Autocorrelation"
 msgstr "Razširjena samodejna korelacija"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spekter"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2516,6 +2545,17 @@ msgstr "Linearna frekvenca"
 msgid "Log frequency"
 msgstr "Logaritemska frekvenca"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Drsi"
@@ -2523,6 +2563,15 @@ msgstr "Drsi"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Povečava"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2583,6 +2632,23 @@ msgstr "Izbranega je preveč zvoka. Analiziranih bo le prvih %.1f sekund zvoka."
 msgid "Not enough data selected."
 msgstr "Oznaka je premajhna."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f s (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f s (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2605,7 +2671,8 @@ msgstr "spekter.txt"
 msgid "Export Spectral Data As:"
 msgstr "Izvozi grafične podatke kot:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Zapisovanje v datoteko ni možno: %s"
@@ -2795,19 +2862,19 @@ msgid "&History..."
 msgstr "&Zgodovina ..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Notranja napaka v %s v %s vrstice %d.\n"
 "Na https://forum.audacityteam.org/ obvestite ekipo Audacity."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Notranja napaka v vrstici %s %d.\n"
 "Na https://forum.audacityteam.org/ obvestite ekipo Audacity."
@@ -2826,7 +2893,9 @@ msgid "Track"
 msgstr "Steza"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Oznaka"
 
@@ -2886,7 +2955,8 @@ msgstr "Vnesite ime steze"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Steza z oznakami"
 
@@ -2897,11 +2967,13 @@ msgstr "Ene ali več shranjenih oznak ni mogoče prebrati."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Prvi zagon Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Izberite jezik programa Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2911,7 +2983,8 @@ msgstr "Izberite jezik programa Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Jezik, ki ste ga izbrali, %s (%s), ni enak sistemskemu jeziku, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Potrdi"
 
@@ -2929,12 +3002,13 @@ msgstr ""
 "Stara datoteka je shranjena pod imenom '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Odpiranje projekta Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke Audacity%s"
 
 #: src/LyricsWindow.cpp
@@ -2985,19 +3059,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mešanje in izdelava stez"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Zvočni mešalnik Audacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Okrepitev"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Hitrost"
 
@@ -3006,28 +3084,43 @@ msgid "Musical Instrument"
 msgstr "Glasbilo"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Zasuk"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Utišaj"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Merilnik ravni signala"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Premaknjeni drsnik ojačitve"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Premaknjeni drsnik hitrosti"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Premaknjeni drsnik zasuka"
 
@@ -3062,9 +3155,9 @@ msgstr ""
 "Ne bo naložen."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3098,16 +3191,19 @@ msgstr ""
 "\n"
 "Uporabi le module iz zaupanja vrednih virov"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Da"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ne"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Nalagalnik modulov Audacity"
 
 #: src/ModuleManager.cpp
@@ -3130,6 +3226,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Notiraj stezo"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3241,7 +3447,8 @@ msgstr "Iz&beri vse"
 msgid "C&lear All"
 msgstr "Po&čisti vse"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Omogoči"
 
@@ -3320,9 +3527,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Neujemajoče mere vzorčenja"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Za snemanje pri tej meri vzorčenja je izbranih premalo stez\n"
@@ -3351,10 +3559,11 @@ msgid "Dropouts"
 msgstr "Izpuščeni deli"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3394,11 +3603,11 @@ msgid "Inspecting project file data"
 msgstr "Proučevanje podatkov projektne datoteke"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3441,11 +3650,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Opozorilo - manjkajo nadimne datoteke"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Preverjanje projekta v mapi »%s« \n"
@@ -3470,12 +3679,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Opozorilo - manjkajo nadimne datoteke"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3534,7 +3743,8 @@ msgstr "Opozorilo - osirotele bločne datoteke"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Potek"
 
@@ -3559,6 +3769,11 @@ msgstr "Opozorilo: težave s samodejnim obnavljanjem"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<neimenovano>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] Audacity »%s«"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3628,12 +3843,14 @@ msgstr ""
 "(ustvarjanje potrebnih začasnih datotek ni možno)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "To ni projektna datoteka Audacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3724,6 +3941,10 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Skupaj izbrisanih osirotelih blokov: %d"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Ciljne zbirke podatkov ni mogoče pripeti."
 
@@ -3761,9 +3982,9 @@ msgid "Error Writing to File"
 msgstr "Napaka pri pisanju v datoteko"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3777,9 +3998,16 @@ msgstr "Strnjevanje projekta"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekt %02i] Audacity »%s«"
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Hitrost"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3788,10 +4016,10 @@ msgstr "(obnovljeno)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Datoteka je bila shranjena z Audacity %s.\n"
 "Vi uporabljate Audacity %s. Morda boste morali slednjega nadgraditi na novejšo različico, da boste lahko odprli to datoteko."
@@ -3803,6 +4031,11 @@ msgstr "Ni mogoče odpreti datoteke projekta"
 #: src/ProjectFileIO.cpp
 msgid "Failed to remove the autosave information from the project file."
 msgstr "Podatkov samodejnega shranjevanja ni bilo mogoče odstraniti iz projektne datoteke."
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Unable to bind to blob"
+msgstr "Kodeka ni mogoče najti"
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to decode project document"
@@ -3859,8 +4092,9 @@ msgid "Backing up project"
 msgstr "Varnostno kopiranje projekta"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3868,8 +4102,9 @@ msgstr ""
 "Na srečo je bil obnovljen na zadnji posnetek stanja."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3946,8 +4181,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sShrani projekt »%s« kot ..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "»Shrani projekt« je za projekt Audacity, ne za zvočno datoteko.\n"
@@ -4024,11 +4260,12 @@ msgid "Error Opening Project"
 msgstr "Napaka pri odpiranju datoteke"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Odpreti želite samodejno ustvarjeno datoteko varnostne kopije.\n"
 "To lahko pripelje do resne izgube podatkov.\n"
@@ -4102,6 +4339,18 @@ msgid "Compact Project"
 msgstr "Strni projekt"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Strnjena projektna datoteka"
 
@@ -4118,8 +4367,8 @@ msgid "Automatic database backup failed."
 msgstr "Samodejno varnostno kopiranje zbirke podatkov je spodletelo."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Dobrodošli v Audacity različice %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4327,6 +4576,11 @@ msgid "All Effects"
 msgstr "Vsi učinki"
 
 #: src/Screenshot.cpp
+#, fuzzy
+msgid "All Scriptables"
+msgstr "Vse datoteke"
+
+#: src/Screenshot.cpp
 msgid "All Preferences"
 msgstr "Vse nastavitve"
 
@@ -4334,7 +4588,8 @@ msgstr "Vse nastavitve"
 msgid "SelectionBar"
 msgstr "VrsticaIzbora"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektralni izbor"
 
@@ -4342,42 +4597,56 @@ msgstr "Spektralni izbor"
 msgid "Timer"
 msgstr "Časovnik"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Orodja"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "&Upravljanje"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mešalec"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Merilnik"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Merilnik predvajanja"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Merilnik posnetega"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Uredi"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Naprava"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Predvajaj pri hitrosti"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Drsaj"
 
@@ -4392,7 +4661,10 @@ msgstr "Ravnilo"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Steze"
 
@@ -4502,7 +4774,8 @@ msgid "Activation level (dB):"
 msgstr "Raven aktivacije (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Dobrodošli v Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4648,9 +4921,9 @@ msgstr ""
 "Za namige o primernih pogonih kliknite gumb za pomoč."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Z Audacity ni mogoče pisati v datoteko:\n"
@@ -4670,9 +4943,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4681,9 +4954,9 @@ msgstr ""
 "za pisanje."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Z Audacity ni mogoče zapisati slik v datoteko:\n"
@@ -4700,9 +4973,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4712,9 +4985,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4723,8 +4996,9 @@ msgstr ""
 "Morda gre za nepravilen zapis png?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Z Audacity ni bilo mogoče prebrati privzete teme.\n"
@@ -4762,9 +5036,9 @@ msgstr ""
 "so že prisotne. Jih želite prepisati?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Ni mogoče shraniti datoteke:\n"
@@ -4803,7 +5077,11 @@ msgstr "Po meri"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Trajanje"
 
@@ -4814,7 +5092,8 @@ msgid "Time Track"
 msgstr "Časovna steza"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Časovno snemanje Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4888,7 +5167,8 @@ msgstr "Trenutni projekt"
 msgid "Recording start:"
 msgstr "Začetek snemanja:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Trajanje:"
 
@@ -4909,7 +5189,8 @@ msgid "Action after Timer Recording:"
 msgstr "Dejanje po časovno omejenem snemanju:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Napredek Časovnega snemanja Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5005,6 +5286,7 @@ msgstr "099 dni 024 u 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Datum in čas pričetka"
@@ -5049,7 +5331,8 @@ msgstr "Želite omogočiti &samodejni izvoz?"
 msgid "Export Project As:"
 msgstr "Izvozi projekt kot:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Možnosti"
 
@@ -5062,7 +5345,8 @@ msgid "Do nothing"
 msgstr "Ne naredi ničesar"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Zapri Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5086,7 +5370,8 @@ msgid "Scheduled to stop at:"
 msgstr "Načrtovan zaključek ob:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Časovno snemanje Audacity - Čakanje na začetek"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5112,8 +5397,14 @@ msgid "Recording Exported:"
 msgstr "Posnetek izvožen:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Časovno snemanje Audacity - Čakanje"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, %d Hz"
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5304,6 +5595,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Izvajanje %s ..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "NEUSPEH"
@@ -5322,16 +5623,29 @@ msgstr "%s ni parameter, ki ga sprejema %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Neveljavna vrednost parametra %s: biti mora %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Ukaz"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ponovi %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
 
 #: src/commands/CommandManager.cpp
 msgid "Shortcuts have been removed"
@@ -5348,6 +5662,10 @@ msgstr "Prag:"
 #: src/commands/CompareAudioCommand.h
 msgid "Compares a range on two tracks."
 msgstr "Primerja obseg na dveh stezah."
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
 
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
@@ -5380,6 +5698,11 @@ msgstr "Steza 0"
 #: src/commands/DragCommand.cpp
 msgid "Track 1"
 msgstr "Steza 1"
+
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
@@ -5433,9 +5756,24 @@ msgstr "Posnetki"
 msgid "Envelopes"
 msgstr "Ovojnice"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Oznake"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5445,7 +5783,8 @@ msgstr "Jedrnato"
 msgid "Type:"
 msgstr "Vrsta:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Zapis:"
 
@@ -5472,6 +5811,10 @@ msgstr "Komentar"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Ukaz:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5509,12 +5852,17 @@ msgstr "Izvoz v datoteko."
 msgid "Builtin Commands"
 msgstr "Vgrajeni ukazi"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Ekipa Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "V Audacity zagotavlja podporo vgrajenih ukazov."
 
 #: src/commands/LoadCommands.cpp
@@ -5577,7 +5925,10 @@ msgstr "Počisti vsebino zapisnika."
 msgid "Get Preference"
 msgstr "Pridobi nastavitev"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Ime:"
 
@@ -5625,9 +5976,15 @@ msgstr "Celozaslonski način"
 msgid "Toolbars"
 msgstr "Orodne vrstice"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Učinki"
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Scriptables"
+msgstr "Skript"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Selectionbar"
@@ -5761,7 +6118,8 @@ msgstr "Določi"
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Odstrani"
 
@@ -5846,7 +6204,8 @@ msgid "Edited Envelope"
 msgstr "Urejena ovojnica"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Ovojnica"
 
@@ -5889,6 +6248,14 @@ msgstr "Bitna hitrost:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Spremeni velikost:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5938,7 +6305,10 @@ msgstr "Zasuk:"
 msgid "Set Track Visuals"
 msgstr "Določite vizualije steze"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linearno"
 
@@ -6042,12 +6412,18 @@ msgstr "Izbrali ste stezo, ki ne vsebuje zvoka. Samodejno spusti lahko procesira
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Samodejno spusti potrebuje nadzorno stezo, ki se mora nahajati pod izbrano/imi slezo/ami."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Količina &spusta:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekund"
 
@@ -6071,7 +6447,8 @@ msgstr "Dolžina n&otranjega pojemanja:"
 msgid "Inner &fade up length:"
 msgstr "Dolžina notranjega n&araščanja:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Prag:"
 
@@ -6209,11 +6586,13 @@ msgstr "do (Hz)"
 msgid "t&o"
 msgstr "d&o"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Spremem&ba v odstotkih:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Sprememba v odstotkih"
 
@@ -6221,9 +6600,23 @@ msgstr "Sprememba v odstotkih"
 msgid "&Use high quality stretching (slow)"
 msgstr "&Uporabi visokokakovostno raztegovanje (počasno)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "ni na voljo"
 
@@ -6251,6 +6644,7 @@ msgstr "Standardno št. obratov na minuto:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Iz obratov na minuto"
@@ -6263,6 +6657,7 @@ msgstr "o&d"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Na obrate na minuto"
@@ -6405,6 +6800,12 @@ msgstr "Stiskalnik"
 msgid "Compresses the dynamic range of audio"
 msgstr "Stisne dinamični obseg zvoka"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6414,6 +6815,20 @@ msgstr "%.2f s"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f s"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6530,7 +6945,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analizator kontrasta za merjenje razlik jakosti korena srednje vrednosti kvadratov (RMS - ang. root mean square) med dvema zvočnima izboroma."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Konec"
 
@@ -6590,6 +7006,18 @@ msgstr "&Razlika:"
 msgid "&Help"
 msgstr "&Pomoč"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nič"
@@ -6597,6 +7025,13 @@ msgstr "nič"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "nedoločljivo"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6650,6 +7085,12 @@ msgstr "Trenutna razlika"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Izmerjena glasnost ospredja"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f s"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6864,6 +7305,16 @@ msgid "Upper Threshold"
 msgstr "Zgornji prag"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Parametri"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Parametri"
+
+#: src/effects/Distortion.cpp
 msgid "Number of repeats"
 msgstr "Število ponovitev"
 
@@ -6995,7 +7446,9 @@ msgstr "Zaporedje &DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Amplituda (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Trajanje:"
 
@@ -7008,12 +7461,29 @@ msgid "Duty cycle:"
 msgstr "Cikel delovanja:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f s"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Trajanje tona:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Trajanje tišine:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7023,7 +7493,8 @@ msgstr "Odmev"
 msgid "Repeats the selected audio again and again"
 msgstr "Izbrani zvok ponavlja znova in znova"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Zahtevana vrednost presega zmogljivost pomnilnika."
 
@@ -7047,7 +7518,8 @@ msgstr "Prednastavitve"
 msgid "Export Effect Parameters"
 msgstr "Izvozi parametre učinka"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Napaka pri odpiranju datoteke: »%s«"
@@ -7084,6 +7556,15 @@ msgstr "Priprava predposlušanja"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Predposlušanje"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Napaka Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7412,6 +7893,14 @@ msgid "Bass Cut"
 msgstr "Porezava nizkih tonov"
 
 #: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefon"
 
@@ -7448,12 +7937,41 @@ msgid "Effect Unavailable"
 msgstr "Učinek ni na voljo"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Največji dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Najmanjši dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7528,8 +8046,16 @@ msgid "D&efault"
 msgstr "Privz&eto"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE, &niteno"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7774,7 +8300,8 @@ msgid "Builtin Effects"
 msgstr "Vgrajeni učinki"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Zagotavlja podporo vgrajenim učinkom v Audacity."
 
 #: src/effects/LoadEffects.cpp
@@ -7784,6 +8311,10 @@ msgstr "Neznano ime vgrajenega učinka"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "zaznana glasnost"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7815,6 +8346,14 @@ msgstr "&Normaliziraj"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Glasnost LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7884,7 +8423,16 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (privzeto)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, brez"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, brez"
 
 #: src/effects/NoiseReduction.cpp
@@ -7984,8 +8532,9 @@ msgid "Step 1"
 msgstr "1. korak"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Izberite nekaj sekund zgolj šuma, da Audacity ve, kaj naj odstrani,\n"
@@ -8037,13 +8586,62 @@ msgstr "Vrste &oken:"
 msgid "Window si&ze:"
 msgstr "Ve&likost okna:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (privzeto)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Korakov na okno:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8169,6 +8767,7 @@ msgstr "Uporabite Paulovrazteg samo za skrajni učinek časovnega raztega oz. za
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Faktor ra&ztega:"
@@ -8450,6 +9049,11 @@ msgstr "Obrne izbrani zvok"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "Časovno raztegovanje/sprememba višine tona SBSMS"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8605,6 +9209,11 @@ msgstr "Uporabi privzete vrednosti"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Obnovi privzete vrednosti"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8764,6 +9373,10 @@ msgstr "Zaznaj tišino"
 msgid "Tr&uncate to:"
 msgstr "Pore&ži na:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "S&tisni na:"
@@ -8777,7 +9390,8 @@ msgid "VST Effects"
 msgstr "Učinki VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Doda zmožnost uporabe učinkov VST v Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8789,7 +9403,8 @@ msgstr "Pregledovanje vstavkov VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registriranje %d od %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Napaka pri nalaganju knjižnice"
 
@@ -8801,15 +9416,25 @@ msgstr "Možnosti učinkov VST"
 msgid "Buffer Size"
 msgstr "Velikost medpomnilnika"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Velikost &medpomnilnika (8-1048576 vzorcev):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Kompenzacija latence"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Omogoči &kompenzacijo"
 
@@ -8835,11 +9460,17 @@ msgid "Save VST Preset As:"
 msgstr "Shrani prednastavitev VST kot:"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Standardna programska datoteka VST"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "Standardna programska datoteka VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Datoteka prednastavitev Audacity VST"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8866,7 +9497,8 @@ msgstr "Napaka pri nalaganju prednastavitev VST"
 msgid "Unable to load presets file."
 msgstr "Datoteke prednastavitev ni mogoče naložiti."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Nastavitve učinka"
 
@@ -8882,6 +9514,12 @@ msgstr "Datoteke prednastavitev ni mogoče prebrati."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Ta datoteka parametrov je bila shranjena iz %s. Želite nadaljevati?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -8917,7 +9555,8 @@ msgid "Audio Unit Effects"
 msgstr "Učinki zvočne enote"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Zagotavlja podporo učinkom Audio Unit Effects v Audacity."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8933,8 +9572,16 @@ msgid "Audio Unit Effect Options"
 msgstr "Možnosti učinkov Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Uporabniški vmesnik"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9069,6 +9716,7 @@ msgstr "Zvočna enota"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Učinki LADSPA"
@@ -9078,7 +9726,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Zagotavlja učinke LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity ne uporablja več vst-bridge."
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9086,8 +9735,29 @@ msgid "LADSPA Effect Options"
 msgstr "Nastavitve učinka LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s v:"
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Izhod učinka"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Učinki LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9097,6 +9767,10 @@ msgstr "Nastavitve učinka LV2"
 #, c-format
 msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Velikost &medpomnilnika (8-%d vzorcev):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -9116,12 +9790,24 @@ msgstr "%s zahteva nepodprto funkcionalnost %s\n"
 msgid "%s requires unsupported option %s\n"
 msgstr "%s zahteva nepodprto možnost %s\n"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Tvori"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Učinki LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Zagotavlja podporo učinkom LV2 v Audacity."
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9129,7 +9815,8 @@ msgid "Nyquist Effects"
 msgstr "Učinki Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Zagotavlja podporo vstavkov Nyquist v Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9357,7 +10044,8 @@ msgstr "Izberite datoteko"
 msgid "Save file as"
 msgstr "Shrani datoteko kot"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "neimenovano"
 
@@ -9366,7 +10054,8 @@ msgid "Vamp Effects"
 msgstr "Učinki Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Zagotavlja podporo za učinke Vamp v Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9384,6 +10073,17 @@ msgstr "Oprostite, vstavek Vamp se ni uspel inicializirati."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Nastavitve vstavka"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9684,7 +10384,8 @@ msgstr "Izvažanje zvoka kot %s"
 msgid "Invalid sample rate"
 msgstr "Neveljavna mera vzorčenja"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Prevzorči"
 
@@ -9716,7 +10417,8 @@ msgstr "Mere vzorčenja"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kb/s"
@@ -9736,12 +10438,52 @@ msgid "%.2f kbps"
 msgstr "%.2f kb/s"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
 msgstr "Vključeno"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Constrained"
 msgstr "Omejeno"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
@@ -9754,6 +10496,27 @@ msgstr "Nizka zakasnitev"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9840,8 +10603,16 @@ msgid "Replace preset '%s'?"
 msgstr "Želite zamenjati prednastavitev »%s«?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Glavno"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9949,6 +10720,10 @@ msgstr "Jezik:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bitni rezervoar"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10082,6 +10857,11 @@ msgstr ""
 "0 - privzeto\n"
 "najmanj - 1\n"
 "največ - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Uporabi LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10354,8 +11134,23 @@ msgid "145-185 kbps"
 msgstr "145-185 kb/s"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "170-210 kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "145-185 kb/s"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
 msgstr "80-120 kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
+msgstr "145-185 kb/s"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -10387,7 +11182,8 @@ msgstr "Noro"
 msgid "Extreme"
 msgstr "Ekstremno"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Navadno"
 
@@ -10412,6 +11208,11 @@ msgid "Joint Stereo"
 msgstr "Združeni stereo"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Način bitne hitrosti:"
 
@@ -10434,8 +11235,8 @@ msgid "Locate LAME"
 msgstr "Najdi LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity potrebuje datoteko %s za ustvarjanje datotek MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10463,10 +11264,10 @@ msgid "Where is %s?"
 msgstr "Kje je %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Povezava kaže na lame_enc.dll razl%d.%d. Ta različica ni kompatibilna z Audacity %d.%d.%d.\n"
 "Prenesite najnovejšo različico knjižnice LAME za Audacity."
@@ -10699,6 +11500,21 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "Ali želite nadaljevati z izvažanjem preostalih datotek?"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, fuzzy, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+"Oznaka ali ime steze »%s« ni veljavno ime datoteke. Ne morete uporabiti »%s«.\n"
+"\n"
+"Predlagana zamenjava:"
+
 #. i18n-hint: The second %s gives a letter that can't be used.
 #: src/export/ExportMultiple.cpp
 #, c-format
@@ -10751,6 +11567,14 @@ msgstr "Izvažanje izbora v Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Izvažanje zvoka kot Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Glava:"
@@ -10764,9 +11588,10 @@ msgid "Other uncompressed files"
 msgstr "Druge nestisnjene datoteke"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Poskusili ste izvoziti datoteko WAV oz. AIFF, večjo od 4 GB.\n"
 "Audacity tega ne zmore, zato je izvoz ustavljen."
@@ -10776,8 +11601,9 @@ msgid "Error Exporting"
 msgstr "Napaka pri izvozu"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Vaša izvožena datoteka WAV je obrezana, saj Audacity ne more izvoziti datotek\n"
@@ -10817,11 +11643,11 @@ msgid "All supported files"
 msgstr "Vse podprte datoteke"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "»%s« \n"
@@ -10830,11 +11656,11 @@ msgstr ""
 "lahko pa jo prikaže, če kliknete Datoteka > Uvozi > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "»%s« \n"
 "ni zvočna datoteka. \n"
@@ -10845,18 +11671,18 @@ msgid "Select stream(s) to import"
 msgstr "Izberite toke za uvoz"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "V tej različici Audacity podpora za %s ni prevedena."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "»%s« je datoteka (steza) glasbenega CD.\n"
 "Te vrste datotek Audacity neposredno ne odpira.\n"
@@ -10865,10 +11691,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "»%s« je datoteka seznama predvajanja datotek.\n"
@@ -10877,10 +11703,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "»%s« je zvočna datoteka Windows Media Audio. \n"
@@ -10889,10 +11715,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "»%s« je datoteka Advanced Audio Coding. \n"
@@ -10901,12 +11727,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "»%s« je šifrirana zvočna datoteka. \n"
@@ -10917,10 +11743,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "»%s« je medijska datoteka RealPlayer. \n"
@@ -10929,12 +11755,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "»%s« je datoteka z opombami in ne zvočna datoteka. \n"
 "Audacity ne more odpreti te vrste datotek.\n"
@@ -10943,10 +11769,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10959,10 +11785,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "»%s« je zvočna datoteka Wavpack. \n"
@@ -10971,10 +11797,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "»%s« je zvočna datoteka Dolby Digital. \n"
@@ -10983,10 +11809,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "»%s« je zvočna datoteka Ogg Speex. \n"
@@ -10995,10 +11821,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "»%s« je video datoteka. \n"
@@ -11012,9 +11838,9 @@ msgstr "Datoteke »%s« ni mogoče najti."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11030,11 +11856,16 @@ msgstr ""
 "Poskusite namestiti FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, preizkuševalec"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11064,12 +11895,13 @@ msgid "Import Project"
 msgstr "Uvozi projekt"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Ta projekt je shranjen z Audacity 1.0 ali starejšim. Zapis se je spremenil\n"
 "in ta različica Audacity ne more uvoziti projekta.\n"
@@ -11120,12 +11952,17 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Mape s projektnimi podatki ni mogoče najti: »%s«"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Projektna datoteka vsebuje steze MIDI, vendar ta gradnja Audacity ne vključuje podpore MIDI, zaradi tega bodo steze preskočene."
 
 #: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Uvoz projekta"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
@@ -11140,9 +11977,34 @@ msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Neveljavni sekvenčni atribut »numsamples«."
 
 #: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid ""
 "Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+"Manjka projektna datoteka %s\n"
+"\n"
+"Namesto tega bo vstavljena tišina."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr "Manjka ali neveljaven atribut pcmaliasblockfile »aliaslen«."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Manjka ali neveljaven atribut pcmaliasblockfile »aliaslen«."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid ""
+"Missing alias file %s\n"
 "\n"
 "Inserting silence instead."
 msgstr ""
@@ -11197,40 +12059,6 @@ msgstr "Kazalo[%02x] kodek[%s], jezik[%s], bitnovzorčenje[%s], kanali[%d], traj
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Datoteke FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer - združljive datoteke"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Dekodirnika ni mogoče dodati v cevovod"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Uvoznik GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Ni mogoče nastaviti stanja toka na prekinjeno."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Kazalo[%02d] vrsta[%s], kanali[%d], mera[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Datoteka ne vsebuje nobenih zvočnih tokov."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Datoteke ni mogoče odpreti, sprememba stanja je spodletela."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Napaka GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -11334,8 +12162,97 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF in druge nestisnjene vrste"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (brez glave)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11374,6 +12291,26 @@ msgid "A-Law"
 msgstr "A-zakon"
 
 #: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12-bitni DWVW"
 
@@ -11386,12 +12323,20 @@ msgid "24 bit DWVW"
 msgstr "24-bitni DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bitni DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8-bitni DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11526,6 +12471,7 @@ msgstr "%s desno"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11551,6 +12497,7 @@ msgstr "konec"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11581,7 +12528,8 @@ msgstr "Časovno zamaknjeni posnetki na desno"
 msgid "Time shifted clips to the left"
 msgstr "Časovno zamaknjeni posnetki na levo"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Časovni zamik"
 
@@ -11719,7 +12667,8 @@ msgstr "Poreži izbrane zvočne posnetke z %.2f sekund na %.2f sekund"
 msgid "Trim Audio"
 msgstr "Poreži zvok"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Razdvoji"
 
@@ -11842,34 +12791,6 @@ msgstr "&Tipka brisanja 2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "&Dodatno"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Me&šalnik"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Prila&godi glasnost predvajanja ..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Z&višaj glasnost predvajanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Z&nižaj glasnost predvajanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Prilago&di glasnost snemanja ..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Zvi&šaj glasnost snemanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Zniža&j glasnost snemanja"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12137,8 +13058,9 @@ msgid "&Getting Started"
 msgstr "&Prvi koraki"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Priročnik za A&udacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "Priro&čnik …"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12164,11 +13086,8 @@ msgstr "Podatki o napravi &MIDI ..."
 msgid "Show &Log..."
 msgstr "Pokaži &zapisnik ..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&O programu Audacity ..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Oznaka dodana"
 
@@ -12418,6 +13337,11 @@ msgid "Uncategorized"
 msgstr "Nekategorizirano"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Nov ..."
+
+#: src/menus/PluginMenus.cpp
 msgid "Unknown"
 msgstr "Neznano"
 
@@ -12496,6 +13420,17 @@ msgid "Simulate Recording Errors"
 msgstr "Simuliraj napake pri snemanju"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Detect Upstream Dropouts"
+msgstr "Zaznaj izpuščene dele"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Script&ables I"
+msgstr "Skript"
+
+#: src/menus/PluginMenus.cpp
 msgid "Select Time..."
 msgstr "Izberi čas ..."
 
@@ -12542,6 +13477,11 @@ msgstr "Določi oznako ..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Določi projekt ..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+msgid "Scripta&bles II"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -12840,6 +13780,7 @@ msgstr "&Dolg skok kazalke desno"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Iš&či"
@@ -13051,18 +13992,21 @@ msgid "Created new label track"
 msgstr "Ustvarjena nova datoteka z oznakami"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Ta različica Audacity dovoljuje le eno časovno stezo za vsako projektno okno."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Ustvarjena nova časovna steza"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Nova frekvenco vzorčenja (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Vnesena vrednost ni veljavna"
 
@@ -13319,7 +14263,9 @@ msgstr "Predvajanje"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Snemanje"
 
@@ -13376,6 +14322,13 @@ msgstr "Izberite vsaj %d kanalov."
 #: src/menus/TransportMenus.cpp
 msgid "Please select a time within a clip."
 msgstr "Izberite čas v okviru posnetka."
+
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Tra&nsport"
+msgstr "&Upravljanje"
 
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
@@ -13462,10 +14415,6 @@ msgstr "Pre&krivaj (vključeno/izključeno)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "Pro&gramsko predvajanje skozi (vključeno/izključeno)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Sa&modejna prilagoditev ravni snemanja (vključeno/izključeno)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13681,7 +14630,7 @@ msgstr "Nastavitve kakovosti"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Posodobi Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13728,7 +14677,8 @@ msgstr "&Gostitelj:"
 msgid "Using:"
 msgstr "Uporablja:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Predvajanje"
 
@@ -13748,7 +14698,8 @@ msgstr "Ka&nali:"
 msgid "Latency"
 msgstr "Latenca"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisekund"
 
@@ -13777,7 +14728,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Mape"
 
@@ -13788,6 +14740,12 @@ msgstr "Nastavitve map"
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Privzete mape"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "O&pen:"
@@ -13877,7 +14835,8 @@ msgid "Directory %s is not writable"
 msgstr "V mapi %s zapisovanje ni dovoljeno"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Spremembe v začasni mapi ne bodo delovale do naslednjega zagona Audacityja."
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13908,6 +14867,40 @@ msgstr "Združeno po izdajateljih"
 msgid "Grouped by Type"
 msgstr "Združeno po vrsti"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Napaka Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Vključi učinke"
@@ -13929,11 +14922,13 @@ msgid "Plugin Options"
 msgstr "Možnosti vstavka"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Preveri posodobitve vstavkov ob zagonu Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Preglej vstavke ob naslednjem zagonu Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13949,6 +14944,11 @@ msgstr "&Uporabi SSE/SSE2/…/AVX"
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Extended Import"
 msgstr "Razširjen uvoz"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ExtImport"
+msgstr "Nastavitve za uvoz/izvoz"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "A&ttempt to use filter in OpenFile dialog first"
@@ -14013,6 +15013,11 @@ msgstr "Resnično želite izbrisati izbrano pravilo?"
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Rule deletion confirmation"
 msgstr "Potrditev brisanja pravila"
+
+#: src/prefs/ExtImportPrefs.h
+#, fuzzy
+msgid "Ext Import"
+msgstr "Razširjen uvoz"
 
 #. i18n-hint: refers to Audacity's user interface settings
 #: src/prefs/GUIPrefs.cpp
@@ -14105,7 +15110,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "O&bdrži oznake, če se izbor pripne na oznako"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Spo&ji temo sistema in Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14197,6 +15203,11 @@ msgid "Keyboard"
 msgstr "Tipkovnica"
 
 #: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Preferences for KeyConfig"
+msgstr "Nastavitve snemanja"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Keyboard preferences currently unavailable."
 msgstr "Osebne nastavitve tipkovnice trenutno niso na voljo."
 
@@ -14270,7 +15281,15 @@ msgid "&Defaults"
 msgstr "&Privzeto"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Izberite datoteko XML z bližnjicami Audacity ..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14279,8 +15298,21 @@ msgstr "Napaka pri uvažanju tipk za bližnjice"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Naloženih %d bližnjic\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -14386,8 +15418,9 @@ msgid "Dow&nload"
 msgstr "Pre&nesi"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity je samodejno zaznal veljavne knjižnice FFmpeg.\n"
@@ -14446,8 +15479,9 @@ msgid "Preferences for Module"
 msgstr "Nastavitve modula"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "To so poskusni moduli. Omogočite jih le, če ste prebrali priročnik za Audacity\n"
@@ -14455,12 +15489,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr " »Vprašaj« pomeni, da vas program povpraša, če želite naložiti modul, vsakič ko se zažene."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr " »Neuspelo« pomeni, da je program mnenja, da je modul okvarjen in se ne bo zagnal."
 
 #. i18n-hint preserve the leading spaces
@@ -14469,7 +15505,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr " »Nov« pomeni, da izbor še ni bil opravljen."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Spremembe teh nastavitev se uveljavijo šele po vnovičnem zagonu Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14532,7 +15569,10 @@ msgstr "Levi povlek"
 msgid "Set Selection Range"
 msgstr "Nastavi obseg izbora"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Dvigalka-levi-klik"
 
@@ -14619,6 +15659,15 @@ msgstr "-levi povlek"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Premakni posnetek gor/dol med stezami"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-levi povlek"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14738,8 +15787,13 @@ msgstr "Predvajanje s spre&menljivo hitrostjo"
 msgid "&Micro-fades"
 msgstr "&Mikro pojemanja"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Nastavitve Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14753,6 +15807,11 @@ msgstr "Nastavitve:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Nastavitve kakovosti"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14872,39 +15931,6 @@ msgid "System T&ime"
 msgstr "Sistemski &čas"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Samodejno prilagajanje ravni snemanja"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Omogoči samodejno prilagoditev ravni snemanja."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Ciljni vrh:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "V okviru:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Čas analize:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisekund (čas ene analize)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Število zaporednih analiz:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 pomeni neskončno"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Z zvokom aktivirano snemanje"
 
@@ -14916,10 +15942,20 @@ msgstr "Pred-pre&dvajanje:"
 msgid "Cross&fade:"
 msgstr "Navzkri&žno pojemanje:"
 
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
 #. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Bark"
 msgstr "Lajež"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15054,6 +16090,10 @@ msgid "1024 - default"
 msgstr "1024 - privzeto"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - najožje"
 
@@ -15151,13 +16191,14 @@ msgid "Info"
 msgstr "Podatki"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15340,7 +16381,8 @@ msgstr "vzorcev"
 msgid "4 Pixels per Sample"
 msgstr "4 slikovne točke na vzorec"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Največja povečava"
 
@@ -15355,6 +16397,10 @@ msgstr "Samodejno &umeri višino stez"
 #: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "Pokaži ime zvočne steze &čeznjo"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "&Pinned Recording/Playback head"
@@ -15458,16 +16504,24 @@ msgid "Stopped"
 msgstr "Zaustavljeno"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Prekinitev"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Skoči na začetek"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Skoči na konec"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Prekinitev"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Izberi do začetka"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Izberi do konca"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15481,13 +16535,17 @@ msgstr "Posnemi novo stezo"
 msgid "Append Record"
 msgstr "Snemaj z dodajanjem"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Izberi do konca"
+#. i18n-hint: These are strings for the status bar, and indicate whether Audacity
+#. is playing or recording or stopped, and whether it is paused.
+#: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy, c-format
+msgid "%s Paused."
+msgstr "Prekinitev"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Izberi do začetka"
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15567,11 +16625,17 @@ msgstr "Utišaj zvočni izbor"
 msgid "Sync-Lock Tracks"
 msgstr "Zakleni steze kot sinhrone"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Povečaj"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Pomanjšaj"
 
@@ -15638,43 +16702,6 @@ msgstr "Vrstica snemalne&ga merilnika"
 msgid "&Playback Meter Toolbar"
 msgstr "Vrstica &predvajalnega merilnika"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Glasnost snemanja"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Glasnost predvajanja"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Glasnost snemanja: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Glasnost snemanja (ni na voljo; uporabite sistemski mešalnik)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Glasnost predvajanja: %.2f (emulirano)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Glasnost predvajanja: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Glasnost predvajanja (ni na voljo; uporabite sistemski mešalnik)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Vrstica me&šanja"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Išči"
@@ -15690,6 +16717,7 @@ msgstr "Drsenje"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Končaj drseti"
@@ -15697,6 +16725,7 @@ msgstr "Končaj drseti"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Začni drseti"
@@ -15704,6 +16733,7 @@ msgstr "Začni drseti"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Ustavi iskanje"
@@ -15711,6 +16741,7 @@ msgstr "Ustavi iskanje"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Začni iskati"
@@ -15765,7 +16796,9 @@ msgstr "Skoči na"
 msgid "Length"
 msgstr "Dolžina"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Sredinski"
 
@@ -15829,8 +16862,8 @@ msgstr "&Časovna vrstica"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Vrstica Audacity %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -15857,7 +16890,8 @@ msgstr "Orodje za optimiranje časa"
 msgid "Zoom Tool"
 msgstr "Orodje za povečavo"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Risanje"
 
@@ -15933,11 +16967,13 @@ msgstr "Povlecite eno ali več mej oznak."
 msgid "Drag label boundary."
 msgstr "Povlecite ročice robu naslova."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Spremenjena oznaka"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Uredi oznako"
 
@@ -15992,31 +17028,42 @@ msgstr "Urejene oznake"
 msgid "New label"
 msgstr "Nova oznaka"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Zvišaj za &oktavo"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Znižaj za o&ktavo"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Kliknite za navpično približanje, kliknite z dvigalko za odmik, povlecite za ustvarjanje določenega področja za povečavo."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Desno kliknite za meni."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Ponastavi povečavo"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Dvigalka+desni klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Levi klik/levi povlek"
 
@@ -16058,7 +17105,8 @@ msgstr "Spoji"
 msgid "Expanded Cut Line"
 msgstr "Črta reza razširjena"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Razpostri"
 
@@ -16081,6 +17129,11 @@ msgstr "Premaknjeni vzorci"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Urejanje vzorcev"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16126,7 +17179,8 @@ msgstr "Obdelovanje ...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Spremenjeno: »%s« v %s"
@@ -16138,6 +17192,54 @@ msgstr "Sprememba formata"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Hitrost"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16157,7 +17259,8 @@ msgstr "Sprememba mere"
 msgid "Set Rate"
 msgstr "Nastavi frekvenco"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Več-pogled"
 
@@ -16176,6 +17279,11 @@ msgstr "Razdvo&ji stereo stezo"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Razdvoji stereo v mo&no"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -16245,17 +17353,36 @@ msgstr "Levo, %d Hz"
 msgid "Right, %dHz"
 msgstr "Desno, %d Hz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Levo"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Desno"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
+msgstr "Kliknite in povlecite za prilagajanje, dvokliknite za ponastavitev."
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Click and drag to rearrange sub-views"
+msgstr "Kliknite in povlecite, da bi premaknili posnetek vzdolž časovne linije"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Rearrange sub-views"
@@ -16362,9 +17489,8 @@ msgstr "Logaritemska &interpolacija"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Kliknite in povlecite, da bi premaknili posnetek vzdolž časovne linije"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16415,6 +17541,7 @@ msgstr "Optimirana kuverta."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Drsaj"
@@ -16426,6 +17553,7 @@ msgstr "Iskanje"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Me&rilo drsenja"
@@ -16445,6 +17573,16 @@ msgstr "Premakni kazalec miške za drsenje"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scru&bbing"
 msgstr "&Drsenje"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Nazaj"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub For&wards"
+msgstr "Naprej"
 
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to move left selection boundary."
@@ -16601,11 +17739,23 @@ msgstr "Pritisnite"
 msgid "Button"
 msgstr "Gumb"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
 #. i18n-hint: One-letter abbreviation for Right, in the Pan slider
 #. i18n-hint: One-letter abbreviation for Right, in VU Meter
 #: src/widgets/ASlider.cpp src/widgets/Meter.cpp
 msgid "R"
 msgstr "D"
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
 
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
@@ -16640,9 +17790,19 @@ msgstr "Prazno"
 msgid "Backwards"
 msgstr "Nazaj"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Naprej"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16855,6 +18015,7 @@ msgstr "0100 u 060 m 060 s+># vzorcev"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "vzorci"
@@ -17020,6 +18181,11 @@ msgstr "010.01000>0100 Hz"
 msgid "centihertz"
 msgstr "centihertzov"
 
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -17027,6 +18193,11 @@ msgstr "centihertzov"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100>01000 kHz|0,001"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hertz"
+msgstr "centihertzov"
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -17092,6 +18263,11 @@ msgstr "(Za spremembo zapisa uporabite kontekstni meni.)"
 msgid "centiseconds"
 msgstr "stotink sekunde"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Pretekli čas:"
@@ -17133,6 +18309,11 @@ msgstr "Potrditev zaprtja"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Prednastavitev iz »%s« ni mogoče prebrati."
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -17233,23 +18414,61 @@ msgstr "Napaka pri odpiranju datoteke: »%s«"
 msgid "Could not parse XML"
 msgstr "XML ni mogoče razčleniti"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny
+#, fuzzy
+msgid "Spectral edit multi tool"
+msgstr "Spektralni izbor"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtriranje …"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Izdano pod pogoji dovoljenja GNU General Public License razl. 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aIzberite frekvence."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Napaka.~%"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+msgid "Spectral edit parametric EQ"
+msgstr ""
 
 #: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
 msgid "Gain (dB)"
@@ -17270,14 +18489,64 @@ msgstr "~aVisoka frekvenca ni določena."
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "~aOsrednja frekvenca mora biti nad 0 Hz."
 
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Spectral edit shelves"
+msgstr "Spektralni izbor"
+
+#: plug-ins/StudioFadeOut.ny
+#, fuzzy
+msgid "Studio Fade Out"
+msgstr "Znižuj glasnost"
+
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Izvajanje pojemanja ..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "&Nastavi privzeto"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Izdano pod pogoji dovoljenja GNU General Public License razl. 2 ali novejšega."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
 msgid "Selection too short.~%It must be more than 2 samples."
 msgstr "Izbor je prekratek.~%Biti mora večji od dveh vzorcev."
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Adjustable Fade"
+msgstr "Prilagojeni zasuk"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -17298,6 +18567,10 @@ msgstr "S-krivulja navzgor"
 #: plug-ins/adjustable-fade.ny
 msgid "S-Curve Down"
 msgstr "S-krivulja navzdol"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
@@ -17390,6 +18663,14 @@ msgstr "~aOdstotkovna vrednost ne more biti negativna."
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "~aOdstotkovna vrednost ne more biti večja od 1000 %."
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Iskalnik udarcev"
@@ -17397,6 +18678,11 @@ msgstr "Iskalnik udarcev"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Iskanje udarcev …"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Zapisnik Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17583,6 +18869,12 @@ msgstr "Prepiši"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Napaka.~%Datoteke ~%~s ni mogoče odpreti."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Napaka.~%Datoteke ni mogoče zapisati:~%»~a.txt«"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
@@ -17591,6 +18883,10 @@ msgstr "Napaka.~%Datoteke ni mogoče zapisati:~%»~a.txt«"
 #: plug-ins/equalabel.ny
 msgid "Regular Interval Labels"
 msgstr "Oznake v rednih intervalih"
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -17620,6 +18916,10 @@ msgstr "Interval oznak (v sekundah)"
 #: plug-ins/equalabel.ny
 msgid "Length of label region (seconds)"
 msgstr "Dolžina območja za oznake (v sekundah)"
+
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
 
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
@@ -17688,6 +18988,17 @@ msgstr "oznake območij"
 msgid "point labels"
 msgstr "oznake točk"
 
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, fuzzy, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr "Področje med zvoki"
+
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
 msgstr "Visoko prepustni filter"
@@ -17696,22 +19007,55 @@ msgstr "Visoko prepustni filter"
 msgid "Performing High-Pass Filter..."
 msgstr "Izvajanje filtriranja visokega prehoda ..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvenca (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Najmanjša frekvenca mora biti vsaj 0,1 Hz."
 
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
+
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Označi zvoke"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Izdano pod pogoji dovoljenja GNU General Public License razl. 2 ali novejšega."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17720,6 +19064,11 @@ msgstr "Raven praga (dB)"
 #: plug-ins/label-sounds.ny
 msgid "Threshold measurement"
 msgstr "Merjenje praga"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Peak level"
+msgstr "Raven vlažnega"
 
 #: plug-ins/label-sounds.ny
 msgid "Average level"
@@ -17786,6 +19135,16 @@ msgstr "Zaznanih preveč tišin.~%Dodanih zgolj prvih 10000 oznak."
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Napaka.~%Izbor mora biti krajši od ~a."
 
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
 #: plug-ins/limiter.ny
 msgid "Limiter"
 msgstr "Omejevalnik"
@@ -17834,6 +19193,10 @@ msgstr ""
 #: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Omeji na (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -17899,12 +19262,36 @@ msgstr "Upad (ms)"
 #, lisp-format
 msgid ""
 "Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
 "Selection too long.\n"
 "Maximum length is ~a."
 msgstr ""
 "Napaka.\n"
 "Izbor je predolg.\n"
 "Največja dolžina je ~a."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
 
 #. i18n-hint: hours and minutes. Do not translate "~a".
 #: plug-ins/noisegate.ny
@@ -17928,6 +19315,14 @@ msgstr "Steve Daulton in Bill Wharrie"
 msgid "Q (higher value reduces width)"
 msgstr "Q (višja vrednost zmanjša širino)"
 
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
+
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
 msgstr "Namestitvenik vstavkov Nyquist"
@@ -17949,7 +19344,8 @@ msgstr "Datoteke Lisp"
 msgid "HTML file"
 msgstr "Datoteka HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Besedilna datoteka"
 
@@ -18014,8 +19410,25 @@ msgid "Error.~%No file selected."
 msgstr "Napaka.~%Izbrana ni nobena datoteka."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Generating pluck sound..."
+msgstr "Tvorjenje Rissetovega bobna ..."
+
+#: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "Vrednosti MIDI za note C: 36, 48, 60 [srednji C], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
@@ -18042,6 +19455,10 @@ msgid "Generating Rhythm..."
 msgstr "Tvorjenje ritma …"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 udarcev/minuto"
 
@@ -18052,6 +19469,19 @@ msgstr "Udarcev na takt"
 #: plug-ins/rhythmtrack.ny
 msgid "1 - 20 beats/measure"
 msgstr "1 - 20 udarcev/takt"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Swing amount"
+msgstr "Količina popačenja"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
@@ -18078,8 +19508,21 @@ msgid "Silence before first beat"
 msgstr "Tišina pred prvim udarcem"
 
 #: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Beat sound"
+msgstr "Iskalnik udarcev"
+
+#: plug-ins/rhythmtrack.ny
 msgid "Metronome Tick"
 msgstr "Bitje metronoma"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Cowbell"
@@ -18089,6 +19532,37 @@ msgstr "Kravji zvonec"
 msgid "Resonant Noise"
 msgstr "Resonančni šum"
 
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Noise Click"
+msgstr "Tla šuma"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
 msgstr "Rissetov boben"
@@ -18096,6 +19570,10 @@ msgstr "Rissetov boben"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Tvorjenje Rissetovega bobna ..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18182,6 +19660,10 @@ msgstr "Postavitev kanalov za stereo"
 msgid "L-R on Same Line"
 msgstr "L-D na isti črti"
 
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
+
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
 msgid "L Channel First"
@@ -18194,6 +19676,11 @@ msgstr "Pokaži sporočila"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Samo napake"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18209,6 +19696,41 @@ msgstr "~%~%Desni kanal.~%~%"
 #, lisp-format
 msgid "~aData written to:~%~a"
 msgstr "~aPodatki zapisani v:~%~a"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18228,6 +19750,34 @@ msgstr "Analiza zvokovnih podatkov:"
 #, lisp-format
 msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
 msgstr "<b>Mera vzorčenja:</b> &nbsp;&nbsp;~a Hz."
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr "<b>Mera vzorčenja:</b> &nbsp;&nbsp;~a Hz."
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr "<b>Mera vzorčenja:</b> &nbsp;&nbsp;~a Hz."
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr "<b>Mera vzorčenja:</b> &nbsp;&nbsp;~a Hz."
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr "<b>Mera vzorčenja:</b> &nbsp;&nbsp;~a Hz."
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -18266,6 +19816,14 @@ msgid "Right (dB)"
 msgstr "Desno (dB)"
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Linearno"
 
@@ -18290,6 +19848,11 @@ msgstr "Ena vrstica na kanal.~%"
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left channel then Right channel on same line.~%"
+msgstr "Levi, nato desni kanal na isti črti.~%"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Left and right channels on alternate lines.~%"
 msgstr "Levi, nato desni kanal na isti črti.~%"
 
 #: plug-ins/sample-data-export.ny
@@ -18378,6 +19941,10 @@ msgid "Error.~%Track sample rate below 100 Hz is not supported."
 msgstr "Napaka.~%Mera vzorčenja steze pod 100 Hz ni podprta."
 
 #: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Izvajanje Tremola ..."
 
@@ -18404,6 +19971,10 @@ msgstr "Redukcija in izolacija vokalov"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Izvajanje dejanja …"
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18452,6 +20023,24 @@ msgstr "Nizka porezava za vokale (Hz)"
 #: plug-ins/vocalrediso.ny
 msgid "High Cut for Vocals (Hz)"
 msgstr "Visoka porezava za vokale (Hz)"
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -18520,8 +20109,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Ta vstavek deluje le s stereo stezami."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Obdelovanje vocoderja ..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18563,6 +20160,236 @@ msgstr "Frekvenca radarskih igel (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Napaka.~%Obvezna je stereo steza."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Posodobi Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Preskoči"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Namesti posodobitev"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Zapisnik sprememb"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Preberi več na GitHubu"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Napaka pri preverjanju obstoja posodobitev"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Povezovanje s strežnikom posodobitev Audacity ni uspelo."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Podatki posodobitve so okvarjeni."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Napaka pri prenašanju posodobitve."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Povezave za prenos Audacity ni moč odpreti."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Na voljo je Audacity %s!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Snemanje"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Id objave:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Čezplatformna knjižnica GUI"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Uvozi prek GStreamerja"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Bolj je ni bilo mogoče optimizirati. Še vedno je previsoka."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Samodejna prilagoditev ravni vhoda je znižala jakost na %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Bolj je ni bilo mogoče optimizirati. Še vedno je prenizka."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Samodejna prilagoditev ravni vhoda je zvišala jakost na %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Skupno število analiz je preseglo mejo brez določitve sprejemljive jakosti. Še vedno je previsoka."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. Skupno število analiz je preseglo mejo brez določitve sprejemljive jakosti. Še vedno je prenizka."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Samodejno prilagajanje ravni vhoda je ustavljeno. %.2f se zdi sprejemljiva jakost."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Prejeto %d med odpiranjem naprav\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Portmixer ni mogoče odpreti.\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Mešalniki na voljo:\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "%d – %s\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Viri snemanja na voljo:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Glasnosti predvajanja na voljo:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Glasnost snemanja je emulirana\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Glasnost snemanja je domorodna\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Glasnost predvajanja je emulirana\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Glasnost predvajanja je domorodna\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Datum in čas zaključka"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer - združljive datoteke"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Dekodirnika ni mogoče dodati v cevovod"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Uvoznik GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Ni mogoče nastaviti stanja toka na prekinjeno."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Kazalo[%02d] vrsta[%s], kanali[%d], mera[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Datoteka ne vsebuje nobenih zvočnih tokov."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Datoteke ni mogoče odpreti, sprememba stanja je spodletela."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Napaka GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Me&šalnik"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Prila&godi glasnost predvajanja ..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Z&višaj glasnost predvajanja"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Z&nižaj glasnost predvajanja"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Prilago&di glasnost snemanja ..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Zvi&šaj glasnost snemanja"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Zniža&j glasnost snemanja"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Priročnik za A&udacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&O programu Audacity ..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Sa&modejna prilagoditev ravni snemanja (vključeno/izključeno)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Samodejno prilagajanje ravni snemanja"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Omogoči samodejno prilagoditev ravni snemanja."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Ciljni vrh:"
+
+#~ msgid "Within:"
+#~ msgstr "V okviru:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Čas analize:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisekund (čas ene analize)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Število zaporednih analiz:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 pomeni neskončno"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Glasnost snemanja"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Glasnost predvajanja"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Glasnost snemanja: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Glasnost snemanja (ni na voljo; uporabite sistemski mešalnik)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Glasnost predvajanja: %.2f (emulirano)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Glasnost predvajanja: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Glasnost predvajanja (ni na voljo; uporabite sistemski mešalnik)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Vrstica me&šanja"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Kliknite in povlecite, da bi premaknili posnetek vzdolž časovne linije"
 
 #~ msgid "Program build date:"
 #~ msgstr "Datum izdelave programa:"

--- a/locale/sr.po
+++ b/locale/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:26+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/tenacity/tenacity/sr/>\n"
@@ -18,47 +18,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Изађи из Аудаситија"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Прескочи"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Канал"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Грешка приликом дешифровања датотеке"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Грешка учитавања метаподатака"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Трака алата Аудаситија %s"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Снимање"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Не могу да одредим"
@@ -67,6 +26,24 @@ msgstr "Не могу да одредим"
 #, c-format
 msgid "%s bytes"
 msgstr "%s бајта"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -193,7 +170,8 @@ msgid "Script"
 msgstr "Скрипта"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Излаз"
 
@@ -209,7 +187,12 @@ msgstr "Скрипте Никвиста (*.ny)|*.ny|Скрипте Лиспа (*
 msgid "Script was not saved."
 msgstr "Скрипта није сачувана."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Упозорење"
 
@@ -238,7 +221,8 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr "© 2009 Леланд Лусјус"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Спољни модул Аудаситија који обезбеђује једноставно ИДЕ за писање ефеката."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -261,7 +245,8 @@ msgstr "Без наслова"
 msgid "Nyquist Effect Workbench - "
 msgstr "Радни сто Никвист ефекта — "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Ново"
 
@@ -301,7 +286,8 @@ msgstr "Умножите"
 msgid "Copy to clipboard"
 msgstr "Умножите у оставу"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Исеци"
 
@@ -309,7 +295,8 @@ msgstr "Исеци"
 msgid "Cut to clipboard"
 msgstr "Исеците у оставу"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Убаци"
 
@@ -334,7 +321,8 @@ msgstr "Изабери све"
 msgid "Select all text"
 msgstr "Изаберите сав текст"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Поништите"
 
@@ -342,7 +330,8 @@ msgstr "Поништите"
 msgid "Undo last change"
 msgstr "Опозовите последњу измену"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Вратите"
 
@@ -399,7 +388,8 @@ msgid "Go to next S-expr"
 msgstr "Идите на следећи С-израз"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Почетак"
 
@@ -407,7 +397,8 @@ msgstr "Почетак"
 msgid "Start script"
 msgstr "Покрените скрипту"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Заустави"
 
@@ -422,7 +413,8 @@ msgid "About %s"
 msgstr "О програму „%s“"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "У реду"
 
@@ -430,17 +422,25 @@ msgstr "У реду"
 msgid "Build Information"
 msgstr "Укључи информације заглавља"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "&Укључене"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "&Искључене"
 
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Наредба:"
+msgid "The Build"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Version:"
+msgstr "Издање"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -451,8 +451,31 @@ msgid "Compiler:"
 msgstr "Сажиматељ"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "&Подешавања"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "&Подешавања"
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -463,12 +486,15 @@ msgstr "Претварач протока &узорка:"
 msgid "MP3 Importing"
 msgstr "Увозим %s"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Увоз / извоз"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "ID3 tag support"
+msgstr "Прикључци су освежени:"
+
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Увоз / извоз"
@@ -478,20 +504,38 @@ msgid "MP2 export"
 msgstr "Извезите"
 
 #: src/AboutDialog.cpp
-msgid "FFmpeg Import/Export"
-msgstr "Библиотека увоза/извоза ФФмпег-а"
+#, fuzzy
+msgid "Import via QuickTime"
+msgstr "Увези сирове податке"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Увези сирове податке"
+msgid "FFmpeg Import/Export"
+msgstr "Библиотека увоза/извоза ФФмпег-а"
 
 #: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Прикључци су освежени:"
 
 #: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Pitch and Tempo Change support"
 msgstr "Почетна промена такта (%)"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Extreme Pitch and Tempo Change support"
+msgstr "Почетна промена такта (%)"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "GPL License"
+msgstr ""
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -606,6 +650,10 @@ msgstr "%s, графика"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (обухвата %s, %s, %s, %s и %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -617,13 +665,33 @@ msgid "Credits"
 msgstr "Заслуге"
 
 #: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
+
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "DarkTenacity Customisation"
 msgstr "Прилагођавање тамног Аудаситија"
 
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s Contributors"
+msgstr "%s, веб програмер"
+
+#: src/AboutDialog.cpp
+msgid "Tenacity Special thanks:"
+msgstr ""
+
 #: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
 msgid "Libraries"
 msgstr "Библиотека"
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s includes code from the following projects:"
+msgstr ""
 
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
@@ -635,11 +703,20 @@ msgstr "Чланови тима %s-ја"
 msgid "Emeritus:"
 msgstr "Почк."
 
+#: src/AboutDialog.cpp
+msgid "Contributors"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
+
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -649,6 +726,36 @@ msgstr ""
 #: src/AboutDialog.cpp
 msgid "Translators"
 msgstr "Пренос"
+
+#: src/AboutDialog.cpp
+msgid "Special thanks:"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s website: "
+msgstr ""
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr ""
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
@@ -667,6 +774,7 @@ msgstr "Време"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Притисните и превуците да измените узорке"
@@ -674,6 +782,7 @@ msgstr "Притисните и превуците да измените узо�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Притисните и превуците да промените величину траке алата"
@@ -681,6 +790,16 @@ msgstr "Притисните и превуците да промените ве�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr "Померите показивач миша за премотавање"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Премести на &следећи натпис"
@@ -688,13 +807,30 @@ msgstr "Премести на &следећи натпис"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Померите показивач миша за прочишћавање"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub. Drag to Seek."
 msgstr "Померите показивач миша за премотавање"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Quick-Play disabled"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Quick-Play enabled"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
@@ -720,7 +856,23 @@ msgstr "Откључајте област пуштања"
 msgid "Pinned Play Head"
 msgstr "Прикачена &глава пуштања/снимања (укљ./искљ.)"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Грешка.n"
 
@@ -734,8 +886,36 @@ msgid "Failed!"
 msgstr "Неуспех"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Поставке Аудаситија"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Tenacity is starting up..."
+msgstr ""
 
 #. i18n-hint: "New" is an action (verb) to create a NEW project
 #: src/AudacityApp.cpp src/BatchProcessDialog.cpp src/menus/FileMenus.cpp
@@ -751,7 +931,7 @@ msgstr "Отвори изборник..."
 msgid "Open &Recent..."
 msgstr "Отвори скорашње"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "О Аудаситију"
@@ -765,7 +945,38 @@ msgid "&File"
 msgstr "Датотека"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+msgid ""
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Please enter an appropriate directory in the preferences dialog."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity could not find a place to store temporary files.\n"
+"Please enter an appropriate directory in the preferences dialog."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Running two copies of Tenacity simultaneously may cause\n"
+"data loss or cause your system to crash.\n"
+"\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Да ли желите да сачувате измене?"
 
 #: src/AudacityApp.cpp
@@ -773,12 +984,74 @@ msgid "Error Locking Temporary Folder"
 msgstr "Грешка приликом дешифровања датотеке"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+msgid "The system has detected that another copy of Tenacity is running.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Use the New or Open commands in the currently running Tenacity\n"
+"process to open multiple projects simultaneously.\n"
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Прво покретање Аудаситија"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Аудаситијева датотека ВСТ претподешености"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
 
 #. i18n-hint: This displays a list of available options
 #: src/AudacityApp.cpp
@@ -792,7 +1065,8 @@ msgstr "&Дијагностика"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Добро дошли у Аудасити издање %s"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -802,36 +1076,78 @@ msgid "audio or project file name"
 msgstr "Не могу да отворим датотеку пројекта"
 
 #: src/AudacityApp.cpp
+msgid ""
+"Audacity project (.aup3) files are not currently \n"
+"associated with Tenacity. \n"
+"\n"
+"Associate them, so they open on double-click?"
+msgstr ""
+
+#: src/AudacityApp.cpp
 msgid "Audacity Project Files"
 msgstr "Пројекти Аудаситија"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Порука..."
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Прилагођавање тамног Аудаситија"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "По&моћ"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Изађи из Аудаситија"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Аудасити"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "Сачувај као..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "Затвори"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -843,44 +1159,53 @@ msgid "Couldn't save log to file: %s"
 msgstr "Не могу да пишем у датотеку: %s"
 
 #: src/AudioIO.cpp
+msgid "Could not find any audio devices.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid ""
+"You will not be able to play or record audio.\n"
+"\n"
+msgstr ""
+
+#: src/AudioIO.cpp
 #, c-format
 msgid "Error: %s"
 msgstr "Грешка.~%"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "Error Initializing Audio"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+msgid "Error Initializing Midi"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Аудасити"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Није било могуће оптимизовати га више. И даље је исувише низак."
-
-#: src/AudioIO.cpp
+#: src/AudioIO.cpp src/ProjectAudioManager.cpp
 #, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Дотеривање нивоа осамостаљеног снимања је смањило јачину звука на %f."
+msgid ""
+"Error opening recording device.\n"
+"Error code: %s"
+msgstr ""
 
 #: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Није било могуће оптимизовати га више. И даље је исувише низак."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Дотеривање нивоа осамостаљеног снимања је повећало јачину звука на %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Укупан број анализа је прекорачен без проналажења прихватљиве јачине звука. И даље је исувише висок."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Укупан број анализа је прекорачен без проналажења прихватљиве јачине звука. И даље је исувише низак."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. %.2f изгледа прихватљива јачина звука."
+msgid "Out of memory!"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -979,48 +1304,6 @@ msgstr "Нисам нашао уређај пуштања за „%s“.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Не могу да проверим узајамне протоке узорака без оба уређаја.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Примих %d приликом отварања уређаја\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Не могу да отворим Портмиксер\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Доступни миксери:\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d – %s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Доступни извори снимања:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Доступне гласности пуштања:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Гласност снимања је опонашајна\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Гласност снимања је изворна\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Гласност пуштања је опонашајна\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Гласност пуштања је изворна\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1063,8 +1346,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Самостални опоравак после пада"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1077,12 +1361,14 @@ msgid "Recoverable &projects"
 msgstr "Пројекти за &опоравак"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Бирање"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Назив"
 
@@ -1168,6 +1454,11 @@ msgstr "Ефекат"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Наредба изборника (са параметрима)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1313,7 +1604,8 @@ msgstr "&Врати"
 msgid "I&mport..."
 msgstr "&Увези..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Извези..."
 
@@ -1354,7 +1646,8 @@ msgstr "Премести &горе"
 msgid "Move &Down"
 msgstr "Премести &доле"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Сачувај"
 
@@ -1437,7 +1730,8 @@ msgid "Run"
 msgstr "Покрени"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Затвори"
 
@@ -1583,9 +1877,14 @@ msgid "No revision identifier was provided"
 msgstr "Није достављен одредник ревизије"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Датум и време заустављања"
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
 
 #: src/BuildInfo.h
 #, fuzzy
@@ -1841,10 +2140,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ако наставите, ваш пројекат неће бити сачуван на диск. Да ли је то оно што желите?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1858,7 +2158,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Провера зависности"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ништа"
 
@@ -1866,7 +2169,7 @@ msgstr "Ништа"
 msgid "Rectangle"
 msgstr "Правоугаони"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Троугаони"
 
@@ -1928,9 +2231,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "ФФмпег подршка није састављена"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1952,8 +2256,8 @@ msgid "Locate FFmpeg"
 msgstr "Пронађи ФФмпег"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Аудасити захтева датотеку „%s“ да би увозио и извозио звук путем ФФмпег-а."
 
 #: src/FFmpeg.cpp
@@ -1966,7 +2270,8 @@ msgstr "„%s“ се налази у:"
 msgid "To find '%s', click here -->"
 msgstr "Да пронађете „%s“, притисните овде >>>"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Разгледај..."
 
@@ -1992,8 +2297,9 @@ msgid "FFmpeg not found"
 msgstr "Нисам нашао ФФмпег"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2023,24 +2329,24 @@ msgid "Only libavformat.so"
 msgstr "Само „libavformat.so“"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Аудасити није успео да отвори датотеку у „%s“."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Аудасити није успео да чита из датотеке у „%s“."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Аудасити је успешно записао датотеку у „%s“ али није успео да је преименује у „%s“."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2078,7 +2384,9 @@ msgstr "&Немој умножавати никакав звук"
 msgid "As&k"
 msgstr "&Питај"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Све датотеке"
 
@@ -2103,6 +2411,10 @@ msgstr "Датотеке текста"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "ХМЛ датотеке"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2167,6 +2479,17 @@ msgstr "Линеарна учесталост"
 msgid "Log frequency"
 msgstr "Логаритамска учесталост"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Клизање"
@@ -2174,6 +2497,15 @@ msgstr "Клизање"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Зумирање"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2234,6 +2566,23 @@ msgstr "Превише звука је изабрано. Само прве %.1f 
 msgid "Not enough data selected."
 msgstr "Није изабрано довољно података."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%.4f сек. (%d Hz) (%s) = %f"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%.4f сек. (%d Hz) (%s) = %.3f"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2256,7 +2605,8 @@ msgstr "спектар.txt"
 msgid "Export Spectral Data As:"
 msgstr "Извези податке спектра као:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Не могу да пишем у датотеку: %s"
@@ -2446,19 +2796,19 @@ msgid "&History..."
 msgstr "&Историјат..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Унутрашња грешка у „%s“ на „%s“ ред %d.\n"
 "Обавестите тим Аудаситија на „https://forum.audacityteam.org/“."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Унутрашња грешка на „%s“ ред %d.\n"
 "Обавестите тим Аудаситија на „https://forum.audacityteam.org/“."
@@ -2477,7 +2827,9 @@ msgid "Track"
 msgstr "Нумера"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Натпис"
 
@@ -2537,7 +2889,8 @@ msgstr "Унесите назив нумере"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Натпис нумере"
 
@@ -2548,11 +2901,13 @@ msgstr "Не могу да прочитам један или више сачу�
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Прво покретање Аудаситија"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Изаберите језик који ће да користи Аудасити:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2562,7 +2917,8 @@ msgstr "Изаберите језик који ће да користи Ауда
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Језик који сте изабрали, %s (%s), није исти као језик на систему, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Потврди"
 
@@ -2580,12 +2936,13 @@ msgstr ""
 "Стара датотека је сачувана као „%s“"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Отварам пројекат Аудаситија"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Караоке%s Аудаситија"
 
 #: src/LyricsWindow.cpp
@@ -2636,19 +2993,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Мешам и исцртавам нумере"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Табла мешача%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Појачање"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Брзина"
 
@@ -2657,17 +3018,23 @@ msgid "Musical Instrument"
 msgstr "Музички инструмент"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Каналисање"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Утишај"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Соло"
 
@@ -2675,15 +3042,18 @@ msgstr "Соло"
 msgid "Signal Level Meter"
 msgstr "Мерач нивоа сигнала"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Померен је клизач појачања"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Померен је клизач брзине"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Померен је клизач каналисања"
 
@@ -2718,9 +3088,9 @@ msgstr ""
 "Неће бити учитан."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2754,16 +3124,19 @@ msgstr ""
 "\n"
 "Користите модуле само из поверљивих извора"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Да"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Не"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Учитавач модула Аудаситија"
 
 #: src/ModuleManager.cpp
@@ -2786,6 +3159,117 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Прибележи нумеру"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+#, fuzzy
+msgid "C"
+msgstr "ЛЦ"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2896,7 +3380,8 @@ msgstr "Изабери &све"
 msgid "C&lear All"
 msgstr "&Очисти све"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Укључи"
 
@@ -2976,9 +3461,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Протоци узорковања се не поклапају"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Премало нумера је изабрано за снимање у овом протоку узорка.\n"
@@ -3007,10 +3493,11 @@ msgid "Dropouts"
 msgstr "Одбачај"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3050,11 +3537,11 @@ msgid "Inspecting project file data"
 msgstr "Надгледам податке датотеке пројекта"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3097,11 +3584,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Упозорење — Недостајуће алијазоване датотеке"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Провера пројекта за фасциклу „%s“ је\n"
@@ -3126,12 +3613,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Упозорење — Недостаје датотека сажетка алијаса"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3189,7 +3676,8 @@ msgstr "Упозорење — Напуштена блок датотека"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Напредак"
 
@@ -3214,6 +3702,11 @@ msgstr "Упозорење: Проблем у самосталном опора�
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<без наслова>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Пројекат %02i] Аудасити „%s“"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3270,13 +3763,22 @@ msgstr ""
 "\n"
 "%s"
 
+#. i18n-hint: An error message.
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Ово није датотека Аудасити пројекта"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3286,6 +3788,67 @@ msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Не могу да покренем датотеку пројекта"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не могу да покренем датотеку пројекта"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не могу да покренем датотеку пројекта"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не могу да покренем датотеку пројекта"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не могу да покренем датотеку пројекта"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не могу да покренем датотеку пројекта"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Не могу да покренем датотеку пројекта"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Не могу да покренем датотеку пројекта"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -3340,9 +3903,9 @@ msgid "Error Writing to File"
 msgstr "Грешка писања у датотеку"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3356,12 +3919,15 @@ msgstr "Сажимам пројекат"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Пројекат %02i] Аудасити „%s“"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Аудасити"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -3371,10 +3937,10 @@ msgstr "(опорављено)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Ова датотека је сачувана употребом Аудаситија %s.\n"
 "Ви користите Аудасити %s. Морате да надоградите на новије издање да бисте отворили ову датотеку."
@@ -3446,8 +4012,9 @@ msgid "Backing up project"
 msgstr "Правим резерву пројекта"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3456,8 +4023,9 @@ msgstr ""
 "Опорављен је на последње сачувано стање."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3536,8 +4104,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sСачувај пројекат „%s“ као..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "„Сачувај пројекат“ је за пројекат Аудаситија, а не за звучну датотеку.\n"
@@ -3614,11 +4183,12 @@ msgid "Error Opening Project"
 msgstr "Грешка отварања пројекта"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Покушавате да отворите самостално направљену датотеку резерве.\n"
 "То може да проузрокује озбиљно губљење података.\n"
@@ -3727,8 +4297,8 @@ msgid "Automatic database backup failed."
 msgstr "Самостално прављење резерве базе података није успело."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Добро дошли у Аудасити издање %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3945,7 +4515,8 @@ msgstr "Све поставке"
 msgid "SelectionBar"
 msgstr "Линија избора"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Избор спектра"
 
@@ -3953,46 +4524,55 @@ msgstr "Избор спектра"
 msgid "Timer"
 msgstr "Одбројавач"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Алати"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Пренос"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Мешач"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Мерач"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Мерач пуштања"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Мерач снимања"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Уређивање"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Уређај"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Пусти-при-брзини"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Прочишћавање"
 
@@ -4007,7 +4587,10 @@ msgstr "Лењир"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Нумере"
 
@@ -4117,7 +4700,8 @@ msgid "Activation level (dB):"
 msgstr "Ниво покретања (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Добро дошли у Аудасити!"
 
 #: src/SplashDialog.cpp
@@ -4264,9 +4848,9 @@ msgstr ""
 "За савете о прикладним уређајима, кликните на дугме за помоћ."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Аудасити не може да запише датотеку:\n"
@@ -4286,9 +4870,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4297,9 +4881,9 @@ msgstr ""
 "за писање."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Аудасити не може да запише слике у датотеку:\n"
@@ -4316,9 +4900,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4328,9 +4912,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4339,8 +4923,9 @@ msgstr ""
 "Можда је лош пнг формат?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Аудасити не може да прочита своју основну тему.\n"
@@ -4378,9 +4963,9 @@ msgstr ""
 "бејаху већ присутне. Да их препишем?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Аудасити не може да сачува датотеку:\n"
@@ -4419,7 +5004,11 @@ msgstr "Произвољна"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Трајање"
 
@@ -4430,7 +5019,8 @@ msgid "Time Track"
 msgstr "Праћење времена"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Временско снимање Аудаситија"
 
 #: src/TimerRecordDialog.cpp
@@ -4504,7 +5094,8 @@ msgstr "Текући пројекат"
 msgid "Recording start:"
 msgstr "Почетак снимања:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Трајање:"
 
@@ -4525,7 +5116,8 @@ msgid "Action after Timer Recording:"
 msgstr "Радња након временског снимања:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Напредак временског снимања Аудаситија"
 
 #: src/TimerRecordDialog.cpp
@@ -4621,6 +5213,7 @@ msgstr "099 дана 024 ч 060 м 060 с"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Датум и време покретања"
@@ -4665,7 +5258,8 @@ msgstr "Да укључим самостални извоз?"
 msgid "Export Project As:"
 msgstr "Извези пројекат као:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Опције"
 
@@ -4678,7 +5272,8 @@ msgid "Do nothing"
 msgstr "Не ради ништа"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Изађи из Аудаситија"
 
 #: src/TimerRecordDialog.cpp
@@ -4702,7 +5297,8 @@ msgid "Scheduled to stop at:"
 msgstr "Заустављање је заказано за:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Временско снимање Аудаситија — чекам да започнем"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4728,7 +5324,8 @@ msgid "Recording Exported:"
 msgstr "Снимање је извезено:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Временско снимање Аудаситија — чекам"
 
 #: src/TrackInfo.cpp
@@ -4924,6 +5521,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Примењујем „%s“..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "НЕУСПЕХ"
@@ -4942,13 +5549,15 @@ msgstr "„%s“ није параметар кога прихвата „%s“"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Неисправна вредност за параметар „%s“: треба бити „%s“"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Наредба"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Понови %s"
@@ -5075,7 +5684,8 @@ msgstr "Одсецања"
 msgid "Envelopes"
 msgstr "Омотнице"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Натписа"
 
@@ -5101,7 +5711,8 @@ msgstr "Кратко"
 msgid "Type:"
 msgstr "Врста:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Формат:"
 
@@ -5128,6 +5739,10 @@ msgstr "Напомена"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Наредба:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5165,12 +5780,17 @@ msgstr "Извезите у датотеку."
 msgid "Builtin Commands"
 msgstr "Уграђене наредбе"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Тим Аудаситија"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Обезбеђује уграђене наредбе у Аудаситију"
 
 #: src/commands/LoadCommands.cpp
@@ -5233,7 +5853,10 @@ msgstr "Очистите садржај дневника."
 msgid "Get Preference"
 msgstr "Добави поставке"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Назив:"
 
@@ -5281,7 +5904,8 @@ msgstr "Цео екран"
 msgid "Toolbars"
 msgstr "Траке алата"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Ефекти"
 
@@ -5421,7 +6045,8 @@ msgstr "Подеси"
 msgid "Add"
 msgstr "Додај"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Уклони"
 
@@ -5506,7 +6131,8 @@ msgid "Edited Envelope"
 msgstr "Поставите омотницу"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Омотница"
 
@@ -5606,7 +6232,10 @@ msgstr "Каналисање:"
 msgid "Set Track Visuals"
 msgstr "Поставите видност нумере"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Линеарна"
 
@@ -5649,6 +6278,12 @@ msgstr "Користите преференце спектра"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Избор спектра"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5704,12 +6339,18 @@ msgstr "Изабрали сте нумеру која не садржи звук
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Самоутишавање захтева управљачку нумеру која мора бити постављена испод изабране нумере."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Износ &утишања:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "секунде"
 
@@ -5733,7 +6374,8 @@ msgstr "Трајање &унутрашњег ишчезавања:"
 msgid "Inner &fade up length:"
 msgstr "Трајање унутрашњег &појављивања:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Осетљивост:"
 
@@ -5871,11 +6513,13 @@ msgstr "до (Hz)"
 msgid "t&o"
 msgstr "&до"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Проценат &промене:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Проценат промене"
 
@@ -5883,9 +6527,23 @@ msgstr "Проценат промене"
 msgid "&Use high quality stretching (slow)"
 msgstr "Користи &растезање високог квалитета (споро)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "неприменљиво"
 
@@ -5913,6 +6571,7 @@ msgstr "Стандардна Винил о/м:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Са о/м"
@@ -5925,6 +6584,7 @@ msgstr "&од"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "На о/м"
@@ -6067,6 +6727,12 @@ msgstr "Сажиматељ"
 msgid "Compresses the dynamic range of audio"
 msgstr "Сажмите динамички опсег звука"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6076,6 +6742,20 @@ msgstr "%.2f сек."
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f сек."
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6192,7 +6872,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Анализатор супротности, за мерење СКК разлика јачине звука између два избора звука."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Крај"
 
@@ -6257,6 +6938,12 @@ msgstr "По&моћ"
 #, c-format
 msgid "RMS = %s."
 msgstr "СКК = %s."
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "zero"
@@ -6326,6 +7013,12 @@ msgstr "Тренутне разлике"
 msgid "Measured foreground level"
 msgstr "Ниво измереног прочеља"
 
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB СКК"
+
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
 msgstr "Није измерено прочеље"
@@ -6393,6 +7086,12 @@ msgstr "Мерило успеха 1.4.7 ВЦАГ-а 2.0: неуспешно"
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
 msgstr "Прикупљени подаци"
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
@@ -6672,7 +7371,9 @@ msgstr "ДТМФ &низ:"
 msgid "&Amplitude (0-1):"
 msgstr "&Досег (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Трајање:"
 
@@ -6685,12 +7386,29 @@ msgid "Duty cycle:"
 msgstr "Радни циклус:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f сек."
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Трајање тона:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Трајање тишине:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -6700,7 +7418,8 @@ msgstr "Одјек"
 msgid "Repeats the selected audio again and again"
 msgstr "Понављајте изабрани звук без прекида"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Затражена вредност превазилази могућност меморије."
 
@@ -6724,7 +7443,8 @@ msgstr "Претподешености"
 msgid "Export Effect Parameters"
 msgstr "Извезите параметре ефекта"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Не могу да отворим датотеку: „%s“"
@@ -7141,12 +7861,41 @@ msgid "Effect Unavailable"
 msgstr "Ефекат није доступан"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Највише dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Најмање dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7475,7 +8224,8 @@ msgid "Builtin Effects"
 msgstr "Уграђени ефекти"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Обезбеђује уграђене ефекте у Аудаситију"
 
 #: src/effects/LoadEffects.cpp
@@ -7705,8 +8455,9 @@ msgid "Step 1"
 msgstr "Корак 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Изаберите неколико секунди чисте буке тако да Аудасити зна шта да избаци,\n"
@@ -7758,13 +8509,62 @@ msgstr "&Врсте прозора:"
 msgid "Window si&ze:"
 msgstr "&Величина прозора:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (основно)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "&Корака по прозору:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7890,6 +8690,7 @@ msgstr "Полстреч је само за екстремно временск�
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "&Фактор развлачења:"
@@ -8332,6 +9133,11 @@ msgstr "Користи основно"
 msgid "Restore Defaults"
 msgstr "Поврати оосновно"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8490,6 +9296,10 @@ msgstr "Откриј тишину"
 msgid "Tr&uncate to:"
 msgstr "&Скрати на:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "&Сажми на:"
@@ -8503,7 +9313,8 @@ msgid "VST Effects"
 msgstr "ВСТ ефекти"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Додаје могућност коришћења ВСТ ефеката у Аудаситију."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8515,7 +9326,8 @@ msgstr "Прегледам ВСТ шкољку"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Бележим %d од %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Не могу да учитам збирку"
 
@@ -8535,7 +9347,8 @@ msgstr "Величина међумеморије контролише број 
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Величина међумеморије (од 8 до 1048576 узорка):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Надокнада кашњења"
 
@@ -8543,7 +9356,8 @@ msgstr "Надокнада кашњења"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "Као део њихове обраде, неки ВСТ ефекти морају одложити враћање звука у Аудасити. Када не надокнађују ово кашњење, приметићете да су у звук убачене мале тишине. Омогућавање ове опције обезбедиће ту надокнаду, али можда неће успети за све ВСТ ефекте."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Укључи &надокнаду"
 
@@ -8577,7 +9391,8 @@ msgid "Standard VST program file"
 msgstr "Стандардна датотека ВСТ програма"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Аудаситијева датотека ВСТ претподешености"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8604,7 +9419,8 @@ msgstr "Грешка учитавања ВСТ претподешености"
 msgid "Unable to load presets file."
 msgstr "Не могу да учитам датотеку претподешености."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Подешавања ефеката"
 
@@ -8661,7 +9477,8 @@ msgid "Audio Unit Effects"
 msgstr "Ефекти звучне јединице"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Обезбеђује Аудаситију подршку ефеката звучне јединице"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8677,7 +9494,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Подешавања ефеката звучне јединице"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "Као део њихове обраде, неки ефекти звучне јединице морају одложити враћање звука у Аудасити. Када не надокнађују ово кашњење, приметићете да су у звук убачене мале тишине. Омогућавање ове опције обезбедиће ту надокнаду, али можда неће успети за све ефекте звучне јединице."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8821,6 +9639,7 @@ msgstr "Звучна јединица"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "ЛАДСПА ефекти"
@@ -8830,7 +9649,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Обезбеђује ЛАДСПА ефекте"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Аудасити више не користи „vst-bridge“"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -8838,8 +9658,18 @@ msgid "LADSPA Effect Options"
 msgstr "Подешавања ЛАДСПА ефеката"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "Као део њихове обраде, неки ЛАДСПА ефекти морају одложити враћање звука у Аудасити. Када не надокнађују ово кашњење, приметићете да су у звук убачене мале тишине. Омогућавање ове опције обезбедиће ту надокнаду, али можда неће успети за све ЛАДСПА ефекте."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s након:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -8847,6 +9677,7 @@ msgstr "Излаз ефекта"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "ЛАДСПА"
@@ -8861,7 +9692,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Величина међумеморије (од 8 до %d) узорка:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "Као део њихове обраде, неки ЛВ2 ефекти морају одложити враћање звука у Аудасити. Када не надокнађују ово кашњење, приметићете да су у звук убачене мале тишине. Омогућавање ове поставке обезбедиће ту надокнаду, али можда неће успети за све ЛВ2 ефекте."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -8897,7 +9729,8 @@ msgid "LV2 Effects"
 msgstr "ЛВ2 ефекти"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Обезбеђује Аудаситију подршку ЛВ2 ефекта"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8905,7 +9738,8 @@ msgid "Nyquist Effects"
 msgstr "Никвист ефекти"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Обезбеђује Аудаситију подршку Никвист ефеката"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8920,6 +9754,12 @@ msgstr "Радник Никвиста"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Лоше формирано заглавље прикључка Никвиста"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -9125,7 +9965,8 @@ msgstr "Изаберите датотеку"
 msgid "Save file as"
 msgstr "Сачувајте датотеку као"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "без наслова"
 
@@ -9134,7 +9975,8 @@ msgid "Vamp Effects"
 msgstr "Вамп ефекти"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Обезбеђује Аудаситију подршку Вамп ефеката"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9462,7 +10304,8 @@ msgstr "Извозим звук као „%s“"
 msgid "Invalid sample rate"
 msgstr "Неисправан проток узорка"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Поново узоркуј"
 
@@ -9494,7 +10337,8 @@ msgstr "Протоци узорка"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d kb/s"
@@ -9512,6 +10356,42 @@ msgstr "Квалитет (kb/s):"
 #, c-format
 msgid "%.2f kbps"
 msgstr "%.2f kb/s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9536,6 +10416,27 @@ msgstr "Слабо кашњење"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "2.5 ms"
 msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "5 ms"
+msgstr "2,5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -10197,7 +11098,8 @@ msgstr "Нездраво"
 msgid "Extreme"
 msgstr "Сулудо"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Обично"
 
@@ -10248,8 +11150,8 @@ msgid "Locate LAME"
 msgstr "Пронађи ЛАМЕ"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Аудаситију је потребна датотека „%s“ да би направио МП3."
 
 #: src/export/ExportMP3.cpp
@@ -10277,10 +11179,10 @@ msgid "Where is %s?"
 msgstr "Где се налази „%s“?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Ви указујете на „lame_enc.dll v%d.%d“. Ово издање није сагласно са Аудаситијем %d.%d.%d.\n"
 "Преузмите најновије издање ЛАМЕ-а за Аудасити."
@@ -10606,9 +11508,10 @@ msgid "Other uncompressed files"
 msgstr "Остале несажете датотеке"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Покушали сте да извезете ВАВ или АИФФ датотеку која би била већа од 4GB.\n"
 "Аудасити не може то да уради, извоз је прекинут."
@@ -10618,8 +11521,9 @@ msgid "Error Exporting"
 msgstr "Грешка извоза"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Ваша извезена ВАВ датотека је скраћена јер Аудасити не може да извезе ВАВ\n"
@@ -10659,11 +11563,11 @@ msgid "All supported files"
 msgstr "Све подржане датотеке"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "„%s“ \n"
@@ -10672,11 +11576,11 @@ msgstr ""
 "да је уређујете кликом на „Датотека > Увези > МИДИ“."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "„%s“ \n"
 "није звучна датотека. \n"
@@ -10687,18 +11591,18 @@ msgid "Select stream(s) to import"
 msgstr "Изаберите ток(ове) за увоз"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Ово издање Аудаситија није састављено са %s подршком."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "„%s“ је нумера звучног ЦД-а. \n"
 "Аудасити не може да отвори звучни ЦД директно. \n"
@@ -10707,10 +11611,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "„%s“ је датотека листе нумера. \n"
@@ -10719,10 +11623,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ је датотека звука Виндоуз медија (WMA). \n"
@@ -10731,10 +11635,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ је датотека Напредног кодирања звука (AAC).\n"
@@ -10743,12 +11647,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "„%s“ је шифрована звучна датотека. \n"
@@ -10759,10 +11663,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ је медијска датотека РилПлејера. \n"
@@ -10771,12 +11675,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "„%s“ је датотека заснована на нотама, а не звучна датотека. \n"
 "Аудасити не може да отвори ову врсту датотеке. \n"
@@ -10785,10 +11689,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10801,10 +11705,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ је Вејвпак звучна датотека. \n"
@@ -10813,10 +11717,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ је Долби дигитал звучна датотека. \n"
@@ -10825,10 +11729,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ је Огг Спикс звучна датотека. \n"
@@ -10837,10 +11741,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "„%s“ је видео датотека. \n"
@@ -10854,9 +11758,9 @@ msgstr "Нашао сам датотеку „%s“."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -10872,11 +11776,16 @@ msgstr ""
 "Покушајте да инсталирате ФФмпег.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, испробавач"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10906,12 +11815,13 @@ msgid "Import Project"
 msgstr "Увези пројекат"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Овај пројекат је сачуван Аудаситијем 1.0 или ранијин. Формат је\n"
 "измењен и ово издање Аудаситија не може да увезе пројекат.\n"
@@ -10962,7 +11872,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Не могу да пронађем фасциклу података пројекта: „%s“"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Нађох МИДИ нумере у датотеци пројекта, али ова изградња Аудаситија не укључује МИДИ подршку, заобилазим нумеру."
 
 #: src/import/ImportAUP.cpp
@@ -11067,40 +11978,6 @@ msgstr "Индекс[%02x] Кодек[%s], Језик[%s], Битски прот
 msgid "FLAC files"
 msgstr "ФЛАЦ датотеке"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Датотеке сагласне са Гстримером"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Не могу да додам декодер на спојку"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Увозник Гстримера"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Не могу да поставим стање тока на паузирано."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Индекс[%02x] Врста[%s], Број канала[%d], Проток[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Датотека не садржи токове звука."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Не могу да увезем датотеку, промена стања није успела."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Грешка Гстримера: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Списак датотека у основном формату текста"
@@ -11203,6 +12080,10 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "ВАВ, АИФФ и остале несажете врсте"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "AVR (Audio Visual Research)"
 msgstr "AVR (Визуелна претрага звука)"
 
@@ -11240,12 +12121,20 @@ msgid "OGG (OGG Container format)"
 msgstr "OGG (ОГГ садржник формата)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "PVF (Portable Voice Format)"
 msgstr "PVF (Преносни формат гласа)"
 
 #: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (сирови)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "SD2 (Sound Designer II)"
@@ -11260,12 +12149,28 @@ msgid "SF (Berkeley/IRCAM/CARL)"
 msgstr "SF (Беркли/IRCAM/CARL)"
 
 #: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAVEX (Мајкрософт)"
 
 #: src/import/ImportPCM.cpp
 msgid "WVE (Psion Series 3)"
 msgstr "WVE (Psion серија 3)"
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11296,8 +12201,32 @@ msgid "64 bit float"
 msgstr "64 бита покретног зареза"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "Microsoft ADPCM"
 msgstr "Мајкрософт ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
@@ -11310,6 +12239,10 @@ msgstr "16 бита DWVW"
 #: src/import/ImportPCM.cpp
 msgid "24 bit DWVW"
 msgstr "24 бита DWVW"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
@@ -11456,6 +12389,7 @@ msgstr "%s десно"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11480,6 +12414,7 @@ msgstr "крај"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11508,7 +12443,8 @@ msgstr "Временски померени одсечци на десно"
 msgid "Time shifted clips to the left"
 msgstr "Временски померени одсечци на лево"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Померање времена"
 
@@ -11646,7 +12582,8 @@ msgstr "Скратите изабране звучне нумере са %.2f с
 msgid "Trim Audio"
 msgstr "Скрати звук"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Подели"
 
@@ -11769,34 +12706,6 @@ msgstr "Тастер брисања&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "&Екстра"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "М&ешач"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "&Дотерај јачину звука пуштања..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Повећај јачину звука пуштања"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Смањи јачину звука пуштања"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Дотерај јачину звука &снимања..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "&Повећај јачину звука снимања"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "&Смањи јачину звука снимања"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12064,8 +12973,9 @@ msgid "&Getting Started"
 msgstr "&Почнимо"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Упутство Аудаситија"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Упутство..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12091,11 +13001,8 @@ msgstr "Подаци о &МИДИ уређају..."
 msgid "Show &Log..."
 msgstr "Прикажи &дневник..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "О Аудаситију"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Натпис је додат"
 
@@ -12343,6 +13250,11 @@ msgstr "Окини нумеру у &фокусу"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Неразврстано"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Ново..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12781,6 +13693,7 @@ msgstr "Дуги скок кур&зора десно"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Пре&мотај"
@@ -12992,18 +13905,21 @@ msgid "Created new label track"
 msgstr "Створена је нова натписна нумера"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Ово издање Аудаситија допушта само једну временску нумеру за сваки прозор пројекта."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Створена је нова временска нумера"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Нови проток узорка (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Унета вредност је неисправна"
 
@@ -13260,7 +14176,9 @@ msgstr "Пуштам"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Снимање"
 
@@ -13409,10 +14327,6 @@ msgstr "&Надосними (укљ./иск.)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "&Софтверско пуштање (укљ./иск.)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Осамостаљено &дотеривање нивоа снимања (укљ./иск.)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13628,7 +14542,7 @@ msgstr "Поставке за квалитет"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Изађи из Аудаситија"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13675,7 +14589,8 @@ msgstr "&Домаћин:"
 msgid "Using:"
 msgstr "Користи:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Пуштање"
 
@@ -13695,7 +14610,8 @@ msgstr "Број &канала:"
 msgid "Latency"
 msgstr "Кашњење"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "милисек."
 
@@ -13724,7 +14640,8 @@ msgid "2 (Stereo)"
 msgstr "2 (Стерео)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Директоријуми"
 
@@ -13832,7 +14749,8 @@ msgid "Directory %s is not writable"
 msgstr "Директоријум „%s“ није уписив"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Измене у привременом директроријуму неће ступити на снагу све док поново не покренете Аудасити"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13865,6 +14783,7 @@ msgstr "Груписани према врсти"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "&ЛАДСПА"
@@ -13916,11 +14835,13 @@ msgid "Plugin Options"
 msgstr "Подешавања прикључка"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Провери за освежењима прикључака приликом покретања Аудаситија"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Претражи прикључке приликом следећег покретања Аудаситија"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14100,13 +15021,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "&Очувај натписе ако избор приања на ивицу натписа"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "&Стопи системску и тему Аудаситија"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Користи углавном распоред са-лева-на-десно у СДНЛ језицима"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -14274,7 +15200,8 @@ msgstr ""
 "   *   „%s“  (зато што пречицу „%s“ користи „%s“)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Изаберите ХМЛ датотеку која садржи пречице тастатуре Аудаситија..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14407,8 +15334,9 @@ msgid "Dow&nload"
 msgstr "Преуз&ми"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Аудасити је сам открио исправне ФФмпег библиотеке.\n"
@@ -14467,8 +15395,9 @@ msgid "Preferences for Module"
 msgstr "Поставке за модул"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Ово су пробни модули. Укључите их само ако сте прочитали упутство Аудаситија\n"
@@ -14476,12 +15405,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  „Питај“ значи да ће Аудасити питати да ли желите учитати модул при сваком његовом покретању."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  „Неуспех“ значи да ће Аудасити мислити да је модул оштећен и неће га покретати."
 
 #. i18n-hint preserve the leading spaces
@@ -14490,7 +15421,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  „Нови“ значи да још увек нема избора."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Измене у овим подешавањима ће ступити на снагу када поново покренете Аудаситија."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14553,7 +15485,10 @@ msgstr "Лево превлачење"
 msgid "Set Selection Range"
 msgstr "Подешавање опсега избора"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Помак + леви тастер"
 
@@ -14640,6 +15575,15 @@ msgstr "—Лево превлачење"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Премештање одсечака горе/доле између нумера"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "—Лево превлачење"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14764,7 +15708,8 @@ msgid "Always scrub un&pinned"
 msgstr "Увек прочисти &неприкачене"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Поставке Аудаситија"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14778,6 +15723,11 @@ msgstr "Поставке:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Поставке за квалитет"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14895,39 +15845,6 @@ msgstr "Системски &датум"
 #: src/prefs/RecordingPrefs.cpp
 msgid "System T&ime"
 msgstr "Системско &време"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Осамостаљено дотеривање нивоа снимања"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Укључите осамостаљено дотеривање нивоа снимања."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Врхунац циља:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Унутар:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Време анализирања:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "милисекунде (време једне анализе)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Број узастопних анализа:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 значи бесконачно"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
@@ -15089,6 +16006,10 @@ msgid "1024 - default"
 msgstr "1024 — основни"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 — најускопојаснији"
 
@@ -15186,13 +16107,14 @@ msgid "Info"
 msgstr "Подаци"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15375,7 +16297,8 @@ msgstr "Узорци"
 msgid "4 Pixels per Sample"
 msgstr "4 пиксела по узорку"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Највеће увеличање"
 
@@ -15497,16 +16420,24 @@ msgid "Stopped"
 msgstr "Заустављено"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Паузирај"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Пребаци на почетак"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Пребаци на крај"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Паузирај"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Избор за почетак"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Избор за крај"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15520,20 +16451,17 @@ msgstr "Сними нову нумеру"
 msgid "Append Record"
 msgstr "Прикачи запис"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Избор за крај"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Избор за почетак"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s је паузирано."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15613,11 +16541,17 @@ msgstr "Утишај звучни избор"
 msgid "Sync-Lock Tracks"
 msgstr "Усклади-закључај нумере"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Увећајте"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Умањите"
 
@@ -15684,43 +16618,6 @@ msgstr "Мерач &снимања"
 msgid "&Playback Meter Toolbar"
 msgstr "Мерач &пуштања"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Јачина звука снимања"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Јачина звука пуштања"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Јачина звука снимања: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Јачина звука снимања (недоступно; користите системски мешач.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Гласност пуштања: %.2f (опонашајна)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Гласност пуштања: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Јачина звука пуштања (недоступно; користите системски мешач.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "М&ешач"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Премотавање"
@@ -15736,6 +16633,7 @@ msgstr "Прочишћавање"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Зауставите прочишћавање"
@@ -15743,6 +16641,7 @@ msgstr "Зауставите прочишћавање"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Покрените прочишћавање"
@@ -15750,6 +16649,7 @@ msgstr "Покрените прочишћавање"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Зауставите премотавање"
@@ -15757,6 +16657,7 @@ msgstr "Зауставите премотавање"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Покрените премотавање"
@@ -15811,7 +16712,9 @@ msgstr "Приони на"
 msgid "Length"
 msgstr "Трајање"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "На средини"
 
@@ -15875,8 +16778,8 @@ msgstr "Трака алата &времена"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Трака алата Аудаситија %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -15903,7 +16806,8 @@ msgstr "Алат померања времена"
 msgid "Zoom Tool"
 msgstr "Алат увећања"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Алат цртања"
 
@@ -15979,11 +16883,13 @@ msgstr "Превуците једну или више граница натпи�
 msgid "Drag label boundary."
 msgstr "Превуците границу натписа."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Измењени натпис"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Уреди натпис"
 
@@ -16038,31 +16944,42 @@ msgstr "Уређени натписи"
 msgid "New label"
 msgstr "Нови натпис"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "&Горња октава"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "&Доња октава"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Притисните за усправно увећање. Помак+притисак на тастер миша за умањење. Превуците да одредите област првог плана."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Десни клик за изборник."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Поништавање увеличавања"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Шифт-десни-клик"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Леви-клик/лево-превлачење"
 
@@ -16104,7 +17021,8 @@ msgstr "Стопи"
 msgid "Expanded Cut Line"
 msgstr "Раширена је линија одсецања"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Рашири"
 
@@ -16127,6 +17045,11 @@ msgstr "Премештен је узорак"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Уређивање узорка"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16172,7 +17095,8 @@ msgstr "Обрађујем...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "„%s“ је измењена у %s"
@@ -16184,6 +17108,54 @@ msgstr "Промена формата"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "П&роток"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16203,7 +17175,8 @@ msgstr "Промена протока"
 msgid "Set Rate"
 msgstr "Постави проток"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Мулти преглед"
 
@@ -16295,14 +17268,23 @@ msgstr "Леви, %dHz"
 msgid "Right, %dHz"
 msgstr "Десни, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%+.1f dB"
+msgstr "%.2f dB СКК"
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% леви"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% десни"
@@ -16420,9 +17402,8 @@ msgstr "Логаритамско &уметање"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Притисните и превуците да преместите нумеру у времену"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16473,6 +17454,7 @@ msgstr "Дотерана омотница."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Прочисти"
@@ -16484,6 +17466,7 @@ msgstr "Премотавам"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "&Лењир прочишћавања"
@@ -16718,9 +17701,19 @@ msgstr "Празно"
 msgid "Backwards"
 msgstr "Назад"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Напред"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16902,6 +17895,18 @@ msgstr "0100 ч 060 м 060>0100 с"
 msgid "hh:mm:ss + milliseconds"
 msgstr "чч:мм:сс + милисекунде"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 ч 060 м 060>0100 с"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
 #: src/widgets/NumericTextCtrl.cpp
@@ -16922,6 +17927,7 @@ msgstr "0100 h 060 m 060 s+># кадрова"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "узорци"
@@ -17075,9 +18081,31 @@ msgstr "ЦДДА кадрови (75 к/с)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 кадрова|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "0100 ч 060 м 060>0100 с"
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centihertz"
 msgstr "центихерц"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hertz"
@@ -17147,6 +18175,11 @@ msgstr "(Користите приручни изборник да измени�
 msgid "centiseconds"
 msgstr "стотинке"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Протекло време:"
@@ -17188,6 +18221,11 @@ msgstr "Потврди затварање"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Не могу да читам претподешеност из „%s“"
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -17292,19 +18330,27 @@ msgstr "Не могу да обрадим ХМЛ"
 msgid "Spectral edit multi tool"
 msgstr "Мулти алат уређивања спектра"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Издвајам..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Paul Licameli"
 msgstr "Пол Ликамели"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Издат под условима Гнуове Опште Јавне Лиценце издање 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aИзаберите учесталости."
@@ -17331,7 +18377,8 @@ msgstr ""
 "                      Покушајте да повећате доњу границу учесталости~%~\n"
 "                      или да смањите филтер „Ширина“."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Грешка.~%"
@@ -17393,9 +18440,23 @@ msgstr "Студијско ишчезавање"
 msgid "Applying Fade..."
 msgstr "Примењујем ишчезавање..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Стив Долтон"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Издат под условима Гнуове Опште Јавне Лиценце издање 2 или новије."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17539,6 +18600,10 @@ msgstr "Налазач такта"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Налазим тактове..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Аудасити"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17867,13 +18932,34 @@ msgstr "Примењујем високопропусни филтер..."
 msgid "Dominic Mazzoni"
 msgstr "Доминик Мацони"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Учесталост (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Одмотај (dB по октави)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17894,10 +18980,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Звуци натписа"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Издат под условима Гнуове Опште Јавне Лиценце издање 2 или новије."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18197,7 +19279,8 @@ msgstr "Лисп датотека"
 msgid "HTML file"
 msgstr "ХТМЛ датотека"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Датотека текста"
 
@@ -18324,6 +19407,10 @@ msgstr "1 – 20 тактова/мери"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Износ замаха"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -19022,6 +20109,210 @@ msgstr "Учесталост радарских игала (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Грешка.~%Потребна је стерео нумера."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Изађи из Аудаситија"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Прескочи"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Канал"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Грешка приликом дешифровања датотеке"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Грешка учитавања метаподатака"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Трака алата Аудаситија %s"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Снимање"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Наредба:"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Није било могуће оптимизовати га више. И даље је исувише низак."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Дотеривање нивоа осамостаљеног снимања је смањило јачину звука на %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Није било могуће оптимизовати га више. И даље је исувише низак."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Дотеривање нивоа осамостаљеног снимања је повећало јачину звука на %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Укупан број анализа је прекорачен без проналажења прихватљиве јачине звука. И даље је исувише висок."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. Укупан број анализа је прекорачен без проналажења прихватљиве јачине звука. И даље је исувише низак."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Дотеривање нивоа осамостаљеног снимања је заустављено. %.2f изгледа прихватљива јачина звука."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Примих %d приликом отварања уређаја\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Не могу да отворим Портмиксер\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Доступни миксери:\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "%d – %s\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Доступни извори снимања:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Доступне гласности пуштања:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Гласност снимања је опонашајна\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Гласност снимања је изворна\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Гласност пуштања је опонашајна\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Гласност пуштања је изворна\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Датум и време заустављања"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Датотеке сагласне са Гстримером"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Не могу да додам декодер на спојку"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Увозник Гстримера"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Не могу да поставим стање тока на паузирано."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Индекс[%02x] Врста[%s], Број канала[%d], Проток[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Датотека не садржи токове звука."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Не могу да увезем датотеку, промена стања није успела."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Грешка Гстримера: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "М&ешач"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "&Дотерај јачину звука пуштања..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Повећај јачину звука пуштања"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Смањи јачину звука пуштања"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Дотерај јачину звука &снимања..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "&Повећај јачину звука снимања"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "&Смањи јачину звука снимања"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Упутство Аудаситија"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "О Аудаситију"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Осамостаљено &дотеривање нивоа снимања (укљ./иск.)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Осамостаљено дотеривање нивоа снимања"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Укључите осамостаљено дотеривање нивоа снимања."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Врхунац циља:"
+
+#~ msgid "Within:"
+#~ msgstr "Унутар:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Време анализирања:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "милисекунде (време једне анализе)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Број узастопних анализа:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 значи бесконачно"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Јачина звука снимања"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Јачина звука пуштања"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Јачина звука снимања: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Јачина звука снимања (недоступно; користите системски мешач.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Гласност пуштања: %.2f (опонашајна)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Гласност пуштања: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Јачина звука пуштања (недоступно; користите системски мешач.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "М&ешач"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Притисните и превуците да преместите нумеру у времену"
 
 #, fuzzy
 #~ msgid "Problem Report for Audacity"
@@ -20407,9 +21698,6 @@ msgstr "Грешка.~%Потребна је стерео нумера."
 
 #~ msgid "Offset"
 #~ msgstr "Померај"
-
-#~ msgid "Version"
-#~ msgstr "Издање"
 
 #~ msgid "C&ategory:"
 #~ msgstr "&Категорија:"

--- a/locale/sr_Latn.po
+++ b/locale/sr_Latn.po
@@ -8,55 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Serbian (latin) <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/sr_Latn/>\n"
+"Language-Team: Serbian (latin) <https://hosted.weblate.org/projects/tenacity/tenacity/sr_Latn/>\n"
 "Language: sr_Latn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 "X-Project-Style: default\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Zatvori Odvažnost"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Kanal"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Greška prilikom otvaranja datoteke"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Greška učitavanja metapodataka"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Linija alata Odvažnosti — %s"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Snimanje"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -66,6 +28,24 @@ msgstr "Ne mogu da odredim"
 #, c-format
 msgid "%s bytes"
 msgstr "bajta"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -88,12 +68,63 @@ msgid "&Nyquist Workbench..."
 msgstr "Upit Nikvista..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Nalepi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Nalepi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Nalepi"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Nalepi"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Izaberi &sve"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -120,15 +151,34 @@ msgid "&Large Icons"
 msgstr "Velika soba"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Small Icons"
+msgstr "Velika soba"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "&Linije alata"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Zaustavi"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Promenljiv"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Podešavanja dejstva"
 
@@ -136,13 +186,50 @@ msgstr "Podešavanja dejstva"
 msgid "Load Nyquist script"
 msgstr "Upit Nikvista"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Upozorenje"
 
 #: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Save Nyquist script"
 msgstr "Upit Nikvista"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -153,6 +240,10 @@ msgid "No matches found"
 msgstr "Nisam pronašao uređaje"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
 msgstr "bez naslova"
 
@@ -160,9 +251,15 @@ msgstr "bez naslova"
 msgid "Nyquist Effect Workbench - "
 msgstr "Ponovo pregledaj dejstva"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Novo"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Otvori skorašnje"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -196,7 +293,8 @@ msgstr "Umnožite"
 msgid "Copy to clipboard"
 msgstr "Isecite u ostavu"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Iseci"
 
@@ -204,7 +302,8 @@ msgstr "Iseci"
 msgid "Cut to clipboard"
 msgstr "Isecite u ostavu"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Ubaci"
 
@@ -229,7 +328,8 @@ msgstr "Izaberi &sve"
 msgid "Select all text"
 msgstr "Izaberi &sve"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Poništite"
 
@@ -237,9 +337,20 @@ msgstr "Poništite"
 msgid "Undo last change"
 msgstr "Promena formata"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Vratite"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Promena formata"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Find"
+msgstr "&Nađi note"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Find text"
@@ -250,23 +361,46 @@ msgid "Match"
 msgstr "Paket"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Top"
 msgstr "na vrh"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Nema natpisa za izvoz."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Up"
 msgstr "Gore"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Prethodni alat"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Premesti prvi plan na prethodnu i izbor"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Sledeći alat"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Početak"
 
@@ -274,7 +408,8 @@ msgstr "Početak"
 msgid "Start script"
 msgstr "Upit Nikvista"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Zaustavi"
 
@@ -282,8 +417,15 @@ msgstr "Zaustavi"
 msgid "Stop script"
 msgstr "Upit Nikvista"
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "U redu"
 
@@ -291,11 +433,13 @@ msgstr "U redu"
 msgid "Build Information"
 msgstr "Podaci o izgradnji"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "uključeno"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "isključeno"
 
@@ -305,8 +449,9 @@ msgid "The Build"
 msgstr "izgradnja za uklanjanje grešaka"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Naredba:"
+#, fuzzy
+msgid "Version:"
+msgstr "Obrćem"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -316,13 +461,23 @@ msgstr "Vrsta izgradnje:"
 msgid "Compiler:"
 msgstr "Sažimatelj"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Fascikla instalacije: "
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Fascikla podešavanja: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Fascikla podešavanja: "
 
 #: src/AboutDialog.cpp
@@ -341,7 +496,6 @@ msgstr "pretvaranje protoka uzorka"
 msgid "MP3 Importing"
 msgstr "MP3 uvoz"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis uvoz i izvoz"
@@ -350,7 +504,6 @@ msgstr "Ogg Vorbis uvoz i izvoz"
 msgid "ID3 tag support"
 msgstr "podrška ID3 oznake"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC uvoz i izvoz"
@@ -368,14 +521,6 @@ msgid "FFmpeg Import/Export"
 msgstr "uvoz/izvoz FFmpeg-a"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "uvoz putem Gstrimera"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Mogućnosti"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "podrška priključka"
 
@@ -390,6 +535,10 @@ msgstr "podrška promene vrhunca i takta"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "podrška krajnjeg vrhunca i promene takta"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Mogućnosti"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -416,6 +565,18 @@ msgstr "Omotnica"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Omotnica"
 
@@ -427,6 +588,24 @@ msgstr "Omotnica"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "osiguranost kvaliteta"
@@ -434,8 +613,26 @@ msgstr "osiguranost kvaliteta"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, graphic artist"
 msgstr "&Grafički EKu"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Omotnica"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Omotnica"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -455,6 +652,15 @@ msgstr "Omotnica"
 msgid "%s, graphics"
 msgstr "&Grafički EKu"
 
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -464,6 +670,10 @@ msgstr "slobodan, otvorenog koda, višeplatformski program za snimanje i uređiv
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Zasluge"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -498,14 +708,23 @@ msgid "%s Team Members"
 msgstr " Zaslužni članovi tima"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Ostali saradnici"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -526,6 +745,26 @@ msgstr "Posebno se zahvaljujemo:"
 msgid "%s website: "
 msgstr "Prvo pokretanje Odvažnosti"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Ostali saradnici"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Kliknite i prevucite da doterate relativnu veličinu stereo numere."
@@ -543,6 +782,7 @@ msgstr "Menjač vremenske linije"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Kliknite i prevucite da promenite veličinu numere."
@@ -550,17 +790,66 @@ msgstr "Kliknite i prevucite da promenite veličinu numere."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Kliknite i prevucite da promenite veličinu numere."
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Premesti prvi plan na sledeću i izbor"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Premesti numeru na &dno"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Zatvori numeru u prvom planu"
 
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
 msgstr " (isključeno)"
 
 #: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
+msgstr " (isključeno)"
+
+#: src/AdornedRulerPanel.cpp
 msgid "Timeline Options"
 msgstr "Podešavanja priključka"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
@@ -578,7 +867,23 @@ msgstr "&Oblast puštanja"
 msgid "Pinned Play Head"
 msgstr "Kraj snimanja"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Greška"
 
@@ -602,7 +907,8 @@ msgstr ""
 "Ovo pitanje se prikazuje samo jednom, nakon „instalacije“ kada ste upitani da li želite vraćanje starih postavki."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Povrati postavke Odvažnosti"
 
 #: src/AudacityApp.cpp
@@ -615,6 +921,14 @@ msgstr ""
 "Ne mogu da pronađem „%s“.\n"
 "\n"
 "Uklonjena je sa spiska nedavnih datoteka."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -635,7 +949,7 @@ msgstr "&Otvori..."
 msgid "Open &Recent..."
 msgstr "Otvori &skorašnju..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&O Odvažnosti..."
@@ -649,9 +963,10 @@ msgid "&File"
 msgstr "&Datoteka"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Odvažnost ne može da nađe mesto za skladištenje\n"
@@ -659,8 +974,9 @@ msgstr ""
 "direktorijum u prozorčetu postavki."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Odvažnost ne može da nađe mesto za skladištenje\n"
@@ -668,15 +984,17 @@ msgstr ""
 "direktorijum u prozorčetu postavki."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr ""
 "Odvažnost će sada da izađe. Molim ponovo\n"
 "pokrenite Odvažnost da biste koristili\n"
 "novi privremeni direktorijum."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -684,9 +1002,10 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Odvažnost nije u mogućnosti da zaključa\n"
 "direktorijum privremenih datoteka.\n"
@@ -694,7 +1013,8 @@ msgstr ""
 "Ovaj direktorijum možda koristi drugi primerak Odvažnosti.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Da li još uvek želite da pokrenete Odvažnost?"
 
 #: src/AudacityApp.cpp
@@ -702,14 +1022,16 @@ msgid "Error Locking Temporary Folder"
 msgstr "Greška zaključavanja privremene fascikle"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr ""
 "Sistem je otkrio da drugi\n"
 "primerak Odvažnosti radi.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Koristite naredbe „Novo“ ili „Otvori“\n"
@@ -717,12 +1039,58 @@ msgstr ""
 "da otvorite više projekata istovremeno.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Odvažnost je već pokrenut"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Datoteke projekta Odvažnosti"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -742,7 +1110,8 @@ msgstr "\t-test (pokreće samodijagnozu)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (prikazuje izdanje Odvažnosti)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -752,9 +1121,10 @@ msgid "audio or project file name"
 msgstr "Ne mogu da otvorim datoteku projekta"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -767,20 +1137,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Datoteke projekta Odvažnosti"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&Ponovo uzorkuj..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Potvrda brisanja pravila"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Pomoć"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Zatvori Odvažnost"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Dnevnik Odvažnosti"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -792,7 +1191,8 @@ msgstr "&Sačuvaj..."
 msgid "Cl&ear"
 msgstr "&Očisti"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Zatvori"
 
@@ -847,7 +1247,8 @@ msgid "Error Initializing Midi"
 msgstr "Greška pri pokretanju midija"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Dnevnik Odvažnosti"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -861,40 +1262,18 @@ msgstr "Greška prilikom otvaranja zvučnog uređaja. "
 msgid "Out of memory!"
 msgstr "Nema više memorije!"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Nije bilo moguće optimizovati ga više. I dalje je isuviše visok."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Doterivanje nivoa osamostaljenog snimanja je smanjilo jačinu zvuka na %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Nije bilo moguće optimizovati ga više. I dalje je isuviše nizak."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Doterivanje nivoa osamostaljenog snimanja je povećalo jačinu zvuka na %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Ukupan broj analiza je prekoračen bez pronalaženja prihvatljive jačine zvuka. I dalje je isuviše visok."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Ukupan broj analiza je prekoračen bez pronalaženja prihvatljive jačine zvuka. I dalje je isuviše nizak."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. %.2f izgleda prihvatljiva jačina zvuka."
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "Izaberi uređaj snimanja\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "Izaberi uređaj snimanja\n"
 
 #: src/AudioIOBase.cpp
@@ -937,8 +1316,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Kraj snimanja\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Kraj snimanja\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Kraj snimanja\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -952,37 +1341,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Izaberi uređaj snimanja\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Izaberi uređaj snimanja\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Izaberi uređaj puštanja\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Ne mogu da otvorim datoteku žanra.\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Izaberi uređaj puštanja\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Klizač snimanja\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Protoci uzorka\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Jačina zvuka puštanja\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Jačina zvuka snimanja\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Jačina zvuka snimanja\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Jačina zvuka puštanja: %.2f%s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Jačina zvuka puštanja: %.2f%s\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -990,8 +1382,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Izaberi uređaj snimanja\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Izaberi uređaj snimanja\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Izaberi uređaj puštanja\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Izaberi uređaj puštanja\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -999,8 +1401,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Samostalni oporavak posle pada"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1012,12 +1415,14 @@ msgid "Recoverable &projects"
 msgstr "Projekti za oporavak"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Biranje"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Naziv"
 
@@ -1028,6 +1433,10 @@ msgstr "Biranje"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "Biranje"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1064,6 +1473,11 @@ msgid "&Parameters"
 msgstr "&Parametri"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "Otkači"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "&Izaberi naredbu"
 
@@ -1098,6 +1512,22 @@ msgstr "Efekti"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Uredi parametre"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Uredi parametre"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1145,6 +1575,10 @@ msgid "Apply %s"
 msgstr "Primeni „%s“"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "Upravljaj krivama"
 
@@ -1153,6 +1587,17 @@ msgstr "Upravljaj krivama"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Izaberi krivu"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Oznake..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Primeni lanac"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1220,7 +1665,8 @@ msgstr "Oblast &povraćaja"
 msgid "I&mport..."
 msgstr "&Uvezi..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Izvezi..."
 
@@ -1261,9 +1707,15 @@ msgstr "Premesti &gore"
 msgid "Move &Down"
 msgstr "Premesti &dole"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Sačuvaj"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1309,11 +1761,38 @@ msgid "Benchmark"
 msgstr "Pokreni &ocenjivanje..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Broj ponavljanja:"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Zatvori"
 
@@ -1328,12 +1807,32 @@ msgid "Export Benchmark Data as:"
 msgstr "Izvezi podatke spektra kao:"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr "Najveći broj nota mora biti u opsegu 1..128"
+
+#: src/Benchmark.cpp
 msgid "Number of edits should be in the range 1 - 10000."
 msgstr "Najveći broj nota mora biti u opsegu 1..128"
 
 #: src/Benchmark.cpp
+#, fuzzy
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr "Najveći broj nota mora biti u opsegu 1..128"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Pripremam pregled\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1342,17 +1841,104 @@ msgstr "Obavljam ponavljanje\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Ubaci\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Snimanje zvuka\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Datum i vreme zaustavljanja"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "izgradnja izdanja"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1373,9 +1959,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Morate prvo da izaberete neki zvuk da ovo koristite."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Nije izabran lanac"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1403,6 +2013,11 @@ msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "Nisam uspeo da pronađem kodek"
 
@@ -1420,10 +2035,24 @@ msgstr "Primeni na tekući &projekat"
 msgid "Checkpointing %s"
 msgstr "Uvozim %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Ne mogu da upišem u datoteku: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Ne mogu da sačuvam projekat. Možda %s \n"
+"nije upisiv ili je disk popunjen."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1440,6 +2069,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "Nisam uspeo da uklonim „%s“"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1537,6 +2170,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Isecite u ostavu"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Nedostaju datoteke"
 
@@ -1545,10 +2183,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Ako nastavite, vaš projekat neće biti sačuvan na disk. Da li je to ono što želite?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1560,7 +2199,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Provera zavisnosti"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ništa"
 
@@ -1568,7 +2210,7 @@ msgstr "Ništa"
 msgid "Rectangle"
 msgstr "Pravougaono"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Trouglasto"
 
@@ -1582,17 +2224,58 @@ msgstr "Pravougaoni"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Dobrodošli!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg podrška nije sastavljena"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -1614,8 +2297,8 @@ msgid "Locate FFmpeg"
 msgstr "Pronađi FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Odvažnost zahteva datoteku „%s“ da bi uvozila i izvozila zvuk putem FFmpeg-a."
 
 #: src/FFmpeg.cpp
@@ -1628,7 +2311,8 @@ msgstr "„%s“ se nalazi u:"
 msgid "To find '%s', click here -->"
 msgstr "Da pronađete „%s“, kliknite ovde >>>"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Razgledaj..."
 
@@ -1654,8 +2338,9 @@ msgid "FFmpeg not found"
 msgstr "Nisam našao FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1675,24 +2360,38 @@ msgstr "Ne prikazuj više ovo upozorenje"
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "Nisam uspeo da pronađem saglasne FFmpeg biblioteke."
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Odvažnost ne može da zapiše datoteku:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Odvažnost ne može da zapiše datoteku:\n"
 "  %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Odvažnost ne može da zapiše datoteku:\n"
-"  %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1729,7 +2428,9 @@ msgstr "&Nemoj umnožavati nikakav zvuk"
 msgid "As&k"
 msgstr "&Pitaj korisnika"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Sve datoteke (*)|*"
 
@@ -1738,6 +2439,11 @@ msgstr "Sve datoteke (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "Čuvam datoteke podataka projekta"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "Biblioteke"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1750,6 +2456,10 @@ msgstr "Datoteke naziva:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3 datoteke"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1814,9 +2524,34 @@ msgstr "Linearna učestalost"
 msgid "Log frequency"
 msgstr "Logaritamska učestalost"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Zumiranje"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1831,6 +2566,10 @@ msgstr "Vodoravni stereo"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "Kursor levo"
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1873,6 +2612,37 @@ msgstr "Previše zvuka je izabrano.  Samo prve %.1f sekunde zvuka će biti anali
 msgid "Not enough data selected."
 msgstr "Nije izabrano dovoljno podataka."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "spektar.txt"
@@ -1881,7 +2651,8 @@ msgstr "spektar.txt"
 msgid "Export Spectral Data As:"
 msgstr "Izvezi podatke spektra kao:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Ne mogu da upišem u datoteku: "
@@ -1957,6 +2728,26 @@ msgid "No Local Help"
 msgstr "Nema lokalne pomoći"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "These are our support methods:"
 msgstr "Ovo su naši načini podrške:"
 
@@ -2011,6 +2802,10 @@ msgid "Used Space"
 msgstr "Prostor na disku"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "Dostupni nivoi poništavanja"
 
@@ -2024,6 +2819,10 @@ msgid "&Discard"
 msgstr "&Odbaci"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Odbaci"
 
@@ -2031,11 +2830,30 @@ msgstr "&Odbaci"
 msgid "&Compact"
 msgstr "&Naredba"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Istorijat..."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -2051,7 +2869,9 @@ msgid "Track"
 msgstr "Numera"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Natpis"
 
@@ -2111,18 +2931,25 @@ msgstr "Unesite naziv numere"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Natpis numere"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Prvo pokretanje Odvažnosti"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Izaberite jezik koji će da koristi Odvažnost:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2132,7 +2959,8 @@ msgstr "Izaberite jezik koji će da koristi Odvažnost:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Jezik koji ste izabrali, %s (%s), nije isti kao jezik na sistemu, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Potvrdi"
 
@@ -2150,13 +2978,19 @@ msgstr ""
 "Stara datoteka je sačuvana kao „%s“"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Otvaram projekat Odvažnosti"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Karaoke%s Odvažnosti"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Razgledaj..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2204,19 +3038,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mešam i iscrtavam numere"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tabla mešača%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Pojačanje"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Brzina"
 
@@ -2225,28 +3063,43 @@ msgid "Musical Instrument"
 msgstr "Muzički instrument"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Kanalisanje"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Utišaj"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Merač nivoa signala"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Pomeren je klizač pojačanja"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Pomeren je klizač brzine"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Pomeren je klizač kanalisanja"
 
@@ -2277,9 +3130,9 @@ msgstr ""
 "Neće biti učitan."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2312,16 +3165,19 @@ msgstr ""
 "\n"
 "Koristite module samo iz poverljivih izvora"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Da"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ne"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Učitavač modula"
 
 #: src/ModuleManager.cpp
@@ -2351,18 +3207,121 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "GB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Prepiši postojeće datoteke"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2392,6 +3351,16 @@ msgstr "Upit Nikvista"
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Ne mogu da učitam „%s“ priključak"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show:"
+msgstr "Prikaži sve kodeke"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp
@@ -2423,6 +3392,21 @@ msgstr "uključeno"
 msgid "E&nabled"
 msgstr "uključeno"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "uključeno"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Path"
 msgstr "Putanja"
@@ -2435,7 +3419,8 @@ msgstr "Izaberi &sve"
 msgid "C&lear All"
 msgstr "&Očisti sve"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "uključeno"
 
@@ -2501,6 +3486,21 @@ msgstr "Greška prilikom otvaranja zvučnog uređaja. Molim proverite podešavan
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Da primenite propusnik, sve izabrane numere moraju biti istog protoka uzorka."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Snimljen je zvuk"
@@ -2508,6 +3508,28 @@ msgstr "Snimljen je zvuk"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "Snimi"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2535,11 +3557,11 @@ msgid "Inspecting project file data"
 msgstr "Nadgledam podatke datoteke projekta"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2582,11 +3604,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Upozorenje — Nedostajuće alijazovane datoteke"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Provera projekta za fasciklu „%s“ je otkrila \n"
@@ -2611,12 +3633,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Upozorenje — Nedostaje datoteka sažetka alijasa"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2674,7 +3696,8 @@ msgstr "Upozorenje — Napuštena blok datoteka"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Napredak"
 
@@ -2699,6 +3722,11 @@ msgstr "Upozorenje: Problem u samostalnom oporavku"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<bez naslova>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Projekti"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2737,11 +3765,96 @@ msgid ""
 msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Nisam uspeo da uklonim „%s“"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Čuvanje projekta Odvažnosti"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Ne mogu da započnem MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ne mogu da započnem MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ne mogu da započnem MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ne mogu da započnem MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ne mogu da započnem MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ne mogu da započnem MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Ne mogu da započnem MP3 tok"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Ne mogu da započnem MP3 tok"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2755,12 +3868,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "Napuštena blok datoteka: „%s“"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Ne mogu da preimenujem „%s“ u „%s“."
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Nisam uspeo da pronađem kodek"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "Nisam uspeo da uklonim „%s“"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2771,9 +3905,9 @@ msgid "Error Writing to File"
 msgstr "Greška pisanja u datoteku"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2784,8 +3918,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Čuvanje &projekata"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Dnevnik Odvažnosti"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2795,10 +3938,10 @@ msgstr "(oporavljeno)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Ova datoteka je sačuvana upotrebom Odvažnosti %s.\n"
 "Vi koristite Odvažnost %s. Morate da nadogradite na novije izdanje da biste otvorili ovu datoteku."
@@ -2806,6 +3949,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Ne mogu da otvorim datoteku projekta"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2820,6 +3967,10 @@ msgid "Unable to parse project information."
 msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Čuvanje &projekata"
 
@@ -2828,12 +3979,35 @@ msgid "Error Saving Project"
 msgstr "Greška čuvanja projekta"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "Čuvanje p&raznog projekta"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2841,8 +4015,24 @@ msgstr ""
 "Na sreću, sledeći projekti mogu biti samostalno oporavljeni:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Neki projekti nisu pravilno sačuvani prilikom poslednjeg pokretanja Odvažnosti.\n"
+"Na sreću, sledeći projekti mogu biti samostalno oporavljeni:"
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Projekat je oporavljen"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Direktorijum privremnih datoteka"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2872,6 +4062,17 @@ msgstr "Upozorenje — Prazan projekat"
 msgid "Insufficient Disk Space"
 msgstr "Prostor na disku"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -2891,12 +4092,26 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "Sačuvaj projekat „%s“ kao..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "„Sačuvaj projekat“ je za projekat Odvažnosti, a ne za zvučnu datoteku.\n"
 "Za zvučnu datoteku koja će se otvarati u drugim programima, koristite „Izvezi“.\n"
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -2950,11 +4165,12 @@ msgid "Error Opening Project"
 msgstr "Greška otvaranja projekta"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Pokušavate da otvorite samostalno napravljenu datoteku rezerve.\n"
 "\n"
@@ -2988,6 +4204,12 @@ msgid "Error Opening File or Project"
 msgstr "Greška otvaranja datoteke ili projekta"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Projekat je oporavljen"
 
@@ -3013,12 +4235,33 @@ msgid "Error Importing"
 msgstr "Greška uvoženja"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Sačuvaj projekat"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Ne mogu da otvorim datoteku projekta"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Naredba"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3029,8 +4272,8 @@ msgid "Automatic database backup failed."
 msgstr "Samostalni oporavak posle pada"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Dobrodošli u Odvažnost izdanje %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -3065,6 +4308,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "Na disku preostaje prostora za još %d minuta snimanja."
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -3080,6 +4327,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -3094,6 +4353,26 @@ msgstr "Vodoravni stereo"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Vertikalni stereo"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(najbolji kvalitet)"
 
 #: src/Resample.cpp
 msgid "Medium Quality"
@@ -3121,6 +4400,10 @@ msgstr "24 bita PCM"
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
 msgstr "32 bita pokretnog zareza"
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -3206,7 +4489,8 @@ msgstr "Postavke: "
 msgid "SelectionBar"
 msgstr "Linija izbora"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Izbor"
 
@@ -3214,44 +4498,58 @@ msgstr "Izbor"
 msgid "Timer"
 msgstr "Vreme"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Alati"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Prenos"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Mešač"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Merač"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Merač puštanja"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Merač snimanja"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Uređivanje"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Uređaj"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Pustite-pri-brzini"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "&Linije alata"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -3264,7 +4562,10 @@ msgstr "Lenjir"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Numere"
 
@@ -3316,6 +4617,15 @@ msgstr "Duge numere"
 msgid "Choose a location to save screenshot images"
 msgstr "Izaberite mesto za čuvanje slika snimaka ekrana"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "\t-help (ova poruka)"
+
 #: src/Sequence.cpp
 #, c-format
 msgid ""
@@ -3366,7 +4676,8 @@ msgid "Activation level (dB):"
 msgstr "Nivo aktiviranja (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Dobrodošli u Odvažnost!"
 
 #: src/SplashDialog.cpp
@@ -3493,19 +4804,45 @@ msgstr "Greška čuvanja datoteke oznaka"
 msgid "Unsuitable"
 msgstr "Neprikladan modul"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Direktorijum privremnih datoteka"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Odvažnost ne može da zapiše datoteku:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3514,18 +4851,26 @@ msgstr ""
 "za pisanje."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Odvažnost ne može da zapiše slike u datoteku:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -3535,9 +4880,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -3546,8 +4891,9 @@ msgstr ""
 "Možda je loš png format?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Odvažnost ne može da pročita svoju osnovnu temu.\n"
@@ -3585,9 +4931,9 @@ msgstr ""
 "bejahu već prisutne."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Odvažnost ne može da sačuva datoteku:\n"
@@ -3604,11 +4950,21 @@ msgstr "Uobičajeni propusnici"
 msgid "Light"
 msgstr "Lagano"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "Suprotnost..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Naziv numere"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3617,7 +4973,11 @@ msgstr "Suprotnost..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Trajanje"
 
@@ -3628,7 +4988,8 @@ msgid "Time Track"
 msgstr "Praćenje vremena"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Vremensko snimanje Odvažnosti"
 
 #: src/TimerRecordDialog.cpp
@@ -3657,12 +5018,38 @@ msgid "Error in Duration"
 msgstr "Greška u trajanju"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Samostalni oporavak posle pada"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "Greška u trajanju"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Izvoz proizvoljnog FFmpeg-a"
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "Greška u trajanju"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "&Vremensko snimanje..."
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3672,7 +5059,8 @@ msgstr "Primeni na tekući &projekat"
 msgid "Recording start:"
 msgstr "Početak snimanja"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Trajanje:"
 
@@ -3693,7 +5081,8 @@ msgid "Action after Timer Recording:"
 msgstr "Vremensko snimanje Odvažnosti"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Napredak vremenskog snimanja Odvažnosti"
 
 #: src/TimerRecordDialog.cpp
@@ -3728,6 +5117,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "Kraj snimanja"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Greška čuvanja projekta"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Klizač snimanja"
@@ -3747,6 +5160,7 @@ msgstr "099 dana 024 č 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Datum i vreme pokretanja"
@@ -3791,7 +5205,8 @@ msgstr "Ne mogu da izvezem"
 msgid "Export Project As:"
 msgstr "Izvezi podešenost"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Opcije..."
 
@@ -3800,8 +5215,21 @@ msgid "After Recording completes:"
 msgstr "Merač snimanja"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Zatvori Odvažnost"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3816,7 +5244,8 @@ msgid "Scheduled to stop at:"
 msgstr "Izbor za početak"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Vremensko snimanje Odvažnosti — čekam da započnem"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3824,6 +5253,14 @@ msgstr "Vremensko snimanje Odvažnosti — čekam da započnem"
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Uređaj snimanja"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3834,8 +5271,19 @@ msgid "Recording Exported:"
 msgstr "Kraj snimanja"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Vremensko snimanje Odvažnosti — čekam da započnem"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Stereo, "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3951,6 +5399,10 @@ msgstr "Premesti numeru &gore"
 msgid "Move Track Down"
 msgstr "Premesti numeru &dole"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3996,25 +5448,79 @@ msgstr "Nema dovoljno dostupnog mesta za ubacivanje izbora"
 msgid "There is not enough room available to expand the cut line"
 msgstr "Nema dovoljno dostupnog mesta za širenje linije odsecanja"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Primenjujem..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Naredba"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Naredba"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Ponovi %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -4029,12 +5535,20 @@ msgid "Compares a range on two tracks."
 msgstr "Sažmi na osnovu vrhunaca"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Vreme zastoja (u sekundama):"
 
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Faktor raspada:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -4056,6 +5570,11 @@ msgstr "Numera"
 msgid "Track 1"
 msgstr "Numera"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Ve&ličina prozora"
@@ -4067,6 +5586,22 @@ msgstr "Sa OUM"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "Sa OUM"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -4092,9 +5627,39 @@ msgstr "Odsecanje"
 msgid "Envelopes"
 msgstr "Omotnica"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Natpisa"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "Vrsta &propusnika:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Format:"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -4108,6 +5673,10 @@ msgstr "Premesti numeru &dole"
 msgid "Types:"
 msgstr "Vrsta &propusnika:"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "Primedbe"
@@ -4115,6 +5684,18 @@ msgstr "Primedbe"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Naredba:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -4133,6 +5714,11 @@ msgid "Number of Channels:"
 msgstr "Broj ponavljanja:"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Izvezi nekoliko"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Izvezi nekoliko"
 
@@ -4140,9 +5726,26 @@ msgstr "Izvezi nekoliko"
 msgid "Builtin Commands"
 msgstr "Izaberite naredbu"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tim podrške Odvažnosti"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Datum i vreme zaustavljanja"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -4184,11 +5787,22 @@ msgstr "&Sačuvaj projekat"
 msgid "Saves a copy of current project."
 msgstr "&Sačuvaj projekat"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Postavke: "
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Naziv"
 
@@ -4199,6 +5813,18 @@ msgstr "Postavke: "
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "Vrednost"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -4224,7 +5850,8 @@ msgstr "Uključi/isključi ceo ekran"
 msgid "Toolbars"
 msgstr "&Linije alata"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Efekti"
 
@@ -4268,6 +5895,10 @@ msgstr "Duge numere"
 msgid "All Tracks Plus"
 msgstr "Duge numere"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -4279,13 +5910,26 @@ msgid "Path:"
 msgstr "Putanja"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "&Poleđe:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Greška prilikom pokušaja čuvanja datoteke: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Alati za snimanje ekrana..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -4332,6 +5976,10 @@ msgid "High:"
 msgstr "Visokopropusni"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "Poređaj &numere"
 
@@ -4344,7 +5992,8 @@ msgstr "Podesi"
 msgid "Add"
 msgstr "&Dodaj"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Ukloni"
 
@@ -4365,6 +6014,11 @@ msgid "Selects a time range."
 msgstr "Izaberite MIDI datoteku..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Izaberite MIDI datoteku..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Molim izaberite radnju"
 
@@ -4376,9 +6030,37 @@ msgstr "Izaberi domaćina zvuka"
 msgid "Set Clip"
 msgstr "Sledeći alat"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Početak"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -4397,9 +6079,14 @@ msgid "Edited Envelope"
 msgstr "Omotnica"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Omotnica"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -4409,6 +6096,10 @@ msgstr "&Obriši natpis"
 msgid "Label Index"
 msgstr "Uredi natpis"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Biranje"
@@ -4416,6 +6107,10 @@ msgstr "Biranje"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Uređeni natpisi"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4429,9 +6124,26 @@ msgstr "Postavi protok"
 msgid "Resize:"
 msgstr "Smanji veličinu"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Lagano"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Sačuvaj projekat"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4462,10 +6174,17 @@ msgid "Gain:"
 msgstr "Pojačanje"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "Poređaj &numere"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linearno"
 
@@ -4476,6 +6195,10 @@ msgstr "&Ponovo postavi"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "Vreme"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4505,13 +6228,28 @@ msgstr "Spektralni procesor"
 msgid "Spectral Select"
 msgstr "Izbor"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Nova numera"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Molim izaberite radnju"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Pojačaj"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -4533,6 +6271,10 @@ msgstr "Dopusti odsecanje"
 msgid "Auto Duck"
 msgstr "Samoutišavanje"
 
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
 #. * in 'Donald-Duck'!
@@ -4547,12 +6289,18 @@ msgstr "Izabrali ste numeru koja ne sadrži zvuk. Samoutišavanje može da obrad
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Samoutišavanje zahteva upravljačku numeru koja mora biti postavljena ispod izabrane numere."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Iznos utišanja:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekunde"
 
@@ -4576,7 +6324,8 @@ msgstr "Trajanje unutrašnjeg iščezavanja:"
 msgid "Inner &fade up length:"
 msgstr "Trajanje unutrašnjeg pojavljivanja:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Osetljivost:"
 
@@ -4591,6 +6340,11 @@ msgstr "Niskotonac i visokotonac"
 #: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Skupi izbor na levo"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Osetljivost"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -4620,6 +6374,10 @@ msgstr "&Visokotonac (dB):"
 msgid "Level"
 msgstr "Nivo"
 
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "Izmeni vrhunac"
@@ -4627,6 +6385,11 @@ msgstr "Izmeni vrhunac"
 #: src/effects/ChangePitch.cpp
 msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Izmeni vrhunac bez menjanja takta"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Krajnja promena takta (%)"
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
@@ -4691,6 +6454,10 @@ msgid "from (Hz)"
 msgstr "od (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "do (Hz)"
 
@@ -4698,13 +6465,23 @@ msgstr "do (Hz)"
 msgid "t&o"
 msgstr "do"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Procenat promene:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Procenat promene"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -4716,7 +6493,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "neprimenljivo"
 
@@ -4744,6 +6523,7 @@ msgstr "Uobičajena Vinil OUM:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Sa OUM"
@@ -4753,6 +6533,14 @@ msgstr "Sa OUM"
 msgctxt "change speed"
 msgid "&from"
 msgstr "od"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "Sa OUM"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4856,6 +6644,10 @@ msgid "Click Removal"
 msgstr "Uklanjanje klika"
 
 #: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
 msgid "Algorithm not effective on this audio. Nothing changed."
 msgstr "Algoritam nije delotvoran na ovom zvuku. Nema izmena."
 
@@ -4884,6 +6676,16 @@ msgstr "Najveća širina šiljka"
 msgid "Compressor"
 msgstr "Sažimatelj"
 
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -4892,6 +6694,20 @@ msgstr "%.1f sek."
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f sek."
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f sek."
 
 #: src/effects/Compressor.cpp
@@ -4989,6 +6805,12 @@ msgstr "Molim izaberite radnju"
 
 #: src/effects/Contrast.cpp
 msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid ""
 "Nothing to measure.\n"
 "Please select a section of a track."
 msgstr ""
@@ -5001,7 +6823,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Analizator suprotnosti, za merenje razlika rms jačine zvuka između dva izbora zvuka."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Kraj"
 
@@ -5061,6 +6884,18 @@ msgstr "&Razlika:"
 msgid "&Help"
 msgstr "Po&moć"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "nula"
@@ -5105,6 +6940,10 @@ msgstr "Krajnje vreme pročelja"
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "Krajnje vreme poleđa"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -5199,6 +7038,12 @@ msgstr "Merilo uspeha 1.4.7 VCAG-a 2.0: neuspešno"
 msgid "Data gathered"
 msgstr "Prikupljeni podaci"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Analiziranje suprotnosti (VCAG 2 saglasnost)"
@@ -5224,6 +7069,19 @@ msgid "Medium Overdrive"
 msgstr "Potvrdi prepisivanje"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "Potvrdi prepisivanje"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Expand and Compress"
 msgstr "Sažimatelj dinamičkog opsega"
 
@@ -5234,6 +7092,96 @@ msgstr "Izravnavač"
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Izobličenje"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Ograničavač"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "Potvrdi prepisivanje"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "Potvrdi prepisivanje"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "Potvrdi prepisivanje"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -5256,8 +7204,16 @@ msgid "Distortion"
 msgstr "Izobličenje"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Izobličenje"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -5272,8 +7228,21 @@ msgid "Clipping level"
 msgstr "Odsecanje"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Primeni lanac"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Osetljivost buke:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -5288,6 +7257,14 @@ msgid "Repeat processing"
 msgstr "smanjiti vreme obrade."
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Stepen izravnavanja:"
 
@@ -5298,6 +7275,15 @@ msgstr "Ograničavač"
 #: src/effects/Distortion.cpp
 msgid "Wet level"
 msgstr "2 nivo"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2 nivo"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -5324,6 +7310,16 @@ msgid "DTMF Tones"
 msgstr "DTMF tonovi..."
 
 #: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "DTMF niz:"
 
@@ -5331,7 +7327,9 @@ msgstr "DTMF niz:"
 msgid "&Amplitude (0-1):"
 msgstr "Doseg (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Trajanje:"
 
@@ -5376,6 +7374,11 @@ msgstr "Odjek"
 msgid "Repeats the selected audio again and again"
 msgstr "Izvozim izabrani zvuk kao %s"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "Vreme zastoja (u sekundama):"
@@ -5396,7 +7399,8 @@ msgstr "Pretpodešavanja:"
 msgid "Export Effect Parameters"
 msgstr "&Uredi parametre"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Ne mogu da otvorim datoteku: „%s“"
@@ -5419,6 +7423,12 @@ msgstr "&Uredi parametre"
 #, c-format
 msgid "%s: is not a valid presets file.\n"
 msgstr "Ne mogu da otvorim/stvorim probnu datoteku.\n"
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
@@ -5471,10 +7481,30 @@ msgid "Factory Defaults"
 msgstr "Postavi &osnovno"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr ""
 "FLAC šifrer nije uspeo da započne\n"
 "Stanje: %d"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -5499,6 +7529,23 @@ msgid "&Bypass"
 msgstr "Opsežnopropusni"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Poravnaj %s/pomeri"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Premesti &gore"
 
@@ -5515,6 +7562,24 @@ msgid "Move effect down in the rack"
 msgstr "Odsečak je premešten na drugu numeru"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Odsečak je premešten na drugu numeru"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Unesite naziv novog lanca"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Pritajenost"
@@ -5524,8 +7589,17 @@ msgid "Some Command"
 msgstr "Izaberite naredbu"
 
 #: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "&Manage"
 msgstr "Upravljaj krivama"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Klizač puštanja"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -5586,14 +7660,33 @@ msgid "Options..."
 msgstr "Opcije..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "Vrsta &propusnika:"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Naziv"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Obrćem"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Greška: "
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "Prepisivanje"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -5655,12 +7748,36 @@ msgid "Graphic EQ"
 msgstr "Grafički EKu"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Niskotonac (dB):"
 
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Niskotonac"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -5695,6 +7812,10 @@ msgid "Effect Unavailable"
 msgstr "Pregled nije dostupan"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Najviše dB"
 
@@ -5707,6 +7828,26 @@ msgstr "%3d dB"
 msgid "Min dB"
 msgstr "Najmanje dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "Vrsta &propusnika:"
@@ -5714,6 +7855,11 @@ msgstr "Vrsta &propusnika:"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Iscrtaj krive"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Alat crtanja"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -5774,6 +7920,10 @@ msgstr "&Obrađujem: "
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "&Osnovno"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
@@ -5956,6 +8106,17 @@ msgstr "Krive su izvezene"
 msgid "No curves exported"
 msgstr "Krive nisu izvezene"
 
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
+
 #: src/effects/Fade.cpp
 msgid "Fade In"
 msgstr "Pojavi se"
@@ -5968,9 +8129,18 @@ msgstr "Iščezni"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Kliknite i prevucite da razvučete izabranu oblast."
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Kliknite i prevucite da razvučete izabranu oblast."
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Nađite odsečke"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
 
 #: src/effects/FindClipping.cpp
 msgid "Clipping"
@@ -5992,13 +8162,37 @@ msgstr "Nema dovoljno dostupnog mesta za stvaranje zvuka"
 msgid "Invert"
 msgstr "Preokreni"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "Efekti zvučne jedinice"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normalizuj najveći doseg na"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -6018,9 +8212,26 @@ msgstr "Obrađujem: "
 msgid "&Normalize"
 msgstr "Normalizuj"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Normalizujte stereo kanale nezavisno"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -6050,6 +8261,10 @@ msgid "Noise"
 msgstr "Buka:"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Vrsta buke:"
 
@@ -6062,16 +8277,73 @@ msgid "Second greatest"
 msgstr "Druga numera"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Osnovno uvećavanje"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Osnovno uvećavanje"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Smanjenje buke"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Da primenite propusnik, sve izabrane numere moraju biti istog protoka uzorka."
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -6130,8 +8402,9 @@ msgid "Step 1"
 msgstr "Korak 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Izaberite nekoliko sekundi čiste buke tako da Odvažnost zna šta da izbaci,\n"
@@ -6157,9 +8430,20 @@ msgstr ""
 msgid "Noise:"
 msgstr "Buka:"
 
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Isolate"
 msgstr "&Odeli"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Smanji veličinu"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -6173,6 +8457,11 @@ msgstr "Vr&sta prozora"
 msgid "Window si&ze:"
 msgstr "Ve&ličina prozora"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
+
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
 msgstr "1"
@@ -6185,17 +8474,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 — osnovni"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "Osnovno uvećavanje"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Uklanjanje buke"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -6234,6 +8569,10 @@ msgid "Normalize"
 msgstr "Normalizuj"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
 msgstr "Uklanjam DC pomeraj i normalizujem...\n"
 
@@ -6244,6 +8583,10 @@ msgstr "Uklanjam DC pomeraj...\n"
 #: src/effects/Normalize.cpp
 msgid "Normalizing without removing DC offset...\n"
 msgstr "Normalizujem bez uklanjanja DC pomeraja...\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 #, c-format
@@ -6290,9 +8633,14 @@ msgstr "Normalizujte stereo kanale nezavisno"
 msgid "Paulstretch"
 msgstr "Polstreč..."
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Faktor razvlačenja:"
@@ -6301,9 +8649,43 @@ msgstr "Faktor razvlačenja:"
 msgid "&Time Resolution (seconds):"
 msgstr "Vremenska rezolucija (sekunde):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Faznik"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -6366,6 +8748,10 @@ msgid "Repair"
 msgstr "Popravi"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -6396,6 +8782,10 @@ msgid "Repeat"
 msgstr "Ponovi"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "Broj ponavljanja:"
 
@@ -6416,6 +8806,10 @@ msgstr "Trajanje novog izbora: "
 #, c-format
 msgid "New selection length: %s"
 msgstr "Trajanje novog izbora: "
+
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
@@ -6456,6 +8850,10 @@ msgstr "Katedrala"
 #: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "Odjek"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "&Room Size (%):"
@@ -6510,6 +8908,10 @@ msgstr "Obrni"
 msgid "Reverses the selected audio"
 msgstr "Izvozim izabrani zvuk kao %s"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
 #. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Butterworth"
@@ -6536,6 +8938,11 @@ msgstr "Visokopropusni"
 #: src/effects/ScienFilter.cpp
 msgid "Classic Filters"
 msgstr "Uobičajeni propusnici"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
@@ -6587,12 +8994,25 @@ msgid "Frame Period:"
 msgstr "Kadar:"
 
 #: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Kadar:"
+
+#: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
 msgstr "Ve&ličina prozora"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "Ve&ličina prozora"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -6608,6 +9028,15 @@ msgstr "Osetljivost buke:"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "Poređaj prema vremenu"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "Poređaj prema vremenu"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -6646,11 +9075,20 @@ msgstr "&Osnovno"
 msgid "Restore Defaults"
 msgstr "Postavi &osnovno"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Utišaj"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -6675,6 +9113,10 @@ msgstr "Mešanje u &mono za vreme izvoza"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "Razvuci"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
 
 #: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
@@ -6733,6 +9175,14 @@ msgid "Tone"
 msgstr "Ton..."
 
 #: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Oblik talasa:"
 
@@ -6773,12 +9223,24 @@ msgid "Truncate Silence"
 msgstr "Skrati tišinu"
 
 #: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Otkrij tišinu"
 
 #: src/effects/TruncSilence.cpp
 msgid "Tr&uncate to:"
 msgstr "Skrati na:"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
@@ -6793,10 +9255,20 @@ msgid "VST Effects"
 msgstr "VST efekti"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Scanning Shell VST"
 msgstr "Tražim VST priključke"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Ne mogu da otvorim biblioteku MP3 kodiranja!"
 
@@ -6808,15 +9280,25 @@ msgstr "Podešavanja dejstva"
 msgid "Buffer Size"
 msgstr "Veličina međumemorije"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Veličina međumemorije (od 8 do 1048576 uzorka):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Uključi &nadoknadu"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Uključi &nadoknadu"
 
@@ -6842,7 +9324,18 @@ msgid "Save VST Preset As:"
 msgstr "Sačuvaj VST podešenost kao:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Izvezi podešenost"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Izvezi podešenost"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Datoteke projekta Odvažnosti"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -6869,9 +9362,15 @@ msgstr "Greška učitavanja VST podešenosti"
 msgid "Unable to load presets file."
 msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Podešavanja dejstva"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
@@ -6882,9 +9381,19 @@ msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Ova datoteka parametra je sačuvana sa %s.  Da nastavim?"
 
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "Vauvau"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -6912,6 +9421,11 @@ msgid "Audio Unit Effects"
 msgstr "Efekti zvučne jedinice"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Efekti zvučne jedinice"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
 msgstr "Ne mogu da učitam datoteku ili nesaglasan sadržaj."
 
@@ -6924,20 +9438,41 @@ msgid "Audio Unit Effect Options"
 msgstr "Efekti zvučne jedinice"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Sučelje"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Skupi izbor na levo"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Višegrupni"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Generisanje"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "Uvezi podešenost"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -7013,6 +9548,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Ne mogu da dovučem opis toka"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "pretvaranje protoka uzorka"
 
@@ -7020,6 +9560,21 @@ msgstr "pretvaranje protoka uzorka"
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Nisam uspeo da uklonim „%s“"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Ne mogu da dovučem opis toka"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Ne mogu da dovučem opis toka"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -7029,13 +9584,36 @@ msgstr "Zvučna jedinica"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "VST efekti"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "VST efekti"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Podešavanja dejstva"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -7043,6 +9621,7 @@ msgstr "Podešavanja dejstva"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "VST efekti"
@@ -7057,8 +9636,16 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Veličina međumemorije (od 8 do 1048576 uzorka):"
 
 #: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
 msgstr "Većina VST dejstava ima grafičko sučelje za podešavanje vrednosti parametara."
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
@@ -7074,13 +9661,27 @@ msgstr "%d krive su izvezene u %s\n"
 msgid "Generator"
 msgstr "Stvaralac"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "VST efekti"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Ponovo pregledaj dejstva"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -7096,6 +9697,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Izlaz Nikvista: "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Nije izabran lanac"
 
@@ -7108,12 +9727,30 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Izvinite, ne mogu da primenim efekat na stereo numerama gde se numere ne podudaraju."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Izlaz Nikvista: "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Obrađujem: "
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -7193,6 +9830,19 @@ msgid "Could not determine language"
 msgstr "Ne mogu da otvorim datoteku: "
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Unesite naredbu Nikvista: "
 
@@ -7209,6 +9859,22 @@ msgstr "Upit Nikvista"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Upit Nikvista"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Ne mogu da otvorim datoteku "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "Nije izmereno pročelje"
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -7229,13 +9895,18 @@ msgstr "Izaberite MIDI datoteku..."
 msgid "Save file as"
 msgstr "Sačuvaj datoteke"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "bez naslova"
 
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "VST efekti"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -7252,6 +9923,22 @@ msgstr "Izvinite, Vamp priključak nije uspeo da započne."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Podešavanja priključka"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Opšte opcije"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -7416,9 +10103,18 @@ msgstr ""
 "Da li želite da nastavite?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "Našao sam modul „%s“."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -7429,8 +10125,32 @@ msgstr ""
 "Možete da ga podesite u „Postavke > Biblioteke“."
 
 #: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "FFmpeg biblioteka:"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -7441,6 +10161,59 @@ msgid ""
 msgstr ""
 "FFmpeg ne može da pronađe kodek zvuka 0x%x.\n"
 "Podrška za ovaj kodek verovatno nije sastavljena."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -7461,7 +10234,8 @@ msgstr "Izvozim izabrani zvuk kao %s"
 msgid "Invalid sample rate"
 msgstr "Neispravan protok uzorka"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Ponovo uzorkuj"
 
@@ -7493,7 +10267,8 @@ msgstr "Protoci uzorka"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%i kb/s"
@@ -7513,6 +10288,45 @@ msgid "%.2f kbps"
 msgstr "%.2f kb/s"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
 msgstr "1"
 
@@ -7525,6 +10339,10 @@ msgid "Constrained"
 msgstr "Stalan"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Zvuk..."
 
@@ -7533,8 +10351,44 @@ msgid "Low Delay"
 msgstr "Kašnjenje"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Srednje"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -7605,8 +10459,17 @@ msgid "Replace preset '%s'?"
 msgstr "Da obrišem podešenost „%s“?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Glavno"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -7714,6 +10577,10 @@ msgstr "Jezik:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Rezervoar bita"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -7847,6 +10714,11 @@ msgstr ""
 "0 — osnovno\n"
 "min — 1\n"
 "max — 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -8006,6 +10878,17 @@ msgstr "Nema natpisa za izvoz."
 msgid "Select xml file to export presets into"
 msgstr "Izaberite hml datoteku u koju izvesti podešenosti"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
 msgstr "Nisam uspeo da pogodim format"
@@ -8092,12 +10975,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(najbolji kvalitet)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f kb/s"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f kb/s"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(manje datoteke)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -8108,7 +11043,8 @@ msgstr "Nezdravo"
 msgid "Extreme"
 msgstr "Suludo"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Obično"
 
@@ -8133,6 +11069,11 @@ msgid "Joint Stereo"
 msgstr "Pridruženi stereo"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Napravi stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Režim bitskog protoka:"
 
@@ -8145,14 +11086,19 @@ msgstr "Kvalitet"
 msgid "Channel Mode:"
 msgstr "Režim kanala:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Uklonjena je linija odsecanja"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Pronađi Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Odvažnosti je potrebna datoteka „%s“ da bi napravio MP3."
 
 #: src/export/ExportMP3.cpp
@@ -8180,13 +11126,34 @@ msgid "Where is %s?"
 msgstr "Gde se nalazi „%s“?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Vi ukazujete na „lame_enc.dll v%d.%d“. Ovo izdanje nije saglasno sa Odvažnošću %d.%d.%d.\n"
 "Molim preuzmite najnovije izdanje LAME MP3 biblioteke."
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Čuvam datoteke podataka projekta"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -8290,6 +11257,10 @@ msgstr ""
 #: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Putanja izvoza:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -8430,6 +11401,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Ne mogu da podesim kvalitet KvikTajm iscrtavanja"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
@@ -8440,6 +11431,10 @@ msgstr "Izvozim izabrani zvuk kao Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Izvozim izabrani zvuk kao Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -8458,8 +11453,28 @@ msgid "Other uncompressed files"
 msgstr "Ostale nesažete datoteke"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Greška uvoženja"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -8487,11 +11502,11 @@ msgid "All supported files"
 msgstr "Sve datoteke|*|Sve podržane datoteke|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "„%s“ \n"
@@ -8500,11 +11515,11 @@ msgstr ""
 "da je uređujete klikom na „Datoteka > Uvezi > MIDI“."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "„%s“ \n"
 "je MIDI datoteka, a ne zvučna datoteka. \n"
@@ -8516,18 +11531,18 @@ msgid "Select stream(s) to import"
 msgstr "Izaberite tok(ove) za uvoz"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Ovo izdanje Odvažnosti nije sastavljeno sa %s podrškom."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "„%s“ je numera zvučnog CD-a. \n"
 "Odvažnost ne može da otvori zvučni CD direktno. \n"
@@ -8536,10 +11551,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "„%s“ je datoteka liste numera. \n"
@@ -8548,10 +11563,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ je datoteka zvuka Vindouz medija (WMA). \n"
@@ -8560,10 +11575,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ je datoteka Naprednog kodiranja zvuka (AAC). \n"
@@ -8572,12 +11587,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "„%s“ je šifrovana zvučna datoteka. \n"
@@ -8588,10 +11603,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ je medijska datoteka RilPlejera. \n"
@@ -8600,12 +11615,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "„%s“ je datoteka zasnovana na notama, a ne zvučna datoteka. \n"
 "Odvažnost ne može da otvori ovu vrstu datoteke. \n"
@@ -8614,10 +11629,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -8630,10 +11645,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ je Vejvpak zvučna datoteka. \n"
@@ -8642,10 +11657,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ je Dolbi digital zvučna datoteka. \n"
@@ -8654,10 +11669,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "„%s“ je Ogg Spiks zvučna datoteka. \n"
@@ -8666,10 +11681,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "„%s“ je video datoteka. \n"
@@ -8683,20 +11698,31 @@ msgstr "Našao sam modul „%s“."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Odvažnost ne prepoznaje vrstu datoteke „%s“.\n"
 "Ako je nesažeta, pokušajte da je uvezete koristeći „Uvezi sirovu“."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -8705,6 +11731,11 @@ msgstr ""
 "Uvoznici koji navodno podržavaju takve datoteke su:\n"
 "%s,\n"
 "ali nijedan od njih ne razume ovaj format datoteke."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Čuvam datoteke podataka projekta"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8721,8 +11752,57 @@ msgid "Import Project"
 msgstr "Uvezi podešenost"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Unutrašnja greška o kojoj izveštava proces poravnanja."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Neispravan protok uzorka"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8730,16 +11810,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Ne mogu da pronađem fasciklu podataka projekta: „%s“"
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Projekti"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Neispravan protok uzorka"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Neispravan protok uzorka"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -8769,31 +11907,6 @@ msgstr "Indeks[%02x] Kodek[%s], Jezik[%s], Bitski protok[%s], Broj kanala[%d], T
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC datoteke"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "FFmpeg saglasne datoteke"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Proširenja uvoza"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Ne mogu da preimenujem „%s“ u „%s“."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Indeks[%02x] Kodek[%s], Jezik[%s], Bitski protok[%s], Broj kanala[%d], Trajanje[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -8851,6 +11964,14 @@ msgstr "Ne mogu da otvorim datoteku "
 msgid "MP3 files"
 msgstr "MP3 datoteke"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis datoteke"
@@ -8885,8 +12006,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "VAV, AIFF, i ostale nesažete vrste"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "VAV (Majkrosoft) označena 16 bita PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16 bita PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -8897,12 +12112,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24 bita PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24 bita PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16 bita PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32 bita pokretnog zareza"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32 bita pokretnog zareza"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "VAV (Majkrosoft) označena 16 bita PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bita"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -8913,12 +12172,20 @@ msgid "24 bit DWVW"
 msgstr "24 bita"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16 bita PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16 bita PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -9029,6 +12296,10 @@ msgstr "Protok uzorka:"
 msgid "&Import"
 msgstr "&Uvezi"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -9049,6 +12320,7 @@ msgstr "desno"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -9073,6 +12345,7 @@ msgstr "Kraj"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -9094,15 +12367,35 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Pomereno je vreme numera/odsečaka %s %.02f sek."
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Pomereno je vreme numera/odsečaka %s %.02f sek."
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Pomeranje vremena"
 
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "Odseci &granice"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "Odseci &granice"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "Odseci &granice"
 
 #: src/menus/ClipMenus.cpp
@@ -9223,7 +12516,8 @@ msgstr "Skratite izabrane zvučne numere sa %.2f sekunde na %.2f"
 msgid "Trim Audio"
 msgstr "Skrati zvuk"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Podeli"
 
@@ -9344,32 +12638,8 @@ msgid "Delete Key&2"
 msgstr "Taster brisanja2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "M&ešač"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Doteraj jačinu zvuka puštanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Povećaj jačinu zvuka puštanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Smanji jačinu zvuka puštanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Doteraj jačinu zvuka snimanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Povećaj jačinu zvuka snimanja"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Smanji jačinu zvuka snimanja"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -9394,6 +12664,13 @@ msgstr "Promeni kanale snimanja"
 #: src/menus/ExtraMenus.cpp
 msgid "&Full Screen (on/off)"
 msgstr "Uključi/isključi ceo ekran"
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -9452,6 +12729,11 @@ msgstr "Uvezite natpise"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Izaberite MIDI datoteku..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Sve datoteke (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -9532,6 +12814,11 @@ msgid "&Labels..."
 msgstr "&Oznake..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Izvezi MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Sirove podatke..."
 
@@ -9548,6 +12835,10 @@ msgstr "&Štampaj..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "&Izađi"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -9580,6 +12871,10 @@ msgid "Nothing to do"
 msgstr "Ništa za poništavanje"
 
 #: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
 msgstr "Zatvori numeru u prvom planu"
 
@@ -9590,6 +12885,10 @@ msgstr "Ne mogu da otvorim datoteku projekta"
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Početak snimanja"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -9608,12 +12907,17 @@ msgid "&Getting Started"
 msgstr "Početak izbora:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Dnevnik Odvažnosti"
+#, fuzzy
+msgid "&Manual"
+msgstr "Upravljaj krivama"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "Po&moć"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -9631,11 +12935,8 @@ msgstr "Podaci &zvučnog uređaja..."
 msgid "Show &Log..."
 msgstr "Prikaži &dnevnik..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&O Odvažnosti..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etiketa je dodata"
 
@@ -9761,6 +13062,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "Nalepi &tekst na novu oznaku"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "&Označei zvuk"
 
@@ -9825,6 +13130,18 @@ msgid "Label Join"
 msgstr "Uredi natpis"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "Premesti unazad sa linija alata do numera"
 
@@ -9865,8 +13182,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Prebaci numeru u prvom planu"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Novo..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -9881,6 +13206,10 @@ msgstr "Priključci od %i do %i"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "&Generisanje"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -9964,6 +13293,16 @@ msgid "Set Track Status..."
 msgstr "na po&četak numere"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Ućutkaj zvuk"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "Poređaj &numere"
+
+#: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
 msgstr "Postavke..."
 
@@ -9986,6 +13325,12 @@ msgstr "&Uredi natpise..."
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "Sačuvaj projekat &kao..."
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Promenljiv"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -10062,6 +13407,11 @@ msgid "In All &Sync-Locked Tracks"
 msgstr "U svim usaglašenim &zaključanim numerama"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr " Zaključavanje usklađenja je izabrano"
+
+#: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "&Oblast puštanja"
 
@@ -10130,8 +13480,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Linearna učestalost"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Izbor za početak"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Položaj zvuka:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -10268,6 +13627,14 @@ msgstr "Dugi skok kursora levo"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "Dugi skok kursora desno"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Short Seek &Left During Playback"
@@ -10476,18 +13843,21 @@ msgid "Created new label track"
 msgstr "Stvorena je nova natpisna numera"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Ovo izdanje Odvažnosti dopušta samo jednu vremensku numeru za svaki prozor projekta."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Stvorena je nova vremenska numera"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Novi protok uzorka (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Uneta vrednost je neispravna"
 
@@ -10567,6 +13937,11 @@ msgid "&Time Track"
 msgstr "&Vremensku numeru"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "M&ešač"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Podeli stereo u &mono"
 
@@ -10605,6 +13980,10 @@ msgstr "&Utišaj sve numere"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "&Poništi utišanje svih numera"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -10736,7 +14115,9 @@ msgstr "Pusti"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Snimanje"
 
@@ -10749,8 +14130,27 @@ msgid "no label track at or below focused track"
 msgstr "Kanališi levo nad numerom u prvom planu"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Stvorena je nova natpisna numera"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -10818,6 +14218,11 @@ msgid "&Timer Record..."
 msgstr "&Vremensko snimanje..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "Snimanje aktivirano zvukom"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "&Oblast puštanja"
 
@@ -10846,16 +14251,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "Snimanje &aktivirano zvukom (uklj./isk.)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Kraj snimanja"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "&Naknadno dupliranje (uklj./isk.)"
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "&Softversko puštanje (uklj./isk.)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Osamostaljeno &doterivanje nivoa snimanja (uklj./isk.)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -10865,6 +14271,11 @@ msgstr "Pre&nos"
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "Pusti/&zaustavi"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -10982,6 +14393,11 @@ msgid "&Fit to Width"
 msgstr "Uklopi u &prozor"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "Uklopi u &prozor"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Skupi sve numere"
 
@@ -11025,6 +14441,18 @@ msgstr "VST efekti"
 msgid "&Window"
 msgstr "prozor"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
@@ -11050,7 +14478,7 @@ msgstr "Postavke: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Zatvori Odvažnost"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -11097,7 +14525,8 @@ msgstr "&Domaćin"
 msgid "Using:"
 msgstr "Koristi:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Puštanje"
 
@@ -11117,7 +14546,8 @@ msgstr "Broj &kanala"
 msgid "Latency"
 msgstr "Pritajenost"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisek."
 
@@ -11137,8 +14567,19 @@ msgstr "Nema sučelja zvuka"
 msgid "No devices found"
 msgstr "Nisam pronašao uređaje"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "Mono — 1 kanal"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "Stereo — 2 kanala"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Direktorijumi"
 
@@ -11151,8 +14592,22 @@ msgid "Default directories"
 msgstr "Direktorijumi"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Razgledaj..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -11212,6 +14667,11 @@ msgstr "Izaberite mesto za čuvanje datoteka"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
 msgid "Directory %s does not exist. Create it?"
 msgstr "Direktorijum %s ne postoji. Da ga napravim?"
 
@@ -11225,7 +14685,8 @@ msgid "Directory %s is not writable"
 msgstr "Direktorijum „%s“ nije upisiv"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Izmene u privremenom direktrorijumu neće stupiti na snagu sve dok ponovo ne pokrenete Odvažnost"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -11240,11 +14701,36 @@ msgstr "Postavke: "
 msgid "Sorted by Effect Name"
 msgstr "Poređaj prema nazivu"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Poređaj prema nazivu"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Poređaj prema nazivu"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "VST efekti"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -11253,6 +14739,18 @@ msgstr "VST efekti"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "Nikvist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -11263,11 +14761,24 @@ msgid "Effect Options"
 msgstr "Podešavanja dejstva"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Podešavanja priključka"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Pretraži VST efekte prilikom sledećeg pokretanja Odvažnosti"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -11419,6 +14930,10 @@ msgid "Location of &Manual:"
 msgstr "&Uputstvo se nalazi:"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "dB opseg &merača/talasnog oblika:"
 
@@ -11431,6 +14946,10 @@ msgid "Show e&xtra menus"
 msgstr "Prikaži mrežu duž &Y ose"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "&Zapišti nakon završetka dužih aktivnosti"
 
@@ -11438,9 +14957,46 @@ msgstr "&Zapišti nakon završetka dužih aktivnosti"
 msgid "Re&tain labels if selection snaps to a label"
 msgstr "&Očuvaj natpise ako izbor prianja na ivicu natpisa"
 
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Podešavanja priključka"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Lenjir"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Uvoz / izvoz"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Postavke: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -11453,6 +15009,10 @@ msgstr "Napredne opcije mešanja"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "Obično"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -11470,9 +15030,22 @@ msgstr "Prilikom izvoza numera u datoteku zvuka"
 msgid "S&how Metadata Tags editor before export"
 msgstr "&Prikaži uređivač metapodataka pred korak izvoženja"
 
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Izvezi natpise kao:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11557,7 +15130,15 @@ msgid "&Defaults"
 msgstr "&Osnovno"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Izaberite HML datoteku koja sadrži prečice tastature Odvažnosti..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -11566,8 +15147,21 @@ msgstr "Greška uvoza prečica tastature"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Učitah %d prečice tastature\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -11588,6 +15182,15 @@ msgstr "Ne možete dodeliti ključ ovom unosu"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "Morate izabrati svezu pre dodeljivanja prečice"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -11658,12 +15261,17 @@ msgid "Dow&nload"
 msgstr "Preuz&mi"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Odvažnost je samostalno otkrio ispravne FFmpeg biblioteke.\n"
 "Da li još uvek želite da ih pronađete ručno?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -11700,6 +15308,10 @@ msgstr "Pritajenost MIDI sintetisajzera (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "Pritajenost MIDI sintetisajzera mora biti ceo broj"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -11710,8 +15322,9 @@ msgid "Preferences for Module"
 msgstr "Postavke: "
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Ovo su probni moduli. Uključite ih samo ako ste pročitali uputstvo\n"
@@ -11719,16 +15332,24 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "„Pitaj“ znači da će Odvažnost pitati da li želite učitati priključak pri svakom njenom pokretanju."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "„Neuspeh“ znači da će Odvažnost misliti da je priključak oštećen i neće ga pokretati."
 
+#. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Izmene u privremenom direktrorijumu neće stupiti na snagu sve dok ponovo ne pokrenete Odvažnost"
 
 #: src/prefs/ModulePrefs.cpp
@@ -11746,6 +15367,10 @@ msgstr "Nisam pronašao uređaje"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Moduli"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -11787,7 +15412,10 @@ msgstr "Levo prevlačenje"
 msgid "Set Selection Range"
 msgstr "Podešavanje opsega izbora"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Šift + levi klik"
 
@@ -11874,6 +15502,15 @@ msgstr "Levo prevlačenje"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Premeštanje odsečaka gore/dole između numera"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Levo prevlačenje"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -11985,8 +15622,21 @@ msgstr "&Kratak period:"
 msgid "Lo&ng period:"
 msgstr "&Dugi period:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Postavke Odvažnosti"
 
 #: src/prefs/PrefsDialog.cpp
@@ -12000,6 +15650,11 @@ msgstr "Postavke: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Postavke: "
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -12060,12 +15715,22 @@ msgid "Play &other tracks while recording (overdub)"
 msgstr "Pre-dupliranje: &Pusti ostale numere za vreme snimanja nove"
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "&Softversko puštanje (uklj./isk.)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Nova numera"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Detect dropouts"
+msgstr "Izaberite tok(ove) za uvoz"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -12106,41 +15771,37 @@ msgid "System &Date"
 msgstr "Datum početka"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Osamostaljeno doterivanje nivoa snimanja"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Uključite osamostaljeno doterivanje nivoa snimanja."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Vrhunac cilja:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Unutar:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Vreme analiziranja:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisekunde (vreme jedne analize)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Broj uzastopnih analiza:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 znači beskonačno"
+#, fuzzy
+msgid "System T&ime"
+msgstr "Datum početka"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Snimanje aktivirano zvukom"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Pribeleži numeru"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -12174,6 +15835,11 @@ msgstr "&Linearno"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Učestalost"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -12234,12 +15900,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "Naj&veća učestanost (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "&Pojačanje (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "&Opseg (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -12262,12 +15936,21 @@ msgid "1024 - default"
 msgstr "256 — osnovni"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 — najuskopojasniji"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "Vr&sta prozora"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Faktor raspada:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -12355,13 +16038,14 @@ msgid "Info"
 msgstr "Podaci"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -12449,6 +16133,18 @@ msgid "\"Move track focus\" c&ycles repeatedly through tracks"
 msgstr "„Premesti prvi plan numere“ &kruži sa ponavljanjem kroz numere"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Napredne opcije mešanja"
 
@@ -12469,6 +16165,10 @@ msgid "Spectrogram"
 msgstr "Spektrogram"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "Ponovo iscrtajte"
 
@@ -12483,6 +16183,10 @@ msgstr "Uvećaj &izbor"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "Osnovno uvećavanje"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -12505,6 +16209,16 @@ msgid "50ths of Seconds"
 msgstr "sekunde"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "sekunde"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "sekunde"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "milisek."
 
@@ -12512,7 +16226,12 @@ msgstr "milisek."
 msgid "Samples"
 msgstr "uzorci"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zumiranje"
 
@@ -12521,8 +16240,29 @@ msgid "Preferences for Tracks"
 msgstr "Postavke: "
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "&Prikaži naziv numere u prikazu talasnog oblika"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Kraj snimanja"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -12531,6 +16271,11 @@ msgstr "Osnovni režim &pregleda:"
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Osnovni &oblik uzorka:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "uzorci"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -12582,6 +16327,10 @@ msgid "Mixing down to &stereo during export"
 msgstr "Mešanje u &stereo za vreme izvoza"
 
 #: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
 msgid "Missing file &name extension during export"
 msgstr "Mešanje u &mono za vreme izvoza"
 
@@ -12606,16 +16355,24 @@ msgid "Stopped"
 msgstr "Zaustavi"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pauziraj"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Prebaci na početak"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Prebaci na kraj"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pauziraj"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Izbor za početak"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Izbor za kraj"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -12629,20 +16386,17 @@ msgstr "Nova numera"
 msgid "Append Record"
 msgstr "Prikači &zapis"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Izbor za kraj"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Izbor za početak"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pauziraj"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -12722,11 +16476,17 @@ msgstr "Utišaj zvučni izbor"
 msgid "Sync-Lock Tracks"
 msgstr "Uskladi-zaključaj numere"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Uvećajte"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Umanjite"
 
@@ -12793,50 +16553,23 @@ msgstr "&Merač"
 msgid "&Playback Meter Toolbar"
 msgstr "&Merač"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Jačina zvuka snimanja"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Jačina zvuka puštanja"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Jačina zvuka snimanja: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Jačina zvuka snimanja (nedostupno; koristite sistemski mešač.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Jačina zvuka puštanja: %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Jačina zvuka puštanja: %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Jačina zvuka puštanja (nedostupno; koristite sistemski mešač.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "M&ešač"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "Lenjir"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Upit Nikvista"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Upit Nikvista"
@@ -12844,6 +16577,7 @@ msgstr "Upit Nikvista"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Upit Nikvista"
@@ -12851,9 +16585,24 @@ msgstr "Upit Nikvista"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Pokreni praćenje"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Pokreni praćenje"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Lenjir"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -12901,7 +16650,9 @@ msgstr "Prioni na"
 msgid "Length"
 msgstr "Trajanje"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Na sredini"
 
@@ -12909,6 +16660,14 @@ msgstr "Na sredini"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "Prioni klikove/izbore na „%s“"
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -12928,8 +16687,17 @@ msgid "Center frequency and Width"
 msgstr "Linearna učestalost"
 
 #: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Low and High Frequencies"
+msgstr "Učestalost"
+
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Center Frequency"
 msgstr "Linearna učestalost"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
@@ -12949,8 +16717,8 @@ msgstr "&Uređaji"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Linija alata Odvažnosti — %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -12977,7 +16745,8 @@ msgstr "Alat pomeranja vremena"
 msgid "Zoom Tool"
 msgstr "Alat uvećanja"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Alat crtanja"
 
@@ -13053,11 +16822,13 @@ msgstr "Prevucite jednu ili više granica natpisa"
 msgid "Drag label boundary."
 msgstr "Prevucite granicu natpisa"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Izmenjeni natpis"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Uredi natpis"
 
@@ -13112,31 +16883,42 @@ msgstr "Uređeni natpisi"
 msgid "New label"
 msgstr "Etiketa je dodata"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "&Gornja oktava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "&Donja oktava"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Kliknite za uspravno uvećanje. Šift-klik za umanjenje. Prevucite da odredite oblast prvog plana."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Desni klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Umanjite"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Šift + levi klik"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Šift + levi klik"
 
@@ -13159,6 +16941,14 @@ msgid "Stretch"
 msgstr "Razvuci"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "Stopljeni su odsečci"
 
@@ -13170,7 +16960,8 @@ msgstr "Stopi"
 msgid "Expanded Cut Line"
 msgstr "Raširena je linija odsecanja"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Raširi"
 
@@ -13194,6 +16985,11 @@ msgstr "Premešten je uzorak"
 msgid "Sample Edit"
 msgstr "Uređivanje uzorka"
 
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Uvećavanje nad tačkom"
@@ -13201,6 +16997,16 @@ msgstr "Uvećavanje nad tačkom"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "&Spektrogram"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -13226,7 +17032,8 @@ msgstr "Obrađujem: "
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "„%s“ je izmenjena u %s"
@@ -13240,7 +17047,60 @@ msgid "Rat&e"
 msgstr "Postavi &protok"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 č 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 č 060 m 060>0100 s"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -13261,7 +17121,8 @@ msgstr "Promena protoka"
 msgid "Set Rate"
 msgstr "Postavi protok"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Više"
 
@@ -13280,6 +17141,10 @@ msgstr "&Podeli stereo numeru"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Podeljen je stereo u mono „%s“"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -13350,10 +17215,25 @@ msgid "Right, %dHz"
 msgstr "Desni, "
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "desno"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -13363,6 +17243,15 @@ msgstr "Kliknite i prevucite da doterate relativnu veličinu stereo numere."
 msgid "Click and drag to rearrange sub-views"
 msgstr "Kliknite i prevucite da promenite veličinu numere."
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Kliknite i prevucite da promenite veličinu numere."
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "Uvećajte"
@@ -13370,6 +17259,10 @@ msgstr "Uvećajte"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "Zumiranje"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -13456,9 +17349,8 @@ msgstr "Logaritamsko &umetanje"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Kliknite i prevucite da promenite veličinu numere."
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -13509,6 +17401,21 @@ msgstr "Doterana omotnica."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "&Linije alata"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Pokreni praćenje"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Lenjir"
@@ -13524,6 +17431,11 @@ msgstr "Zatvori numeru u prvom planu"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Premesti numeru na &dno"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Upit Nikvista"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -13580,6 +17492,11 @@ msgstr "Kliknite i prevucite da razvučete izabranu oblast."
 msgid "Click and drag to select audio"
 msgstr "Kliknite i prevucite da razvučete izabranu oblast."
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Kliknite i prevucite da promenite veličinu numere."
@@ -13601,6 +17518,10 @@ msgstr "Utišane su izabrane numere za %.2f sekunde pri %.2f"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Utišane su izabrane numere za %.2f sekunde pri %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -13630,6 +17551,12 @@ msgstr "Ktrl + levi klik"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Molim izaberite radnju"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track."
 msgstr "Molim izaberite radnju"
@@ -13649,6 +17576,18 @@ msgstr "„%s“ je premeštena %s"
 msgid "Move Track"
 msgstr "Premeštena je numera"
 
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Click to Zoom In, Shift-Click to Zoom Out"
+msgstr ""
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Drag to Zoom Into Region, Right-Click to Zoom Out"
+msgstr ""
+
+#: src/tracks/ui/ZoomHandle.cpp
+msgid "Left=Zoom In, Right=Zoom Out, Middle=Normal"
+msgstr ""
+
 #: src/widgets/AButton.cpp
 msgid "(disabled)"
 msgstr " (isključeno)"
@@ -13661,6 +17600,12 @@ msgstr "Pritisni"
 msgid "Button"
 msgstr "Dugme"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
 #. i18n-hint: One-letter abbreviation for Right, in the Pan slider
 #. i18n-hint: One-letter abbreviation for Right, in VU Meter
 #: src/widgets/ASlider.cpp src/widgets/Meter.cpp
@@ -13672,6 +17617,19 @@ msgstr "D"
 #, c-format
 msgid "%.2fx"
 msgstr "%.1f dB"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"„%s“ ne postoji.\n"
+"\n"
+"Da li želite da napravite?"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy
+msgid "Please choose an existing file."
+msgstr "Molim izaberite radnju"
 
 #: src/widgets/FileDialog/mac/FileDialogPrivate.mm
 msgid "File type:"
@@ -13696,6 +17654,21 @@ msgstr "Prazno"
 #: src/widgets/HelpSystem.cpp
 msgid "Backwards"
 msgstr "Pozadina"
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Prebaci na početak"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -13764,12 +17737,21 @@ msgid "Meter Style"
 msgstr "Merač"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Vrsta &propusnika:"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Trajanje"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Samostalni oporavak posle pada"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -13784,9 +17766,22 @@ msgid " Monitoring "
 msgstr "Zaustavi praćenje"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Show Log for Details"
@@ -13856,6 +17851,18 @@ msgstr "0100 č 060 m 060>0100 s"
 msgid "hh:mm:ss + milliseconds"
 msgstr "čč:mm:ss + milisekunde"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 č 060 m 060>0100 s"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
 #: src/widgets/NumericTextCtrl.cpp
@@ -13876,6 +17883,7 @@ msgstr "0100 h 060 m 060 s+># kadrova"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "uzorci"
@@ -14037,6 +18045,15 @@ msgstr "01000,01000 kadrova|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 č 060 m 060>0100 s"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -14044,6 +18061,10 @@ msgstr "0100 č 060 m 060>0100 s"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 č 060 m 060>0100 s"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -14059,11 +18080,47 @@ msgstr "do oktave"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 kadrova|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 kadrova|24"
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
@@ -14072,6 +18129,11 @@ msgstr "(Koristite priručni izbornik da izmenite zapis.)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "stotinke"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -14115,6 +18177,11 @@ msgstr "Potvrdi"
 msgid "Unable to write files to directory: %s."
 msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -14133,6 +18200,10 @@ msgid "Don't show this warning again"
 msgstr "Ne prikazuj više ovo upozorenje"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "—Beskonačno"
 
@@ -14141,13 +18212,31 @@ msgid "-Infinity"
 msgstr "—Beskonačno"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Prazno"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Prikači &zapis"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Uvećavanje nad opsegom"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Greška LOF-a"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -14165,11 +18254,20 @@ msgid "Value must not be greater than %s"
 msgstr "Pokretanje i zaustavljanje moraju biti veći od 0."
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Stvoren je novi projekt"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
+msgstr "Direktorijumi"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
 msgstr "Direktorijumi"
 
 #: src/xml/XMLFileReader.cpp
@@ -14190,16 +18288,49 @@ msgstr "Ne mogu da otvorim datoteku "
 msgid "Spectral edit multi tool"
 msgstr "Izbor"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filter"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Učestalost"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Greška"
@@ -14214,8 +18345,34 @@ msgstr "&Pojačanje (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Najmanja učestanost mora biti barem 0 Hz"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -14229,9 +18386,22 @@ msgstr "Iščezni"
 msgid "Applying Fade..."
 msgstr "Primenjujem..."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "Postavi &osnovno"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -14263,8 +18433,16 @@ msgid "S-Curve Down"
 msgstr "Premesti &dole"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Početak"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -14273,6 +18451,14 @@ msgstr "Pojačanje"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Početak"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -14285,6 +18471,14 @@ msgstr "Linearno"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Linearno"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -14333,6 +18527,14 @@ msgstr "Pojačanje učestanosti ne može biti negativno"
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "Pojačanje učestanosti ne može biti negativno"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Ponovi"
@@ -14340,6 +18542,10 @@ msgstr "Ponovi"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Nađi odsečke..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Dnevnik Odvažnosti"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -14353,6 +18559,23 @@ msgstr "Odsecanje"
 msgid "Reconstructing clips..."
 msgstr "Uklanjam klikove i oblačiće..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Osetljivost %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Pribeleži numeru"
@@ -14360,6 +18583,21 @@ msgstr "Pribeleži numeru"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Pribeleži numeru"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -14393,6 +18631,19 @@ msgstr "Naziv numere"
 msgid "Fade direction"
 msgstr "čitaj posredno"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Kašnjenje"
@@ -14408,6 +18659,19 @@ msgstr "Kašnjenje"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "Pravougaoni"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "&Smanjenje buke (dB):"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -14433,6 +18697,14 @@ msgstr "&Prikaži"
 msgid "Number of echoes"
 msgstr "Broj ponavljanja:"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Ponovi poslednje dejstvo"
@@ -14444,6 +18716,10 @@ msgstr "Ujednačavanje"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3 datoteke"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -14458,10 +18734,24 @@ msgstr "Potvrdi prepisivanje"
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Ne mogu da otvorim datoteku žanra."
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Greška (datoteka nije mogla biti zapisana): %s"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Greška (datoteka nije mogla biti zapisana): %s"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -14492,10 +18782,50 @@ msgstr "Trajanje (u sekundama)"
 msgid "Length of label region (seconds)"
 msgstr "Trajanje (u sekundama)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Uredi natpis"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -14509,6 +18839,11 @@ msgstr "Otkači"
 msgid "Warnings only"
 msgstr "Upozorenja"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -14517,6 +18852,12 @@ msgstr "Oblast &čuvanja"
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Uređeni natpisi"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -14531,13 +18872,50 @@ msgstr "Uobičajeni propusnici"
 msgid "Performing High-Pass Filter..."
 msgstr "Izvršavam uobičajeno izdvajanje"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Učestanost (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Najmanja učestanost mora biti barem 0 Hz"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -14585,6 +18963,11 @@ msgid "Point after sound"
 msgstr "Pridruženi stereo"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "Sa trajanja u sekundama"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "Sa trajanja u sekundama"
 
@@ -14592,11 +18975,41 @@ msgstr "Sa trajanja u sekundama"
 msgid "Maximum leading silence"
 msgstr "Skraćujem tišinu..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Skraćujem tišinu..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Izbor mora biti veći od %d uzorka."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -14628,8 +19041,25 @@ msgid "Hard Clip"
 msgstr "Nađite odsečke"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Desni kanal"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "&Nivo (dB):"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -14691,6 +19121,44 @@ msgstr "Vreme napada/raspada"
 msgid "Decay (ms)"
 msgstr "Vreme napada/raspada"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Izbor mora biti veći od %d uzorka."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Trajanje filtera"
@@ -14702,6 +19170,18 @@ msgstr "Primenjujem izravnavača..."
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "Postavi &osnovno"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -14724,7 +19204,8 @@ msgstr "MP3 datoteke"
 msgid "HTML file"
 msgstr "MP3 datoteke"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Datoteke naziva:"
 
@@ -14741,9 +19222,24 @@ msgid "Disallow"
 msgstr "Odbijeno"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Odbijeno"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Nisam uspeo da uklonim „%s“"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -14754,16 +19250,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Izaberite MIDI datoteku..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Nekorišćeni filteri:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Izaberite MIDI datoteku..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Stvaram ton"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Vrsta &propusnika:"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -14776,6 +19314,10 @@ msgstr "Ukloni numeru"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "Stvaram cvrkut"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -14794,8 +19336,20 @@ msgid "Swing amount"
 msgstr "Izobličenje"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Broj ponavljanja:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -14818,12 +19372,54 @@ msgid "Beat sound"
 msgstr "Ponovi"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Uklanjam buku"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Pod buke"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -14846,6 +19442,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "Linearna učestalost"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Učestanost (Hz)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "Doseg (0-1)"
 
@@ -14856,6 +19461,10 @@ msgstr "Ne mogu da izvezem"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Primenjujem..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -14874,6 +19483,10 @@ msgid "HTML files"
 msgstr "MP3 datoteke"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Uređivanje uzorka"
 
@@ -14886,8 +19499,29 @@ msgid "Include header information"
 msgstr "Podaci o izgradnji"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "Sve"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -14902,6 +19536,11 @@ msgstr "\t-help (ova poruka)"
 msgid "Errors Only"
 msgstr "Greška: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -14914,6 +19553,46 @@ msgstr "Desni kanal"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "uzorci"
 
@@ -14921,6 +19600,43 @@ msgstr "uzorci"
 #, lisp-format
 msgid "~a seconds."
 msgstr "sekunde"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -14939,6 +19655,10 @@ msgid "Value (dB)"
 msgstr "&Visokotonac (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Linearno"
 
@@ -14955,6 +19675,14 @@ msgid "Right (dB)"
 msgstr "Desni, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Linearno"
 
@@ -14965,6 +19693,40 @@ msgstr "Stereo — 2 kanala"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "Mono — 1 kanal"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Greška (datoteka nije mogla biti zapisana): %s"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -14979,8 +19741,40 @@ msgid "Select file"
 msgstr "Izaberite MIDI datoteku..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Greška"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -14990,6 +19784,15 @@ msgstr "Ne mogu da otvorim datoteku žanra."
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Izbor"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -15012,8 +19815,16 @@ msgid "Wet level (percent)"
 msgstr "2 nivo"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Primenjujem..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -15055,9 +19866,96 @@ msgstr "&Analiziranje"
 msgid "Strength"
 msgstr "Filter"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Obrađujem: "
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -15091,6 +19989,189 @@ msgstr "Učestanost (Hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Učestanost (Hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Zatvori Odvažnost"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Kanal"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Greška prilikom otvaranja datoteke"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Greška učitavanja metapodataka"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Linija alata Odvažnosti — %s"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Snimanje"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Naredba:"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "uvoz putem Gstrimera"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Nije bilo moguće optimizovati ga više. I dalje je isuviše visok."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Doterivanje nivoa osamostaljenog snimanja je smanjilo jačinu zvuka na %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Nije bilo moguće optimizovati ga više. I dalje je isuviše nizak."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Doterivanje nivoa osamostaljenog snimanja je povećalo jačinu zvuka na %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Ukupan broj analiza je prekoračen bez pronalaženja prihvatljive jačine zvuka. I dalje je isuviše visok."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. Ukupan broj analiza je prekoračen bez pronalaženja prihvatljive jačine zvuka. I dalje je isuviše nizak."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Doterivanje nivoa osamostaljenog snimanja je zaustavljeno. %.2f izgleda prihvatljiva jačina zvuka."
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Ne mogu da otvorim datoteku žanra.\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Klizač snimanja\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Jačina zvuka puštanja\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Jačina zvuka snimanja\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Jačina zvuka snimanja\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Jačina zvuka puštanja: %.2f%s\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Jačina zvuka puštanja: %.2f%s\n"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "FFmpeg saglasne datoteke"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Proširenja uvoza"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Ne mogu da preimenujem „%s“ u „%s“."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Indeks[%02x] Kodek[%s], Jezik[%s], Bitski protok[%s], Broj kanala[%d], Trajanje[%d]"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Doteraj jačinu zvuka puštanja"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Povećaj jačinu zvuka puštanja"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Smanji jačinu zvuka puštanja"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Doteraj jačinu zvuka snimanja"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Povećaj jačinu zvuka snimanja"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Smanji jačinu zvuka snimanja"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Dnevnik Odvažnosti"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&O Odvažnosti..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Osamostaljeno &doterivanje nivoa snimanja (uklj./isk.)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Osamostaljeno doterivanje nivoa snimanja"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Uključite osamostaljeno doterivanje nivoa snimanja."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Vrhunac cilja:"
+
+#~ msgid "Within:"
+#~ msgstr "Unutar:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Vreme analiziranja:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisekunde (vreme jedne analize)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Broj uzastopnih analiza:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 znači beskonačno"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Jačina zvuka snimanja"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Jačina zvuka puštanja"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Jačina zvuka snimanja: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Jačina zvuka snimanja (nedostupno; koristite sistemski mešač.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Jačina zvuka puštanja: %.2f%s"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Jačina zvuka puštanja: %.2f%s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Jačina zvuka puštanja (nedostupno; koristite sistemski mešač.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "M&ešač"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Kliknite i prevucite da promenite veličinu numere."
+
 #~ msgid "Program build date:"
 #~ msgstr "Datum izgradnje programa: "
 
@@ -15104,10 +20185,6 @@ msgstr "Učestanost (Hz)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "Ne"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Ne mogu da otvorim/stvorim probnu datoteku."
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -16145,10 +21222,6 @@ msgstr "Učestanost (Hz)"
 #~ msgstr "Prepisivanje"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "&Linije alata"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "Naredba"
 
@@ -16256,10 +21329,6 @@ msgstr "Učestanost (Hz)"
 #, fuzzy
 #~ msgid "S-E"
 #~ msgstr "SSE"
-
-#, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
 
 #, fuzzy
 #~ msgid "Show start time and end time"
@@ -16488,10 +21557,6 @@ msgstr "Učestanost (Hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "Skrati na:"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Obrćem"
 
 #~ msgid "C&ategory:"
 #~ msgstr "&Kategorija:"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -9,11 +9,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-27 11:11+0000\n"
 "Last-Translator: Snakecharmer <floup@gmx.com>\n"
-"Language-Team: Swedish <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/sv/>\n"
+"Language-Team: Swedish <https://hosted.weblate.org/projects/tenacity/tenacity/sv/>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,64 +21,41 @@ msgstr ""
 "X-Generator: Weblate 4.8.1-dev\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Uppdatera Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Hoppa över"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Installera uppdatering"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Ändringslogg"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Läs mer på GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Fel vid sökning efter uppdatering"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Fel uppstod när metadata lästes in"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s är tillgänglig!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Inspelning"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Kunde inte fastställas"
 
+#: libraries/lib-strings/Internat.cpp
+#, fuzzy, c-format
+msgid "%s bytes"
+msgstr "byte"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Förenklad"
+
+#: libraries/lib-strings/Languages.cpp
+#, fuzzy
+msgid "System"
+msgstr "System&datum"
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -198,7 +174,8 @@ msgid "Script"
 msgstr "Skript"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Utmatning"
 
@@ -214,7 +191,12 @@ msgstr "Nyquist-skript (*.ny)|*.ny|Lisp-skript (*.lsp)|*.lsp|Alla filer|*"
 msgid "Script was not saved."
 msgstr "Skriptet sparades inte."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Varning"
 
@@ -235,14 +217,18 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango ikongalleri (verktygsfältsikoner)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Leland Lucius"
+msgstr "(C) 2009 av Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "(C) 2009 av Leland Lucius"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
-msgstr ""
-"Extern Tenacity-modul som tillhandahåller en enkel utvecklingsmiljö för att "
-"skriva effekter."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr "Extern Tenacity-modul som tillhandahåller en enkel utvecklingsmiljö för att skriva effekter."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -264,7 +250,8 @@ msgstr "Namnlös"
 msgid "Nyquist Effect Workbench - "
 msgstr "Instrumentpanel för Nyquist-effekter - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Nytt"
 
@@ -304,7 +291,8 @@ msgstr "Kopiera"
 msgid "Copy to clipboard"
 msgstr "Kopiera till urklipp"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Klipp ut"
 
@@ -312,7 +300,8 @@ msgstr "Klipp ut"
 msgid "Cut to clipboard"
 msgstr "Klipp ut till urklipp"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Klistra in"
 
@@ -337,7 +326,8 @@ msgstr "Markera allt"
 msgid "Select all text"
 msgstr "Markera all text"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Ångra"
 
@@ -345,7 +335,8 @@ msgstr "Ångra"
 msgid "Undo last change"
 msgstr "Ångra senaste ändring"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Gör om"
 
@@ -402,7 +393,8 @@ msgid "Go to next S-expr"
 msgstr "Gå till nästa S-uttryck"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Början"
 
@@ -410,7 +402,8 @@ msgstr "Början"
 msgid "Start script"
 msgstr "Starta skript"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Stoppa"
 
@@ -424,15 +417,23 @@ msgstr "Stoppa skript"
 msgid "About %s"
 msgstr "Om %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr "OK"
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Versionsinformation"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Inaktiverad"
 
@@ -442,8 +443,9 @@ msgid "The Build"
 msgstr "Kompilering"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Commit-ID:"
+#, fuzzy
+msgid "Version:"
+msgstr "Gör baklänges"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -453,22 +455,28 @@ msgstr "Versionstyp:"
 msgid "Compiler:"
 msgstr "Kompilator:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Installationsprefix:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Inställningsmapp:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Inställningsmapp:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Stöd av filformat"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Plattformsoberoende gränssnittsbibliotek"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -482,7 +490,6 @@ msgstr "Konvertering av samplingsfrekvens"
 msgid "MP3 Importing"
 msgstr "MP3-import"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Import och export av Ogg Vorbis"
@@ -491,7 +498,6 @@ msgstr "Import och export av Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Stöd för ID3-tagg"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Import och export av FLAC"
@@ -509,14 +515,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Import-/exportbibliotek för FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Importera via GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Innehåll"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Stöd för insticksmoduler"
 
@@ -531,6 +529,10 @@ msgstr "Stöd för ändring av tonhöjd och tempo"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Stöd för extrem ändring av tonhöjd och tempo"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Innehåll"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -649,6 +651,10 @@ msgstr "%s, Tenacity-grafik"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (inkluderande %s, %s, %s, %s and %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -658,6 +664,10 @@ msgstr "%s är den fria, plattformsoberoende mjukvaran med öppen källkod för 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Tack till"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Lägg märke till att namnen är sorterade i alfabetisk ordning, inte efter betydelse."
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -691,6 +701,10 @@ msgid "%s Team Members"
 msgstr "%s teammedlemmar"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr "Tenacity Emeritus:"
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Tenacitys Bidragsgivare"
 
@@ -703,6 +717,7 @@ msgstr "Tenacitys webbplats och grafik"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Lars \"musselasse\" Carlsson (200X-2014) och A. Regnander (2018) för översättning till svenska"
@@ -720,6 +735,22 @@ msgstr "Tenacity vill speciellt tacka:"
 #, c-format
 msgid "%s website: "
 msgstr "%ss webbplats: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s medarbetarna"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Tenacity%ss varumärke används i den här mjukvaran endast för deskriptiva och informationsmässiga ändamål."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -742,6 +773,7 @@ msgstr "Tidslinje"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Klicka och dra för att redigera samplingar"
@@ -749,6 +781,7 @@ msgstr "Klicka och dra för att redigera samplingar"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Klicka och dra för att börja använda scrubbing"
@@ -756,6 +789,7 @@ msgstr "Klicka och dra för att börja använda scrubbing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Klicka och flytta för att använda scrubbing. Klicka och dra för att söka."
@@ -763,6 +797,7 @@ msgstr "Klicka och flytta för att använda scrubbing. Klicka och dra för att s
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Flytta för att söka"
@@ -770,6 +805,7 @@ msgstr "Flytta för att söka"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Flytta för att använda scrubbing"
@@ -826,7 +862,17 @@ msgstr ""
 "Kan inte låsa området bortom\n"
 "slutet på projektet."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Fel"
 
@@ -850,7 +896,8 @@ msgstr ""
 "Denna fråga ställs en gång, efter en \"installering\" där du tillfrågas om återställning av inställningarna."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Återställ Tenacitys inställningar"
 
 #: src/AudacityApp.cpp
@@ -863,6 +910,11 @@ msgstr ""
 "%s kunde inte hittas.\n"
 "\n"
 "Den har raderats från listan över senaste filer."
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr "Kunde inte initiera SQLite-biblioteket.  Tenacity kan inte fortsätta."
 
 #: src/AudacityApp.cpp
 msgid "Block size must be within 256 to 100000000\n"
@@ -886,7 +938,7 @@ msgstr "&Öppna..."
 msgid "Open &Recent..."
 msgstr "Öppna senaste..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&Om Tenacity..."
 
@@ -899,33 +951,34 @@ msgid "&File"
 msgstr "&Arkiv"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity kunde inte hitta säker plats att spara temporära filer. \n"
-"Tenacity behöver en plats där automatiserade upprensningsprogram inte "
-"raderar temporära filer.\n"
+"Tenacity behöver en plats där automatiserade upprensningsprogram inte raderar temporära filer.\n"
 "Var vänlig och skriv in lämplig katalog i inställningarna."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity kunde inte hitta plats att spara temporära filer. \n"
 "Var vänlig och skriv in lämplig plats i inställningarna."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
-msgstr ""
-"Tenacity kommer nu att avslutas. Var vänlig och starta om Tenacity för att "
-"använda den nya temporära katalogen."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
+msgstr "Tenacity kommer nu att avslutas. Var vänlig och starta om Tenacity för att använda den nya temporära katalogen."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -934,15 +987,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity kunde inte låsa katalogen för temporära filer.\n"
 "Denna mapp används eventuellt av en annan instans av Tenacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Vill du ändå starta Tenacity?"
 
 #: src/AudacityApp.cpp
@@ -950,19 +1005,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Fel uppstod när temporär mapp låstes"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Systemet har upptäckt att en annan instans av Tenacity körs.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Använd kommandon Ny eller Öppna i pågående instans av\n"
 "Tenacity för att öppna flera projekt samtidigt.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity körs redan"
 
 #: src/AudacityApp.cpp
@@ -978,7 +1036,8 @@ msgstr ""
 "och en omstart kan krävas."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Fel vid start av Tenacity"
 
 #: src/AudacityApp.cpp
@@ -1018,8 +1077,9 @@ msgstr ""
 "och en omstart kan krävas."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1051,7 +1111,8 @@ msgstr "kör självdiagnostik"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "visa Tenacity-version"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1061,9 +1122,10 @@ msgid "audio or project file name"
 msgstr "ljud- eller projektfilnamn"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1076,16 +1138,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tenacity-projektfiler"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Meddelande"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Fel vid konfigurering av Tenacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1095,28 +1159,27 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Följande konfigurationsfil kunde inte öppnas:\n"
 "\n"
 "%s\n"
 "\n"
-"Det kan bero på många saker, men det troligaste är att hårddisken är full "
-"eller att du inte har tillstånd att skriva till filen. Du kan få mer "
-"information genom att klicka på hjälpknappen nedan.\n"
+"Det kan bero på många saker, men det troligaste är att hårddisken är full eller att du inte har tillstånd att skriva till filen. Du kan få mer information genom att klicka på hjälpknappen nedan.\n"
 "\n"
-"Du kan försöka åtgärda problemet och sedan klicka på \"Försök igen\" för att "
-"fortsätta.\n"
+"Du kan försöka åtgärda problemet och sedan klicka på \"Försök igen\" för att fortsätta.\n"
 "\n"
-"Om du väljer \"Avsluta Tenacity\" kan ditt projekt hamna i ett osparat "
-"tillstånd och återställas nästa gång du öppnar det."
+"Om du väljer \"Avsluta Tenacity\" kan ditt projekt hamna i ett osparat tillstånd och återställas nästa gång du öppnar det."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Hjälp"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Avsluta Tenacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1124,7 +1187,8 @@ msgid "&Retry"
 msgstr "&Försök igen"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacity-logg"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1136,9 +1200,14 @@ msgstr "&Spara..."
 msgid "Cl&ear"
 msgstr "Re&nsa"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "S&täng"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1187,7 +1256,8 @@ msgid "Error Initializing Midi"
 msgstr "Fel uppstod när MIDI initialiserades"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity-ljud"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1202,37 +1272,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Slut på minne!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Automatisk justering av inspelningsnivån stoppades. Det var inte möjligt att optimera det mer. Fortfarande för hög."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Automatisk justering av inspelningsnivån minskade volymen till %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Automatisk justering av inspelningsnivån stoppades. Det var inte möjligt att optimera det mer. Fortfarande för låg."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Automatisk justering av inspelningsnivån ökade volymen till %2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Automatisk justering av inspelningsnivån stoppades. Antalet analyser överskreds utan att finna en acceptabel volym. Fortfarande för hög."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Automatisk justering av inspelningsnivån stoppades. Antalet analyser överskreds utan att finna en acceptabel volym. Fortfarande för låg."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Automatisk justering av inspelningsnivån stoppades. %2f verkar vara en acceptabel volym."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1331,43 +1370,6 @@ msgstr "Ingen uppspelningsenhet funnen för '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Kan inte kontrollera gemensam samplingsfrekvens utan båda enheterna.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Fick %d medan enheterna öppnades\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Kunde inte öppna Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Tillgängliga mixers:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Tillgängliga inspelningskällor:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Tillgänglig uppspelningsvolymer:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Inspelningsvolymen är emulerad\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Inspelningsvolymen är ursprunglig\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Uppspelningsvolymen är emulerad\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Uppspelningsvolym är ursprunglig\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1410,28 +1412,29 @@ msgid "Automatic Crash Recovery"
 msgstr "Automatiskt återskapande vid krasch"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
-"Följande projekt sparades inte ordentligt förra gången Tenacity kördes, men "
-"de kan återskapas automatiskt.\n"
+"Följande projekt sparades inte ordentligt förra gången Tenacity kördes, men de kan återskapas automatiskt.\n"
 "\n"
-"Spara projekten efter återställning för att vara säker på att de skrivs till "
-"disk."
+"Spara projekten efter återställning för att vara säker på att de skrivs till disk."
 
 #: src/AutoRecoveryDialog.cpp
 msgid "Recoverable &projects"
 msgstr "&Projekt möjliga att återskapa"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Markera"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Namn"
 
@@ -1517,6 +1520,11 @@ msgstr "Effekt"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menykommando (med parametrar)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1662,7 +1670,8 @@ msgstr "Åter&ställ"
 msgid "I&mport..."
 msgstr "I&mportera..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "E&xportera..."
 
@@ -1703,7 +1712,8 @@ msgstr "Flytta &upp"
 msgid "Move &Down"
 msgstr "Flytta &ned"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Spara"
 
@@ -1786,9 +1796,17 @@ msgid "Run"
 msgstr "Kör"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Stäng"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "Prestandatest"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1922,9 +1940,8 @@ msgid "Benchmark completed successfully.\n"
 msgstr "Prestandatestet slutfördes.\n"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Slutdatum och -tid"
+msgid "No revision identifier was provided"
+msgstr ""
 
 #: src/BuildInfo.h
 #, c-format
@@ -2179,6 +2196,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "&Kopiera namn till urklipp"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Filer saknas"
 
@@ -2187,15 +2209,15 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Om du fortsätter, kommer inte ditt projekt att sparas. Är det det du vill?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
-"Ditt projekt är för tillfället oberoende; det förlitar sig inte på några "
-"externa ljudfiler.\n"
+"Ditt projekt är för tillfället oberoende; det förlitar sig inte på några externa ljudfiler.\n"
 "\n"
 "En del äldre Tenacity-projekt kanske inte är oberoende och\n"
 "försiktighet krävs för att hålla deras externa beroenden på rätt ställe.\n"
@@ -2205,7 +2227,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Kontrollera beroenden"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Inget"
 
@@ -2213,7 +2238,7 @@ msgstr "Inget"
 msgid "Rectangle"
 msgstr "Rektangel"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Triangel"
 
@@ -2227,25 +2252,65 @@ msgstr "Rekangulär"
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "Välkommen!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Stöd för FFmpeg kompilerades inte i"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
 "FFmpeg konfigurerades i inställningarna och har kunnat startas tidigare,\n"
 "men denna gång misslyckades Tenacity att ladda det vid uppstart.\n"
 "\n"
-"Gå kanske vill gå tillbaka till Inställningar > Bibliotek och konfigurera "
-"det rätt."
+"Gå kanske vill gå tillbaka till Inställningar > Bibliotek och konfigurera det rätt."
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -2260,11 +2325,9 @@ msgid "Locate FFmpeg"
 msgstr "Hitta FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"Tenacity behöver filen \"%s\" för att importera och exportera ljud via "
-"FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "Tenacity behöver filen \"%s\" för att importera och exportera ljud via FFmpeg."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2276,7 +2339,8 @@ msgstr "Plats för \"%s\":"
 msgid "To find '%s', click here -->"
 msgstr "För att hitta \"%s\", klicka här -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Bläddra..."
 
@@ -2302,8 +2366,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg hittades inte"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2312,8 +2377,7 @@ msgstr ""
 "Tenacity försökte använda FFmpeg för att importera en ljudfil,\n"
 "men biblioteken kunde inte hittas.\n"
 "\n"
-"För att kunna importera med FFmpeg, gå till Redigera > Inställningar > "
-"Bibliotek\n"
+"För att kunna importera med FFmpeg, gå till Redigera > Inställningar > Bibliotek\n"
 "för att ladda ner eller lokalisera FFmpeg-biblioteken."
 
 #: src/FFmpeg.cpp
@@ -2334,24 +2398,24 @@ msgid "Only libavformat.so"
 msgstr "Endast libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity misslyckades att öppna en fil i %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity misslyckades att läsa in en fil i %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Tenacity skrev en till i %s men misslyckades att döpa om den till %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2389,7 +2453,9 @@ msgstr "Kopiera &inte något ljud"
 msgid "As&k"
 msgstr "Frå&ga"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Alla filer|*"
 
@@ -2414,6 +2480,10 @@ msgstr "Namnge filer:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3-filer"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2455,6 +2525,14 @@ msgstr "Cuberoot-autokorrelation"
 msgid "Enhanced Autocorrelation"
 msgstr "Förbättrad autokorrelation"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Spektrum"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2471,9 +2549,35 @@ msgstr "Linjär frekvens"
 msgid "Log frequency"
 msgstr "Logga frekvens"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "B"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Rulla"
+
+#: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom"
+msgstr "&Zooma"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2534,6 +2638,23 @@ msgstr "För mycket ljud har markerats. Bara de första %.1f sekunderna av ljud 
 msgid "Not enough data selected."
 msgstr "Inte tillräckligt mycket data har markerats."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr "s"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2549,10 +2670,16 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f sek (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Spektrum"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Exportera spektrumsdata som:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Kunde inte skriva till fil: %s"
@@ -2629,8 +2756,7 @@ msgstr "Ingen lokal hjälp"
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
-msgstr ""
-"<br><br>Versionen av Tenacity du använder är en <b>alfatestsversion</b>."
+msgstr "<br><br>Versionen av Tenacity du använder är en <b>alfatestsversion</b>."
 
 #: src/HelpText.cpp
 msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
@@ -2642,9 +2768,7 @@ msgstr "Vi rekommenderar starkt att du använder vår senaste stabila utgivna ve
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"Du kan hjälpa oss att göra Tenacity redo för utgivning genom att gå med i "
-"vår [[https://tenacityaudio.org|gemenskap]].<hr><br><br>"
+msgstr "Du kan hjälpa oss att göra Tenacity redo för utgivning genom att gå med i vår [[https://tenacityaudio.org|gemenskap]].<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2657,16 +2781,12 @@ msgstr "Dessa är våra sätt att ge support:"
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[file:quick_help.html|Snabbhjälp]] - om den inte är installerad lokalt, läs "
-"den online"
+msgstr "[[file:quick_help.html|Snabbhjälp]] - om den inte är installerad lokalt, läs den online"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
-msgstr ""
-" [[file:index.html|Manual]] - om den inte är installerad lokalt, läs den "
-"online"
+msgstr " [[file:index.html|Manual]] - om den inte är installerad lokalt, läs den online"
 
 #: src/HelpText.cpp
 msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
@@ -2674,38 +2794,23 @@ msgstr " Forum- ställ din fråga direkt på internet."
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"Mer:</b> Besök vår wiki för tips, tricks, extra guider och insticksmoduler "
-"till effekter."
+msgstr "Mer:</b> Besök vår wiki för tips, tricks, extra guider och insticksmoduler till effekter."
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"Tenacity kan importera oskyddade filer i många andra format (som M4A och "
-"WMA, komprimerade WAV-filer från portabla inspelningsenheter och ljud från "
-"videofiler) om du laddar ned och installerar det valfria FFmpeg-biblioteket "
-"på din dator."
+msgstr "Tenacity kan importera oskyddade filer i många andra format (som M4A och WMA, komprimerade WAV-filer från portabla inspelningsenheter och ljud från videofiler) om du laddar ned och installerar det valfria FFmpeg-biblioteket på din dator."
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"Du kan också läsa vår hjälp om hur man importerar MIDI-filer och spår från "
-"ljud-CD."
+msgstr "Du kan också läsa vår hjälp om hur man importerar MIDI-filer och spår från ljud-CD."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Manualen verkar inte vara installerad. Du kan [[*URL*|läsa manualen på "
-"internet]].<br><br>För att alltid läsa manualen online, ändra \"Manualens "
-"plats\" i gränssnittsinställningarna till \"Från internet\"."
+msgstr "Manualen verkar inte vara installerad. Du kan [[*URL*|läsa manualen på internet]].<br><br>För att alltid läsa manualen online, ändra \"Manualens plats\" i gränssnittsinställningarna till \"Från internet\"."
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"Manualen verkar inte vara installerad. Du kan [[*URL*|läsa manualen på "
-"internet]] eller ladda ner manualen.<br><br>För att alltid läsa manualen "
-"online, ändra \"Manualens plats\" i gränssnittsinställningarna till \"Från "
-"internet\"."
+msgstr "Manualen verkar inte vara installerad. Du kan [[*URL*|läsa manualen på internet]] eller ladda ner manualen.<br><br>För att alltid läsa manualen online, ändra \"Manualens plats\" i gränssnittsinställningarna till \"Från internet\"."
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2764,19 +2869,19 @@ msgid "&History..."
 msgstr "&Historik..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internt fel i %s på %s rad %d.\n"
 "Var god meddela Tenacity-teamet på https://tenacityaudio.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Internt fel på %s vid %s rad %d.\n"
 "Var god meddela Tenacity-teamet på https://tenacityaudio.org/."
@@ -2795,7 +2900,9 @@ msgid "Track"
 msgstr "Spår"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etikett"
 
@@ -2855,7 +2962,8 @@ msgstr "Ange spårets namn"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Etikettspår"
 
@@ -2866,11 +2974,13 @@ msgstr "En eller fler sparade etiketter kunde inte läsas."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Första gången Tenacity körs"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Välj språk för Tenacity att använda:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2880,7 +2990,8 @@ msgstr "Välj språk för Tenacity att använda:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Språket du valde, %s (%s), är inte densamma som systemspråket, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Bekräfta"
 
@@ -2898,8 +3009,18 @@ msgstr ""
 "Den gamla filen sparades som \"%s\""
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Öppnar Tenacity-projekt"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Tenacity Karaoke%s"
+
+#: src/LyricsWindow.cpp
+msgid "&Karaoke..."
+msgstr "&Karaoke..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2945,19 +3066,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Mixar och renderar spår"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tenacitys mixerbord%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Förstärkning"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Hastighet"
 
@@ -2966,28 +3091,42 @@ msgid "Musical Instrument"
 msgstr "Musikinstrument"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Panorering"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Tyst"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Signalnivåmätare"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Flyttade förstärkningsreglaget"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Flyttade hastighetsreglaget"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Flyttade panoreringsreglaget"
 
@@ -3018,9 +3157,9 @@ msgstr ""
 "Den kommer inte att läsas in."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3053,16 +3192,19 @@ msgstr ""
 "\n"
 "Använd endast moduler från pålitliga källor"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Ja"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Nej"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity modulinläsare"
 
 #: src/ModuleManager.cpp
@@ -3084,6 +3226,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Notspår"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "C"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "C♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "D"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "D♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "E"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "F"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "F♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "G"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "G♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "A"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "A♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "B"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "D♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "E♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "G♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "A♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "B♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "C♯/D♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "D♯/E♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "F♯/G♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "G♯/A♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "A♯/B♭"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3193,7 +3445,8 @@ msgstr "&Markera allt"
 msgid "C&lear All"
 msgstr "A&vmarkera allt"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Aktivera"
 
@@ -3272,9 +3525,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Samplingsfrekvenserna passar inte ihop"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "För få spår är valda för att spela in vid den här samplingsfrekvenser.\n"
@@ -3303,10 +3557,11 @@ msgid "Dropouts"
 msgstr "Signalförluster"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3346,11 +3601,11 @@ msgid "Inspecting project file data"
 msgstr "Undersöker data i projektfil"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3393,11 +3648,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Varning - Saknar aliasfil(er)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Projektkontrollen av mappen \"%s\" \n"
@@ -3422,12 +3677,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Varning - Saknar aliassammanfattningsfil(er)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3485,7 +3740,8 @@ msgstr "Varning - Föräldralösa blockfil(er)"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Förlopp"
 
@@ -3510,6 +3766,11 @@ msgstr "Varning: Problem med automatisk återställning"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<namnlös>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[Projekt %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3572,12 +3833,14 @@ msgstr ""
 "(Kan inte skapa de nödvändiga tillfälliga filerna)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Det här är inte en Tenacity-projektfil"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3709,9 +3972,9 @@ msgid "Error Writing to File"
 msgstr "Fel vid skrivning till fil"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3725,9 +3988,16 @@ msgstr "Projekt &sparas"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Projekt %02i] Tenacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3736,10 +4006,10 @@ msgstr "(återskapad)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Denna fil är sparad i Tenacity %s.\n"
 "Du använder Tenacity %s. Du behöver kanske uppgradera till\n"
@@ -3748,6 +4018,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Kan inte öppna projektfil"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr "Borttagning av automatiskt sparad information från projektfilen misslyckades."
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -3762,6 +4036,10 @@ msgid "Unable to parse project information."
 msgstr "Kunde inte läsa förinställningsfil."
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr "Projektets databas kunde inte öppnas på nytt, kanske för att det är ont om utrymme på lagringsenheten."
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "Projekt &sparas"
 
@@ -3770,12 +4048,43 @@ msgid "Error Saving Project"
 msgstr "Fel uppstod när projektet sparades"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr "Synkroniserar"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+"Projektfilen kunde inte öppnas, kanske på grund av begränsat utrymme\n"
+"på lagringsenheten.\n"
+"\n"
+"%s"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+"Projektfilen kunde inte öppnas, kanske på grund av begränsat utrymme\n"
+"på lagringsenheten.\n"
+"\n"
+"%s"
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "&Tomma projekt sparas"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3783,8 +4092,26 @@ msgstr ""
 "Lyckligtvis kan följande projekt återskapas automatiskt:"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"Det här projektet sparades inte ordentligt förra gången Tenacity kördes.\n"
+"\n"
+"Det har återställts till den sista ögonblicksbilden, men du måste spara det\n"
+"för att bevara dess innehåll."
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "Projektet återskapades"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Katalog för temporära filer"
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -3814,6 +4141,17 @@ msgstr "Varning - Tomt projekt"
 msgid "Insufficient Disk Space"
 msgstr "Diskutrymme"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
@@ -3833,8 +4171,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sSpara projektet \"%s\" som..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "\"Spara projekt\" är för ett Tenacity-projekt, inte en ljudfil.\n"
@@ -3911,11 +4250,12 @@ msgid "Error Opening Project"
 msgstr "Fel uppstod när projekt öppnades"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Du försöker öppna en automatisk skapad säkerhetskopia.\n"
 "Detta kan leda till att data går förlorad.\n"
@@ -3948,6 +4288,12 @@ msgid "Error Opening File or Project"
 msgstr "Fel uppstod när fil eller projekt skulle öppnas"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "Projektet återskapades"
 
@@ -3973,12 +4319,33 @@ msgid "Error Importing"
 msgstr "Fel uppstod under import"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "Ändra projekt"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Kan inte öppna projektfil"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Kommando"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -3989,8 +4356,8 @@ msgid "Automatic database backup failed."
 msgstr "Automatisk sparning har aktiverats:"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Välkommen till Tenacity version %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4049,6 +4416,14 @@ msgstr[1] "%d minuter"
 msgid "%s and %s."
 msgstr "%s och %s."
 
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
+"Den här återställningsfilen sparades i Tenacity 2.3.0 eller tidigare.\n"
+"Du behöver köra den versionen av Tenacity för att återställa projektet."
+
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
 #. Other tabs in that notebook may have instruments, patch panels etc.
@@ -4063,6 +4438,21 @@ msgstr "Horisontell rullningslist"
 #: src/ProjectWindow.cpp
 msgid "Vertical Scrollbar"
 msgstr "Vertikalt rullningslist"
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
 
 #: src/Resample.cpp
 msgid "Low Quality (Fastest)"
@@ -4183,7 +4573,8 @@ msgstr "Alla inställningar"
 msgid "SelectionBar"
 msgstr "Markeringsfält"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektrumsmarkering"
 
@@ -4191,36 +4582,60 @@ msgstr "Spektrumsmarkering"
 msgid "Timer"
 msgstr "Tid:"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Verktyg"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "&Transport"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Mixer"
+msgstr "Mixerpanel"
+
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Mätare"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Uppspelningsmätare"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Inspelningsmätare"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Redigera"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Enhet"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Spela upp efter hastighet"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "Aktivera &scrubbing"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -4233,7 +4648,10 @@ msgstr "Linjal"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Spår"
 
@@ -4343,7 +4761,8 @@ msgid "Activation level (dB):"
 msgstr "Aktiveringsnivå (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Välkommen till Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4373,6 +4792,11 @@ msgstr "Spårnummer"
 #: src/Tags.cpp
 msgid "Year"
 msgstr "År"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genre"
+msgstr "Genrer"
 
 #: src/Tags.cpp src/prefs/MousePrefs.cpp
 msgid "Comments"
@@ -4466,10 +4890,28 @@ msgstr "Fel uppstod när taggfil sparades"
 msgid "Unsuitable"
 msgstr "Opassande modul"
 
-#: src/Theme.cpp
-#, c-format
+#: src/TempDirectory.cpp
+#, fuzzy
 msgid ""
-"Audacity could not write file:\n"
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Katalog för temporära filer"
+
+#: src/TempDirectory.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+"Disken är full.\n"
+"%s\n"
+"Klicka på hjälpknappen för tips om hur du kan frigöra utrymme."
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity kunde inte skriva till fil:\n"
@@ -4489,9 +4931,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4500,9 +4942,9 @@ msgstr ""
 " för att skriva till."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity kunde inte skriva bilder till fil:\n"
@@ -4519,9 +4961,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4531,9 +4973,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4542,8 +4984,9 @@ msgstr ""
 "Kanske ett dåligt png-format?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity kunde inte läsa dess standardtema.\n"
@@ -4581,9 +5024,9 @@ msgstr ""
 "finns redan. Vill du skriva över?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity kunde inte spara fil:\n"
@@ -4622,7 +5065,11 @@ msgstr "Anpassat"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Längd"
 
@@ -4633,7 +5080,8 @@ msgid "Time Track"
 msgstr "Tidspår"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Tenacitys timerinspelning"
 
 #: src/TimerRecordDialog.cpp
@@ -4707,7 +5155,8 @@ msgstr "Nuvarande projekt"
 msgid "Recording start:"
 msgstr "Inspelningens början:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Längd:"
 
@@ -4728,7 +5177,8 @@ msgid "Action after Timer Recording:"
 msgstr "Handling efter timerinspelning:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Tenacitys Tidsinställd inspelning"
 
 #: src/TimerRecordDialog.cpp
@@ -4809,6 +5259,12 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Timerinspelning"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "099 dygn 024 h 060 m 060 s"
+
 #. i18n-hint a format string for days, hours, minutes, and seconds
 #: src/TimerRecordDialog.cpp
 msgid "099 days 024 h 060 m 060 s"
@@ -4819,6 +5275,7 @@ msgstr "099 dygn 024 h 060 m 060 s"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Startdatum och -tid"
@@ -4863,7 +5320,8 @@ msgstr "Aktivera automatisk &exportering?"
 msgid "Export Project As:"
 msgstr "Exportera projektet som:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Alternativ"
 
@@ -4876,7 +5334,8 @@ msgid "Do nothing"
 msgstr "Gör ingenting"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Avsluta Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4900,7 +5359,8 @@ msgid "Scheduled to stop at:"
 msgstr "Schemalagt att stoppas vid:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Tenacitys timerinspelning - Väntar på att starta"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4926,8 +5386,13 @@ msgid "Recording Exported:"
 msgstr "Inspelning exporterades:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Tenacitys timerinspelning - Väntar"
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5048,6 +5513,10 @@ msgstr "Flytta upp spåret"
 msgid "Move Track Down"
 msgstr "Flytta ned spåret"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -5114,6 +5583,20 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Verkställer %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Batchkommando"
@@ -5128,16 +5611,33 @@ msgstr "%s är inte en parameter som accepteras av %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Ogiltigt värde parametern \"%s\": Den bör vara %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Kommando"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Upprepa %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -5150,6 +5650,10 @@ msgstr "Tröskel:"
 #: src/commands/CompareAudioCommand.h
 msgid "Compares a range on two tracks."
 msgstr "Jämför ett intervall på två spår."
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
 
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
@@ -5166,6 +5670,11 @@ msgstr "Utför demoåtgärden."
 #: src/commands/DragCommand.cpp
 msgid "Drag"
 msgstr "Dra"
+
+#: src/commands/DragCommand.cpp src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Panel"
+msgstr "Spårpanel"
 
 #: src/commands/DragCommand.cpp src/prefs/ApplicationPrefs.cpp
 msgid "Application"
@@ -5236,13 +5745,24 @@ msgstr "Klipp"
 msgid "Envelopes"
 msgstr "Envelopper"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiketter"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Fält"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5251,6 +5771,12 @@ msgstr "Kort"
 #: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
 msgid "Type:"
 msgstr "Typ:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "Nuvarande projekt"
 
 #: src/commands/GetInfoCommand.h
 msgid "Gets information in JSON format."
@@ -5276,9 +5802,17 @@ msgstr "Kommentarer"
 msgid "Command:"
 msgstr "Kommando:"
 
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
 msgstr "Ger hjälp om ett kommando."
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -5308,17 +5842,26 @@ msgstr "Exporterar till en fil."
 msgid "Builtin Commands"
 msgstr "Inbyggda kommandon"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tenacity-teamet"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Tillhandahåller inbyggda kommandon i Tenacity"
 
 #: src/commands/LoadCommands.cpp
 msgid "Unknown built-in command name"
 msgstr "Okänt namn på inbyggt kommando"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -5360,11 +5903,22 @@ msgstr "Sparar ett projekt."
 msgid "Saves a copy of current project."
 msgstr "Sparar ett projekt."
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Hämta inställning"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Namn:"
 
@@ -5412,7 +5966,8 @@ msgstr "Helskärm"
 msgid "Toolbars"
 msgstr "Verktygsfält"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Effekter"
 
@@ -5552,7 +6107,8 @@ msgstr "Ändra"
 msgid "Add"
 msgstr "Lägg till"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Radera"
 
@@ -5612,6 +6168,11 @@ msgstr "Vid:"
 msgid "Color:"
 msgstr "Färg:"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
+#, fuzzy
+msgid "Start:"
+msgstr "Början"
+
 #: src/commands/SetClipCommand.h
 msgid "Sets various values for a clip."
 msgstr "Ändrar olika värden för ett klipp."
@@ -5633,7 +6194,8 @@ msgid "Edited Envelope"
 msgstr "Ändra envelopp"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Envelopp"
 
@@ -5676,6 +6238,14 @@ msgstr "Frekvens:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Ändra storlek:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5725,7 +6295,10 @@ msgstr "Panorera:"
 msgid "Set Track Visuals"
 msgstr "Ändra spårets utseende"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Linjär"
 
@@ -5748,6 +6321,11 @@ msgstr "Visning:"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
 msgstr "Skala:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "VZoom max:"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
@@ -5825,12 +6403,18 @@ msgstr "Du har valt ett spår som inte innehåller ljud. Duckning kan bara bearb
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Automatisk ducking behöver ett kontrollspår som måste vara placerad under valt spår."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Duckingsmängd:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "sekunder"
 
@@ -5854,7 +6438,8 @@ msgstr "Längd för inre nedtoning:"
 msgid "Inner &fade up length:"
 msgstr "Längd för inre upptoning:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Tröskel:"
 
@@ -5981,6 +6566,10 @@ msgid "from (Hz)"
 msgstr "från (Hz)"
 
 #: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
 msgstr "till (Hz)"
 
@@ -5988,11 +6577,13 @@ msgstr "till (Hz)"
 msgid "t&o"
 msgstr "till"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Procentuell ändring:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Procentuell ändring"
 
@@ -6001,12 +6592,24 @@ msgid "&Use high quality stretching (slow)"
 msgstr "Använd sträckning i hög kvalitet (långsam)"
 
 #: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
 msgid "45"
 msgstr "4"
 
 #: src/effects/ChangeSpeed.cpp
 msgid "78"
 msgstr "8"
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -6032,6 +6635,7 @@ msgstr "Rpm för standardvinyl:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Från rpm"
@@ -6044,6 +6648,7 @@ msgstr "från"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Till rpm"
@@ -6186,6 +6791,12 @@ msgstr "Komprimerare"
 msgid "Compresses the dynamic range of audio"
 msgstr "Komprimerar ljudets dynamiska intervall"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6194,6 +6805,20 @@ msgstr "%.2f sek"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f sek"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f sek"
 
 #: src/effects/Compressor.cpp
@@ -6311,7 +6936,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Kontrastanalys, för att mäta skillnaden i RMS-volym mellan två ljudmarkeringar."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Slut"
 
@@ -6371,6 +6997,18 @@ msgstr "&Skillnad:"
 msgid "&Help"
 msgstr "&Hjälp"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "noll"
@@ -6378,6 +7016,13 @@ msgstr "noll"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "obestämd"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB RMS"
+msgstr "%.1f dB medelvärde rms"
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6431,6 +7076,12 @@ msgstr "Nuvarande skillnad"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Mätt förgrundsnivå"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -6500,6 +7151,12 @@ msgstr "Framgångskriterier 1.4.7 av WCAG 2.0: Misslyckades"
 msgid "Data gathered"
 msgstr "Samlad data"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
 msgstr "Kontrastanalys (WCAG 2-överensstämmelse)"
@@ -6565,6 +7222,10 @@ msgstr "Mjukt klipp -12dB, 80% ombrytningsförstärkning"
 #: src/effects/Distortion.cpp
 msgid "Fuzz Box"
 msgstr "Fuzzbox"
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Blues drive sustain"
@@ -6633,6 +7294,16 @@ msgstr "Perkussionsbegränsare"
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
 msgstr "Övre tröskel"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Parametrar"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Parametrar"
 
 #: src/effects/Distortion.cpp
 msgid "Number of repeats"
@@ -6751,6 +7422,12 @@ msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by t
 msgstr "Generar tvåtoniga multifrekvenstoner (DTMF) som efterliknar knappsatstoner på telefoner"
 
 #: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "DTMF-sekvens:"
 
@@ -6758,7 +7435,9 @@ msgstr "DTMF-sekvens:"
 msgid "&Amplitude (0-1):"
 msgstr "Amplitud (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Varaktighet:"
 
@@ -6779,6 +7458,12 @@ msgstr "%.1f sek"
 msgid "Tone duration:"
 msgstr "Tonlängd:"
 
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
+
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Tystnadslängd:"
@@ -6797,7 +7482,8 @@ msgstr "Upprepning"
 msgid "Repeats the selected audio again and again"
 msgstr "Upprepar markerat ljud om och om igen"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Begärt värde överskrider minneskapaciteten."
 
@@ -6821,7 +7507,8 @@ msgstr "Förinställning:"
 msgid "Export Effect Parameters"
 msgstr "&Ändra parametrar"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Kunde inte öppna fil: \"%s\""
@@ -6858,6 +7545,15 @@ msgstr "Förbereder förhandsvisning"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Förhandsvisning"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -6942,6 +7638,10 @@ msgstr "&Verkställ"
 #: src/effects/EffectUI.cpp
 msgid "Latency: 0"
 msgstr "Latens: 0"
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Active State"
@@ -7081,6 +7781,11 @@ msgid "Name: %s"
 msgstr "Namn: %s"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Gör baklänges"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Vendor: %s"
 msgstr "Utgivare: %s"
@@ -7131,6 +7836,11 @@ msgstr "S&toppa uppspelning"
 msgid "Play"
 msgstr "Spela upp"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "Cosinus"
@@ -7139,13 +7849,31 @@ msgstr "Cosinus"
 msgid "Cubic"
 msgstr "Kubisk"
 
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Equalization"
+msgstr "Equalization"
+
 #: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
 msgid "Filter Curve EQ"
 msgstr "Välj kurva"
 
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Graphic EQ"
+msgstr "&Grafisk"
+
 #: src/effects/Equalization.cpp
 msgid "Adjusts the volume levels of particular frequencies"
 msgstr "Justerar volymnivåerna för vissa frekvenser"
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Bass Boost"
@@ -7154,6 +7882,18 @@ msgstr "Bas (dB):"
 #: src/effects/Equalization.cpp
 msgid "Bass Cut"
 msgstr "Bas"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Treble Boost"
@@ -7186,6 +7926,37 @@ msgstr "Spårets samplingsfrekvens är för låg för denna effekt."
 #: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Effekt otillgänglig"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
 
 #. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
 #: src/effects/Equalization.cpp
@@ -7266,8 +8037,16 @@ msgid "D&efault"
 msgstr "&Standard"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE-&trådad"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7512,7 +8291,8 @@ msgid "Builtin Effects"
 msgstr "Inbyggda effekter"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Tillhandahåller inbyggda effekter i Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7522,6 +8302,14 @@ msgstr "Okänt namn på inbyggd effekt"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Normalisera högljuddhet till"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Sets the loudness of one or more tracks"
@@ -7551,8 +8339,20 @@ msgid "Loudness LUFS"
 msgstr "Högljuddhets-LUFS"
 
 #: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Normalisera stereokanalerna var och en för sig"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -7598,8 +8398,37 @@ msgid "Second greatest"
 msgstr "Andra spår"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "4 (standard)"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "4 (standard)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -7694,8 +8523,9 @@ msgid "Step 1"
 msgstr "Steg 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Välj några sekunder brus så Tenacity vet vad som skall filtreras bort,\n"
@@ -7747,13 +8577,63 @@ msgstr "Fönster&typer"
 msgid "Window si&ze:"
 msgstr "Fönster&storlek"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (standard)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "S&teg per fönster"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -7869,12 +8749,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Normalisera stereokanalerna var och en för sig"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Sträck"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch är endast avsedd för en extrem tidsutsträckt effekt eller \"stasiseffekt\""
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Sträckningsfaktor:"
@@ -7926,6 +8812,11 @@ msgstr ""
 "eller reducera \"Tidsupplösningen\" till mindre än %.1f sekunder."
 
 #: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Phaser"
+msgstr "Phaser"
+
+#: src/effects/Phaser.cpp
 msgid "Combines phase-shifted signals with the original signal"
 msgstr "Kombinerar fasskiftade signaler med originalsignalen"
 
@@ -7936,6 +8827,14 @@ msgstr "&Steg:"
 #: src/effects/Phaser.cpp
 msgid "Stages"
 msgstr "Steg"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
@@ -8144,6 +9043,11 @@ msgstr "Vänd på markerat ljud"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS-tid / Tonhöjdssträckning"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8157,6 +9061,11 @@ msgstr "Chebyshev, typ II"
 #: src/effects/ScienFilter.cpp
 msgid "Lowpass"
 msgstr "Lågpass"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Highpass"
+msgstr "Hög:"
 
 #: src/effects/ScienFilter.cpp
 msgid "Classic Filters"
@@ -8295,6 +9204,11 @@ msgstr "Använd standardvärden"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Återställ standardvärden"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8454,6 +9368,10 @@ msgstr "Upptäck tystnad"
 msgid "Tr&uncate to:"
 msgstr "Trunkera till:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Komprimera till:"
@@ -8467,7 +9385,8 @@ msgid "VST Effects"
 msgstr "VST-effekter"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Lägger till funktionalitet att använda VST-effekter i Tenacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8479,7 +9398,8 @@ msgstr "Skannar Shell VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Registrerar %d av %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Kunde inte läsa in biblioteket"
 
@@ -8491,15 +9411,25 @@ msgstr "VST-effektalternativ"
 msgid "Buffer Size"
 msgstr "Buffertstorlek"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Buffertstorlek (8 till 1048576 samplingar):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Latenskompensering"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Aktiverar &kompensering"
 
@@ -8525,11 +9455,17 @@ msgid "Save VST Preset As:"
 msgstr "Spara VST-förinställning som:"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Ladda VST-program:"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "Ladda VST-program:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity-projektfiler"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8556,7 +9492,8 @@ msgstr "Fel uppstod när VST-förinställning lästes in"
 msgid "Unable to load presets file."
 msgstr "Kunde inte läsa in förinställningsfil."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Effektinställningar"
 
@@ -8572,6 +9509,16 @@ msgstr "Kunde inte läsa förinställningsfil."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Denna parameterfil sparades från %s. Vill du fortsätta?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8603,7 +9550,8 @@ msgid "Audio Unit Effects"
 msgstr "Ljudenhetseffekter"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Tillhandahåller stöd för ljudenhetseffekter till Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8619,8 +9567,16 @@ msgid "Audio Unit Effect Options"
 msgstr "Alternativ för ljudenhetseffekter"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Användargränssnitt"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -8722,6 +9678,11 @@ msgid "Failed to retrieve preset content"
 msgstr "Kunde inte hämta strömbeskrivning"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Kunde inte läsa förinställningsfil."
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "Konvertering av samplingsfrekvens"
 
@@ -8732,6 +9693,21 @@ msgstr ""
 "Misslyckades att registrera:\n"
 "%s"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Kunde inte hämta strömbeskrivning"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Kunde inte hämta strömbeskrivning"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Kunde inte skicka krashrapport"
+
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
 #: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
@@ -8740,6 +9716,7 @@ msgstr "Ljudenhet"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA-effekter"
@@ -8749,16 +9726,23 @@ msgid "Provides LADSPA Effects"
 msgstr "Tillhandahåller LADSPA-effekter"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity använder inte längre vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "LADSPA-effektalternativ"
 
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s i:"
@@ -8766,6 +9750,14 @@ msgstr "%s i:"
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Effektutmatning"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -8775,6 +9767,10 @@ msgstr "LV2-effektinställningar"
 #, c-format
 msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Buffertstorlek (8 till 1048576 samplingar):"
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -8794,12 +9790,24 @@ msgstr "%d kurvor exporterades till %s\n"
 msgid "%s requires unsupported option %s\n"
 msgstr "%d kurvor exporterades till %s\n"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "Tongenerator"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2-effekter"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Tillhandahåller LV2-effekter till Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -8807,7 +9815,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist-effekter"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Lägger till stöd för Nyquist-effekter i Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -8822,6 +9831,12 @@ msgstr "Nyquist-arbetare"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Ill-formed Nyquist plug-in header"
 msgstr "Felaktig header för Nyquist-insticksmodul"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid ""
@@ -9027,7 +10042,8 @@ msgstr "Välj en fil"
 msgid "Save file as"
 msgstr "Spara fil som"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "namnlös"
 
@@ -9036,7 +10052,8 @@ msgid "Vamp Effects"
 msgstr "Vamp-effekter"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Lägger till stöd för Vamp-effekter i Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9054,6 +10071,18 @@ msgstr "Tyvärr, Vamp-insticksmodul misslyckades att initialiseras."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Inställningar för insticksmoduler"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+#, fuzzy
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9210,15 +10239,29 @@ msgid "Command Output"
 msgstr "Kommandoutmatning"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "&OK"
+msgstr "OK"
+
+#: src/export/ExportCL.cpp
 msgid "You've specified a file name without an extension. Are you sure?"
 msgstr ""
 "Du har valt ett filnamn med filändelse som programmet inte känner igen.\n"
 "Vill du fortsätta?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "Modulen \"%s\" hittades."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Kunde inte läsa in förinställningsfil."
 
 #: src/export/ExportFFmpeg.cpp
 msgid ""
@@ -9265,6 +10308,14 @@ msgid ""
 msgstr ""
 "FFmpeg kan inte hitta ljudkodek 0x%x.\n"
 "Stöd för denna kodek har förmodligen inte kompilerats."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpeg.cpp
@@ -9330,7 +10381,8 @@ msgstr "Exporterar ljudet som %s"
 msgid "Invalid sample rate"
 msgstr "Felaktig samplingsfrekvens"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Återsampla"
 
@@ -9360,6 +10412,14 @@ msgstr "Du kan återsampla till någon av frekvenserna nedan."
 msgid "Sample Rates"
 msgstr "Samplingsfrekvenser"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Bithastighet:"
@@ -9367,6 +10427,49 @@ msgstr "Bithastighet:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Kvalitet:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f sek"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -9381,6 +10484,10 @@ msgid "Constrained"
 msgstr "Konstant"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Ljud..."
 
@@ -9389,8 +10496,44 @@ msgid "Low Delay"
 msgstr "Fördröjning"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Mellanstor"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -9459,6 +10602,20 @@ msgstr "Förinställningen \"%s\" finns inte."
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "Ersätta förinställningen \"%s\"?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "V"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "Huvudmix"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9566,6 +10723,10 @@ msgstr "Språk:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bitreservoar"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -9701,6 +10862,11 @@ msgstr ""
 "max - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Använd LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Prediction Order Method\n"
 "Estimate - fastest, lower compression\n"
@@ -9731,6 +10897,10 @@ msgstr ""
 "max - 32 (med LPC) eller 4 (utan LPC)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal prediction order\n"
 "Optional\n"
@@ -9743,6 +10913,10 @@ msgstr ""
 "-1 - standard\n"
 "min - 0\n"
 "max - 32 (med LPC) eller 4 (utan LPC)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -9759,6 +10933,10 @@ msgstr ""
 "max - 8"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid ""
 "Maximal partition order\n"
 "Optional\n"
@@ -9771,6 +10949,10 @@ msgstr ""
 "-1 - standard\n"
 "min - 0\n"
 "max - 8"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
 
 #. i18n-hint:  Abbreviates "Linear Predictive Coding",
 #. but this text needs to be kept very short
@@ -9841,6 +11023,17 @@ msgstr "Inga etiketter att exportera."
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Select xml file to export presets into"
 msgstr "Välj xml-fil att exportera förinställningar till"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to guess format"
@@ -9944,8 +11137,23 @@ msgid "145-185 kbps"
 msgstr "Medel, 145-185 kbps"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "Standard, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "Medel, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
 msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
+msgstr "Medel, 145-185 kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -9961,6 +11169,11 @@ msgid "Extreme, 220-260 kbps"
 msgstr "Extremt, 220-260 kbps"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Standard, 170-210 kbps"
+msgstr "Standard, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "Medium, 145-185 kbps"
 msgstr "Medel, 145-185 kbps"
 
@@ -9972,6 +11185,12 @@ msgstr "Galet"
 #: src/export/ExportMP3.cpp
 msgid "Extreme"
 msgstr "Extrem"
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Standard"
+msgstr "Standard"
 
 #: src/export/ExportMP3.cpp
 msgid "Medium"
@@ -9988,6 +11207,16 @@ msgstr "Medelvärde"
 #: src/export/ExportMP3.cpp
 msgid "Constant"
 msgstr "Konstant"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Joint Stereo"
+msgstr "Joint Stereo"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "2 (stereo)"
 
 #: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
@@ -10012,8 +11241,8 @@ msgid "Locate LAME"
 msgstr "Hitta Lame"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity behöver filen %s för att skapa MP3-filer."
 
 #: src/export/ExportMP3.cpp
@@ -10041,13 +11270,36 @@ msgid "Where is %s?"
 msgstr "Var hittar man %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Du länkar till lame_enc.dll v%d.%d. Denna version är inte kompatibel med Audacity %d.%d.%d.\n"
 "Var vänlig och ladda ned den senaste versionen av LAME MP3-bibliotek."
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Only lame_enc.dll"
+msgstr "Endast avformat.dll"
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Only libmp3lame.so.0"
+msgstr "Endast libavformat.so"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Spara projektdatafiler"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -10297,6 +11549,26 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Kunde inte ändra renderingskvaliteten för QuickTime"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Kunde inte läsa in förinställningsfil."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Kunde inte läsa in förinställningsfil."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Kunde inte läsa in förinställningsfil."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Kunde inte läsa in förinställningsfil."
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "Kunde inte läsa in förinställningsfil."
 
@@ -10307,6 +11579,10 @@ msgstr "Exporterar markerat ljud som Ogg Vorbis"
 #: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Exporterar ljudet som Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
 msgid "WAV (Microsoft)"
@@ -10325,8 +11601,28 @@ msgid "Other uncompressed files"
 msgstr "Andra okomprimerade filer"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Fel uppstod under import"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -10354,11 +11650,11 @@ msgid "All supported files"
 msgstr "Alla filer|*|Alla filer som stöds|"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" /när en MIDI-fil, inte en ljudfil. \n"
@@ -10366,11 +11662,11 @@ msgstr ""
 "du kan redigera den genom att välja Arkiv > Importera > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" /när en MIDI-fil, inte en ljudfil. \n"
 "Audacity kan inte öppna denna filtyp för uppspelning och redigering, men\n"
@@ -10381,18 +11677,18 @@ msgid "Select stream(s) to import"
 msgstr "Välj ström(mar) att importera"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Denna version av Audacity kompilerades inte med stöd för %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en Audio CD-fil. \n"
 "Audacity kan inte öppna denna typ av fil. \n"
@@ -10401,10 +11697,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" är en spellista.\n"
@@ -10413,10 +11709,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en Windows Media Audio-fil (.wma). \n"
@@ -10425,10 +11721,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en avancerad ljudkodningsfil. \n"
@@ -10437,12 +11733,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en krypterad ljudfil. \n"
@@ -10453,10 +11749,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en RealPlayer-mediafil. \n"
@@ -10465,12 +11761,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" är en textbaserad fil, inte en ljudfil. \n"
 "Audacity kan inte öppna denna filtyp. \n"
@@ -10479,10 +11775,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10495,10 +11791,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en Wavpack-ljudfil. \n"
@@ -10507,10 +11803,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en Dolby Digital-ljudfil. \n"
@@ -10519,10 +11815,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en Ogg Speex-ljudfil. \n"
@@ -10531,10 +11827,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" är en videofil. \n"
@@ -10548,20 +11844,31 @@ msgstr "Modulen \"%s\" hittades."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
 "Audacity känner inte igen filtypen \"%s\".\n"
 "Försök att installera FFmpeg. För okomprimerade filer, försök även Arkiv > Importera rådata."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, Tenacity-testare"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -10570,6 +11877,11 @@ msgstr ""
 "Importverktyg som förmodligen har stöd för dessa filer är:\n"
 "%s,\n"
 "men ingen av dem förstod detta filformat."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Spara projektdatafiler"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10586,8 +11898,57 @@ msgid "Import Project"
 msgstr "Importera förinställningar"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "Internt fel från processen med placering."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "Felaktig samplingsfrekvens"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10595,16 +11956,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Kunde inte hitta projektets datamapp: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Projektets början"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "Felaktig samplingsfrekvens"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "Felaktig samplingsfrekvens"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -10634,40 +12053,6 @@ msgstr "Index[%02x] Kodek[%s],Språk[%s], Bithastighet[%s], Kanaler[%d], Längd[
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC-filer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer-kompatibla filer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Kunde inte lägga till avkodare till pipeline"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Gstreamer-importering"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Kunde inte ändra strömmens tillstånd till pausad."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Index[%02x] Kodek[%s],Språk[%s], Bithastighet[%s], Kanaler[%d], Längd[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Filen innehåller inte några ljudströmmar."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Kunde inte importera fil, ändring av tillstånd misslyckades."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer-fel: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -10725,6 +12110,14 @@ msgstr "Kunde inte öppna filen %s."
 msgid "MP3 files"
 msgstr "MP3-filer"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Ogg Vorbis-filer"
@@ -10759,8 +12152,102 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF och andra okomprimerade typer"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "WAVEX (Microsoft)"
 msgstr "WAV (Microsoft) 32-bitars flyttal PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bitars PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
@@ -10771,12 +12258,56 @@ msgid "Signed 24 bit PCM"
 msgstr "24-bitars PCM"
 
 #: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bitars PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bitars PCM"
+
+#: src/import/ImportPCM.cpp
 msgid "32 bit float"
 msgstr "32-bitars flyttal"
 
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "32-bitars flyttal"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Microsoft ADPCM"
+msgstr "WAV (Microsoft) 32-bitars flyttal PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 bitar"
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
@@ -10787,12 +12318,20 @@ msgid "24 bit DWVW"
 msgstr "24 bitar"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-bitars PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-bitars PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -10841,6 +12380,19 @@ msgstr "Importera rådata"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Ingen endian"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Medium"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -10891,6 +12443,10 @@ msgstr "Samplingsfrekvens:"
 msgid "&Import"
 msgstr "&Importera"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
 #, c-format
@@ -10911,6 +12467,7 @@ msgstr "%s höger"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -10934,6 +12491,7 @@ msgstr "slutet"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -10960,7 +12518,8 @@ msgstr "Tidsförsköt klipp till höger"
 msgid "Time shifted clips to the left"
 msgstr "Tidsförsköt klipp till vänster"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Tidsförskjutning"
 
@@ -11098,7 +12657,8 @@ msgstr "Beskärde valda ljudspår från %.2f sekunder till %.2f sekunder"
 msgid "Trim Audio"
 msgstr "Beskär ljud"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Dela"
 
@@ -11203,6 +12763,11 @@ msgid "Detac&h at Silences"
 msgstr "Avskil&j vid tystnad"
 
 #: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "&Metadata..."
+msgstr "R&ådata..."
+
+#: src/menus/EditMenus.cpp
 msgid "Pre&ferences..."
 msgstr "&Inställningar..."
 
@@ -11215,28 +12780,8 @@ msgid "Delete Key&2"
 msgstr "Raderingstangent &2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Justera uppspelnings&volym..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "&Öka uppspelningsvolym"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "&Minska uppspelningsvolym"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "J&ustera inspelningsvolym..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Ö&ka inspelningsvolym"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "M&inska inspelningsvolym"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -11274,6 +12819,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Exportera markerat ljud"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Etikettext"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -11323,6 +12874,11 @@ msgstr "Importera etiketter"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Välj en MIDI-fil"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Alla filer|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -11403,6 +12959,11 @@ msgid "&Labels..."
 msgstr "&Etiketter..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "Exportera &MIDI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "R&ådata..."
 
@@ -11419,6 +12980,10 @@ msgstr "S&kriv ut..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "A&vsluta"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -11487,12 +13052,17 @@ msgid "&Getting Started"
 msgstr "&Kom igång"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacitys &manual"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Hantera"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&Snabbhjälp..."
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -11510,11 +13080,8 @@ msgstr "&MIDI-enhetsinfo..."
 msgid "Show &Log..."
 msgstr "&Visa logg..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Om Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Skapade etikett"
 
@@ -11714,6 +13281,10 @@ msgstr "Flytta bakåt genom aktiva fönster"
 #: src/menus/NavigationMenus.cpp
 msgid "Move Forward Through Active Windows"
 msgstr "Flytta framåt genom aktiva fönster"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
@@ -11943,6 +13514,11 @@ msgstr "Skärmdump (kort format)..."
 #: src/menus/SelectMenus.cpp
 msgid "Set Left Selection Boundary"
 msgstr "Ändra vänster markeringsgräns"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Ljudposition"
 
 #: src/menus/SelectMenus.cpp
 msgid "Set Right Selection Boundary"
@@ -12196,6 +13772,7 @@ msgstr "Flytta markören ett l&ångt hopp till höger"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Sö&k"
@@ -12407,18 +13984,21 @@ msgid "Created new label track"
 msgstr "Skapade nytt etikettspår"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Denna versionen av Audacity tillåter bara ett tidsspår för varje projektfönster."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Skapade nytt tidsspår"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Ny samplingsfrekvens (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Det angivna värdet är ogiltigt"
 
@@ -12562,6 +14142,11 @@ msgid "Pan Right"
 msgstr "Panorera höger"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Center"
+msgstr "Centrera"
+
+#: src/menus/TrackMenus.cpp
 msgid "Pan Center"
 msgstr "Centrera panorering"
 
@@ -12671,7 +14256,9 @@ msgstr "Spelar upp"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Inspelning"
 
@@ -12820,10 +14407,6 @@ msgstr "&Pålägg (på/av)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "&Mjukvaruuppspelning (på/av)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "A&utomatisk justering av inspelningsnivå (på/av)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13039,13 +14622,18 @@ msgstr "Inställningar: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Uppdatera Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
 msgid "&Check for Updates"
 msgstr "&Kolla efter uppdateringar..."
+
+#: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
+#, fuzzy
+msgid "Batch"
+msgstr "Matcha"
 
 #: src/prefs/BatchPrefs.cpp
 msgid "Preferences for Batch"
@@ -13082,7 +14670,8 @@ msgstr "&Värd:"
 msgid "Using:"
 msgstr "Används:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Uppspelning"
 
@@ -13102,7 +14691,8 @@ msgstr "Ka&naler:"
 msgid "Latency"
 msgstr "Latens"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "millisekunder"
 
@@ -13131,7 +14721,8 @@ msgid "2 (Stereo)"
 msgstr "2 (stereo)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Kataloger"
 
@@ -13144,8 +14735,22 @@ msgid "Default directories"
 msgstr "Kataloger"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Bläddra..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -13223,7 +14828,8 @@ msgid "Directory %s is not writable"
 msgstr "Katalog %s är inte skrivbar"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Ändringar i den temporära katalogen kommer inte att få effekt förrän Audacity startas om"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13256,9 +14862,16 @@ msgstr "Gruppera efter typ"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -13273,6 +14886,12 @@ msgstr "Nyquist"
 #: src/prefs/EffectsPrefs.cpp
 msgid "&Vamp"
 msgstr "Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -13295,11 +14914,13 @@ msgid "Plugin Options"
 msgstr "Alternativ för insticksmoduler"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Kolla efter uppdaterade insticksmoduler när Audacity startas"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Sök efter insticksmoduler igen nästa gång Audacity startas"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -13479,13 +15100,18 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Be&håll etiketter om markeringen fästs till en etikett"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "B&landa systemets och Audacitys tema"
 
 #. i18n-hint: RTL stands for 'Right to Left'
 #: src/prefs/GUIPrefs.cpp
 msgid "Use mostly Left-to-Right layouts in RTL languages"
 msgstr "Använd mestadels vänster-till-höger-utseenden i höger-till-vänster-språk"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
@@ -13500,9 +15126,18 @@ msgstr "Visa scrublinjal"
 msgid "Language \"%s\" is unknown"
 msgstr "Språket \"%s\" är okänt"
 
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "Importera/exportera"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Inställningar: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -13548,6 +15183,10 @@ msgstr "Exportera etiketter som:"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Allegro (.gro) files save time as:"
 msgstr "Exporterade Allegro-filer (.gro) sparningstid som:"
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13632,7 +15271,15 @@ msgid "&Defaults"
 msgstr "&Standardvärden"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Välj en XML-fil som innehåller Audacity kortkommandon..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -13641,8 +15288,21 @@ msgstr "Fel uppstod när tangentbordskommandon skulle importeras"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "Läste in %d kortkommandon\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -13663,6 +15323,15 @@ msgstr "Man kan inte tilldela en tangent till detta"
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "Du måste välja en koppling innan du väljer kortkommando"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -13733,12 +15402,17 @@ msgid "Dow&nload"
 msgstr "Lad&da ned"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity har automatiskt hittat giltiga FFmpeg-bibliotek.\n"
 "Vill du fortfarande leta dem manuellt?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -13775,6 +15449,10 @@ msgstr "Latens för MIDI-synthesizer (ms):"
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "Latensen för MIDI-synthesizer måste var ett heltal"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -13785,8 +15463,9 @@ msgid "Preferences for Module"
 msgstr "Inställningar: "
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Dessa moduler är experimentella. Använd bara dem om du har läst Audacitys manual\n"
@@ -13794,12 +15473,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "\"Fråga\" betyder att Audacity kommer att fråga dig om du vill läsa in modulen varje gång den startas."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "\"Misslyckades\" betyder att Audacity tror att modulen är trasig och kommer inte köra den."
 
 #. i18n-hint preserve the leading spaces
@@ -13808,7 +15489,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "\"Ny\" betyder att inget val har gjort ännu."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Ändringar i dessa inställningar kommer inte få effekt innan Audacity har startas om."
 
 #: src/prefs/ModulePrefs.cpp
@@ -13826,6 +15508,10 @@ msgstr "Inga moduler hittades"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Moduler"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -13867,7 +15553,10 @@ msgstr "Vänsterdra"
 msgid "Set Selection Range"
 msgstr "Ändra markeringsintervall"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-vänsterklick"
 
@@ -13954,6 +15643,15 @@ msgstr "-vänsterdra"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Flytta klipp upp/ned mellan spår"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-vänsterdra"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14078,7 +15776,8 @@ msgid "Always scrub un&pinned"
 msgstr "Utför alltid scrubbing på o&fästade"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Inställningar för Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14094,8 +15793,18 @@ msgid "Preferences for Quality"
 msgstr "Inställningar: "
 
 #: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Other..."
 msgstr "Övrigt..."
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Sampling"
+msgstr "Samplingar"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Default Sample &Rate:"
@@ -14207,45 +15916,38 @@ msgid "System T&ime"
 msgstr "Systemt&id"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Automatisk justering av inspelningsnivå"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Aktivera automatisk justering av inspelningsnivå."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Målets maxpunkt:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Inom:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Analystid:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "millisekunder (tid från en analys)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Antal analyser i följd:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 betyder oändligt"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "Punch and Roll-inspelning"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Pre-ro&ll:"
 msgstr "&Ljud innan inspelning:"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Kör crossfade på klipp"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Period"
+msgstr "Bildruteperiod"
 
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -14375,6 +16077,10 @@ msgid "1024 - default"
 msgstr "1024 - standard"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - mest smalband"
 
@@ -14472,13 +16178,14 @@ msgid "Info"
 msgstr "Information"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -14661,7 +16368,8 @@ msgstr "Samplingar"
 msgid "4 Pixels per Sample"
 msgstr "4 bildpunkter per sampling"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Max. zoom"
 
@@ -14783,16 +16491,24 @@ msgid "Stopped"
 msgstr "Stoppades"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Pausa"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Hoppa till början"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Hoppa till slutet"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Markera till början"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Markera till slutet"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -14806,20 +16522,17 @@ msgstr "Spela in ett nytt spår"
 msgid "Append Record"
 msgstr "Lägg till i inspelning"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Markera till slutet"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Markera till början"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Pausades"
+
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy, c-format
+msgid "%s."
+msgstr "%s i:"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -14899,11 +16612,17 @@ msgstr "Tysta ljudmarkeringen"
 msgid "Sync-Lock Tracks"
 msgstr "Synkroniseringslås spår"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Zooma in"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Zooma ut"
 
@@ -14970,43 +16689,6 @@ msgstr "Verktygsfält för i&nspelningsmätare"
 msgid "&Playback Meter Toolbar"
 msgstr "Verktygsfält för u&ppspelningsmätare"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Inspelningsvolym"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Uppspelningsvolym"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Inspelningsvolym: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Inspelningsvolym (inte tillgänglig; använd systemmixer.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Uppspelningsvolym: %s (emulerad)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Uppspelningsvolym: %s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Uppspelningsvolym (inte tillgänglig; använd systemmixer.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Verktygsfält för &mixer"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Sök"
@@ -15015,9 +16697,15 @@ msgstr "Sök"
 msgid "Scrub Ruler"
 msgstr "Scrublinjal"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Sluta scrubbing"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Sluta scrubbing"
@@ -15025,6 +16713,7 @@ msgstr "Sluta scrubbing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Starta scrubbing"
@@ -15032,6 +16721,7 @@ msgstr "Starta scrubbing"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Sluta söka"
@@ -15039,6 +16729,7 @@ msgstr "Sluta söka"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Börja söka"
@@ -15093,7 +16784,9 @@ msgstr "Fäst mot"
 msgid "Length"
 msgstr "Längd"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Centrera"
 
@@ -15157,8 +16850,8 @@ msgstr "Verktygsfält för &enhet"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacitys verktygsfält för %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -15185,7 +16878,8 @@ msgstr "Tidsförskjutningsverktyg"
 msgid "Zoom Tool"
 msgstr "Zoomverktyg"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Ritverktyg"
 
@@ -15261,11 +16955,13 @@ msgstr "Dra en eller flera etikettgränser."
 msgid "Drag label boundary."
 msgstr "Dra gräns för etikett."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Ändrade etikett"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Redigera etikett"
 
@@ -15320,31 +17016,42 @@ msgstr "Redigerade etiketter"
 msgid "New label"
 msgstr "Ny etikett"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Upp en &oktav"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Ned en ok&tav"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Klicka för att zooma in vertikalt, Shift-klicka för att zooma ut. Dra för att skapa ett speciellt zoomområde."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Högerklicka för meny."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Återställ zoom"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-vänsterklick"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Zooma in\tVänsterklick/Vänsterdra"
 
@@ -15386,7 +17093,8 @@ msgstr "Sammanfoga"
 msgid "Expanded Cut Line"
 msgstr "Expanderad klipplinje"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Expandera"
 
@@ -15409,6 +17117,11 @@ msgstr "Flyttade samplingar"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Redigera sampling"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -15435,6 +17148,11 @@ msgid "S&pectrogram Settings..."
 msgstr "Spektrogram&inställningar..."
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Byt format"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Changing sample format"
 msgstr "Ändrar tempo"
 
@@ -15450,7 +17168,8 @@ msgstr "Bearbetar: %s"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Bytte \"%s\" till %s"
@@ -15462,6 +17181,54 @@ msgstr "Byt format"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Hastighet"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -15481,7 +17248,8 @@ msgstr "Byt frekvens"
 msgid "Set Rate"
 msgstr "Ändra frekvens"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Flera"
 
@@ -15500,6 +17268,11 @@ msgstr "&Dela stereospår"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Dela stereo till &mono"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Mono"
+msgstr "1 (mono)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -15550,6 +17323,16 @@ msgid "Split to Mono"
 msgstr "Dela till mo&no"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Vänster, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Vänster, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Vänster, %dHz"
@@ -15560,19 +17343,22 @@ msgid "Right, %dHz"
 msgstr "Höger, %dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.2f dB"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% vänster"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% höger"
@@ -15585,6 +17371,25 @@ msgstr "Klicka och dra för att justera, dubbelklicka för att återställa"
 msgid "Click and drag to rearrange sub-views"
 msgstr "Klicka och dra för att flytta ett spår i tid"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Klicka och dra för att flytta ett spår i tid"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Zooma in"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Zooma in"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Half Wave"
 msgstr "Halvvåg"
@@ -15596,6 +17401,11 @@ msgstr "Vå&gform"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Färg på &vågform"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Musikinstrument"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -15669,9 +17479,8 @@ msgstr "Logaritmisk &interpolering"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Klicka och dra för att flytta ett spår i tid"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -15722,6 +17531,7 @@ msgstr "Justerade envelopp."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "Aktivera &scrubbing"
@@ -15733,6 +17543,7 @@ msgstr "Söker"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Scrub&linjal"
@@ -15748,6 +17559,11 @@ msgstr "Flytta muspekaren till sök"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Flytta muspekaren för att använda scrubbing"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Sluta scrubbing"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -15963,9 +17779,19 @@ msgstr "Tom"
 msgid "Backwards"
 msgstr "Bakåt"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Framåt"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16034,6 +17860,10 @@ msgid "Meter Style"
 msgstr "Mätarstil"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Mätartyp"
 
@@ -16090,6 +17920,29 @@ msgstr "Välj vad som ska göras"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 sekunder"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + samplingar"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 dygn 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -16105,11 +17958,35 @@ msgstr "0100 dygn 024 h 060 m 060 s"
 msgid "hh:mm:ss + hundredths"
 msgstr "hh:mm:ss + hundratal"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 h 060 m 060 s+>30 bildrutor|N"
+
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + millisekunder"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 h 060 m 060 s+>30 bildrutor|N"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -16131,6 +18008,7 @@ msgstr "0100 h 060 m 060 s+># samplingar"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "samplingar"
@@ -16292,6 +18170,28 @@ msgstr "01000,01000 bildrutor|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100000>0100 Hz"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "01000>01000 kHz|0.001"
+msgstr "0100000>0100 Hz"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
@@ -16356,6 +18256,11 @@ msgstr "(Använd menyn för att ändra formatet.)"
 msgid "centiseconds"
 msgstr "centisekunder"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Förbrukad tid:"
@@ -16397,6 +18302,11 @@ msgstr "Bekräfta nedstängning"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Kunde inte läsa förinställningsfil."
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -16468,6 +18378,11 @@ msgid "Value must not be greater than %s"
 msgstr "Värdet får inte vara högre än %s"
 
 #: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Dialog"
+msgstr "Fildialog"
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Välj en katalog"
 
@@ -16497,15 +18412,27 @@ msgstr "Kunde inte öppna filen"
 msgid "Spectral edit multi tool"
 msgstr "Multiverktyg för spektrumredigering"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Filtrering..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Släppt under villkoren för licensen GNU General Public version 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aVar god välj frekvenser."
@@ -16532,7 +18459,8 @@ msgstr ""
 "                      Försök att öka lågfrekvensens gräns~%~\n"
 "                      eller reducera filtret \"Width\"."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Fel.~%"
@@ -16593,6 +18521,25 @@ msgstr "Studiouttoning"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Tillämpar toning..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "An&ge som standard"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Släppt under villkoren för licensen GNU General Public version 2"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -16738,6 +18685,10 @@ msgid "Finding beats..."
 msgstr "Hittar slag.."
 
 #: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
+
+#: plug-ins/beat.ny
 msgid "Threshold Percentage"
 msgstr "Tröskelprocent"
 
@@ -16767,6 +18718,11 @@ msgstr "Reducera amplituden för att tillåta återställda maxpunkter (dB)"
 
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
+msgstr "Kör crossfade på klipp"
+
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Crossfading..."
 msgstr "Kör crossfade på klipp"
 
 #: plug-ins/crossfadeclips.ny
@@ -16886,6 +18842,10 @@ msgid "Allow duration to change"
 msgstr "Tillåt längden att ändras"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Använd senaste effekten"
 
@@ -16896,6 +18856,10 @@ msgstr "Equalization"
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "XML file"
 msgstr "MP3-filer"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
@@ -16909,6 +18873,12 @@ msgstr "Bekräfta överskrivning"
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Fel.~%Kan inte öppna fil"
+
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Fel.~%\"~a\" kan inte skrivas."
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
@@ -17042,13 +19012,38 @@ msgstr "Högpassfilter"
 msgid "Performing High-Pass Filter..."
 msgstr "Utför högpassfilter..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekvens (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB per oktav)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17069,10 +19064,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Etikettsammanfogning"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Släppt under villkoren för licensen GNU General Public version 2"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -17115,12 +19106,37 @@ msgid "Point after sound"
 msgstr "Joint Stereo"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "~aOmrådeslängd = ~a sekunder."
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "~aOmrådeslängd = ~a sekunder."
 
 #: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Hittar tystnad..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Hittar tystnad..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
@@ -17132,6 +19148,11 @@ msgstr "Markeringen måste vara större än %d samplingar."
 #, lisp-format
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "Inget ljud hittades. Försök att reducera ~%tystnadsnivån och den minimala tystnadslängden."
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -17207,6 +19228,10 @@ msgid "Select Function"
 msgstr "Markering"
 
 #: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
 msgid "Analyze Noise Level"
 msgstr "Analystid:"
 
@@ -17241,6 +19266,44 @@ msgstr "Attack/decay tid"
 #: plug-ins/noisegate.ny
 msgid "Decay (ms)"
 msgstr "Attack/decay tid"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Markeringen måste vara större än %d samplingar."
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
 
 #: plug-ins/notch.ny
 msgid "Notch Filter"
@@ -17290,7 +19353,8 @@ msgstr "MP3-filer"
 msgid "HTML file"
 msgstr "MP3-filer"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Namnge filer:"
 
@@ -17307,9 +19371,24 @@ msgid "Disallow"
 msgstr "Nekad"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Nekad"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "Misslyckades att ta bort %s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -17327,6 +19406,20 @@ msgstr "Fel.~%\"~a\" kan inte skrivas."
 msgid "Unsupported file type:"
 msgstr "Oanvända filter:"
 
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Välj en fil"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
 #: plug-ins/pluck.ny
 msgid "Pluck"
 msgstr "Gitarrsträng"
@@ -17340,12 +19433,20 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "MIDI-värden för C-noter: 36, 48, 60 [mitten-C], 72, 84, 96."
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "MIDI-tonhöjd för sträng"
 
 #: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Uttoningstyp"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Gradual"
@@ -17364,6 +19465,10 @@ msgid "Generating Rhythm..."
 msgstr "Skapar rytm..."
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 slag/minut"
 
@@ -17378,6 +19483,10 @@ msgstr "1 - 20 slag/takt"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Förvrängningsmängd"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -17448,6 +19557,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "MIDI-tonhöjd för starkt slag"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "MIDI-tonhöjd för svagt slag"
 
@@ -17466,6 +19579,10 @@ msgstr "Risset-trumma"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Skapar Risset-trumma..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -17835,6 +19952,15 @@ msgstr "Fel.~%Kan inte öppna fil"
 msgid "Spectral Delete"
 msgstr "Spektrumsmarkering"
 
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
 msgstr "Tillämpar tremolo..."
@@ -17862,6 +19988,10 @@ msgstr "Sångreducering och -isolering"
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Tillämpar åtgärd..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -18004,8 +20134,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Denna insticksmodul fungerar endast med stereospår."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Bearbetar Vocoder..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18048,6 +20186,217 @@ msgstr "Frekvens för radarnålar (Hz)"
 msgid "Error.~%Stereo track required."
 msgstr "Fel.~%Stereospår krävs."
 
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Uppdatera Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Hoppa över"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Installera uppdatering"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Ändringslogg"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Läs mer på GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Fel vid sökning efter uppdatering"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Fel uppstod när metadata lästes in"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s är tillgänglig!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Inspelning"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Commit-ID:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Plattformsoberoende gränssnittsbibliotek"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Importera via GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Automatisk justering av inspelningsnivån stoppades. Det var inte möjligt att optimera det mer. Fortfarande för hög."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Automatisk justering av inspelningsnivån minskade volymen till %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Automatisk justering av inspelningsnivån stoppades. Det var inte möjligt att optimera det mer. Fortfarande för låg."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Automatisk justering av inspelningsnivån ökade volymen till %2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Automatisk justering av inspelningsnivån stoppades. Antalet analyser överskreds utan att finna en acceptabel volym. Fortfarande för hög."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Automatisk justering av inspelningsnivån stoppades. Antalet analyser överskreds utan att finna en acceptabel volym. Fortfarande för låg."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Automatisk justering av inspelningsnivån stoppades. %2f verkar vara en acceptabel volym."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Fick %d medan enheterna öppnades\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Kunde inte öppna Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Tillgängliga mixers:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Tillgängliga inspelningskällor:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Tillgänglig uppspelningsvolymer:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Inspelningsvolymen är emulerad\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Inspelningsvolymen är ursprunglig\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Uppspelningsvolymen är emulerad\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Uppspelningsvolym är ursprunglig\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Slutdatum och -tid"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer-kompatibla filer"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Kunde inte lägga till avkodare till pipeline"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Gstreamer-importering"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Kunde inte ändra strömmens tillstånd till pausad."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Index[%02x] Kodek[%s],Språk[%s], Bithastighet[%s], Kanaler[%d], Längd[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Filen innehåller inte några ljudströmmar."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Kunde inte importera fil, ändring av tillstånd misslyckades."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer-fel: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Justera uppspelnings&volym..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "&Öka uppspelningsvolym"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "&Minska uppspelningsvolym"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "J&ustera inspelningsvolym..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Ö&ka inspelningsvolym"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "M&inska inspelningsvolym"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacitys &manual"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Om Audacity..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "A&utomatisk justering av inspelningsnivå (på/av)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Automatisk justering av inspelningsnivå"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Aktivera automatisk justering av inspelningsnivå."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Målets maxpunkt:"
+
+#~ msgid "Within:"
+#~ msgstr "Inom:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Analystid:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "millisekunder (tid från en analys)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Antal analyser i följd:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 betyder oändligt"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Inspelningsvolym"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Uppspelningsvolym"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Inspelningsvolym: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Inspelningsvolym (inte tillgänglig; använd systemmixer.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Uppspelningsvolym: %s (emulerad)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Uppspelningsvolym: %s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Uppspelningsvolym (inte tillgänglig; använd systemmixer.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Verktygsfält för &mixer"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Klicka och dra för att flytta ett spår i tid"
+
 #~ msgid "Program build date:"
 #~ msgstr "Kompileringsdatum:"
 
@@ -18077,9 +20426,6 @@ msgstr "Fel.~%Stereospår krävs."
 
 #~ msgid "Unknown error"
 #~ msgstr "Okänt fel"
-
-#~ msgid "Failed to send crash report"
-#~ msgstr "Kunde inte skicka krashrapport"
 
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
 #~ msgstr ""
@@ -18705,10 +21051,6 @@ msgstr "Fel.~%Stereospår krävs."
 #~ msgstr ""
 #~ "Ogiltigt jokerteckensträng i kontrollen \"path\".'\n"
 #~ "Använder tom sträng istället."
-
-#, fuzzy
-#~ msgid "%d kpbs"
-#~ msgstr "%d kbps"
 
 #, fuzzy
 #~ msgid ""
@@ -19487,10 +21829,6 @@ msgstr "Fel.~%Stereospår krävs."
 #~ msgstr "Frekvens (Hz)"
 
 #, fuzzy
-#~ msgid "Phase"
-#~ msgstr "Phaser"
-
-#, fuzzy
 #~ msgid "Depth"
 #~ msgstr "Djup:"
 
@@ -19590,10 +21928,6 @@ msgstr "Fel.~%Stereospår krävs."
 #~ msgid "Truncate"
 #~ msgstr "Trunkera tystnad"
 
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Gör baklänges"
-
 #~ msgid "C&ategory:"
 #~ msgstr "K&ategori:"
 
@@ -19657,10 +21991,6 @@ msgstr "Fel.~%Stereospår krävs."
 
 #~ msgid "To use Draw, choose 'Waveform' in the Track Drop-down Menu."
 #~ msgstr "För att använda Rita, välj 'Vågform' i spårets rullgardinsmeny."
-
-#, fuzzy
-#~ msgid "%.2f dB Average RMS"
-#~ msgstr "%.1f dB medelvärde rms"
 
 #, fuzzy
 #~ msgid "Average RMS = %.2f dB."
@@ -20349,9 +22679,6 @@ msgstr "Fel.~%Stereospår krävs."
 #~ msgid "Chirp Generator"
 #~ msgstr "Chirp generator"
 
-#~ msgid "Tone Generator"
-#~ msgstr "Tongenerator"
-
 #~ msgid "Truncate Silence..."
 #~ msgstr "Trunkera tystnad..."
 
@@ -20641,243 +22968,10 @@ msgstr "Fel.~%Stereospår krävs."
 #~ msgid "Enable these Modules (if present), next time Audacity is started"
 #~ msgstr "Gör dessa moduler tillgängliga nästa gång audacity har startat"
 
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s medarbetarna"
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Kan inte ansluta till Tenacitys uppdateringsserver."
 
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Lägg märke till att namnen är sorterade i alfabetisk ordning, inte efter "
-"betydelse."
-
-#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
-msgid "OK"
-msgstr "OK"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Kan inte ansluta till Tenacitys uppdateringsserver."
-
-#: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
-msgstr "Kunde inte initiera SQLite-biblioteket.  Tenacity kan inte fortsätta."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Tenacity%ss varumärke används i den här mjukvaran endast för deskriptiva och "
-"informationsmässiga ändamål."
-
-#: src/AboutDialog.cpp
-msgid "Emeritus:"
-msgstr "Tenacity Emeritus:"
-
-#: src/ProjectSerializer.cpp
-msgid ""
-"This recovery file was saved by Audacity 2.3.0 or before.\n"
-"You need to run that version of Audacity to recover the project."
-msgstr ""
-"Den här återställningsfilen sparades i Tenacity 2.3.0 eller tidigare.\n"
-"Du behöver köra den versionen av Tenacity för att återställa projektet."
-
-#: src/ProjectFileManager.cpp
-msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
-"\n"
-"It has been recovered to the last snapshot, but you must save it\n"
-"to preserve its contents."
-msgstr ""
-"Det här projektet sparades inte ordentligt förra gången Tenacity kördes.\n"
-"\n"
-"Det har återställts till den sista ögonblicksbilden, men du måste spara det\n"
-"för att bevara dess innehåll."
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
-msgstr "Tenacity Karaoke%s"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Kan inte öppna Tenacitys nedladdningslänk."
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid ""
-"The project failed to open, possibly due to limited space\n"
-"on the storage device.\n"
-"\n"
-"%s"
-msgstr ""
-"Projektfilen kunde inte öppnas, kanske på grund av begränsat utrymme\n"
-"på lagringsenheten.\n"
-"\n"
-"%s"
-
-#: src/ProjectFileIO.cpp
-msgid "Syncing"
-msgstr "Synkroniserar"
-
-#: src/ProjectFileIO.cpp
-msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
-msgstr ""
-"Projektets databas kunde inte öppnas på nytt, kanske för att det är ont om "
-"utrymme på lagringsenheten."
-
-#: src/ProjectFileIO.cpp
-msgid "Failed to remove the autosave information from the project file."
-msgstr ""
-"Borttagning av automatiskt sparad information från projektfilen misslyckades."
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[Projekt %02i] "
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "A♯/B♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "G♯/A♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "F♯/G♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "D♯/E♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "C♯/D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "B♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "A♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "G♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "B"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "A♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "A"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "G♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "G"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "F♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "F"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "E"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "D♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "D"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "C♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "C"
-
-#. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Solo"
-msgstr "Solo"
-
-#: src/LyricsWindow.cpp
-msgid "&Karaoke..."
-msgstr "&Karaoke..."
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: short form of 'seconds'.
-#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
-msgid "s"
-msgstr "s"
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Kan inte öppna Tenacitys nedladdningslänk."

--- a/locale/ta.po
+++ b/locale/ta.po
@@ -8,53 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Tamil <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"ta/>\n"
+"Language-Team: Tamil <https://hosted.weblate.org/projects/tenacity/tenacity/ta/>\n"
 "Language: ta\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Audacity வெளியேறவும்"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "சானெல்"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "கோப்பை திறப்பதில் வழ"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "சுமையேற்றுவதில் வழு"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s கருவித்தட்டு "
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Google Translate"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -64,6 +27,24 @@ msgstr "தீர்மானிக்க முடியாதுள்ளத�
 #, c-format
 msgid "%s bytes"
 msgstr "பைட்டுகள்"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -82,12 +63,68 @@ msgid "2nd Experimental Command"
 msgstr "கட்டளையை தெரிவு செய்க."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "விளைவுகள்"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "ஒட்டு"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "ஒட்டு"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "ஒட்டு"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "ஒட்டு"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "தெரிக"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -114,21 +151,87 @@ msgid "&Large Icons"
 msgstr "பெரிய அறை"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Small Icons"
+msgstr "பெரிய அறை"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "க&ருவி பட்டியில்"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "&நிறுத்து"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "மாறி"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "வெளியீட்டு அலகு"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Load Nyquist script"
+msgstr "விளைவுகள்"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "எச்சரிக்கை"
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Save Nyquist script"
+msgstr "விளைவுகள்"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
@@ -139,6 +242,10 @@ msgid "No matches found"
 msgstr "கருவிகள் தென்படவில்லை"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Untitled"
 msgstr "பெயரிடப்படாத"
 
@@ -146,9 +253,15 @@ msgstr "பெயரிடப்படாத"
 msgid "Nyquist Effect Workbench - "
 msgstr "விளைவுகள்"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&புதியது"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "கிட்டடியை திற"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -182,7 +295,8 @@ msgstr "பிரதி"
 msgid "Copy to clipboard"
 msgstr "இடைநிலை பலகைக்கு வெட்டு"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "வெட்டு"
 
@@ -190,7 +304,8 @@ msgstr "வெட்டு"
 msgid "Cut to clipboard"
 msgstr "இடைநிலை பலகைக்கு வெட்டு"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "ஒட்டு"
 
@@ -215,7 +330,8 @@ msgstr "தெரிக"
 msgid "Select all text"
 msgstr "தெரிக"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "மீளமை"
 
@@ -223,24 +339,69 @@ msgstr "மீளமை"
 msgid "Undo last change"
 msgstr "அமைப்பு மாற்றம்"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "மறுபடியும் செய்"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "அமைப்பு மாற்றம்"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Match"
 msgstr "தொகுதி"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "ஏற்றுமதிக்கு சிட்டை இல்லை"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "பிந்திய கருவி"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "உரையை புதிய சிட்டையில் ஒட்டு"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "அடுத்த கருவி"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "ஆரம்பி"
 
@@ -248,12 +409,25 @@ msgstr "ஆரம்பி"
 msgid "Start script"
 msgstr "ஆரம்ப நேரம்"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "நிறுத்து"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Stop script"
+msgstr "ஆரம்ப நேரம்"
+
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "சரி"
 
@@ -261,11 +435,13 @@ msgstr "சரி"
 msgid "Build Information"
 msgstr "உருவாக்கிய தகவல்"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "செயல்படுத்த பட்டுள்ளது"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "முடக்கி விடப்படுள்ளது"
 
@@ -275,8 +451,9 @@ msgid "The Build"
 msgstr "வழுநீக்க கட்டல்"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "கட்டளை:"
+#, fuzzy
+msgid "Version:"
+msgstr "பின்னோகுதல்"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -286,13 +463,23 @@ msgstr "கட்டிய வகை:"
 msgid "Compiler:"
 msgstr "அழுத்தி"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "நிறுவப்பட்டும் கோப்பகம்:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "அடைவு அமைவுகள்"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "அடைவு அமைவுகள்"
 
 #: src/AboutDialog.cpp
@@ -311,7 +498,6 @@ msgstr "மாற்றலிற்க்கான மாதிரி வீத�
 msgid "MP3 Importing"
 msgstr "MP3 இறக்குமதி"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis இறக்குமதியும் ஏற்றுமதியும்"
@@ -320,7 +506,6 @@ msgstr "Ogg Vorbis இறக்குமதியும் ஏற்றுமத
 msgid "ID3 tag support"
 msgstr "ID3 ஒட்டு ஆதரவு"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC இறக்குமதியும் ஏற்றுமதியும்"
@@ -338,14 +523,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg இறக்கு/ஏற்று"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "GStreamer ஊடாக இறக்குமதிச் செய்"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "அம்சங்கள்"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Plug-in ஆதரவிற்கு"
 
@@ -360,6 +537,10 @@ msgstr "சுருதியையும் போக்கையும் ம�
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "உட்சக்கட்ட சுருதியையும் போக்கையும் மாற்றும் ஆதரவு"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "அம்சங்கள்"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -386,6 +567,18 @@ msgstr "மட்டம்"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "மட்டம்"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "மட்டம்"
 
@@ -397,9 +590,51 @@ msgstr "மட்டம்"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "மட்டம்"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "மட்டம்"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "மட்டம்"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
 msgstr "தர உறுதி"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphic artist"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "மட்டம்"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "மட்டம்"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -413,6 +648,21 @@ msgstr "Nyquist வெளியீடு"
 msgid "%s, web developer"
 msgstr "மட்டம்"
 
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, graphics"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -422,6 +672,10 @@ msgstr "அனைத்து இயங்குதளங்களிலும�
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "நன்றிகள்"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -456,14 +710,23 @@ msgid "%s Team Members"
 msgstr " Emeritus அணி உறுப்பினர்கள்"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "ஏனைய பங்களித்தவர்கள்"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "தமிழ் மொழிமாற்றத்திற்கு பங்களித்தவர்கள்"
@@ -482,6 +745,26 @@ msgstr "விசேட நன்றிகள்"
 msgid "%s website: "
 msgstr "Audacity யின் முதலாவது பாவனை"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "ஏனைய பங்களித்தவர்கள்"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "ஒலித்துண்டின் அளவை மாற்ற சொடுக்கி இழுக்கவும்."
@@ -499,6 +782,7 @@ msgstr "Timeline Changer"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "மாதிரிகளை மாற்றுவதற்கு தேர்ந்தெடுத்து இழுக்கவும்"
@@ -506,12 +790,57 @@ msgstr "மாதிரிகளை மாற்றுவதற்கு தே�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "ஒலித்துண்டின் அளவை மாற்ற சொடுக்கி இழுக்கவும்."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "உரையை புதிய சிட்டையில் ஒட்டு"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "ஒலித்துண்டை கீழே நகர்த்து"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "ஒலித்துண்டை மேலே நகர்த்து"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr "(துர்பலமாக்கப்பட்ட )"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr "(துர்பலமாக்கப்பட்ட )"
 
 #: src/AdornedRulerPanel.cpp
@@ -519,8 +848,16 @@ msgid "Timeline Options"
 msgstr "பொதுவான தெரிவுகள்"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "தேர்ந்தெடுக்காத ஒலியை அமைதியாக்கு"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Lock Play Region"
@@ -530,7 +867,23 @@ msgstr "பகுதி&யை ஆரம்பி"
 msgid "Pinned Play Head"
 msgstr "பதிதல் முடிவு"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "வழு."
 
@@ -554,7 +907,8 @@ msgstr ""
 "இதனை மீள மாற்ற முடியாது, 'நிறுவிய' பின் எங்குசேமிப்பீர்கள்?"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Audacity விருப்பங்களை மீட்டமைக்க"
 
 #: src/AudacityApp.cpp
@@ -567,6 +921,14 @@ msgstr ""
 "%s கண்டு பிடிக்க முடியவில்லை.\n"
 "\n"
 "இது அண்மைய கோப்புகளில் இருந்து நீக்கபட்டு விட்டது."
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -587,7 +949,7 @@ msgstr "&திற...."
 msgid "Open &Recent..."
 msgstr "&அண்மையில் திறந்த..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "Audacity &பற்றி..."
@@ -601,29 +963,33 @@ msgid "&File"
 msgstr "&கோப்பு"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "தற்காலிக கோப்புகளை சேமிக்க ஒரு கோப்பகத்தை தெரிய முடியவில்லை.\n"
 "தயவு செய்து பொருத்தமான கோப்பகத்தை விருப்பங்கள் பட்டியலில் தெரியவும்."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "தற்காலிக கோப்புகளை சேமிக்க ஒரு கோப்பகத்தை தெரிய முடியவில்லை.\n"
 "தயவு செய்து பொருத்தமான கோப்பகத்தை விருப்பங்கள் பட்டியலில் தெரியவும்."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity ஆனது தற்போது மூடப்படவுள்ளது. தயவு செய்து மறுபடியும் தொடங்கவும் புதிய திறக்க. தற்காலிக கோப்பகம்."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -632,15 +998,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "தற்காலிக கோப்புகளின் கோப்பகத்தை Audacity இனாலபூட்ட இயலவில்லை.\n"
 "Audacity இன் இன்னொரு பிரதியால் பாவிக்கப்படலாம்.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Audacity இனை ஆரம்பிக்க விரும்புகிறீர்களா?"
 
 #: src/AudacityApp.cpp
@@ -648,24 +1016,72 @@ msgid "Error Locking Temporary Folder"
 msgstr "தற்காலிக கோப்பகத்தை பூட்டுவதில் வழு"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Audacity இன் மற்றுமொரு பிரதியானது இயங்கிகொண்டு இருக்குறது.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "தற்போது இயங்கும்  Audacity இல் புதிய அல்லது திறக்க கட்டளைகளை உபயோகிக்கவும்.\n"
 "ஒரே நேரத்தில் பல செயத்திட்டங்களை திறக்க முனைகிறது.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity முன்னரே பாவனையில் உள்ளது"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity செயற்திட்ட கோப்புகள்"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
 
 #. i18n-hint: This controls the number of bytes that Audacity will
 #. *           use when writing files to the disk
@@ -685,7 +1101,8 @@ msgstr "\t-test (சுய பரிசோதனைச் செய்)"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "\t-version (Audacity பதிப்பை பாண்பி)"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -695,9 +1112,10 @@ msgid "audio or project file name"
 msgstr "திட்ட கோப்பினை திறக்க முடியாதுள்ளது"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -710,20 +1128,49 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity செயற்திட்ட கோப்புகள்"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "புது&பிக்கவும்"
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "விதியை அழிப்பதை உறுதி செய்தல்"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "உதவி"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Audacity வெளியேறவும்"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity பதிவுகள்"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -735,9 +1182,14 @@ msgstr "&சேமி..."
 msgid "Cl&ear"
 msgstr "துடை"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&மூடு"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -786,7 +1238,8 @@ msgid "Error Initializing Midi"
 msgstr "மிடியை தொடங்குவதில் வழு."
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity பதிவுகள்"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -800,40 +1253,18 @@ msgstr "ஒலி சாதனத்தை திறப்பதில் வழ
 msgid "Out of memory!"
 msgstr "நினைவகம் பற்றாக்குறை"
 
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.சரி செய்வதற்கு சாத்தியமில்லை இன்னும் அதிகமாக உள்ளது"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது மூலம் சத்தம் %f இற்கு குறைக்கப்பட்டுள்ளது "
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.சரி செய்வதற்கு சாத்தியமில்லை இன்னும் குறைவாக உள்ளது"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது மூலம் சத்தம் %f இற்கு கூட்டப்படுள்ளது"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.ஆய்வின் மொத்த எண்ணிக்கையானது ஏற்கக்கூடிய சத்தத்தை அறியாமலே அதிகரித்துவிட்டது. இன்னும் அதிகமாக உள்ளது."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.ஆய்வின் மொத்த எண்ணிக்கையானது ஏற்கக்கூடிய சத்தத்தை அறியாமலே அதிகரித்துவிட்டது. இன்னும் குறைவாக உள்ளது."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.%.2f ஆனது ஏற்கக்கூடிய ஒரு சத்தம் ஆகும்"
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
+msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
 msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
 
 #: src/AudioIOBase.cpp
@@ -876,8 +1307,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "பதிதல் முடிவு\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "பதிதல் முடிவு\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "பதிதல் முடிவு\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "பதிதல் முடிவு\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -891,37 +1332,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "வகை கோப்பை திறக்க முடியவில்லை\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Google Translate\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "மாதிரி அளவுகள்\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "பின்னணி\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "பதிதல் முடிவு\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "பதிதல் முடிவு\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "வெளியீட்டு சத்தம்: %.2f%s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "வெளியீட்டு சத்தம்: %.2f%s\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -929,8 +1373,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -938,8 +1392,9 @@ msgid "Automatic Crash Recovery"
 msgstr "தானியங்கி பாதிப்பு மீட்பு."
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -951,12 +1406,14 @@ msgid "Recoverable &projects"
 msgstr "மீட்கக்கூடிய  செயற்திட்டங்கள்"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "தெரிக"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "செயற்திட்ட பெயர"
 
@@ -967,6 +1424,10 @@ msgstr "தெரிக"
 #: src/AutoRecoveryDialog.cpp
 msgid "&Recover Selected"
 msgstr "தெரிக"
+
+#: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
@@ -1003,6 +1464,11 @@ msgid "&Parameters"
 msgstr "&அளவுருக்கள்"
 
 #: src/BatchCommandDialog.cpp
+#, fuzzy
+msgid "&Details"
+msgstr "பிரி"
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "கட்டளையை &தெரிக"
 
@@ -1011,8 +1477,18 @@ msgid "MP3 Conversion"
 msgstr "நிகழ்-நேர மாற்றம்"
 
 #: src/BatchCommands.cpp
+#, fuzzy
+msgid "Fade Ends"
+msgstr "கிழே நகர்த்&த"
+
+#: src/BatchCommands.cpp
 msgid "Import Macro"
 msgstr "MIDI இறக்குவதற்கு"
+
+#: src/BatchCommands.cpp
+#, c-format
+msgid "Macro %s already exists. Would you like to replace it?"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Export Macro"
@@ -1025,6 +1501,22 @@ msgstr "விளைவுகள்"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "அளவுருக்களை &தொகுக்க."
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "அளவுருக்களை &தொகுக்க."
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -1072,6 +1564,10 @@ msgid "Apply %s"
 msgstr "%s ஐ நிறைவேற்றுக"
 
 #: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
 msgid "Manage Macros"
 msgstr "வளைவுகளை நிர்வாகி"
 
@@ -1080,6 +1576,17 @@ msgstr "வளைவுகளை நிர்வாகி"
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "வளைவை தெரிவுசெய்"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&சிட்டைகள்"
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "சங்கிலி கட்டளை நிறைவேற்றுக"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -1147,7 +1654,8 @@ msgstr "பகுதி&யை மிளபேறு"
 msgid "I&mport..."
 msgstr "&இறக்குமதி..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "ஏற்றுமதி"
 
@@ -1188,9 +1696,15 @@ msgstr "&மேலே நகர்த்த"
 msgid "Move &Down"
 msgstr "கிழே நகர்த்&த"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "சேமிக்க"
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -1236,11 +1750,38 @@ msgid "Benchmark"
 msgstr "ஒப்பிடை தொடங்கு ...."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "திரும்ப செய்ய வேண்டிய தடவைகள்"
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "மூடு"
 
@@ -1255,8 +1796,30 @@ msgid "Export Benchmark Data as:"
 msgstr "வர்ணபட்டை தரவாக ஏற்மதிச்செய்:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "முன்தோற்றம் தயார் செய்யப்படுகிறது\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1265,17 +1828,104 @@ msgstr "திரும்ப செய் செயற்படுத்தப�
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "ஒட்டு\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "ஒலி பதிவு செய்தல்\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "முடிவு திகதி மற்றும் நேரம்"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, fuzzy, c-format
+msgid "Debug build (debug level %d)"
+msgstr "வெளியீடு கட்டல்"
 
 #: src/BuildInfo.h
 #, c-format
@@ -1296,9 +1946,33 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "இதை பயன்படுத்த கட்டாயம் முதலில் நிங்கள் எதாவது ஒலியை தெரிவு செய்ய வேண்டும்"
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "சங்கிலி தெரியப்படவில்லை"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
 
 #: src/CommonCommandFlags.cpp
 msgid ""
@@ -1322,6 +1996,11 @@ msgstr "இதை பயன்படுத்த கட்டாயம் மு
 
 #: src/DBConnection.cpp
 #, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, c-format
 msgid "Failed to set safe mode on primary connection to %s"
 msgstr "நேரடியாக வாசிக்கவும்"
 
@@ -1339,10 +2018,24 @@ msgstr "தற்போதைய &செயற்திட்டத்தில�
 msgid "Checkpointing %s"
 msgstr "இறக்குமதி %s"
 
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
 #: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "கோப்பில் எழுத முடியவில்லை: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"திட்டத்தை சேமிக்க முடியவில்லை. %s \n"
+"எழுத முடியவில்லை.அல்லது வன் தட்டு நிரம்பி உள்ளது"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1359,6 +2052,10 @@ msgid ""
 "\n"
 "%s"
 msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
@@ -1456,6 +2153,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "இடைநிலை பலகைக்கு வெட்டு"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "கோப்புகளை காணவில்லை"
 
@@ -1464,10 +2166,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "தொடர்வீர்கள் ஆனால், உங்கள் செயற்திட்டம் வன்தட்டில் சேமிக்கப்படாது. இதற்குத்தான் ஆசைப்பட்டீர்களா?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -1479,7 +2182,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "சார்புகளை செவ்வை பார்த்தல்"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "எதுவும் இல்லை "
 
@@ -1487,7 +2193,7 @@ msgstr "எதுவும் இல்லை "
 msgid "Rectangle"
 msgstr "செவ்வகம்"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "முக்கோணம்"
 
@@ -1501,12 +2207,60 @@ msgstr "செவ்வகம் "
 
 #. i18n-hint a proper name
 #: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
 msgid "Welch"
 msgstr "நல்வரவு!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg ஆதரவு தொகுக்கப்படவில்லை"
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -1521,8 +2275,8 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg யை இடங்குறி"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacityக்கு ஒலிக் கோப்பை FFmpeg ஊடக ஏற்றுமதி மற்றும் இறக்குமதி செய்ய '%s' கோப்பு தேவை."
 
 #: src/FFmpeg.cpp
@@ -1535,7 +2289,8 @@ msgstr "'%s' இன் இடம்:"
 msgid "To find '%s', click here -->"
 msgstr "'%s' இனை கண்டறிய இங்கே சொடுக்கவும -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "உலாவு..."
 
@@ -1561,8 +2316,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg இல்லை"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -1582,24 +2338,38 @@ msgstr "இந்த எச்சரிக்கையை மிண்டும�
 msgid "Failed to find compatible FFmpeg libraries."
 msgstr "ஏற்புடைய FFmpeg நூலகத்தை கண்டுபிடிப்பதில் தோல்வி"
 
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity யால் கோப்பை எழுத முடியவில்லை:\n"
+" %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Audacity யால் கோப்பை எழுத முடியவில்லை:\n"
 " %s."
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
-"Audacity யால் கோப்பை எழுத முடியவில்லை:\n"
-" %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1609,6 +2379,12 @@ msgstr ""
 #: src/FileException.h
 msgid "File Error"
 msgstr "LOF பிழை"
+
+#. i18n-hint: %s will be the error message from the libsndfile software library
+#: src/FileFormats.cpp
+#, c-format
+msgid "Error (file may not have been written): %s"
+msgstr ""
 
 #: src/FileFormats.cpp
 msgid "&Copy uncompressed files into the project (safer)"
@@ -1630,7 +2406,9 @@ msgstr "எந்த ஒலியையும் பிரதி செய்ய
 msgid "As&k"
 msgstr "பாவனையாளரிடம் கேள்"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "எல்லா கோப்புகளும்  (*)|*"
 
@@ -1639,6 +2417,11 @@ msgstr "எல்லா கோப்புகளும்  (*)|*"
 #: src/FileNames.cpp
 msgid "AUP3 project files"
 msgstr "செயற்திட்ட தரவு கோப்புகள் சேமிக்கப்படுகின்றன"
+
+#: src/FileNames.cpp
+#, fuzzy
+msgid "Dynamically Linked Libraries"
+msgstr "நூலகங்கள்"
 
 #: src/FileNames.cpp
 msgid "Dynamic Libraries"
@@ -1651,6 +2434,10 @@ msgstr "கோப்புகளின் பெயர்கள்:"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "MP3 கோப்புகள்"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -1667,12 +2454,37 @@ msgstr "குறிப்பிடப்பட்ட கோப்பு பெ�
 msgid "Specify New Filename:"
 msgstr "புதிய கோப்பு பெயரை குறிப்பிடுக:"
 
+#: src/FileNames.cpp
+#, c-format
+msgid "Directory %s does not have write permissions"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Frequency Analysis"
 msgstr "அதிர்வெண் ஆய்வு"
 
 #: src/FreqWindow.cpp src/prefs/SpectrumPrefs.h
 msgid "Spectrum"
+msgstr "வர்ணப்பட்டை"
+
+#: src/FreqWindow.cpp
+msgid "Standard Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Cuberoot Autocorrelation"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "Enhanced Autocorrelation"
+msgstr ""
+
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
 msgstr "வர்ணப்பட்டை"
 
 #. i18n-hint: This refers to a "window function",
@@ -1691,9 +2503,34 @@ msgstr "நேரியல் நிகழ்வெண்"
 msgid "Log frequency"
 msgstr "பதிவு நிகழ்வெண்"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "dB"
+msgstr "dB"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
+
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "பெரிதாக்குக"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -1708,6 +2545,10 @@ msgstr "கிடையான ஸ்டீரியோ"
 #: src/FreqWindow.cpp
 msgid "Cursor:"
 msgstr "&நிலைக்காட்டியை அசைக்குக "
+
+#: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Grids"
@@ -1750,11 +2591,48 @@ msgstr "அதிகளவான ஒலி தெரிவுசெய்யப�
 msgid "Not enough data selected."
 msgstr "போதுமான தரவு தேர்ந்தெடுக்கப்படவில்லை."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "வர்ணப்பட்டை"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "வர்ணபட்டை தரவாக ஏற்மதிச்செய்:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "கோப்பில் எழுத முடியவில்லை: "
@@ -1830,8 +2708,62 @@ msgid "No Local Help"
 msgstr "உள்ளக உதவி இல்லை"
 
 #: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
 msgid "These are our support methods:"
 msgstr "இவை எமது உதவி முறைகள்:"
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1850,6 +2782,10 @@ msgid "Used Space"
 msgstr "வன்தட்டு இடம்"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&படிமுறை மீளமைவுகள் உள்ளன"
 
@@ -1863,6 +2799,10 @@ msgid "&Discard"
 msgstr "&கைவிடு"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&கைவிடு"
 
@@ -1870,11 +2810,30 @@ msgstr "&கைவிடு"
 msgid "&Compact"
 msgstr "&கட்டளை"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&வரலாறு. . . ."
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
 
 #: src/InconsistencyException.h
 msgid "Internal Error"
@@ -1890,7 +2849,9 @@ msgid "Track"
 msgstr "ஒலித்துண்டு"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "சிட்டை"
 
@@ -1950,21 +2911,36 @@ msgstr "ஒலித்துண்டின் பெயரை உள்ளி�
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "சிட்டை ஒலித்துண்டு"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
 
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity யின் முதலாவது பாவனை"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Audacity க்கான மொழியினை தெரிவு செய்க: "
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "உறுதி"
 
@@ -1973,12 +2949,20 @@ msgid "Error Converting Legacy Project File"
 msgstr "திட்டத்தை சேமிப்பதில் வழு"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, c-format
+msgid ""
+"Converted a 1.0 project file to the new format.\n"
+"The old file has been saved as '%s'"
+msgstr ""
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity திட்டம் திறக்கிறது"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity வெற்றிசைப்பாடல் %s"
 
 #: src/LyricsWindow.cpp
@@ -2029,19 +3013,23 @@ msgid "Mixing and rendering tracks"
 msgstr "கலந்து வழங்கப்பட்ட தடங்கள்"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity கலக்கும் பலகை %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "பெறு"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "வேகம்"
 
@@ -2050,17 +3038,23 @@ msgid "Musical Instrument"
 msgstr "சங்கீத கருவி"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "நகர்த்தி"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "ஓசையற்ற"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "தனி"
 
@@ -2068,11 +3062,19 @@ msgstr "தனி"
 msgid "Signal Level Meter"
 msgstr "சமிக்ஞை மட்ட கருவி"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "பெறும் நகர்த்தி நகர்த்தப்பட்டுள்ளது"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "பெறும் நகர்த்தி நகர்த்தப்பட்டுள்ளது"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "நகர்த்தும் நகர்த்தி நகர்த்தப்பட்டுள்ளது"
 
@@ -2094,6 +3096,30 @@ msgstr "கூறு பொருத்தமற்றது"
 
 #: src/ModuleManager.cpp
 #, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
 msgid "Module \"%s\" found."
 msgstr "கூறு \"%s\" உள்ளது."
 
@@ -2107,21 +3133,32 @@ msgstr ""
 "\n"
 "அனுமதிக்கப்பட்டவற்றில் இருந்து பெறப்பட்ட கூறுகளை மட்டும் பயன்படுத்துக"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "ஆம்"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "இல்லை"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "கூறு ஏற்றி"
 
 #: src/ModuleManager.cpp
 msgid "Try and load this module?"
 msgstr "இக் கூறை ஏற்றி முயற்சிசெய்வதா?"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -2136,13 +3173,121 @@ msgstr "LC"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "கிகா பைட்டுகள்"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "B"
 msgstr "dB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
+#: src/PluginManager.cpp
+#, fuzzy, c-format
+msgid "Overwrite the plug-in file %s?"
+msgstr "உள்ள வளைவின் மேல் எழுது"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -2164,9 +3309,29 @@ msgstr[1] "மன்னிக்கவும், Vamp சொருகியை �
 msgid "Enable new plug-ins"
 msgstr "மன்னிக்கவும், Vamp சொருகியை சுமையேற்றுவதில் தோல்வி"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "விளைவுகள்"
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "மன்னிக்கவும், Vamp சொருகியை சுமையேற்றுவதில் தோல்வி"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "செயல்படுத்த பட்டுள்ளது"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -2193,6 +3358,21 @@ msgstr "செயல்படுத்த பட்டுள்ளது"
 msgid "E&nabled"
 msgstr "செயல்படுத்த பட்டுள்ளது"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "செயல்படுத்த பட்டுள்ளது"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Path"
 msgstr "பாதை"
@@ -2205,7 +3385,8 @@ msgstr "தெரிக"
 msgid "C&lear All"
 msgstr "&amp;தெளிவாக்கு"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "செயல்படுத்த பட்டுள்ளது"
 
@@ -2259,9 +3440,30 @@ msgstr ""
 msgid "Actual Rate: %d"
 msgstr "உண்மை வீதம் : %d"
 
+#: src/ProjectAudioManager.cpp src/effects/Effect.cpp
+msgid ""
+"Error opening sound device.\n"
+"Try changing the audio host, playback device and the project sample rate."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "வர்ணப்பட்டையை வரைவதற்கு தெரிவு செய்யப்பட்ட ஒலித்துண்டுகள் அனைத்தும் ஒரே மாதிரி அளவை கொண்டிருக்க வேண்டும். "
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
 
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
@@ -2270,6 +3472,28 @@ msgstr "ஒலி அமைவை பதிவு செய்"
 #: src/ProjectAudioManager.cpp src/toolbars/ControlToolBar.cpp
 msgid "Record"
 msgstr "பதிவு செய்"
+
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
 
 #. i18n-hint: The audacity project file is XML and has 'tags' in it,
 #. rather like html tags <something>some stuff</something>.
@@ -2297,11 +3521,11 @@ msgid "Inspecting project file data"
 msgstr "செயற்திட்ட தரவு கோப்புகளை ஆய்வு செய்கிறது..."
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2344,11 +3568,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "எச்சரிக்கை - பெயர் மாற்றபட்ட கோப்பு(கள்) காணவில்லை"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "கோப்பகம் \"%s\" செயற்திட்ட பரிசீலனை\n"
@@ -2372,12 +3596,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "எச்சரிக்கை - சுருக்க கோப்பு(களை) காணவில்லை"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -2433,7 +3657,8 @@ msgstr "எச்சரிக்கை - அனாதை தொகுதி �
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "போக்கு"
 
@@ -2442,12 +3667,24 @@ msgid "Cleaning up unused directories in project data"
 msgstr "திட்ட தரவில் பயன்படுத்தாத கோப்பகங்களை துப்பரவாக்குகிறது"
 
 #: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "எச்சரிக்கை: தானியக்க மீட்பில் பிரச்சினைகள்"
 
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "பெயரிடப்படாத"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "திட்டங்கள்"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -2486,11 +3723,96 @@ msgid ""
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Audacity திட்டத்தை சேமிக்கிறது"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -2504,12 +3826,33 @@ msgid "Total orphan blocks deleted %d"
 msgstr "அனாதை தொகுதி கோப்பு: '%s'"
 
 #: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "'%s' இருந்து   '%s' ஆக மறுபடி பெயரிட முடியவில்லை"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -2520,9 +3863,9 @@ msgid "Error Writing to File"
 msgstr "கோப்பில் எழுதுவதில் பிழை"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2533,8 +3876,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "திட்டங்கள் சேமிக்கப்படுகிறது"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Tenacity பதிவுகள்"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -2544,10 +3896,10 @@ msgstr "மீள பெறபட்டது"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Audacity %s இனை பாவித்து உங்களது கோப்பானது சேமிக்கப்பட்டுள்ளது.\n"
 "நீங்கள் Audacity %s இனை பாவிக்குறீர்கள்.கோப்பை திறக்கும் பொருட்டு புதிய அமைபிற்கு தரமுயர்த்த வேண்டும்."
@@ -2555,6 +3907,10 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "திட்ட கோப்பினை திறக்க முடியாதுள்ளது"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -2569,6 +3925,10 @@ msgid "Unable to parse project information."
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "திட்டங்கள் சேமிக்கப்படுகிறது"
 
@@ -2577,12 +3937,35 @@ msgid "Error Saving Project"
 msgstr "திட்டத்தை சேமிப்பதில் வழு"
 
 #: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Backing up project"
 msgstr "வெற்று திட்டம் சேமிக்கப்படுகிறது"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -2590,8 +3973,23 @@ msgstr ""
 "ஆயினும், பின்வரும் செயற்திட்டங்கள் மீத்கக்கூடியதாகும்: "
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
+msgstr ""
+"கடந்த முறையின் போது சரியாக சில செயற்திட்டங்கள் சேமிக்கப்படவில்லை.\n"
+"ஆயினும், பின்வரும் செயற்திட்டங்கள் மீத்கக்கூடியதாகும்: "
+
+#: src/ProjectFileManager.cpp
 msgid "Project Recovered"
 msgstr "திட்டம் மீள பெறபட்டது"
+
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+msgid "Projects cannot be saved to FAT drives."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid ""
@@ -2621,10 +4019,27 @@ msgstr "எச்சரிக்கை - காலி கோப்பகம்"
 msgid "Insufficient Disk Space"
 msgstr "வன்தட்டு இடம்"
 
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
+
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Saved %s"
 msgstr "சேமிக்கப்பட்டுள்ளது %s"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 #, c-format
@@ -2632,9 +4047,45 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "செயற்திட்டத்தை \"%s\" ஆக சேமி..."
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
+
+#. i18n-hint: Heading: A warning that a project is about to be overwritten.
+#: src/ProjectFileManager.cpp
+msgid "Overwrite Project Warning"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "சுருக்கப்பட்ட திட்டத்தை சேமிக்க \"%s\" ஆக..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -2662,11 +4113,12 @@ msgid "Error Opening Project"
 msgstr "திட்டத்தை ஆரம்பிப்பதில் வழு"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "தானாக உருவாக்கப்பட்ட காப்பு கோப்பினை திறக்க முயல்கிறீர்.\n"
 "இதன் மூலம் பலத்த தரவு இழப்பு ஏற்படும்.\n"
@@ -2699,6 +4151,12 @@ msgid "Error Opening File or Project"
 msgstr "கோப்பை அல்லது திட்டத்தை திறப்பதில் வழு"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Project was recovered"
 msgstr "திட்டம் மீள பெறபட்டது"
 
@@ -2724,12 +4182,33 @@ msgid "Error Importing"
 msgstr "இறக்குவதில் வழு"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&திட்டத்தை சேமி"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "திட்ட கோப்பினை திறக்க முடியாதுள்ளது"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&கட்டளை"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -2740,8 +4219,8 @@ msgid "Automatic database backup failed."
 msgstr "தானியங்கி பாதிப்பு மீட்பு."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Audacity Version %s இற்கு வரவேற்கிறோம்"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -2776,6 +4255,10 @@ msgid "Disk space remaining for recording: %s"
 msgstr "%d நிமிடங்கள் வன்தட்டில் பதிவிற்கு எஞ்சியுள்ளது."
 
 #: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -2788,6 +4271,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2804,6 +4299,26 @@ msgstr "கிடையான ஸ்டீரியோ"
 msgid "Vertical Scrollbar"
 msgstr "செங்குத்து ஸ்டீரியோ"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "(சிறந்த தரம்)"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "தரம்"
@@ -2815,6 +4330,28 @@ msgstr "தரம்"
 #: src/Resample.cpp
 msgid "Best Quality (Slowest)"
 msgstr "(சிறந்த தரம்)"
+
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "16-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "24-bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+#, fuzzy
+msgid "32-bit float"
+msgstr "32-bit float"
+
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
 
 #: src/Screenshot.cpp
 msgid "Screen Capture Frame"
@@ -2865,6 +4402,11 @@ msgid "Capture Full Window"
 msgstr "முழு சாளரத்தையும் பிடிக்கவும்"
 
 #: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "சாளரத்தை மட்டும் பிடிக்கவும்"
+
+#: src/Screenshot.cpp
 msgid "Capture Full Screen"
 msgstr "முழு திரையையும் பிடிக்கவும்"
 
@@ -2896,7 +4438,8 @@ msgstr "விருப்பங்கள்: "
 msgid "SelectionBar"
 msgstr "தெரிவு சட்டம்"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "தேர்வு"
 
@@ -2904,44 +4447,58 @@ msgstr "தேர்வு"
 msgid "Timer"
 msgstr "நேரம்"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "கருவிகள்"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "போக்குவரத்து"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "கலப்பான்"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "அளவைக்கருவி"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "மீட்டரை ஓடச்செய்"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "மீட்டரை பதிவு செய்"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "தொகு"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "சாதனம்"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "வேகமாக செயல்படு"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "க&ருவி பட்டியில்"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
@@ -2954,7 +4511,10 @@ msgstr "அடிமட்டம்"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "தடங்கள்"
 
@@ -3006,9 +4566,20 @@ msgstr "நீண்ட தடங்கள்"
 msgid "Choose a location to save screenshot images"
 msgstr "பிடிக்கப்பட்ட படங்களை சேமிக்க கோப்பகத்தை தெரியவும்"
 
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
 #: src/Screenshot.cpp src/commands/CommandTargets.cpp
 msgid "Long Message"
 msgstr "\t-help (இச்செய்தி)"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
 
 #: src/Sequence.cpp
 msgid "Warning - Truncating Overlong Block File"
@@ -3051,7 +4622,8 @@ msgid "Activation level (dB):"
 msgstr "செயல்படுத்தப்பட்ட அளவு (db) :"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Audacity இற்கு வரவேற்கிறோம்"
 
 #: src/SplashDialog.cpp
@@ -3178,19 +4750,44 @@ msgstr "குறிச்சொற்கள் கோப்பை சேம�
 msgid "Unsuitable"
 msgstr "கூறு பொருத்தமற்றது"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr ""
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity யால் கோப்பை எழுத முடியவில்லை:\n"
 " %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -3198,25 +4795,57 @@ msgstr ""
 " %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity யால் படிமத்தை  கோப்பில் எழுத முடியவில்லை:\n"
 "  %s."
 
-#. i18n-hint: Do not translate png.  It is the name of a file format.
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
+"  %s.\n"
+"Theme not loaded."
+msgstr ""
+"Audacity யால் கோப்பை எழுத முடியவில்லை:\n"
+" %s."
+
+#. i18n-hint: Do not translate png.  It is the name of a file format.
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
 "கோப்பை சுமையேற்ற முடியவில்லை:\n"
 "  %s.\n"
 "ஒரு வேளை தவறான png அமைப்பு?"
+
+#: src/Theme.cpp
+msgid ""
+"Tenacity could not read its default theme.\n"
+"Please report the problem."
+msgstr ""
+
+#: src/Theme.cpp
+#, c-format
+msgid ""
+"None of the expected theme component files\n"
+" were found in:\n"
+"  %s."
+msgstr ""
 
 #: src/Theme.cpp
 #, c-format
@@ -3238,24 +4867,40 @@ msgstr ""
 "ஏற்கனவே உள்ளன."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity யால் கோப்பை சேமிக்க முடியவில்லை:\n"
 "  %s"
+
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
 
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "ஒளி"
 
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
 #. i18n-hint: greater difference between foreground and
 #. background colors
 #: src/Theme.cpp
 msgid "High Contrast"
 msgstr "பேதம் காட்டு ..."
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "ஒலித்துண்டு பெயர்"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -3264,7 +4909,11 @@ msgstr "பேதம் காட்டு ..."
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "கால அளவு"
 
@@ -3275,12 +4924,20 @@ msgid "Time Track"
 msgstr "நேரத் தடம்"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity நேர பதியி"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
 msgstr "Google Translate"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Error Saving Timer Recording Project"
@@ -3295,12 +4952,38 @@ msgid "Error in Duration"
 msgstr "கால அளவில் வழு"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "தானியங்கி பாதிப்பு மீட்பு."
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Save"
 msgstr "கால அளவில் வழு"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "தானியங்கி பாதிப்பு மீட்பு."
+
+#: src/TimerRecordDialog.cpp
 msgid "Error in Automatic Export"
 msgstr "கால அளவில் வழு"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
+msgstr "கா&லத்தை பதிவு செய்"
 
 #: src/TimerRecordDialog.cpp
 msgid "Current Project"
@@ -3310,7 +4993,8 @@ msgstr "தற்போதைய &செயற்திட்டத்தில�
 msgid "Recording start:"
 msgstr "பதிதல் ஆரம்பம்"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "காலஅளவு:"
 
@@ -3331,7 +5015,8 @@ msgid "Action after Timer Recording:"
 msgstr "Audacity நேர பதியி"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity நேர பதியி செயற்பாடு"
 
 #: src/TimerRecordDialog.cpp
@@ -3366,6 +5051,30 @@ msgid ""
 "Recording exported: %s"
 msgstr "பதிதல் முடிவு"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "திட்டத்தை சேமிப்பதில் வழு"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
+
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
 msgstr "Google Translate"
@@ -3385,6 +5094,7 @@ msgstr "099 நாட்கள் 024 ம 060 நி 060 நொ"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "ஆரம்ப திகதி மற்றும் நேரம்"
@@ -3429,7 +5139,8 @@ msgstr "ஏற்றுமதி செய்ய முடியவில்ல�
 msgid "Export Project As:"
 msgstr "முன்னமைக்கப்பட்டவையை ஏற்றுமதி செய்"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "விருப்பத்தேர்வுகள்..."
 
@@ -3438,8 +5149,21 @@ msgid "After Recording completes:"
 msgstr "மீட்டரை பதிவு செய்"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Audacity வெளியேறவும்"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Waiting to start recording at:"
@@ -3454,7 +5178,8 @@ msgid "Scheduled to stop at:"
 msgstr "ஆரம்பத்தை தேர்ந்தெடு"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity நேர பதியி - தொடங்க காத்திருக்கிறது"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -3462,6 +5187,14 @@ msgstr "Audacity நேர பதியி - தொடங்க காத்த�
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "பதிதல் முடிவு"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -3472,12 +5205,18 @@ msgid "Recording Exported:"
 msgstr "பதிதல் முடிவு"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity நேர பதியி - தொடங்க காத்திருக்கிறது"
 
 #: src/TrackInfo.cpp
 msgid "Stereo, 999999Hz"
 msgstr "பிரியோசை, 999999Hz"
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -3507,6 +5246,29 @@ msgstr "தனி"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "தெரிக"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+msgid " Sync Locked"
+msgstr ""
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Mute On"
+msgstr "ஓசையற்ற"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Solo On"
+msgstr "தனி"
+
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Select On"
+msgstr "தேர்வு"
 
 #: src/TrackPanelResizeHandle.cpp
 msgid "Click and drag to adjust relative size of stereo tracks, double-click to make heights equal"
@@ -3573,6 +5335,10 @@ msgstr "ஒலித்துண்டை மேலே நகர்த்து"
 msgid "Move Track Down"
 msgstr "ஒலித்துண்டை கீழே நகர்த்து"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -3581,6 +5347,10 @@ msgstr "ஒலித்துண்டை கீழே நகர்த்து"
 #: src/VoiceKey.cpp
 msgid "Selection is too small to use voice key."
 msgstr "குரல் சாவியை பயன்படுத்த தெரிவு மிகவும் சிறியது"
+
+#: src/VoiceKey.cpp
+msgid "Calibration Results\n"
+msgstr ""
 
 #. i18n-hint: %1.4f is replaced by a number.  sd stands for 'Standard Deviations'
 #: src/VoiceKey.cpp
@@ -3598,6 +5368,10 @@ msgstr "குறி மாற்றம்        -- mean: %1.4f  sd: (%1.4f)\n"
 msgid "Direction Changes  -- mean: %1.4f  sd: (%1.4f)\n"
 msgstr "திசை மாற்றம்  -- mean: %1.4f  sd: (%1.4f)\n"
 
+#: src/VoiceKey.cpp
+msgid "Calibration Complete"
+msgstr ""
+
 #: src/WaveClip.cpp
 msgid "Resampling failed."
 msgstr "%d தடம் மீள் மாதிரி செய்யப்படுகிறது"
@@ -3606,37 +5380,114 @@ msgstr "%d தடம் மீள் மாதிரி செய்யப்ப
 msgid "There is not enough room available to paste the selection"
 msgstr "தெரிவினை ஒட்ட போதுமான இடம் இல்லை"
 
+#: src/WaveTrack.cpp
+#, fuzzy
+msgid "There is not enough room available to expand the cut line"
+msgstr "தெரிவினை ஒட்ட போதுமான இடம் இல்லை"
+
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "நிறைவேற்றபடுகிறது....."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "கட்டளை"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "கட்டளை"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "திரும்பச்செய் %s"
 
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
+
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
 msgstr "பெயரிடப்பட்ட பாடலை பிரதி செய்"
+
+#: src/commands/CompareAudioCommand.cpp
+#, fuzzy
+msgid "Threshold:"
+msgstr "அமைதிக்கான தொடக்கநிலை"
 
 #: src/commands/CompareAudioCommand.h
 msgid "Compares a range on two tracks."
 msgstr "உச்சத்தை பயன்படுத்தி சுருக்கு"
 
 #: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
+#: src/commands/Demo.cpp
+#, fuzzy
+msgid "Delay time (seconds):"
+msgstr "சிதைவு நேரம் %.1f நொடிகள்"
+
+#: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "சிதைவு காரணி:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -3658,6 +5509,11 @@ msgstr "ஒலித்துண்டு"
 msgid "Track 1"
 msgstr "ஒலித்துண்டு"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "சாளர அளவு"
@@ -3669,6 +5525,22 @@ msgstr "RPM இல் இருந்து"
 #: src/commands/DragCommand.cpp
 msgid "From Y:"
 msgstr "RPM இல் இருந்து"
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -3686,13 +5558,52 @@ msgstr "நிரல்"
 msgid "Preferences"
 msgstr "விருப்பங்கள்: "
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "அடுத்த கருவி"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "உறை கருவி"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "சிட்டை"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "வடிகட்டும் வகை"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Format:"
+msgstr "அமைப்பு மாற்றம்"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
@@ -3702,6 +5613,10 @@ msgstr "ஒலித்துண்டை கீழே நகர்த்து"
 msgid "Types:"
 msgstr "வடிகட்டும் வகை"
 
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
+
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
 msgstr "பின்னூட்டங்கள்"
@@ -3709,6 +5624,18 @@ msgstr "பின்னூட்டங்கள்"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "கட்டளை:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -3727,6 +5654,11 @@ msgid "Number of Channels:"
 msgstr "திரும்ப செய்ய வேண்டிய தடவைகள்"
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "பல ஏற்றுமதி..."
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "பல ஏற்றுமதி..."
 
@@ -3734,9 +5666,26 @@ msgstr "பல ஏற்றுமதி..."
 msgid "Builtin Commands"
 msgstr "கட்டளையை தெரிவு செய்க."
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity இணை அணி"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "முடிவு திகதி மற்றும் நேரம்"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
 
 #: src/commands/MessageCommand.h
 msgid "Echos a message."
@@ -3778,11 +5727,22 @@ msgstr "&திட்டத்தை சேமி"
 msgid "Saves a copy of current project."
 msgstr "&திட்டத்தை சேமி"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "விருப்பங்கள்: "
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "செயற்திட்ட பெயர"
 
@@ -3793,6 +5753,18 @@ msgstr "விருப்பங்கள்: "
 #: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
 msgid "Value:"
 msgstr "பெறுமதி"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Screenshot"
@@ -3818,7 +5790,8 @@ msgstr "முழுத்திரை செயல்படுத்து/ம�
 msgid "Toolbars"
 msgstr "க&ருவி பட்டியில்"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "விளைவுகள்"
 
@@ -3862,6 +5835,10 @@ msgstr "நீண்ட தடங்கள்"
 msgid "All Tracks Plus"
 msgstr "நீண்ட தடங்கள்"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -3873,13 +5850,26 @@ msgid "Path:"
 msgstr "பாதை"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Background:"
 msgstr "பின்னணி:"
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
 
 #: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "கோப்பை சேமிக்க முயன்றதில் வழு: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "திரை புகைப்பட கருவி  ...."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -3926,6 +5916,10 @@ msgid "High:"
 msgstr "Highpass"
 
 #: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "படல்களை வரிசைப்படுத்து"
 
@@ -3938,7 +5932,8 @@ msgstr "சரி செய்ய"
 msgid "Add"
 msgstr "&இணைக்க"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "நீக்கு"
 
@@ -3959,6 +5954,11 @@ msgid "Selects a time range."
 msgstr "ஒரு MIDI கோப்பினை தெரியவும்... "
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "ஒரு MIDI கோப்பினை தெரியவும்... "
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
 
@@ -3970,9 +5970,37 @@ msgstr "ஒலியை அமைதியாக்கு"
 msgid "Set Clip"
 msgstr "அடுத்த கருவி"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "ஆரம்பி"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -3990,6 +6018,17 @@ msgstr "அழி"
 msgid "Edited Envelope"
 msgstr "மட்டம்"
 
+#. i18n-hint: The envelope is a curve that controls the audio loudness.
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Envelope"
+msgstr "உறை கருவி"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
 msgstr "பெயரிடப்பட்ட பாடலை அழி"
@@ -3998,6 +6037,10 @@ msgstr "பெயரிடப்பட்ட பாடலை அழி"
 msgid "Label Index"
 msgstr "சிட்டை  தொகு"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "தெரிக"
@@ -4005,6 +6048,10 @@ msgstr "தெரிக"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "தொகுக்கப்பட்ட சிட்டைகள்"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -4018,9 +6065,26 @@ msgstr "அளவை நிர்ணயி"
 msgid "Resize:"
 msgstr "மீள சிறிதாக்கவும்"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "ஒளி"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&திட்டத்தை சேமி"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -4051,10 +6115,17 @@ msgid "Gain:"
 msgstr "பெறு"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "படல்களை வரிசைப்படுத்து"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "நேர்கோடு"
 
@@ -4065,6 +6136,10 @@ msgstr "மீளமை"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Times 2"
 msgstr "நேரம்"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
@@ -4094,13 +6169,28 @@ msgstr "Spectral Processor"
 msgid "Spectral Select"
 msgstr "தேர்வு"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "புதிய தடம்"
 
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
+
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "விஸ்தரி"
+
+#: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
 
 #: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
@@ -4119,11 +6209,39 @@ msgid "Allo&w clipping"
 msgstr "வெட்டப்பட &துண்டை காட்டு"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "You selected a track which does not contain audio. AutoDuck can only process audio tracks."
+msgstr ""
+
+#. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
+#. * of the audio automatically when there is sound on another track.  Not as
+#. * in 'Donald-Duck'!
+#: src/effects/AutoDuck.cpp
+msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Duck அளவு:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "விநாடிகள்"
 
@@ -4131,7 +6249,24 @@ msgstr "விநாடிகள்"
 msgid "Ma&ximum pause:"
 msgstr "அதிகபட்ச இடைநிறுத்தம்"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &down length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Outer fade &up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner fade d&own length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
+msgid "Inner &fade up length:"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "அமைதிக்கான தொடக்கநிலை"
 
@@ -4140,8 +6275,41 @@ msgid "Preview not available"
 msgstr "முன்தோற்றம் இல்லை"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Simple tone control effect"
+msgstr "ஆரம்பத்தை தேர்ந்தெடு"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "அமைதிக்கான தொடக்க நிலை"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass (dB):"
+msgstr "உயர்வு (dB):"
+
+#: src/effects/BassTreble.cpp
 msgid "Ba&ss (dB):"
 msgstr "உயர்வு (dB):"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "மட்டம் (dB)"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "சிட்டை  தொகு"
 
 #: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
@@ -4151,6 +6319,10 @@ msgstr "வீச்சு (dB):"
 msgid "Level"
 msgstr "மட்டம்"
 
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
 msgstr "சுருதியை மாற்று"
@@ -4158,6 +6330,21 @@ msgstr "சுருதியை மாற்று"
 #: src/effects/ChangePitch.cpp
 msgid "Changes the pitch of a track without changing its tempo"
 msgstr "சுருதியை மாற்றாது டெம்போ வை மாற்று"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "இறுதி போக்கு மாற்ற (%)"
+
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "Change Pitch without Changing Tempo"
+msgstr "சுருதியை மாற்றாது டெம்போ வை மாற்று"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
@@ -4176,6 +6363,11 @@ msgctxt "change pitch"
 msgid "&from"
 msgstr "இருந்து"
 
+#: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "from Octave"
+msgstr "கிழ் அட்டமசுரம்"
+
 #. i18n-hint: changing musical pitch "from" one value "to" another
 #: src/effects/ChangePitch.cpp
 msgctxt "change pitch"
@@ -4189,12 +6381,29 @@ msgid "&to"
 msgstr "இடத்திற்கு"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "to Octave"
+msgstr "கிழ் அட்டமசுரம்"
+
+#: src/effects/ChangePitch.cpp
+msgid "Semitones (half-steps)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "&Semitones (half-steps):"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
 msgid "Frequency"
 msgstr "அதிர்வெண் (hz)"
 
 #: src/effects/ChangePitch.cpp
 msgid "from (Hz)"
 msgstr "இருந்து (Hz)"
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "to (Hz)"
@@ -4204,13 +6413,23 @@ msgstr "இடத்திற்கு (Hz)"
 msgid "t&o"
 msgstr "இடத்திற்கு"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "சதவீத மாற்றம்:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "சதவீத மாற்றம்"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -4222,7 +6441,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "பயன்படுத்த முடியாதது"
 
@@ -4238,8 +6459,19 @@ msgstr "சுருதியை மாற்றாது டெம்போ 
 msgid "Change Speed, affecting both Tempo and Pitch"
 msgstr "வேக மாற்றம், சுருதி மற்றும் டெம்போ மாற்றம் செய்கிறது"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "&Speed Multiplier:"
+msgstr ""
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "RPM இல் இருந்து"
@@ -4249,6 +6481,14 @@ msgstr "RPM இல் இருந்து"
 msgctxt "change speed"
 msgid "&from"
 msgstr "இருந்து"
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "To rpm"
+msgstr "RPM இல் இருந்து"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -4351,9 +6591,49 @@ msgstr "நீளம் (நொடிகள்)"
 msgid "Click Removal"
 msgstr "அகற்றுதலை சொடுக்கு"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "பெயரானது காலியாக இருக்க கூடாது"
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "அமைதிக்கான தொடக்கநிலை"
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 msgid "Compressor"
 msgstr "அழுத்தி"
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
 
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
@@ -4363,6 +6643,20 @@ msgstr "%.2f செக்கன்கள்"
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "%.1f secs"
+msgstr "%.1f நொடிகள்"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.1f:1"
 msgstr "%.1f நொடிகள்"
 
 #: src/effects/Compressor.cpp
@@ -4419,11 +6713,21 @@ msgstr "கடந்துவிட்ட நேரம்"
 msgid "Release Time"
 msgstr "உருவாக்க வெளியீடு"
 
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
 #. i18n-hint: "Compress" here means reduce variations of sound volume,
 #. NOT related to file-size compression; Peaks means extremes in volume
 #: src/effects/Compressor.cpp
 msgid "C&ompress based on Peaks"
 msgstr "உச்சத்தை பயன்படுத்தி சுருக்கு"
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Threshold %d dB"
+msgstr "அமைதிக்கான தொடக்கநிலை"
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -4448,8 +6752,27 @@ msgstr "உங்களால் ஒரு  நேரத்தில் ஒர�
 msgid "Please select an audio track."
 msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "முடிவு"
 
@@ -4490,6 +6813,15 @@ msgid "Mea&sure selection"
 msgstr "தேர்வை வெட்டவும்"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Result"
+msgstr "முடிவுகள்"
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
 msgid "R&eset"
 msgstr "மீளமை"
 
@@ -4500,6 +6832,18 @@ msgstr "வித்தியாசம்:"
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&உதவி"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "zero"
@@ -4545,6 +6889,10 @@ msgstr "முன்னணி முடிவு நேரம்"
 #: src/effects/Contrast.cpp
 msgid "Background level too high"
 msgstr "பின்னணி முடிவு நேரம்"
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
 
 #. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
 #: src/effects/Contrast.cpp
@@ -4592,6 +6940,17 @@ msgid "Background not yet measured"
 msgstr "பின்னணி அளவு இல்லை"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "சிட்டைகளை ஏற்றுமதி செய்ய"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr "வெற்றி வரையறை 1.4.7 of WCAG 2.0: தேர்ச்சி"
+
+#: src/effects/Contrast.cpp
 #, c-format
 msgid "Filename = %s."
 msgstr "கோப்பு பெயர்  = %s."
@@ -4630,6 +6989,16 @@ msgstr "வெற்றி வரையறை 1.4.7 of WCAG 2.0: தோல்
 msgid "Data gathered"
 msgstr "திரட்டப்பட்ட தரவு"
 
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Contrast..."
 msgstr "பேதம் காட்டு ..."
@@ -4651,12 +7020,119 @@ msgid "Medium Overdrive"
 msgstr "மேலெழுவதை உறுதிப்படுத்து"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Overdrive"
+msgstr "மேலெழுவதை உறுதிப்படுத்து"
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Expand and Compress"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "மட்டம்"
 
 #: src/effects/Distortion.cpp
 msgid "Rectifier Distortion"
 msgstr "Distortion"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "மட்டுபடுத்தி"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Light Crunch Overdrive"
+msgstr "மேலெழுவதை உறுதிப்படுத்து"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Heavy Overdrive"
+msgstr "மேலெழுவதை உறுதிப்படுத்து"
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Valve Overdrive"
+msgstr "மேலெழுவதை உறுதிப்படுத்து"
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -4675,8 +7151,21 @@ msgid "Number of repeats"
 msgstr "திரும்ப செய்ய வேண்டிய தடவைகள்"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion"
+msgstr "Distortion"
+
+#: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Distortion"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -4691,8 +7180,21 @@ msgid "Clipping level"
 msgstr "எதிரொலி பிரயோகிக்கப்படுகிறது"
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "சங்கிலி கட்டளை நிறைவேற்றுக"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "அமைதிக்கான தொடக்கநிலை"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Distortion amount"
@@ -4707,12 +7209,33 @@ msgid "Repeat processing"
 msgstr "நடைமுறைப்படுத்தபடுகிறது : "
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "dB Limit"
 msgstr "மட்டுபடுத்தி"
 
 #: src/effects/Distortion.cpp
 msgid "Wet level"
 msgstr "2-மட்டம்"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "2-மட்டம்"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -4739,6 +7262,16 @@ msgid "DTMF Tones"
 msgstr "DTMF இசைகள்..."
 
 #: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
 msgstr "DTMF வரிசை"
 
@@ -4746,13 +7279,19 @@ msgstr "DTMF வரிசை"
 msgid "&Amplitude (0-1):"
 msgstr "வீச்சு (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "காலஅளவு:"
 
 #: src/effects/DtmfGen.cpp
 msgid "&Tone/silence ratio:"
 msgstr "இசை/சத்தமற்ற விகிதம்:"
+
+#: src/effects/DtmfGen.cpp
+msgid "Duty cycle:"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 #, c-format
@@ -4787,6 +7326,11 @@ msgstr "எதிரொலி"
 msgid "Repeats the selected audio again and again"
 msgstr "தெரிவு செய்யப்பட்ட ஒலி FLAC ஆக ஏற்றுமதிசெய்கிறது"
 
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "சிதைவு நேரம் %.1f நொடிகள்"
@@ -4807,7 +7351,8 @@ msgstr "முன்னமைக்கப்பட்ட வடிவங்க�
 msgid "Export Effect Parameters"
 msgstr "அளவுருக்களை &தொகுக்க."
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "கோப்பை திறக்க முடியவில்லை: \"%s\""
@@ -4831,6 +7376,12 @@ msgstr "அளவுருக்களை &தொகுக்க."
 msgid "%s: is not a valid presets file.\n"
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "முன்தோற்றம் தயார் செய்யப்படுகிறது"
@@ -4838,6 +7389,25 @@ msgstr "முன்தோற்றம் தயார் செய்யப்�
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "முன்தோற்றம் காட்டுகிறது"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist"
+
+#: src/effects/EffectManager.cpp
+#, fuzzy, c-format
+msgid "Applied effect: %s"
+msgstr "பிரயோகிக்கப்பட்ட மேருகூட்டிகள்: %s %.1f%%"
+
+#: src/effects/EffectManager.cpp
+#, fuzzy, c-format
+msgid "Applied command: %s"
+msgstr "%s ஐ நிறைவேற்றுக"
 
 #: src/effects/EffectManager.cpp
 msgid "Select Preset"
@@ -4864,8 +7434,28 @@ msgid "Factory Defaults"
 msgstr "இயல்பான பெறுமதிகளை அளிக்க"
 
 #: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
 msgid "Effect failed to initialize"
 msgstr "மன்னிக்கவும், Vamp சொருகியை ஆரம்பிப்பதில் தோல்வி"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
 
 #: src/effects/EffectManager.cpp
 msgid "Command failed to initialize"
@@ -4888,6 +7478,23 @@ msgid "&Bypass"
 msgstr "Bandpass"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "%s/ நகர்த்த"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "&மேலே நகர்த்த"
 
@@ -4904,6 +7511,24 @@ msgid "Move effect down in the rack"
 msgstr "தடங்களுக்கு இடையே மேலும் கீழுமாக நகர்த்தவும்"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "தடங்களுக்கு இடையே மேலும் கீழுமாக நகர்த்தவும்"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "புதிய சங்கிலியின் பெயரை இடவும்"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "மறைநிலை"
@@ -4913,8 +7538,17 @@ msgid "Some Command"
 msgstr "கட்டளையை தெரிவு செய்க."
 
 #: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "&Manage"
 msgstr "வளைவுகளை நிர்வாகி"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "பின்னணி"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -4975,14 +7609,33 @@ msgid "Options..."
 msgstr "விருப்பத்தேர்வுகள்..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "வடிகட்டும் வகை"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "செயற்திட்ட பெயர"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "பின்னோகுதல்"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "பிழை:"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Description: %s"
 msgstr "எடுத்தெழுதிய பொருள்"
+
+#: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -5018,6 +7671,11 @@ msgstr "பின்னணி"
 msgid "Play"
 msgstr "ஒலி"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "கோசைன்"
@@ -5034,9 +7692,60 @@ msgstr "சரிநிகராக்கம்"
 msgid "Filter Curve EQ"
 msgstr "வளைவை தெரிவுசெய்"
 
+#: src/effects/Equalization.cpp plug-ins/eq-xml-to-txt-converter.ny
+msgid "Graphic EQ"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Bass Boost"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Bass Cut"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "சிட்டை  தொகு"
+
 #: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "சிட்டை  தொகு"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -5051,6 +7760,10 @@ msgid "Effect Unavailable"
 msgstr "முன்தோற்றம் இல்லை"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "உயர்ந்த dB"
 
@@ -5063,6 +7776,26 @@ msgstr "%3d dB"
 msgid "Min dB"
 msgstr "குறைந்த dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
 msgstr "வடிகட்டும் வகை"
@@ -5070,6 +7803,15 @@ msgstr "வடிகட்டும் வகை"
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "வளைவுகளை வரை"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "வரையும் கருவி"
+
+#: src/effects/Equalization.cpp
+msgid "&Graphic"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Interpolation type"
@@ -5127,10 +7869,46 @@ msgstr "நடைமுறைப்படுத்தபடுகிறது : 
 msgid "D&efault"
 msgstr "இயல்பு&நிலை"
 
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "ஒப்பிடை தொடங்கு ...."
+
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
 msgid "unnamed"
 msgstr "பெயரிடப்படாதது"
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "VST திட்டத்தை சுமையேற்றுவதில் வழு"
 
 #: src/effects/Equalization.cpp
 msgid "Error Saving Equalization Curves"
@@ -5173,6 +7951,16 @@ msgid "De&faults"
 msgstr "இயல்பு&நிலை"
 
 #: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "'unnamed' is special"
 msgstr "'பெயரிடப்படாதது' விசேடமானது"
 
@@ -5189,6 +7977,10 @@ msgstr "பெயர்மாற்றம்..."
 #, c-format
 msgid "Rename '%s'"
 msgstr "பெயர்மாற்றம் '"
+
+#: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Same name"
@@ -5230,6 +8022,16 @@ msgid "You cannot delete the 'unnamed' curve, it is special."
 msgstr "பெயரிடப்படாத' வளைவை உங்களால் நீக்க இயலாது, அது சிறப்பானது"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "கோப்புகளை சேமிக்க கோப்பகத்தை தெரியவும்"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "சிட்டை ஏற்றுமதி..."
+
+#: src/effects/Equalization.cpp
 msgid "You cannot export 'unnamed' curve, it is special."
 msgstr "'பெயரிடப்படாத' வளைவை உங்களால் ஏற்றுமதி செய்ய இயலாது, அது சிறப்பானது."
 
@@ -5250,9 +8052,59 @@ msgstr "வளைவுகள் ஏற்றுமதி செய்யப்�
 msgid "No curves exported"
 msgstr "வளைவுகள் ஏற்றுமதி செய்யப்படவில்லை"
 
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade In"
+msgstr "கிழே நகர்த்&த"
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Fade Out"
+msgstr "வடிகட்டும் வகை"
+
 #: src/effects/Fade.cpp
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "ஒலியை தேர்ந்தெடுத்து இழுக்கவும்"
+
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "ஒலியை தேர்ந்தெடுத்து இழுக்கவும்"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "வெட்டப்பட &துண்டை காட்டு"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "வெட்டப்பட &துண்டை காட்டு"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "அமைதிக்கான தொடக்கநிலை"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "அமைதிக்கான தொடக்கநிலை"
 
 #: src/effects/Generator.cpp
 msgid "There is not enough room available to generate the audio"
@@ -5262,13 +8114,37 @@ msgstr "ஒலியை உற்பத்தி செய்ய போதும
 msgid "Invert"
 msgstr "நேர்மாறாக்கி"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
 #: src/effects/LoadEffects.cpp
 msgid "Builtin Effects"
 msgstr "ஒலி அலகு விளைவுகள்"
 
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "அதி உயர் வளமையை இற்கு சாதரணமாக்கு....."
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -5288,9 +8164,26 @@ msgstr "நடைமுறைப்படுத்தபடுகிறது : 
 msgid "&Normalize"
 msgstr "சாதாரணபடுத்தல்"
 
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "பலதிசை ஒலி தடங்களை சுயாதீனமாக சாதாரணமாக்கு"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -5320,6 +8213,10 @@ msgid "Noise"
 msgstr "இரைச்சல்:"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "இரைச்சல் வகை"
 
@@ -5332,16 +8229,73 @@ msgid "Second greatest"
 msgstr "இரண்டாவது"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "இயல்பாக பெரிதாக்கவும்"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "இயல்பாக பெரிதாக்கவும்"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "இரைச்சலை குறைத்தல்"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "வர்ணப்பட்டையை வரைவதற்கு தெரிவு செய்யப்பட்ட ஒலித்துண்டுகள் அனைத்தும் ஒரே மாதிரி அளவை கொண்டிருக்க வேண்டும். "
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -5400,8 +8354,9 @@ msgid "Step 1"
 msgstr "படி 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "இரைச்சலை கொண்ட பகுதியை தெரியவும்.இதனால் Audacity இற்கு எதனை வடிகட்ட வேண்டும் என்று அறிய முடியும்,\n"
@@ -5427,9 +8382,20 @@ msgstr ""
 msgid "Noise:"
 msgstr "இரைச்சல்:"
 
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "&Isolate"
 msgstr "த&amp;னிமையாக்கல்"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "மீள சிறிதாக்கவும்"
 
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
@@ -5443,6 +8409,11 @@ msgstr "சாளர வ&amp;கை"
 msgid "Window si&ze:"
 msgstr "சாளர அளவு"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
+
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
 msgstr "1"
@@ -5455,17 +8426,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - இயல்பானது"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "இயல்பாக பெரிதாக்கவும்"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "சத்தம் நீக்கி"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -5504,6 +8521,10 @@ msgid "Normalize"
 msgstr "சாதாரணபடுத்தல்"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
 msgstr "DC offset நீக்கமும் சாதாரணபடுத்தலும்.....\n"
 
@@ -5514,6 +8535,10 @@ msgstr "DC offset நீக்கப்படுகிறது......\n"
 #: src/effects/Normalize.cpp
 msgid "Normalizing without removing DC offset...\n"
 msgstr "DC offset நீக்காமல் சாதாரணபடுத்தல்....\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 #, c-format
@@ -5560,9 +8585,14 @@ msgstr "பலதிசை ஒலி தடங்களை சுயாதீன
 msgid "Paulstretch"
 msgstr "Paulstretch..."
 
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "இழுக்கும் காரணி"
@@ -5570,6 +8600,45 @@ msgstr "இழுக்கும் காரணி"
 #: src/effects/Paulstretch.cpp
 msgid "&Time Resolution (seconds):"
 msgstr "நேர தீர்மானம் (செக்கன்கள்)"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Phaser"
+msgstr "Phaser"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -5632,6 +8701,10 @@ msgid "Repair"
 msgstr "திருத்த"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -5660,6 +8733,10 @@ msgid "Repeat"
 msgstr "திரும்ப செய்"
 
 #: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
 msgstr "திரும்ப செய்ய வேண்டிய தடவைகள்"
 
@@ -5680,6 +8757,10 @@ msgstr "புதிய தெரிவு நீளம் :"
 #, c-format
 msgid "New selection length: %s"
 msgstr "புதிய தெரிவு நீளம் :"
+
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "Vocal I"
@@ -5720,6 +8801,10 @@ msgstr "கிறிஸ்துவர்களின் பிரதான க�
 #: src/effects/Reverb.cpp
 msgid "Reverb"
 msgstr "எதிரொலி"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
 
 #: src/effects/Reverb.cpp
 msgid "&Room Size (%):"
@@ -5774,6 +8859,15 @@ msgstr "பின்னோக்கு"
 msgid "Reverses the selected audio"
 msgstr "தெரிவு செய்யப்பட்ட ஒலி FLAC ஆக ஏற்றுமதிசெய்கிறது"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -5783,6 +8877,25 @@ msgstr "Chebyshev வகை I"
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type II"
 msgstr "Chebyshev வகை II"
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Highpass"
+msgstr "Highpass"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "விஞ்ஞான வடிகட்டி...."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
 
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
@@ -5816,6 +8929,14 @@ msgstr "வெட்டுப்புள்ளி"
 #: src/effects/ScienFilter.cpp
 msgid "C&utoff:"
 msgstr "வெட்டுப்புள்ளி"
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
@@ -5905,11 +9026,20 @@ msgstr "இயல்பான பெறுமதிகளை பாவிக்�
 msgid "Restore Defaults"
 msgstr "இயல்பான பெறுமதிகளை அளிக்க"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "மௌனம்"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
@@ -5936,6 +9066,10 @@ msgid "Sliding Stretch"
 msgstr "இழு"
 
 #: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
 msgid "Initial Tempo Change (%)"
 msgstr "ஆரம்ப போக்கு மாற்ற (%)"
 
@@ -5950,6 +9084,11 @@ msgstr "ஆரம்ப சுருதி நகரத்தி"
 #: src/effects/TimeScale.cpp
 msgid "(&semitones) [-12 to 12]:"
 msgstr "(semitones) [-12 to 12]:"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "(%) [-50 to 100]:"
+msgstr "(%) [-50 to 100]:"
 
 #: src/effects/TimeScale.cpp
 msgid "Final Pitch Shift"
@@ -5971,6 +9110,11 @@ msgstr "இல்லாமல்"
 msgid "Square"
 msgstr "சதுரம்"
 
+#: src/effects/ToneGen.cpp plug-ins/tremolo.ny
+#, fuzzy
+msgid "Sawtooth"
+msgstr "Sawtooth"
+
 #: src/effects/ToneGen.cpp
 msgid "Square, no alias"
 msgstr "சதுரம் , வேறுதுவும் இல்லை"
@@ -5982,6 +9126,14 @@ msgstr "கீச்சிடு....."
 #: src/effects/ToneGen.cpp
 msgid "Tone"
 msgstr "சத்தம்...."
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
 
 #: src/effects/ToneGen.cpp
 msgid "&Waveform:"
@@ -6016,8 +9168,20 @@ msgid "Truncate Detected Silence"
 msgstr "அமைதியை வெட்டு"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "அமைதியை வெட்டு"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
@@ -6026,6 +9190,10 @@ msgstr "அமைதி உருவாகின்றது"
 #: src/effects/TruncSilence.cpp
 msgid "Tr&uncate to:"
 msgstr "அமைதியை வெட்டு"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
@@ -6040,10 +9208,20 @@ msgid "VST Effects"
 msgstr "VST விளைவுகள்"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Scanning Shell VST"
 msgstr "VST சொருகிகளை ஸ்கேனிங் செய்கிறது"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "கோப்பை சுமையேற்ற முடியவில்லை: \"%s\""
 
@@ -6051,13 +9229,44 @@ msgstr "கோப்பை சுமையேற்ற முடியவில�
 msgid "VST Effect Options"
 msgstr "மெருகூட்டல் தொகுப்புகள்"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "நீளம்"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "அமைதி சுருக்கம்"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "அமைதி சுருக்கம்"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Graphical Mode"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 #, c-format
@@ -6069,11 +9278,17 @@ msgid "Save VST Preset As:"
 msgstr "VST திட்டத்தை ஆக சேமி"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "VST திட்டத்தை சுமையேற்று"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Standard VST program file"
 msgstr "VST திட்டத்தை சுமையேற்று"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity செயற்திட்ட கோப்புகள்"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -6100,13 +9315,38 @@ msgstr "VST திட்டத்தை சுமையேற்றுவதி�
 msgid "Unable to load presets file."
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "மெருகூட்டல் தொகுப்புகள்"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -6124,9 +9364,19 @@ msgstr "அதிர்வலை"
 msgid "Wah Frequency Offse&t (%):"
 msgstr "அதிர்வெண் (hz)"
 
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "அதிர்வெண் (hz)"
+
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Audio Unit Effects"
+msgstr "ஒலி அலகு விளைவுகள்"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "ஒலி அலகு விளைவுகள்"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -6142,20 +9392,41 @@ msgid "Audio Unit Effect Options"
 msgstr "ஒலி அலகு விளைவுகள்"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "இடைமுகம்"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "வெளியிட்டு சாதனத்தை தெரிவுசெய்"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr "Multiband"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "உருவாக்கு"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
 msgstr "முன்னமைக்கப்பட்டவையை இறக்குமதி செய்"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -6231,6 +9502,11 @@ msgid "Failed to retrieve preset content"
 msgstr "%s இனை நீக்க முடியாதுள்ளது"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "XML data is empty after conversion"
 msgstr "மாற்றலிற்க்கான மாதிரி வீதம்"
 
@@ -6238,6 +9514,21 @@ msgstr "மாற்றலிற்க்கான மாதிரி வீத�
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
 #. i18n-hint: the name of an Apple audio software protocol
 #. i18n-hint: Audio Unit is the name of an Apple audio software protocol
@@ -6247,13 +9538,36 @@ msgstr "ஒலி  அலகு"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "VST விளைவுகள்"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "VST விளைவுகள்"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "மெருகூட்டல் தொகுப்புகள்"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -6261,6 +9575,7 @@ msgstr "மெருகூட்டல் தொகுப்புகள்"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "VST விளைவுகள்"
@@ -6268,6 +9583,23 @@ msgstr "VST விளைவுகள்"
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
 msgstr "மெருகூட்டல் தொகுப்புகள்"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 #, c-format
@@ -6283,13 +9615,27 @@ msgstr "%d வளைவுகள் %s இற்கு ஏற்றுமதி 
 msgid "Generator"
 msgstr "உருவாக்கி"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "VST விளைவுகள்"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "விளைவுகள்"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -6305,6 +9651,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Nyquist வெளியீடு"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "சங்கிலி தெரியப்படவில்லை"
 
@@ -6313,12 +9677,40 @@ msgid "Nyquist Error"
 msgstr "Nyquist"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Nyquist வெளியீடு"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "நடைமுறைப்படுத்தபடுகிறது : "
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -6343,12 +9735,41 @@ msgid "Nyquist returned too many audio channels.\n"
 msgstr "Nyquist அதிகளவான ஒலி சானல்களை தந்துள்ளது. \n"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned one audio channel as an array.\n"
+msgstr "Nyquist அதிகளவான ஒலி சானல்களை தந்துள்ளது. \n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned an empty array.\n"
+msgstr "Ny"
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist ஒலியினை தரவில்லை \n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "This version of Audacity does not support Nyquist plug-in version %ld"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Could not open file"
 msgstr "கோப்பை திறக்கமுடியவில்லை"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Error in Nyquist code"
@@ -6358,6 +9779,19 @@ msgstr "Nyquist இல் வழு"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "கோப்பை திறக்க முடியவில்லை: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -6378,6 +9812,22 @@ msgid "Lisp scripts"
 msgstr "கிட்டடியை திற"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "கோப்பை திறக்கமுடியவில்லை"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be saved"
+msgstr "முன்னணி அளவு இல்லை"
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -6396,13 +9846,22 @@ msgstr "ஒரு MIDI கோப்பினை தெரியவும்... "
 msgid "Save file as"
 msgstr "கோப்புகளை சேமி"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "பெயரிடப்படாத"
 
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "VST விளைவுகள்"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, failed to load Vamp Plug-in."
@@ -6413,8 +9872,24 @@ msgid "Sorry, Vamp Plug-in failed to initialize."
 msgstr "மன்னிக்கவும், Vamp சொருகியை ஆரம்பிப்பதில் தோல்வி"
 
 #: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "பொதுவான தெரிவுகள்"
+
+#: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "திட்டம்"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "பொதுவான தெரிவுகள்"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
@@ -6443,8 +9918,34 @@ msgstr "உங்களுக்கு நிச்சயமாக கோப்�
 
 #: src/export/Export.cpp
 #, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Sorry, pathnames longer than 256 characters not supported."
+msgstr ""
+
+#: src/export/Export.cpp
+#, c-format
 msgid "A file named \"%s\" already exists. Replace?"
 msgstr "\"%s\" என்று பெயரிடப்பட்ட கோப்பு  ஏற்கனவே உள்ளது.  பிரதியிடுவதா?"
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one mono file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one stereo file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down to one exported file according to the encoder settings."
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Advanced Mixing Options"
@@ -6491,6 +9992,16 @@ msgstr "ஏற்றுமதி செய்ய முடியவில்ல�
 msgid "Show output"
 msgstr "வெளியீட்டை காட்டு"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
@@ -6514,6 +10025,16 @@ msgid "Export"
 msgstr "ஏற்றுமதி"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Exporting the selected audio using command-line encoder"
+msgstr "தெரிவு செய்யப்பட்ட ஒலி FLAC ஆக ஏற்றுமதிசெய்கிறது"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Exporting the audio using command-line encoder"
+msgstr "தெரிவு செய்யப்பட்ட ஒலியினை %s ஆக ஏற்றுமதி செய்கிறது"
+
+#: src/export/ExportCL.cpp
 msgid "Command Output"
 msgstr "கட்டளை வெளியீடு"
 
@@ -6528,13 +10049,118 @@ msgstr ""
 "உங்களுக்கு தொடர வேண்டுமா?"
 
 #: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
 #, c-format
 msgid "\"%s\" couldn't be found."
 msgstr "கூறு \"%s\" உள்ளது."
 
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "FFmpeg நூலகம்"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -6550,9 +10176,28 @@ msgstr "தெரிவு செய்யப்பட்ட ஒலியின�
 msgid "Invalid sample rate"
 msgstr "தவறான மாதிரி அளவு"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "மீள்மாதிரி"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
 msgid "Sample Rates"
@@ -6560,7 +10205,8 @@ msgstr "மாதிரி அளவுகள்"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%i kbps"
@@ -6572,6 +10218,51 @@ msgstr "பிட் அளவு:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "தரம்:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%i kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -6586,6 +10277,10 @@ msgid "Constrained"
 msgstr "மாறாத எண்"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&ஒலி..."
 
@@ -6594,8 +10289,44 @@ msgid "Low Delay"
 msgstr "தாமதம்"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "நடுத்தரம்"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -6622,6 +10353,10 @@ msgid "Cutoff:"
 msgstr "வெட்டுப்புள்ளி"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "தற்போதைய &செயற்திட்டத்தில் நிறைவேற்றவும்"
 
@@ -6634,8 +10369,28 @@ msgid "Error Saving FFmpeg Presets"
 msgstr "திட்டத்தை சேமிப்பதில் வழு"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "'%s' முன்னமைக்கப்பட்டவையை நீக்குவதா ?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Confirm Overwrite"
 msgstr "மேலெழுவதை உறுதிப்படுத்து"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Preset '%s' does not exist."
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 #, c-format
@@ -6643,8 +10398,17 @@ msgid "Replace preset '%s'?"
 msgstr "'%s' முன்னமைக்கப்பட்டவையை நீக்குவதா ?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "முதன்மை"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -6667,6 +10431,11 @@ msgid "WMA (version 2) Files (FFmpeg)"
 msgstr "WMA (பதிப்பு 2) கோப்புகள் (FFmpeg)"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "FFmpeg இறக்கு/ஏற்று"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Estimate"
 msgstr "மதிப்பீடு"
 
@@ -6687,6 +10456,15 @@ msgid "Full search"
 msgstr "முழு தேடல்"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Log search"
+msgstr "முழு தேடல்"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Preset:"
 msgstr "முன்னமைக்கப்பட்டவை:"
 
@@ -6702,8 +10480,23 @@ msgstr "முன்னமைக்கப்பட்டவையை இறக�
 msgid "Export Presets"
 msgstr "முன்னமைக்கப்பட்டவையை ஏற்றுமதி செய்"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "தற்போதைய &செயற்திட்டத்தில் நிறைவேற்றவும்"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Formats"
+msgstr "அனைத்து வடிவங்களையும் காட்டு"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Show All Codecs"
 msgstr "அனைத்து வடிவங்களையும் காட்டு"
 
 #: src/export/ExportFFmpegDialogs.cpp
@@ -6729,36 +10522,179 @@ msgid "Bit Reservoir"
 msgstr "Bit களஞ்சியம்"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+"ISO 639 3-கடித மொழி\n"
+"விரும்பினால் மட்டும்\n"
+"வெறுமை - தானியங்கி"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Tag:"
 msgstr "அடையளபடுத்தல்"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "தரம்:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Sample Rate:"
 msgstr "மாதிரி அளவு:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "எல்லா கோப்புகளும்  (*)|*"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "FLAC options"
 msgstr "FLAC தெரிவுகள்"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "அழுத்தி"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "செயற்திட்ட பெயர"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "PdO Method:"
 msgstr "PdO முறை"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Min. PdO"
 msgstr "குறைந்த. PdO"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Max. PdO"
 msgstr "அதிகபட்ச. PdO"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Min. PtO"
 msgstr "குறைந்த. PtO"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Max. PtO"
@@ -6769,6 +10705,42 @@ msgstr "அதிகபட்ச. PtO"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Use LPC"
 msgstr "LPC ஐ பயன்படுத்து"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "முடிவை தேர்ந்தெடு"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "அளவை நிர்ணயி"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "தட பெயர்"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "You can't delete a preset without name"
@@ -6784,8 +10756,39 @@ msgid "You can't save a preset without a name"
 msgstr "பெயர் அற்ற முன்னமைக்கப்பட்டவையை உங்களால் சேமிக்க முடியாது"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "ஏற்றுமதிக்கு சிட்டை இல்லை"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "தொகுதி செயல்முறைக்கு உள்ளாக்குவதற்கு  கோப்பு(கள்) தெரியபடுகின்றன"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -6814,6 +10817,18 @@ msgstr "பிட் ஆழம்:"
 #: src/export/ExportFLAC.cpp
 msgid "FLAC Files"
 msgstr "FLAC கோப்புகள்"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "கோப்பை திறக்க முடியவில்லை: \"%s\""
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr "மன்னிக்கவும், Vamp சொருகியை ஆரம்பிப்பதில் தோல்வி"
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
@@ -6850,12 +10865,64 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "(சிறந்த தரம்)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "110-150 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "95-135 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "80-120 kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "65-105 kbps"
 msgstr "%.2f kbps"
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "(சிறிய கோப்புகள்)"
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
 
 #. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
 #: src/export/ExportMP3.cpp
@@ -6866,7 +10933,8 @@ msgstr "அற்புதம்"
 msgid "Extreme"
 msgstr "அறுதி"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "நியமம்"
 
@@ -6907,14 +10975,19 @@ msgstr "தரம்"
 msgid "Channel Mode:"
 msgstr "சேனல் முறை:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "வெட்டும் வரி நீக்கப்பட்டது"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "லேமின் அமைவிடம்"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "MP3களை உருவாக்குவதற்கு audacity இற்கு %s கோப்புகள் தேவை"
 
 #: src/export/ExportMP3.cpp
@@ -6942,13 +11015,34 @@ msgid "Where is %s?"
 msgstr "%s எங்குள்ளது"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "நீங்கள் lame_enc.dll யுடன் இணைக்கிறீர்கள் v%d.%d. இப்பதிப்பு ஒவ்வாது Audacity %d.%d.%d.\n"
 "LAME MP3 நுலகத்தின் சமீபத்திய பதிப்பை பதிவிறக்கவும்"
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "செயற்திட்ட தரவு கோப்புகள் சேமிக்கப்படுகின்றன"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -6959,9 +11053,38 @@ msgid "MP3 Files"
 msgstr "MP3 கோப்புகள்"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Could not open MP3 encoding library!"
+msgstr "கோப்பை சுமையேற்ற முடியவில்லை: \"%s\""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Could not initialize MP3 encoding library!"
+msgstr "கோப்பை திறக்கமுடியவில்லை"
+
+#: src/export/ExportMP3.cpp
+msgid "Not a valid or supported MP3 encoding library!"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "தேர்ந்தெடுத்த ஒலிப்பகுதி %ld kbps ஏற்றுமதியாகுகிறது"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
 msgstr "தேர்ந்தெடுத்த ஒலிப்பகுதி %ld kbps ஏற்றுமதியாகுகிறது"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
+msgstr "தெரிவு செய்யப்பட்ட ஒலியினை %s ஆக ஏற்றுமதி செய்கிறது"
 
 #: src/export/ExportMP3.cpp
 #, c-format
@@ -6969,17 +11092,66 @@ msgid "Exporting the audio with VBR quality %s"
 msgstr "தெரிவு செய்யப்பட்ட ஒலியினை %s ஆக ஏற்றுமதி செய்கிறது"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "தேர்ந்தெடுத்த ஒலிப்பகுதி %ld kbps ஏற்றுமதியாகுகிறது"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "தேர்ந்தெடுத்த ஒலிப்பகுதி %ld kbps ஏற்றுமதியாகுகிறது"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "MP3 export library not found"
+msgstr "FFmpeg நூலகத்தை காணவில்லை"
 
 #: src/export/ExportMP3.cpp
 msgid "(Built-in)"
 msgstr "ஒலி அலகு விளைவுகள்"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export Multiple"
+msgstr "பல ஏற்றுமதி..."
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Cannot Export Multiple"
+msgstr "பல ஏற்றுமதி..."
+
+#: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "ஏற்றுமதி இடம்:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -7010,25 +11182,154 @@ msgid "Name files:"
 msgstr "கோப்புகளின் பெயர்கள்:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Using Label/Track Name"
+msgstr "ஒலித்துண்டு பெயர்"
+
+#: src/export/ExportMultiple.cpp
+msgid "Numbering before Label/Track Name"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+msgid "Numbering after File name prefix"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix:"
+msgstr "வடிகட்டும் வகை"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
+msgstr "வடிகட்டும் வகை"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Overwrite existing files"
+msgstr "உள்ள வளைவின் மேல் எழுது"
+
+#: src/export/ExportMultiple.cpp
 #, c-format
 msgid "\"%s\" successfully created."
 msgstr "\"%s\" வெற்றிகரமாக உருவாக்கப்பட்டது"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Choose a location to save the exported files"
+msgstr "கோப்புகளை சேமிக்க கோப்பகத்தை தெரியவும்"
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"\"%s\" doesn't exist.\n"
+"\n"
+"Would you like to create it?"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Continue to export remaining files?"
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "இவ்வாறு சேமிக்கவும்..."
 
 #: src/export/ExportOGG.cpp
+msgid "Ogg Vorbis Files"
+msgstr ""
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Exporting the selected audio as Ogg Vorbis"
+msgstr "தெரிவு செய்யப்பட்ட ஒலியினை %s ஆக ஏற்றுமதி செய்கிறது"
+
+#: src/export/ExportOGG.cpp
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "தெரிவு செய்யப்பட்ட ஒலியினை %s ஆக ஏற்றுமதி செய்கிறது"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Header:"
@@ -7039,8 +11340,53 @@ msgid "Encoding:"
 msgstr "என்கோர்டிங்:"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "சுருக்கப்படாத ஒலிக்கோப்புகள் இறக்குமதி செய்யப்படுகிறது"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "இறக்குவதில் வழு"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Cannot export audio in this format."
+msgstr "ஒலியை %s க்கு ஏற்றுமதி செய்ய முடியவில்லை"
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "தெரிவு செய்யப்பட்ட ஒலியினை %s ஆக ஏற்றுமதி செய்கிறது"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -7048,8 +11394,184 @@ msgstr "எல்லா கோப்புகளும்|*|எல்லா ஒ�
 
 #: src/import/Import.cpp
 #, c-format
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "மன்னிக்கவும், Vamp சொருகியை ஆரம்பிப்பதில் தோல்வி"
+
+#: src/import/Import.cpp
+#, c-format
+msgid "This version of Tenacity was not compiled with %s support."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
 msgid "File \"%s\" not found."
 msgstr "கூறு \"%s\" உள்ளது."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "செயற்திட்ட தரவு கோப்புகள் சேமிக்கப்படுகின்றன"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7066,8 +11588,57 @@ msgid "Import Project"
 msgstr "முன்னமைக்கப்பட்டவையை இறக்குமதி செய்"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Internal error in importer...tag not recognized"
 msgstr "வரிசைப்படுத்தல் செயற்பாடானது உள்ளக வழுவினை தெரிவிக்குறது"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Invalid project '%s' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'vpos' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'h' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'zoom' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel0' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'sel1' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selLow' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid project 'selHigh' attribute."
+msgstr "தவறான மாதிரி அளவு"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7075,16 +11646,74 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "திட்ட தரவு கோப்பகத்தை கண்டுபிடிக்க முடியவில்லை : \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "திட்டங்கள்"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "தவறான மாதிரி அளவு"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
 msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr "தவறான மாதிரி அளவு"
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7101,39 +11730,49 @@ msgstr "சோதனை கோப்பை திறக்க/உருவாக
 msgid "Unable to read %lld samples from %s"
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
+#: src/import/ImportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg-compatible files"
+msgstr "GStreamer தொடங்கல் தோல்வி"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC கோப்புகள்"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer தொடங்கல் தோல்வி"
+#: src/import/ImportLOF.cpp
+msgid "List of Files in basic text format"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "விரிவாக்கப்பட்ட இறக்கம்"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "'%s' இருந்து   '%s' ஆக மறுபடி பெயரிட முடியவில்லை"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer %s: %s"
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+msgid "Invalid window offset in LOF file."
+msgstr ""
 
 #. i18n-hint: You do not need to translate "LOF"
 #: src/import/ImportLOF.cpp
 msgid "LOF Error"
 msgstr "LOF பிழை"
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+#, fuzzy
+msgid "Invalid duration in LOF file."
+msgstr "சரிநிகராக்கம்"
+
+#: src/import/ImportLOF.cpp
+msgid "MIDI tracks cannot be offset individually, only audio files can be."
+msgstr ""
+
+#. i18n-hint: You do not need to translate "LOF"
+#: src/import/ImportLOF.cpp
+msgid "Invalid track offset in LOF file."
+msgstr ""
 
 #: src/import/ImportMIDI.cpp
 #, c-format
@@ -7163,6 +11802,145 @@ msgstr "கோப்பை திறக்கமுடியவில்லை"
 msgid "MP3 files"
 msgstr "MP3 கோப்புகள்"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Ogg Vorbis files"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Media read error"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Not an Ogg Vorbis file"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Vorbis version mismatch"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Invalid Vorbis bitstream header"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+msgid "Internal logic fault"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV, AIFF, and other uncompressed types"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-bit PCM"
+
 #: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-bit PCM"
@@ -7170,6 +11948,16 @@ msgstr "16-bit PCM"
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-bit PCM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -7180,12 +11968,49 @@ msgid "64 bit float"
 msgstr "32-bit float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 பிட்"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "16 பிட்"
 
 #: src/import/ImportPCM.cpp
 msgid "24 bit DWVW"
 msgstr "24 பிட்"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
@@ -7195,10 +12020,63 @@ msgstr "16-bit PCM"
 msgid "8 bit DPCM"
 msgstr "16-bit PCM"
 
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
 msgid "Importing %s"
 msgstr "இறக்குமதி %s"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "கோப்புகளின் பெயர்கள்:"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "இறக்கு"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw Data"
+msgstr "GStreamer ஊடாக இறக்குமதிச் செய்"
+
+#. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "No endianness"
+msgstr ""
 
 #. i18n-hint: Refers to byte-order.  Don't translate this if you don't
 #. know the correct technical word.
@@ -7212,9 +12090,52 @@ msgstr "லிட்டில்-இண்டியன்"
 msgid "Big-endian"
 msgstr "பிக்-இண்டியன்"
 
+#. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Default endianness"
+msgstr "புதிய திட்டம் உருவாக்கப்பட்டுள்ளது"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "1 Channel (Mono)"
+msgstr "சேனல் முறை:"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "2 Channels (Stereo)"
+msgstr "பிரியோசையை உருவாக்கு"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "%d Channels"
+msgstr "சானெல்"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Byte order:"
+msgstr "இறக்கும் வரிசை"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "சானெல்"
+
+#. i18n-hint: (noun)
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Start offset:"
+msgstr "ஆரம்ப நேரம்"
+
 #: src/import/ImportRaw.cpp
 msgid "bytes"
 msgstr "பைட்டுகள்"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Amount to import:"
+msgstr "இடைநிலை பலகைக்கு வெட்டு"
 
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
@@ -7224,6 +12145,10 @@ msgstr "சாம்பிள் வீதம்:"
 #: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
 msgid "&Import"
 msgstr "&இறக்குமதி"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -7245,6 +12170,7 @@ msgstr "வலது"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -7268,6 +12194,7 @@ msgstr "முடிவு"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -7286,8 +12213,38 @@ msgid_plural "%d of %d clips %s"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "தேர்ந்தெடுத்த பாடல்களை  %.2f யிலிருந்து %.2f வினாடிகளுக்கு அமைதிப்படுத்து"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the left"
+msgstr "தேர்ந்தெடுத்த பாடல்களை  %.2f யிலிருந்து %.2f வினாடிகளுக்கு அமைதிப்படுத்து"
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Time-Shift"
+msgstr "நேரம் மாற்றும் கருவி"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
 #: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
 msgid "Clip B&oundaries"
+msgstr "பகுதி ஓரங்கள்"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr "பகுதி ஓரங்கள்"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
 msgstr "பகுதி ஓரங்கள்"
 
 #: src/menus/ClipMenus.cpp
@@ -7408,7 +12365,8 @@ msgstr "%.2f வினாடிகளை t=%.2f இல் தேர்ந்த�
 msgid "Trim Audio"
 msgstr "ஒலியை ஒழுங்கமைக்குக"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "பிள"
 
@@ -7529,32 +12487,8 @@ msgid "Delete Key&2"
 msgstr "அகற்றும் சாவி2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "கல&வை கருவி பட்டியல் "
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "பின்னணி வேகத்தை மாற்றியமைக்கவும்"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "பின்னணி வேகத்தை கூட்டவும்"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "பின்னணி வேகத்தை குறைக்கவும்"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "பதிதல் முடிவு"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "பின்னணி வேகத்தை கூட்டவும்"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "பின்னணி வேகத்தை குறைக்கவும்"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -7579,6 +12513,13 @@ msgstr "வெளி ஆதாயத்தை மாற்றியமைக்�
 #: src/menus/ExtraMenus.cpp
 msgid "&Full Screen (on/off)"
 msgstr "முழுத்திரை செயல்படுத்து/முடக்கு"
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -7637,6 +12578,11 @@ msgstr "சிட்டைகளை இறக்குவதற்கு"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "ஒரு MIDI கோப்பினை தெரியவும்... "
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "எல்லா கோப்புகளும்  (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -7739,6 +12685,10 @@ msgid "E&xit"
 msgstr "&வெளியேறு"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "சிட்டைகளை ஏற்றுமதி செய்ய"
 
@@ -7761,8 +12711,17 @@ msgid "Fix"
 msgstr "கல"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "&உதவி"
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "மீளமைக்க ஒன்றுமில்லை"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -7775,6 +12734,10 @@ msgstr "திட்ட கோப்பினை திறக்க முடி
 #: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "பதிதல் ஆரம்பம்"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -7793,12 +12756,17 @@ msgid "&Getting Started"
 msgstr "தேர்வு ஆரம்பம்:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity பதிவுகள்"
+#, fuzzy
+msgid "&Manual"
+msgstr "வளைவுகளை நிர்வாகி"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
 msgstr "&உதவி"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "&Diagnostics"
@@ -7816,11 +12784,8 @@ msgstr "ஒலி சாதனா தகவல் ..."
 msgid "Show &Log..."
 msgstr "புகுபதிகையை காண்பி"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "Audacity &பற்றி..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "சேர்க்கப்பட்ட சிட்டை"
 
@@ -7946,6 +12911,10 @@ msgid "Paste Te&xt to New Label"
 msgstr "உரையை புதிய சிட்டையில் ஒட்டு"
 
 #: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "சிட்டைப்படுத்தப்பட்ட  ஒலி"
 
@@ -8010,6 +12979,18 @@ msgid "Label Join"
 msgstr "சிட்டை  தொகு"
 
 #: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
 msgid "Move &Backward from Toolbars to Tracks"
 msgstr "கருவிபடியயிலிருந்து பின்நோக்கி பாடலுக்கு செல்"
 
@@ -8050,8 +13031,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "ஒலித்துண்டை மேலே நகர்த்து"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "புதிய..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -8066,6 +13055,10 @@ msgstr "சொருகிகள் %i இருந்து %i"
 #: src/menus/PluginMenus.cpp
 msgid "&Generate"
 msgstr "உருவாக்கு"
+
+#: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
@@ -8123,6 +13116,10 @@ msgstr "ஒப்பிடை தொடங்கு ...."
 msgid "Simulate Recording Errors"
 msgstr "Google Translate"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -8143,6 +13140,16 @@ msgstr "தெரிக"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "பாடல் &ஆரம்பம்"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "ஒலியை அமைதியாக்கு"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "படல்களை வரிசைப்படுத்து"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -8167,6 +13174,12 @@ msgstr "சிட்டையை தொகு"
 #: src/menus/PluginMenus.cpp
 msgid "Set Project..."
 msgstr "திட்டத்தை &ஆக சேமி"
+
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "மாறி"
 
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
@@ -8243,6 +13256,11 @@ msgid "In All &Sync-Locked Tracks"
 msgstr "அனைத்து &ஒத்திசைந்த பாடல்கள்"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "தேர்வு"
+
+#: src/menus/SelectMenus.cpp
 msgid "R&egion"
 msgstr "பகுதி&யை ஆரம்பி"
 
@@ -8311,8 +13329,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "நேரியல் நிகழ்வெண்"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "ஆரம்பத்தை தேர்ந்தெடு"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "ஒலி நிலை"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -8426,6 +13453,56 @@ msgstr "பாடல் &முடிவு நிலை காட்டி"
 msgid "&Cursor"
 msgstr "&நிலைக்காட்டியை அசைக்குக "
 
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Left"
+msgstr "&நிலைக்காட்டியை அசைக்குக "
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Right"
+msgstr "&நிலைக்காட்டியை அசைக்குக "
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Sh&ort Jump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Shor&t Jump Right"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long J&ump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long Ju&mp Right"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
 #: src/menus/ToolbarMenus.cpp
 msgid "&Toolbars"
 msgstr "க&ருவி பட்டியில்"
@@ -8443,6 +13520,13 @@ msgstr "&மீட்டமைக்கும் கருவி பட்டி
 #, c-format
 msgid "Rendered all audio in track '%s'"
 msgstr "தடம்  '%s' இலுள்ள அனைத்து render செய்யப்பட்ட ஒலி அலைகள்"
+
+#. i18n-hint: Convert the audio into a more usable form, so apply
+#. * panning and amplification and write to some external file.
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Render"
+msgstr "கலந்து வழங்கு"
 
 #: src/menus/TrackMenus.cpp
 #, c-format
@@ -8587,6 +13671,16 @@ msgid "Synchronizing MIDI and Audio Tracks"
 msgstr "MIDI மற்றும் ஒலி துண்டுகளை ஒருங்கிணைத்தல்"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted gain"
+msgstr "உள்ளீட்டு ஆதாயத்தை மாற்றியமைக்கவும்"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Adjusted Pan"
+msgstr "உள்ளீட்டு ஆதாயத்தை மாற்றியமைக்கவும்"
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new audio track"
 msgstr "புதிய ஒலி தடம் உருவாக்கப்பட்டுள்ளது"
 
@@ -8603,18 +13697,21 @@ msgid "Created new label track"
 msgstr "புதிய சிட்டை தடம் உருவாக்கப்பட்டுள்ளது"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "இந்த Audacity அமைப்பானது ஒரு நேரத்தில் ஒரு தட சாளரத்தையே அனுமதிக்கும்"
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "புதிய நேர தடம் உருவாக்கப்பட்டுள்ளது"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "புதிய மாதிரி வீதம்"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "உள்ளிடப்பட்ட பெறுமதி செல்லுபடி அற்றதாகும்"
 
@@ -8694,6 +13791,11 @@ msgid "&Time Track"
 msgstr "தட்டுகளின் நேரத்தை க&ணி"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "கல&வை கருவி பட்டியல் "
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "பிரியோசையை மோனோவாக பிரி"
 
@@ -8732,6 +13834,10 @@ msgstr "தட்டுகளை &ஊமையாக்கு"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "தட்டுகளை &மீள பேசவை"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -8863,7 +13969,9 @@ msgstr "ஒலி"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Google Translate"
 
@@ -8872,8 +13980,32 @@ msgid "no label track"
 msgstr "சிட்டை ஒலித்துண்டு"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track at or below focused track"
+msgstr "புதிய சிட்டை தடம் உருவாக்கப்பட்டுள்ளது"
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "புதிய சிட்டை தடம் உருவாக்கப்பட்டுள்ளது"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -8941,6 +14073,11 @@ msgid "&Timer Record..."
 msgstr "கா&லத்தை பதிவு செய்"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "ஒலி செயலாக்கப்பட்டது பதிவுசெய்கிறது"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "பகுதி&யை ஆரம்பி"
 
@@ -8969,16 +14106,17 @@ msgid "Sound A&ctivated Recording (on/off)"
 msgstr "ஒலி செயல்ப&டுத்தப்படும் பதிவு (ஏற்று/அணை)"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "பதிதல் முடிவு"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Overdub (on/off)"
 msgstr "பெய&ர்கொடு (ஏற்று/அணை) "
 
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "மெ&ன்பொருள் உள்ளோட்டம் (ஏற்று/அணை)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr " (ஏற்று/அணை)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -8988,6 +14126,11 @@ msgstr "இ&டம் பெயர்வு "
 #: src/menus/TransportMenus.cpp
 msgid "Pl&ay"
 msgstr "தொடங்கவும்"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -9105,6 +14248,11 @@ msgid "&Fit to Width"
 msgstr "தளத்தில் &பொருந்து"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "தளத்தில் &பொருந்து"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "அனைத்து பாடல்களையும் &தகர் "
 
@@ -9148,11 +14296,37 @@ msgstr "VST விளைவுகள்"
 msgid "&Window"
 msgstr "சாளரம்"
 
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
 #. i18n-hint: Shrink all project windows to icons on the Macintosh
 #. tooldock
 #: src/menus/WindowMenus.cpp
 msgid "Minimize All Projects"
 msgstr "திட்டத்தில் உள்ள எல்லா தடத்தையும் சாதாரணப&amp;டுத்துக"
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "பதிதல் முடிவு"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -9160,7 +14334,7 @@ msgstr "விருப்பங்கள்: "
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Audacity வெளியேறவும்"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -9207,7 +14381,8 @@ msgstr "பெருந்திரள்"
 msgid "Using:"
 msgstr "பயன்படுத்தபடுகிறது:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "பின்னணி"
 
@@ -9227,7 +14402,8 @@ msgstr "சானெல்"
 msgid "Latency"
 msgstr "மறைநிலை"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "மில்லிசெக்கன்கள்"
 
@@ -9247,6 +14423,23 @@ msgstr "ஒலி இடைமுகங்கள் இல்லை"
 msgid "No devices found"
 msgstr "கருவிகள் தென்படவில்லை"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "மொனோ"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "ஒலிசாதனம்"
+
+#. i18n-hint:  Directories, also called directories, in computer file systems
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#, fuzzy
+msgid "Directories"
+msgstr "புதிய திட்டம் உருவாக்கப்பட்டுள்ளது"
+
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Preferences for Directories"
 msgstr "விருப்பங்கள்: "
@@ -9256,8 +14449,22 @@ msgid "Default directories"
 msgstr "புதிய திட்டம் உருவாக்கப்பட்டுள்ளது"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "உலாவு..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -9284,8 +14491,17 @@ msgid "&Macro output:"
 msgstr "வெளியீட்டை காட்டு"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory"
+msgstr "புதிய திட்டம் உருவாக்கப்பட்டுள்ளது"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Location:"
 msgstr "&amp;இடம்:"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Brow&se..."
@@ -9296,8 +14512,41 @@ msgid "&Free Space:"
 msgstr "இலவச இடம்:"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Choose a location to place the temporary directory"
+msgstr "பிடிக்கப்பட்ட படங்களை சேமிக்க கோப்பகத்தை தெரியவும்"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "கோப்புகளை சேமிக்க கோப்பகத்தை தெரியவும்"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s does not exist. Create it?"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "New Temporary Directory"
+msgstr "தற்காலிக கோப்பகத்தை நிரப்ப"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not writable"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temp Directory Update"
@@ -9311,11 +14560,36 @@ msgstr "விருப்பங்கள்: "
 msgid "Sorted by Effect Name"
 msgstr "பெயரால் ஒழுங்கமைக்கவும்"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "பெயரால் ஒழுங்கமைக்கவும்"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "பெயரால் ஒழுங்கமைக்கவும்"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "VST விளைவுகள்"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -9324,6 +14598,18 @@ msgstr "VST விளைவுகள்"
 #: src/prefs/EffectsPrefs.cpp
 msgid "N&yquist"
 msgstr "Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
@@ -9334,16 +14620,33 @@ msgid "Effect Options"
 msgstr "மெருகூட்டல் தொகுப்புகள்"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "பொதுவான தெரிவுகள்"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Audacity அடுத்த முறை ஆரம்பிக்கும் போது VST விளைவுகளை பரிசீலிக்கவும்"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Instruction Set"
 msgstr "வாத்தியக்கருவி"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
 
 #. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
 #. * audio file import options
@@ -9486,6 +14789,10 @@ msgid "Location of &Manual:"
 msgstr "கைந்நூல் இன் &amp;கோப்பகம்"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Meter dB &range:"
 msgstr "அளவைக் கருவி/அலை வடிவம் db வீ&amp;ச்சு"
 
@@ -9498,6 +14805,10 @@ msgid "Show e&xtra menus"
 msgstr "Y-அச்சு உடன் கட்டங்களை காட்டு"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "&Beep on completion of longer activities"
 msgstr "நீண்ட செயற்பாடுக&amp;ளின் முடிவில் பீப் ஒலியை தரவும்"
 
@@ -9505,9 +14816,46 @@ msgstr "நீண்ட செயற்பாடுக&amp;ளின் மு�
 msgid "Re&tain labels if selection snaps to a label"
 msgstr "சிட்டை விளிம்பில் தெரிவு இருக்குமாயின் சிட்டைகளை பெறுக"
 
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "பொதுவான தெரிவுகள்"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "அடிமட்டம்"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
 msgstr "இறக்க/ஏற்ற"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "விருப்பங்கள்: "
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -9520,6 +14868,10 @@ msgstr "உயர்தர கலவை தெரிவுகள்"
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&tandard"
 msgstr "நியமம்"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
@@ -9545,6 +14897,14 @@ msgstr "ஆரம்பத்திலும் இறுதியிலும�
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "சிட்டைகளை ஏற்றுமதி செய்ய"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9584,6 +14944,10 @@ msgid "&Name"
 msgstr "மீட்கக்கூடிய செயற்திட்ட பெயர்."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "View by tree"
 msgstr "மரம் மூலம் பார்க்க"
 
@@ -9607,6 +14971,12 @@ msgstr "பிணைப்புக்கள்"
 msgid "Short cut"
 msgstr "குறுக்கு வழி"
 
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "தெரிவுகள்..."
+
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
 msgstr "குறிப்பு : Cmd+Q இனை அழுத்துவதன் மூலம் வெளியேறலாம்.மற்றையவை செல்லுபடியாகும்"
@@ -9620,7 +14990,15 @@ msgid "&Defaults"
 msgstr "இயல்பு&நிலை"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Audacity விசைப்பலகை குறுக்குவழியை கொண்ட XML கோப்பை தெரியவும்"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9629,8 +15007,21 @@ msgstr "விசைப்பலகை குறுக்கு வழியை 
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d விசைப்பலகை குறுக்குவழிகள் சுமையேற்றப்பட்டது\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -9651,6 +15042,15 @@ msgstr "இந்த உள்ளீட்டுக்கு விசைப்�
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "You must select a binding before assigning a shortcut"
 msgstr "குறுக்கு வழியை வழங்க முதல் ஒரு பிணைப்பை தெரிய வேண்டும்"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
@@ -9721,12 +15121,17 @@ msgid "Dow&nload"
 msgstr "தரவிறக்கம்"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity ஆனது தானாக செல்லுபடியான FFmpeg நூலகங்களை கண்டுபிடித்துள்ளது.\n"
 "தங்கள் இன்னும் அதனை நீங்களாக காட்ட விரும்புகுறீர்களா?"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
 
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
@@ -9763,6 +15168,10 @@ msgstr "MIDI கூட்டிணைப்பு கண்ணுக்கு �
 msgid "The MIDI Synthesizer Latency must be an integer"
 msgstr "MIDI கூட்டிணைப்பு கண்ணுக்கு புலப்படாமல் இருக்கும் நிலை முழு எண்ணாக இருக்க வேண்டும்"
 
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
 #. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
 msgid "Modules"
@@ -9773,12 +15182,32 @@ msgid "Preferences for Module"
 msgstr "விருப்பங்கள்: "
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "இவை பரிசோதனையாகும். தாம் செய்வது என்ன என்று தெரிந்தும் மற்றும் கைந்நூலை\n"
 "வாசித்தால் மட்டுமே செயற்படுத்துக"
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr ""
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
@@ -9795,6 +15224,10 @@ msgstr "கருவிகள் தென்படவில்லை"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "தொகுதிகள்"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -9836,7 +15269,10 @@ msgstr "இடது இழுவை"
 msgid "Set Selection Range"
 msgstr "தெரிவு வீச்சை வழங்குக"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-இடது-சுட்டி"
 
@@ -9923,6 +15359,21 @@ msgstr "இடது இழுவை"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "தடங்களுக்கு இடையே மேலும் கீழுமாக நகர்த்தவும்"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "இடது இழுவை"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
+#. i18n-hint: The envelope is a curve that controls the audio loudness.
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Change Amplification Envelope"
+msgstr "விஸ்தரிப்பு dB"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Pencil"
@@ -10018,6 +15469,10 @@ msgid "&After cut region:"
 msgstr "வெட்டிய பகுத்திக்கு பின்னைய முன்தோற்றம்:"
 
 #: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
 msgid "&Short period:"
 msgstr "குறுகிய காலம்:"
 
@@ -10025,8 +15480,21 @@ msgstr "குறுகிய காலம்:"
 msgid "Lo&ng period:"
 msgstr "நீண்ட காலம்:"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity விருப்பங்கள்"
 
 #: src/prefs/PrefsDialog.cpp
@@ -10040,6 +15508,11 @@ msgstr "விருப்பங்கள்: "
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "விருப்பங்கள்: "
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -10065,6 +15538,11 @@ msgstr "நிகழ்-நேர மாற்றம்"
 msgid "Sample Rate Con&verter:"
 msgstr "மாதிரி விகித மாற்றி:"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
 #: src/prefs/QualityPrefs.cpp
 msgid "High-quality Conversion"
 msgstr "உயர்-தர மாற்றம்"
@@ -10072,6 +15550,11 @@ msgstr "உயர்-தர மாற்றம்"
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "மாதிரி விகித மாற்றி:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -10086,12 +15569,25 @@ msgid "Preferences for Recording"
 msgstr "விருப்பங்கள்: "
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
 msgstr "மெ&ன்பொருள் உள்ளோட்டம் (ஏற்று/அணை)"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "புதிய தடம்"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Sound Activated Recording"
@@ -10116,6 +15612,11 @@ msgid "Custom Track &Name"
 msgstr "ஒலித்துண்டு பெயர்"
 
 #: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "சிட்டை  தொகு"
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
 msgstr "ஒலி அமைவை பதிவு செய்"
 
@@ -10128,41 +15629,37 @@ msgid "System &Date"
 msgstr "ஆரம்ப திகதி"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "தானியங்கி உள்ளீட்டு அளவை சரி செய்தல்"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "தானியங்கி உள்ளீட்டு அளவை சரி செய்தலை செயற்படுத்த"
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "உச்ச இலக்கு:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "உள்ளகத்தே:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "பகுப்பாய்வு நேரம்:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "மில்லிசெக்கன்கள்(ஒரு பகுப்பாய்விற்கான நேரம்)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "தொடர்ச்சியான பகுப்பாய்வுகளின் எண்ணிக்கை"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 என்பது முடிவிலி"
+#, fuzzy
+msgid "System T&ime"
+msgstr "ஆரம்ப திகதி"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "ஒலி செயலாக்கப்பட்டது பதிவுசெய்கிறது"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "குறிப்பு தடம்"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -10173,6 +15670,13 @@ msgstr "சட்ட காலம்"
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
+msgstr "இயல்பாக பெரிதாக்கவும்"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
 msgstr "இயல்பாக பெரிதாக்கவும்"
 
 #. i18n-hint: Grayscale color scheme for spectrograms
@@ -10190,6 +15694,11 @@ msgstr "நேரியல்"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "அதிர்வெண் (hz)"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -10225,6 +15734,11 @@ msgid "Spectrogram Settings"
 msgstr "மெருகூட்டல் தொகுப்புகள்"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Spectrograms"
+msgstr "வர்ணப்பட்டை"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Preferences for Spectrum"
 msgstr "விருப்பங்கள்: "
 
@@ -10246,12 +15760,20 @@ msgid "Ma&x Frequency (Hz):"
 msgstr "உச்ச மீடிறன் (Hz):"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "&Gain (dB):"
 msgstr "உயர்வு (dB):"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "&Range (dB):"
 msgstr "வீச்சு (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -10266,12 +15788,29 @@ msgid "Window &size:"
 msgstr "சாளர அளவு"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "8 - most wideband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "1024 - default"
 msgstr "256 - இயல்பானது"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "32768 - most narrowband"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "சாளர வ&amp;கை"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "சிதைவு காரணி:"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
@@ -10281,9 +15820,26 @@ msgstr "தேர்வு"
 msgid "Show a grid along the &Y-axis"
 msgstr "Y-அச்சு உடன் கட்டங்களை காட்டு"
 
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Minimum Amplitude (dB):"
 msgstr "குறைந்த வீச்சு (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -10317,6 +15873,24 @@ msgstr "மீடிறன் உயர்வு கட்டாயம் மு
 msgid "The minimum amplitude (dB) must be an integer"
 msgstr "குறைந்த வீச்சு (dB) கட்டாயம் முழு எண்ணாக இருக்க வேண்டும்"
 
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "உயர் மீடிறன் முழு எண்ணாக இருக்க வேண்டும்"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "உயர் மீடிறன் முழு எண்ணாக இருக்க வேண்டும்"
+
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
+#: src/prefs/ThemePrefs.cpp src/prefs/ThemePrefs.h
+msgid "Theme"
+msgstr ""
+
 #: src/prefs/ThemePrefs.cpp
 msgid "Preferences for Theme"
 msgstr "விருப்பங்கள்: "
@@ -10324,6 +15898,43 @@ msgstr "விருப்பங்கள்: "
 #: src/prefs/ThemePrefs.cpp
 msgid "Info"
 msgstr "தகவல்"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
+
+#. i18n-hint: && in here is an escape character to get a single & on screen,
+#. * so keep it as is
+#: src/prefs/ThemePrefs.cpp
+msgid "Theme Cache - Images && Color"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Save Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Load Theme Cache"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid "Individual Theme Files"
+msgstr ""
 
 #: src/prefs/ThemePrefs.cpp
 msgid "Save Files"
@@ -10364,6 +15975,26 @@ msgid "Enable &dragging selection edges"
 msgstr "தேர்ந்தெடுக்காத ஒலியை அமைதியாக்கு"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "உயர்தர கலவை தெரிவுகள்"
 
@@ -10384,6 +16015,10 @@ msgid "Spectrogram"
 msgstr "வர்ணப்பட்டை"
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Stem plot"
 msgstr "மீள்வரை"
 
@@ -10398,6 +16033,10 @@ msgstr "தேர்வுக்கு &விரிவாக்கு"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "இயல்பாக பெரிதாக்கவும்"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -10420,6 +16059,16 @@ msgid "50ths of Seconds"
 msgstr "விநாடிகள்"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "விநாடிகள்"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "விநாடிகள்"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "மில்லிசெக்கன்கள்"
 
@@ -10427,7 +16076,12 @@ msgstr "மில்லிசெக்கன்கள்"
 msgid "Samples"
 msgstr "மாதிரிகள்"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "பெரிதாக்குக"
 
@@ -10436,8 +16090,29 @@ msgid "Preferences for Tracks"
 msgstr "விருப்பங்கள்: "
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Sho&w track name as overlay"
 msgstr "அலைவடிவ திரையில் தட பெ&amp;யரை காட்டவும்"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "பதிதல் முடிவு"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
@@ -10446,6 +16121,11 @@ msgstr "இயல்பான காட்சி முறை"
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "இயல்பு மாதிரி அமைப்பு:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "மாதிரிகள்"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -10488,6 +16168,24 @@ msgstr "திட்டங்கள் சேமிக்கப்படுக�
 msgid "Saving &empty project"
 msgstr "வெற்று திட்டம் சேமிக்கப்படுகிறது"
 
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "பிரியோசையை மோனோவாக பிரி"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "பிரியோசையை மோனோவாக பிரி"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
+
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
 msgid "Waveforms"
@@ -10509,16 +16207,24 @@ msgid "Stopped"
 msgstr "நிறுத்து"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "இடை நிறுத்து"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "ஆரம்பத்திற்கு தவிர்த்து செல்"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "முடிவிற்கு தவிர்த்து செல்"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "இடை நிறுத்து"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "ஆரம்பத்தை தேர்ந்தெடு"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "முடிவை தேர்ந்தெடு"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -10532,20 +16238,17 @@ msgstr "புதிய தடம்"
 msgid "Append Record"
 msgstr "மு&டிவில் எழுதி சேர்"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "முடிவை தேர்ந்தெடு"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "ஆரம்பத்தை தேர்ந்தெடு"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "இடை நிறுத்து"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -10562,6 +16265,11 @@ msgstr "பின்னணி வேகம்"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "பதிதல் முடிவு"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "ஒலி நிலை"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -10582,6 +16290,11 @@ msgstr "உள்ளீட்டு சாதனத்தை தெரிவு�
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Select Playback Device"
 msgstr "உள்ளீட்டு சாதனத்தை தெரிவுசெய்"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "ஒலியை அமைதியாக்கு"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
@@ -10617,11 +16330,17 @@ msgstr "தேர்ந்தெடுக்காத ஒலியை அமை�
 msgid "Sync-Lock Tracks"
 msgstr "ஒலித்தட்டுகளை Sync-Lock செய்"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "உள்ளே ஜூம் செய்"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "வெளியே ஜூம் செய்"
 
@@ -10688,50 +16407,23 @@ msgstr "மீட்டரை பதிவு செய்"
 msgid "&Playback Meter Toolbar"
 msgstr "மீட்டரை ஓடச்செய்"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "பதிதல் முடிவு"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "பின்னணி"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "உள்ளீட்டு சத்தம்: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "உள்ளீட்டு சத்தம் (கிடைக்கவில்லை; கணினி கலவையை பாவிக்கவும்.)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "வெளியீட்டு சத்தம்: %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "வெளியீட்டு சத்தம்: %.2f%s"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "உள்ளீட்டு சத்தம் (கிடைக்கவில்லை; கணினி கலவையை பாவிக்கவும்.)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "கல&வை கருவி பட்டியல் "
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub Ruler"
 msgstr "அடிமட்டம்"
 
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "மேற்பார்வையை நிறுத்தவும்"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "மேற்பார்வையை நிறுத்தவும்"
@@ -10739,6 +16431,7 @@ msgstr "மேற்பார்வையை நிறுத்தவும்"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "ஆரம்ப நேரம்"
@@ -10746,9 +16439,24 @@ msgstr "ஆரம்ப நேரம்"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "மேற்பார்வையை தொடங்கவும்"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "மேற்பார்வையை தொடங்கவும்"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "அடிமட்டம்"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -10784,6 +16492,10 @@ msgstr "தேர்வு ஆரம்பத்தை நிறுத்து"
 msgid "Length and Center of Selection"
 msgstr "தேர்வை வெட்டவும்"
 
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Snap To"
 msgstr "மாறு"
@@ -10792,7 +16504,9 @@ msgstr "மாறு"
 msgid "Length"
 msgstr "நீளம்"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "மையம்"
 
@@ -10800,6 +16514,14 @@ msgstr "மையம்"
 #, c-format
 msgid "Snap Clicks/Selections to %s"
 msgstr "உடனடி கிளிக்/தேர்வுகள் %s"
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -10819,8 +16541,17 @@ msgid "Center frequency and Width"
 msgstr "நேரியல் நிகழ்வெண்"
 
 #: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Low and High Frequencies"
+msgstr "அதிர்வெண் (hz)"
+
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Center Frequency"
 msgstr "நேரியல் நிகழ்வெண்"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
@@ -10840,8 +16571,8 @@ msgstr "&சாதன கருவி பட்டியில்"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %s கருவித்தட்டு "
 
 #: src/toolbars/ToolBar.cpp
@@ -10868,7 +16599,8 @@ msgstr "நேரம் மாற்றும் கருவி"
 msgid "Zoom Tool"
 msgstr "ஜூம் கருவி"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "வரையும் கருவி"
 
@@ -10944,11 +16676,13 @@ msgstr "ஒன்று அல்லது மேற்பட்ட சிட்
 msgid "Drag label boundary."
 msgstr "சிட்டை எல்லையை இழு"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "திருத்தப்பட்ட சிட்டை"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "சிட்டை  தொகு"
 
@@ -11003,27 +16737,42 @@ msgstr "தொகுக்கப்பட்ட சிட்டைகள்"
 msgid "New label"
 msgstr "சேர்க்கப்பட்ட சிட்டை"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "மேல் அட்டமசுரம்"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "கிழ் அட்டமசுரம்"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
+msgstr ""
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "வலது-சுட்டி"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "வெளியே ஜூம் செய்"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-இடது-சுட்டி"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-இடது-சுட்டி"
 
@@ -11046,6 +16795,14 @@ msgid "Stretch"
 msgstr "இழு"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
 msgstr "இணைக்கப்பட்ட ஒலிகள்"
 
@@ -11057,7 +16814,8 @@ msgstr "இணை"
 msgid "Expanded Cut Line"
 msgstr "வெட்டும் வரி விரிவாக்கப்பட்டது"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "விரிவாக்கு"
 
@@ -11070,12 +16828,21 @@ msgid "Click and drag to edit the samples"
 msgstr "மாதிரிகளை மாற்றுவதற்கு தேர்ந்தெடுத்து இழுக்கவும்"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "அசைக்கப்பட்ட மாதிரி"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "மாதிரி தொகு"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -11084,6 +16851,16 @@ msgstr "ஒரு புள்ளியில் பெரிதாக்கு�
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "வர்ணப்பட்டை"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -11109,7 +16886,8 @@ msgstr "நடைமுறைப்படுத்தபடுகிறது : 
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' இல் இருந்து %s க்கு மாற்றப்பட்டது"
@@ -11123,7 +16901,60 @@ msgid "Rat&e"
 msgstr "அளவை  நிர்ணயி"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 h 060 m 060>0100 s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 h 060 m 060>0100 s"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -11144,7 +16975,8 @@ msgstr "அளவு மாற்றம்"
 msgid "Set Rate"
 msgstr "அளவை நிர்ணயி"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "பல"
 
@@ -11237,10 +17069,25 @@ msgid "Right, %dHz"
 msgstr "வலது, "
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%.1f dB"
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "வலது"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
@@ -11250,6 +17097,15 @@ msgstr "ஒலித்துண்டின் அளவை மாற்ற ச
 msgid "Click and drag to rearrange sub-views"
 msgstr "ஒலித்தட்டை கால நேரத்திற்குள் மாற்றுவதற்கு தேர்ந்தெடுத்து இழுக்கவும்"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "ஒலித்தட்டை கால நேரத்திற்குள் மாற்றுவதற்கு தேர்ந்தெடுத்து இழுக்கவும்"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
 msgstr "உள்ளே ஜூம் செய்"
@@ -11257,6 +17113,10 @@ msgstr "உள்ளே ஜூம் செய்"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x2"
 msgstr "பெரிதாக்குக"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
@@ -11302,12 +17162,28 @@ msgid "Set Range"
 msgstr "எல்லையை நிர்ணயி"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "காட்சியை அமை"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "இடை கணிப்பை நிர்ணயி"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
@@ -11327,9 +17203,8 @@ msgstr "மடக்கை இடை கணிப்பு"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "ஒலித்தட்டை கால நேரத்திற்குள் மாற்றுவதற்கு தேர்ந்தெடுத்து இழுக்கவும்"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -11372,9 +17247,30 @@ msgstr "ஒலித்தட்டை கால நேரத்திற்க�
 msgid "Click and drag to edit the amplitude envelope"
 msgstr "வளமையை மாற்றுவதற்கு தேர்ந்தெடுத்து இழுக்கவும்"
 
+#. i18n-hint: (verb) Audacity has just adjusted the envelope .
+#: src/tracks/ui/EnvelopeHandle.cpp
+#, fuzzy
+msgid "Adjusted envelope."
+msgstr "மட்டம்"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "க&ருவி பட்டியில்"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "மேற்பார்வையை தொடங்கவும்"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "அடிமட்டம்"
@@ -11390,6 +17286,11 @@ msgstr "ஒலித்துண்டை மேலே நகர்த்து"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "ஒலித்துண்டை கீழே நகர்த்து"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "மேற்பார்வையை நிறுத்தவும்"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub Bac&kwards"
@@ -11432,6 +17333,12 @@ msgstr "ஒலியை தேர்ந்தெடுத்து இழுக�
 msgid "Edit, Preferences..."
 msgstr "விருப்பங்கள்..."
 
+#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac
+#: src/tracks/ui/SelectHandle.cpp
+#, c-format
+msgid "Multi-Tool Mode: %s for Mouse and Keyboard Preferences."
+msgstr ""
+
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to set frequency bandwidth."
 msgstr "ஒலியை தேர்ந்தெடுத்து இழுக்கவும்"
@@ -11439,6 +17346,11 @@ msgstr "ஒலியை தேர்ந்தெடுத்து இழுக�
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to select audio"
 msgstr "ஒலியை தேர்ந்தெடுத்து இழுக்கவும்"
+
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
@@ -11461,6 +17373,10 @@ msgstr "தேர்ந்தெடுத்த பாடல்களை  %.2f �
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "தேர்ந்தெடுத்த பாடல்களை  %.2f யிலிருந்து %.2f வினாடிகளுக்கு அமைதிப்படுத்து"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -11487,6 +17403,12 @@ msgstr "கட்டளை"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Ctrl-இடது-சுட்டி"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -11533,11 +17455,33 @@ msgstr "அழுத்து"
 msgid "Button"
 msgstr "பட்டன்"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
 #. i18n-hint: "x" suggests a multiplicative factor
 #: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.2fx"
 msgstr "%.1f dB"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy
+msgid "Please choose an existing file."
+msgstr "தயவுசெய்து ஒரு செய்கையை தேர்ந்தெடுங்கள்"
 
 #: src/widgets/FileDialog/mac/FileDialogPrivate.mm
 msgid "File type:"
@@ -11563,9 +17507,19 @@ msgstr "வெறுமை"
 msgid "Backwards"
 msgstr "பின்னோக்கி"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "முன்னோக்கி"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -11633,12 +17587,21 @@ msgid "Meter Style"
 msgstr "அளவைக்கருவி"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "வடிகட்டும் வகை"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "கால அளவு"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "தானியங்கி பாதிப்பு மீட்பு."
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -11653,9 +17616,22 @@ msgid " Monitoring "
 msgstr "மேற்பார்வையை நிறுத்தவும்"
 
 #: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
 #, c-format
 msgid " Peak %2.f dB"
 msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+#, fuzzy, c-format
+msgid " Peak %.2f "
+msgstr "%.1f dB"
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
 
 #: src/widgets/MultiDialog.cpp
 msgid "Show Log for Details"
@@ -11678,6 +17654,23 @@ msgstr "01000,01000 விநாடிகள்"
 msgid "hh:mm:ss"
 msgstr "மணி:நிமி:செக்"
 
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "099 ம 060 நி 060 நொ"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "dd:hh:mm:ss"
+msgstr "மணி:நிமி:செக்"
+
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
 #. * for hours, 'm' to the abbreviation for minutes and 's' to the
@@ -11686,6 +17679,51 @@ msgstr "மணி:நிமி:செக்"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 நாட்கள் 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "hh:mm:ss + NTSC விழும் சட்டங்கள்"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "099 ம 060 நி 060 நொ"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and milliseconds (1/1000 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + milliseconds"
+msgstr "மில்லிசெக்கன்கள்"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "099 ம 060 நி 060 நொ"
+
+#. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and samples (at the current project sample rate)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + samples"
+msgstr "hh:mm:ss + NTSC விழும் சட்டங்கள்"
 
 #. i18n-hint: Format string for displaying time in hours, minutes, seconds
 #. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
@@ -11701,6 +17739,7 @@ msgstr "0100 h 060 m 060 s+># மாதிரிகள்"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "மாதிரிகள்"
@@ -11862,6 +17901,15 @@ msgstr "01000,01000 சட்டங்கள் |75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 h 060 m 060>0100 s"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -11869,6 +17917,16 @@ msgstr "0100 h 060 m 060>0100 s"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 h 060 m 060>0100 s"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in octaves
+#: src/widgets/NumericTextCtrl.cpp
+msgid "octaves"
+msgstr ""
 
 #. i18n-hint: Format string for displaying log of frequency in octaves.
 #. * Change the decimal points for your locale. Don't change the numbers.
@@ -11878,11 +17936,47 @@ msgstr "0100 h 060 m 060>0100 s"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 சட்டங்கள்|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 சட்டங்கள்|24"
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
 
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
@@ -11891,6 +17985,11 @@ msgstr "(வடிவத்தை மாற்றுவதற்கு கான
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "சென்டிசெகண்ட்ஸ்"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -11934,6 +18033,11 @@ msgstr "உறுதி"
 msgid "Unable to write files to directory: %s."
 msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -11952,6 +18056,10 @@ msgid "Don't show this warning again"
 msgstr "இந்த எச்சரிக்கையை மீண்டும் காட்டாதீர்"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "-முடிவிலி"
 
@@ -11960,13 +18068,31 @@ msgid "-Infinity"
 msgstr "-முடிவிலி"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "வெறுமை"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "மு&டிவில் எழுதி சேர்"
 
 #: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "ஒரு வீச்சில் பெரிதாக்குக"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "LOF பிழை"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -11984,8 +18110,20 @@ msgid "Value must not be greater than %s"
 msgstr "ஆரம்பமும் நிறுத்தமும் 0 இனை விட பெரியதாக இருக்க வேண்டும்."
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "புதிய திட்டம் உருவாக்கப்பட்டுள்ளது"
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Directory Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
+msgid "File Dialog"
+msgstr ""
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
@@ -12005,16 +18143,49 @@ msgstr "கோப்பை திறக்கமுடியவில்லை"
 msgid "Spectral edit multi tool"
 msgstr "தேர்வு"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "வடிகட்டி"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "அதிர்வெண் (hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "வழு."
@@ -12029,20 +18200,72 @@ msgstr "உயர்வு (dB):"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "குறைந்த  மீடிறன் கட்டாயம் குறைந்தது 0 Hz ஆக இருக்க வேண்டும்"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
 msgstr "தேர்வு"
 
+#: plug-ins/StudioFadeOut.ny
+msgid "Studio Fade Out"
+msgstr ""
+
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "நிறைவேற்றபடுகிறது....."
 
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
 msgstr "இயல்பாக அ&amp;மைக்க"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Adjustable Fade"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Type"
@@ -12065,8 +18288,16 @@ msgid "S-Curve Down"
 msgstr "கிழே நகர்த்&த"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "ஆரம்பி"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -12075,6 +18306,14 @@ msgstr "பெறு"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "ஆரம்பி"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -12087,6 +18326,14 @@ msgstr "நேர்கோடு"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "நேர்கோடு"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -12135,6 +18382,14 @@ msgstr "மீடிறன் உயர்வு மறை எண்ணாக �
 msgid "~aPercentage values cannot be more than 1000 %."
 msgstr "மீடிறன் உயர்வு மறை எண்ணாக இருக்க முடியாது"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "திரும்ப செய்"
@@ -12144,8 +18399,37 @@ msgid "Finding beats..."
 msgstr "சத்தமற்றதை துண்டிக்கிறது..."
 
 #: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity பதிவுகள்"
+
+#: plug-ins/beat.ny
 msgid "Threshold Percentage"
 msgstr "அமைதிக்கான தொடக்க நிலை"
+
+#: plug-ins/clipfix.ny
+msgid "Clip Fix"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Reconstructing clips..."
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "அமைதிக்கான தொடக்கநிலை"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
 
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
@@ -12154,6 +18438,21 @@ msgstr "குறிப்பு தடம்"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "குறிப்பு தடம்"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -12187,6 +18486,19 @@ msgstr "ஒலித்துண்டு பெயர்"
 msgid "Fade direction"
 msgstr "நேரடியாக வாசிக்கவும்"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "தாமதம்"
@@ -12202,6 +18514,19 @@ msgstr "தாமதம்"
 #: plug-ins/delay.ny
 msgid "Regular"
 msgstr "செவ்வகம் "
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "இரைச்ச&amp;லை குறைத்தல்(db)"
 
 #: plug-ins/delay.ny
 msgid "Delay time (seconds)"
@@ -12227,6 +18552,14 @@ msgstr "முற்&amp;பார்வை"
 msgid "Number of echoes"
 msgstr "திரும்ப செய்ய வேண்டிய தடவைகள்"
 
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "பிந்திய மெருகூட்டலை திரும்பச்செய்"
@@ -12240,6 +18573,10 @@ msgid "XML file"
 msgstr "MP3 கோப்புகள்"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "மு&டிவில் எழுதி சேர்"
 
@@ -12251,6 +18588,25 @@ msgstr "மேலெழுவதை உறுதிப்படுத்து"
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "வகை கோப்பை திறக்க முடியவில்லை"
+
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, lisp-format
+msgid "Error.~%File cannot be written:~%\"~a.txt\""
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -12281,10 +18637,50 @@ msgstr "நீளம் (நொடிகள்)"
 msgid "Length of label region (seconds)"
 msgstr "நீளம் (நொடிகள்)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "சிட்டை  தொகு"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "Message on completion"
@@ -12298,6 +18694,11 @@ msgstr "பிரி"
 msgid "Warnings only"
 msgstr "எச்சரிக்கைகள்"
 
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
 msgid "region labels"
@@ -12306,6 +18707,12 @@ msgstr "பகு&தியை சேமி "
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "தொகுக்கப்பட்ட சிட்டைகள்"
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 #, lisp-format
@@ -12320,13 +18727,50 @@ msgstr "கோப்புகளை சுமையேற்று "
 msgid "Performing High-Pass Filter..."
 msgstr "விஞ்ஞான வடிகட்டி செயற்படுத்தபடுகிறது"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "அதிர்வெண் (hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "குறைந்த  மீடிறன் கட்டாயம் குறைந்தது 0 Hz ஆக இருக்க வேண்டும்"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -12374,6 +18818,11 @@ msgid "Point after sound"
 msgstr "இணைந்த ஒலிசாதனம்"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region around sounds"
+msgstr "மெட்டு நீளம் (நொடிகள்)"
+
+#: plug-ins/label-sounds.ny
 msgid "Region between sounds"
 msgstr "மெட்டு நீளம் (நொடிகள்)"
 
@@ -12381,11 +18830,41 @@ msgstr "மெட்டு நீளம் (நொடிகள்)"
 msgid "Maximum leading silence"
 msgstr "சத்தமற்றதை துண்டிக்கிறது..."
 
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "சத்தமற்றதை துண்டிக்கிறது..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "பெயரானது காலியாக இருக்க கூடாது"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -12417,8 +18896,25 @@ msgid "Hard Clip"
 msgstr "வெட்டப்பட &துண்டை காட்டு"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "வலது சானெல்"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "மட்டம் (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -12480,6 +18976,44 @@ msgstr "சிதைவு நேரம்"
 msgid "Decay (ms)"
 msgstr "சிதைவு நேரம்"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "பெயரானது காலியாக இருக்க கூடாது"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "வடிகட்டியின் நீளம்"
@@ -12491,6 +19025,18 @@ msgstr "Nyquist மெருகூட்டல் நிகழ்கிறது
 #: plug-ins/notch.ny
 msgid "Steve Daulton and Bill Wharrie"
 msgstr "இயல்பாக அ&amp;மைக்க"
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -12513,7 +19059,8 @@ msgstr "MP3 கோப்புகள்"
 msgid "HTML file"
 msgstr "MP3 கோப்புகள்"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "கோப்புகளின் பெயர்கள்:"
 
@@ -12522,13 +19069,33 @@ msgid "All supported"
 msgstr "எல்லா கோப்புகளும்|*|எல்லா ஒத்து போகும் கோப்புகளும்|"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow overwriting"
+msgstr "வெட்டப்பட &துண்டை காட்டு"
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Disallow"
 msgstr "அனுமதிக்கப்படவில்லை"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "அனுமதிக்கப்படவில்லை"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "%s இனை நீக்க முடியாதுள்ளது"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -12539,16 +19106,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "ஒரு MIDI கோப்பினை தெரியவும்... "
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "உபயோகிக்கப்படாத வடிகட்டிகள்"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "ஒரு MIDI கோப்பினை தெரியவும்... "
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "சத்தத்தை உருவாக்கிறது"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "வடிகட்டும் வகை"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -12561,6 +19170,10 @@ msgstr "தடத்தை அகற்ற"
 #: plug-ins/rhythmtrack.ny
 msgid "Generating Rhythm..."
 msgstr "கீச்சிடுதலை உருவாக்கிறது"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
@@ -12579,8 +19192,20 @@ msgid "Swing amount"
 msgstr "Distortion"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "திரும்ப செய்ய வேண்டிய தடவைகள்"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -12603,12 +19228,54 @@ msgid "Beat sound"
 msgstr "திரும்ப செய்"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "இரைச்சல் நீக்கபடுகிறது"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "இரைச்சல் தளம்"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -12631,6 +19298,15 @@ msgid "Center frequency of noise (Hz)"
 msgstr "நேரியல் நிகழ்வெண்"
 
 #: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "அதிர்வெண் (hz)"
+
+#: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
 msgstr "வீச்சு (0-1)"
 
@@ -12641,6 +19317,10 @@ msgstr "ஏற்றுமதி செய்ய முடியவில்ல�
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "நிறைவேற்றபடுகிறது....."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -12659,6 +19339,10 @@ msgid "HTML files"
 msgstr "MP3 கோப்புகள்"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "மாதிரி தொகு"
 
@@ -12671,8 +19355,29 @@ msgid "Include header information"
 msgstr "உருவாக்கிய தகவல்"
 
 #: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "எல்லா"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -12687,6 +19392,11 @@ msgstr "\t-help (இச்செய்தி)"
 msgid "Errors Only"
 msgstr "பிழை:"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -12699,6 +19409,46 @@ msgstr "வலது சானெல்"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "மாதிரிகள்"
 
@@ -12706,6 +19456,43 @@ msgstr "மாதிரிகள்"
 #, lisp-format
 msgid "~a seconds."
 msgstr "விநாடிகள்"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -12724,6 +19511,10 @@ msgid "Value (dB)"
 msgstr "வீச்சு (dB):"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "நேர்கோடு"
 
@@ -12740,8 +19531,58 @@ msgid "Right (dB)"
 msgstr "வலது, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "நேர்கோடு"
+
+#: plug-ins/sample-data-export.ny
+msgid "2 channels (stereo)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "1 channel (mono)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -12756,8 +19597,40 @@ msgid "Select file"
 msgstr "ஒரு MIDI கோப்பினை தெரியவும்... "
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "வழு."
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -12767,6 +19640,15 @@ msgstr "வகை கோப்பை திறக்க முடியவில
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "தேர்வு"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -12789,8 +19671,16 @@ msgid "Wet level (percent)"
 msgstr "2-மட்டம்"
 
 #: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "நிறைவேற்றபடுகிறது....."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -12832,9 +19722,96 @@ msgstr "பகுப்பாய்"
 msgid "Strength"
 msgstr "வடிகட்டி"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "நடைமுறைப்படுத்தபடுகிறது : "
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -12868,6 +19845,183 @@ msgstr "அதிர்வெண் (hz)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "அதிர்வெண் (hz)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Audacity வெளியேறவும்"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "சானெல்"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "கோப்பை திறப்பதில் வழ"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "சுமையேற்றுவதில் வழு"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s கருவித்தட்டு "
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Google Translate"
+
+#~ msgid "Commit Id:"
+#~ msgstr "கட்டளை:"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.சரி செய்வதற்கு சாத்தியமில்லை இன்னும் அதிகமாக உள்ளது"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது மூலம் சத்தம் %f இற்கு குறைக்கப்பட்டுள்ளது "
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.சரி செய்வதற்கு சாத்தியமில்லை இன்னும் குறைவாக உள்ளது"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது மூலம் சத்தம் %f இற்கு கூட்டப்படுள்ளது"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.ஆய்வின் மொத்த எண்ணிக்கையானது ஏற்கக்கூடிய சத்தத்தை அறியாமலே அதிகரித்துவிட்டது. இன்னும் அதிகமாக உள்ளது."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.ஆய்வின் மொத்த எண்ணிக்கையானது ஏற்கக்கூடிய சத்தத்தை அறியாமலே அதிகரித்துவிட்டது. இன்னும் குறைவாக உள்ளது."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "உள்ளீட்டு மட்டத்தை தானியங்கி சரி செய்வது நிறுத்தப்பட்டுள்ளது.%.2f ஆனது ஏற்கக்கூடிய ஒரு சத்தம் ஆகும்"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "வகை கோப்பை திறக்க முடியவில்லை\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Google Translate\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "பின்னணி\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "பதிதல் முடிவு\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "பதிதல் முடிவு\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "வெளியீட்டு சத்தம்: %.2f%s\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "வெளியீட்டு சத்தம்: %.2f%s\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "விரிவாக்கப்பட்ட இறக்கம்"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "'%s' இருந்து   '%s' ஆக மறுபடி பெயரிட முடியவில்லை"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer %s: %s"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "பின்னணி வேகத்தை மாற்றியமைக்கவும்"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "பின்னணி வேகத்தை கூட்டவும்"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "பின்னணி வேகத்தை குறைக்கவும்"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "பதிதல் முடிவு"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "பின்னணி வேகத்தை கூட்டவும்"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "பின்னணி வேகத்தை குறைக்கவும்"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity பதிவுகள்"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "Audacity &பற்றி..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr " (ஏற்று/அணை)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "தானியங்கி உள்ளீட்டு அளவை சரி செய்தல்"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "தானியங்கி உள்ளீட்டு அளவை சரி செய்தலை செயற்படுத்த"
+
+#~ msgid "Target Peak:"
+#~ msgstr "உச்ச இலக்கு:"
+
+#~ msgid "Within:"
+#~ msgstr "உள்ளகத்தே:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "பகுப்பாய்வு நேரம்:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "மில்லிசெக்கன்கள்(ஒரு பகுப்பாய்விற்கான நேரம்)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "தொடர்ச்சியான பகுப்பாய்வுகளின் எண்ணிக்கை"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 என்பது முடிவிலி"
+
+#~ msgid "Recording Volume"
+#~ msgstr "பதிதல் முடிவு"
+
+#~ msgid "Playback Volume"
+#~ msgstr "பின்னணி"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "உள்ளீட்டு சத்தம்: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "உள்ளீட்டு சத்தம் (கிடைக்கவில்லை; கணினி கலவையை பாவிக்கவும்.)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "வெளியீட்டு சத்தம்: %.2f%s"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "வெளியீட்டு சத்தம்: %.2f%s"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "உள்ளீட்டு சத்தம் (கிடைக்கவில்லை; கணினி கலவையை பாவிக்கவும்.)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "கல&வை கருவி பட்டியல் "
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "ஒலித்தட்டை கால நேரத்திற்குள் மாற்றுவதற்கு தேர்ந்தெடுத்து இழுக்கவும்"
+
 #~ msgid "Program build date:"
 #~ msgstr "மென்பொருள் கட்டிய தேதி:"
 
@@ -12881,10 +20035,6 @@ msgstr "அதிர்வெண் (hz)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "தெ"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "சோதனை கோப்பை திறக்க/உருவாக்க முடியவில்லை"
 
 #, fuzzy
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
@@ -13235,10 +20385,6 @@ msgstr "அதிர்வெண் (hz)"
 #~ msgstr "திட்ட ஆரம்பத்தில் வன்தட்டில் குறைந்த இடம்"
 
 #, fuzzy
-#~ msgid "&Importing uncompressed audio files"
-#~ msgstr "சுருக்கப்படாத ஒலிக்கோப்புகள் இறக்குமதி செய்யப்படுகிறது"
-
-#, fuzzy
 #~ msgid "Silence Finder"
 #~ msgstr "அமைதி பிறப்பாக்கி"
 
@@ -13522,16 +20668,8 @@ msgstr "அதிர்வெண் (hz)"
 #~ msgstr "ஒலி  அலகு"
 
 #, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "விளைவுகள்"
-
-#, fuzzy
 #~ msgid "Save Device Info"
 #~ msgstr "ஒலி கருவி விபரங்கள்"
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "வகை கோப்பை சேமிக்க முடியவில்லை"
 
 #, fuzzy
 #~ msgid "Save MIDI Device Info"
@@ -13693,10 +20831,6 @@ msgstr "அதிர்வெண் (hz)"
 #~ msgstr "எடுத்தெழுதிய பொருள்"
 
 #, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "க&ருவி பட்டியில்"
-
-#, fuzzy
 #~ msgid "Ext-Co&mmand"
 #~ msgstr "கட்டளை"
 
@@ -13776,20 +20910,12 @@ msgstr "அதிர்வெண் (hz)"
 #~ msgstr "நீளம்"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "முடிவை தேர்ந்தெடு"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "தேர்வு முடிவை தொடங்கு"
 
 #, fuzzy
 #~ msgid "Start - Center - End"
 #~ msgstr "தேர்வு முடிவை தொடங்கு"
-
-#, fuzzy
-#~ msgid "L-C"
-#~ msgstr "LC"
 
 #, fuzzy
 #~ msgid "Show start time and end time"
@@ -13885,10 +21011,6 @@ msgstr "அதிர்வெண் (hz)"
 #, fuzzy
 #~ msgid "Freq"
 #~ msgstr "அதிர்வெண் (hz)"
-
-#, fuzzy
-#~ msgid "Phase"
-#~ msgstr "Phaser"
 
 #, fuzzy
 #~ msgid "Depth"
@@ -13989,10 +21111,6 @@ msgstr "அதிர்வெண் (hz)"
 #, fuzzy
 #~ msgid "Truncate"
 #~ msgstr "அமைதியை வெட்டு"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "பின்னோகுதல்"
 
 #, fuzzy
 #~ msgid "C&ategory:"
@@ -14430,9 +21548,6 @@ msgstr "அதிர்வெண் (hz)"
 #~ msgid "Changing Pitch"
 #~ msgstr "சுருதி மாறுகின்றது"
 
-#~ msgid "Applied effect: %s %.1f%%"
-#~ msgstr "பிரயோகிக்கப்பட்ட மேருகூட்டிகள்: %s %.1f%%"
-
 #~ msgid "Change Speed..."
 #~ msgstr "வேக மாற்றம்..."
 
@@ -14600,10 +21715,6 @@ msgstr "அதிர்வெண் (hz)"
 #~ msgid "Reverb..."
 #~ msgstr "எதிரொலி..."
 
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "விஞ்ஞான வடிகட்டி...."
-
 #~ msgid "Silence..."
 #~ msgstr "அமைதி...."
 
@@ -14748,9 +21859,6 @@ msgstr "அதிர்வெண் (hz)"
 
 #~ msgid "Decrease output gain"
 #~ msgstr "வெளி ஆதாயத்தை குறைக்கவும்"
-
-#~ msgid "Adjust input gain"
-#~ msgstr "உள்ளீட்டு ஆதாயத்தை மாற்றியமைக்கவும்"
 
 #~ msgid "Increase input gain"
 #~ msgstr "உள்ளீட்டு ஆதாயத்தை கூட்டவும்"

--- a/locale/tenacity.pot
+++ b/locale/tenacity.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,71 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr ""
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr ""
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr ""
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr ""
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -286,7 +221,7 @@ msgid "(C) 2009 by Leland Lucius"
 msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -502,7 +437,7 @@ msgid "The Build"
 msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
+msgid "Version:"
 msgstr ""
 
 #: src/AboutDialog.cpp
@@ -513,21 +448,25 @@ msgstr ""
 msgid "Compiler:"
 msgstr ""
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+msgid "Config folder:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Data folder:"
 msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
-msgstr ""
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
 msgstr ""
 
 #: src/AboutDialog.cpp
@@ -542,7 +481,6 @@ msgstr ""
 msgid "MP3 Importing"
 msgstr ""
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr ""
@@ -551,7 +489,6 @@ msgstr ""
 msgid "ID3 tag support"
 msgstr ""
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr ""
@@ -569,14 +506,6 @@ msgid "FFmpeg Import/Export"
 msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr ""
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr ""
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr ""
 
@@ -590,6 +519,10 @@ msgstr ""
 
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
 msgstr ""
 
 #: src/AboutDialog.cpp
@@ -947,7 +880,7 @@ msgid ""
 msgstr ""
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Reset Tenacity Preferences"
 msgstr ""
 
 #: src/AudacityApp.cpp
@@ -959,7 +892,7 @@ msgid ""
 msgstr ""
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr ""
 
 #: src/AudacityApp.cpp
@@ -984,7 +917,7 @@ msgstr ""
 msgid "Open &Recent..."
 msgstr ""
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr ""
 
@@ -998,36 +931,36 @@ msgstr ""
 
 #: src/AudacityApp.cpp
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 
 #: src/AudacityApp.cpp
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr ""
 
 #: src/AudacityApp.cpp
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
 
 #: src/AudacityApp.cpp
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+msgid "Do you still want to start Tenacity?"
 msgstr ""
 
 #: src/AudacityApp.cpp
@@ -1035,17 +968,17 @@ msgid "Error Locking Temporary Folder"
 msgstr ""
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr ""
 
 #: src/AudacityApp.cpp
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+msgid "Tenacity is already running"
 msgstr ""
 
 #: src/AudacityApp.cpp
@@ -1057,7 +990,7 @@ msgid ""
 msgstr ""
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid "Tenacity Startup Failure"
 msgstr ""
 
 #: src/AudacityApp.cpp
@@ -1086,7 +1019,7 @@ msgstr ""
 
 #: src/AudacityApp.cpp
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1114,7 +1047,7 @@ msgstr ""
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+msgid "display Tenacity version"
 msgstr ""
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1126,7 +1059,7 @@ msgstr ""
 #: src/AudacityApp.cpp
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1141,7 +1074,7 @@ msgid "Message"
 msgstr ""
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+msgid "Tenacity Configuration Error"
 msgstr ""
 
 #: src/AudacityFileConfig.cpp
@@ -1155,7 +1088,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 
 #: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
@@ -1165,7 +1098,7 @@ msgid "Help"
 msgstr ""
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+msgid "&Quit Tenacity"
 msgstr ""
 
 #: src/AudacityFileConfig.cpp
@@ -1173,7 +1106,7 @@ msgid "&Retry"
 msgstr ""
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+msgid "Tenacity Log"
 msgstr ""
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1237,7 +1170,7 @@ msgid "Error Initializing Midi"
 msgstr ""
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "Tenacity Audio"
 msgstr ""
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1249,37 +1182,6 @@ msgstr ""
 
 #: src/AudioIO.cpp
 msgid "Out of memory!"
-msgstr ""
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr ""
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr ""
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr ""
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr ""
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr ""
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr ""
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
 msgstr ""
 
 #: src/AudioIOBase.cpp
@@ -1379,48 +1281,6 @@ msgstr ""
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr ""
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr ""
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr ""
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1464,7 +1324,7 @@ msgstr ""
 
 #: src/AutoRecoveryDialog.cpp
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1980,10 +1840,6 @@ msgid "No revision identifier was provided"
 msgstr ""
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr ""
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr ""
@@ -2219,7 +2075,7 @@ msgstr ""
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2239,7 +2095,7 @@ msgstr ""
 msgid "Rectangle"
 msgstr ""
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr ""
 
@@ -2303,7 +2159,7 @@ msgstr ""
 #: src/FFmpeg.cpp
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2322,7 +2178,7 @@ msgstr ""
 
 #: src/FFmpeg.cpp
 #, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr ""
 
 #: src/FFmpeg.cpp
@@ -2363,7 +2219,7 @@ msgstr ""
 
 #: src/FFmpeg.cpp
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2389,23 +2245,23 @@ msgstr ""
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to open a file in %s."
+msgid "Tenacity failed to open a file in %s."
 msgstr ""
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity failed to read from a file in %s."
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 
 #: src/FileException.cpp
 #, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr ""
 
 #: src/FileException.cpp
 #, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2853,14 +2709,14 @@ msgstr ""
 #, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 
 #: src/InconsistencyException.cpp
 #, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 
 #: src/InconsistencyException.h
@@ -2951,11 +2807,11 @@ msgstr ""
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+msgid "Tenacity First Run"
 msgstr ""
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+msgid "Choose Language for Tenacity to use:"
 msgstr ""
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2982,12 +2838,12 @@ msgid ""
 msgstr ""
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+msgid "Opening Tenacity Project"
 msgstr ""
 
 #: src/LyricsWindow.cpp
 #, c-format
-msgid "Audacity Karaoke%s"
+msgid "Tenacity Karaoke%s"
 msgstr ""
 
 #: src/LyricsWindow.cpp
@@ -3037,7 +2893,7 @@ msgstr ""
 
 #: src/MixerBoard.cpp
 #, c-format
-msgid "Audacity Mixer Board%s"
+msgid "Tenacity Mixer Board%s"
 msgstr ""
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
@@ -3127,7 +2983,7 @@ msgstr ""
 #: src/ModuleManager.cpp
 #, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3163,7 +3019,7 @@ msgid "No"
 msgstr ""
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+msgid "Tenacity Module Loader"
 msgstr ""
 
 #: src/ModuleManager.cpp
@@ -3470,7 +3326,7 @@ msgstr ""
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 
@@ -3499,7 +3355,7 @@ msgstr ""
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3538,7 +3394,7 @@ msgstr ""
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3570,7 +3426,7 @@ msgstr ""
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 
@@ -3596,7 +3452,7 @@ msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3720,12 +3576,12 @@ msgid ""
 msgstr ""
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+msgid "This is not an Tenacity project file"
 msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3838,7 +3694,7 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 #, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3850,13 +3706,13 @@ msgstr ""
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
 #, c-format
-msgid "[Project %02i] Audacity \"%s\""
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr ""
 
 #: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
 #: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
-#: src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#: src/prefs/PrefsPanel.cpp
+msgid "Tenacity"
 msgstr ""
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -3868,8 +3724,8 @@ msgstr ""
 #: src/ProjectFileIO.cpp
 #, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 
 #: src/ProjectFileIO.cpp
@@ -3932,14 +3788,14 @@ msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4002,7 +3858,7 @@ msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 
@@ -4071,7 +3927,7 @@ msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 
 #: src/ProjectFileManager.cpp
@@ -4166,7 +4022,7 @@ msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
-msgid "Welcome to Audacity version %s"
+msgid "Welcome to Tenacity version %s"
 msgstr ""
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4392,8 +4248,7 @@ msgstr ""
 msgid "Transport"
 msgstr ""
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
-#: src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr ""
 
@@ -4557,7 +4412,7 @@ msgid "Activation level (dB):"
 msgstr ""
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+msgid "Welcome to Tenacity!"
 msgstr ""
 
 #: src/SplashDialog.cpp
@@ -4701,7 +4556,7 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 
@@ -4719,7 +4574,7 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4727,7 +4582,7 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 
@@ -4742,7 +4597,7 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4751,14 +4606,14 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
 
 #: src/Theme.cpp
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 
@@ -4788,7 +4643,7 @@ msgstr ""
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 
@@ -4840,7 +4695,7 @@ msgid "Time Track"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+msgid "Tenacity Timer Record"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
@@ -4927,7 +4782,7 @@ msgid "Action after Timer Recording:"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+msgid "Tenacity Timer Record Progress"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
@@ -5064,7 +4919,7 @@ msgid "Do nothing"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Exit Tenacity"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
@@ -5088,7 +4943,7 @@ msgid "Scheduled to stop at:"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr ""
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5114,7 +4969,7 @@ msgid "Recording Exported:"
 msgstr ""
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+msgid "Tenacity Timer Record - Waiting"
 msgstr ""
 
 #: src/TrackInfo.cpp
@@ -5568,11 +5423,11 @@ msgstr ""
 #: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
 #: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
 #: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+msgid "The Tenacity Team"
 msgstr ""
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+msgid "Provides builtin commands to Tenacity"
 msgstr ""
 
 #: src/commands/LoadCommands.cpp
@@ -7973,7 +7828,7 @@ msgid "Builtin Effects"
 msgstr ""
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+msgid "Provides builtin effects to Tenacity"
 msgstr ""
 
 #: src/effects/LoadEffects.cpp
@@ -8204,7 +8059,7 @@ msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 
@@ -9034,7 +8889,7 @@ msgid "VST Effects"
 msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9111,7 +8966,7 @@ msgid "Standard VST program file"
 msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+msgid "Tenacity VST preset file"
 msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9196,7 +9051,7 @@ msgid "Audio Unit Effects"
 msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9212,7 +9067,7 @@ msgid "Audio Unit Effect Options"
 msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9360,7 +9215,7 @@ msgid "Provides LADSPA Effects"
 msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+msgid "Tenacity no longer uses vst-bridge"
 msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9368,7 +9223,7 @@ msgid "LADSPA Effect Options"
 msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr ""
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
@@ -9401,7 +9256,7 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9437,7 +9292,7 @@ msgid "LV2 Effects"
 msgstr ""
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr ""
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9445,7 +9300,7 @@ msgid "Nyquist Effects"
 msgstr ""
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9663,7 +9518,7 @@ msgid "Vamp Effects"
 msgstr ""
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
@@ -10750,7 +10605,7 @@ msgstr ""
 
 #: src/export/ExportMP3.cpp
 #, c-format
-msgid "Audacity needs the file %s to create MP3s."
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr ""
 
 #: src/export/ExportMP3.cpp
@@ -10780,8 +10635,8 @@ msgstr ""
 #: src/export/ExportMP3.cpp
 #, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 
 #: src/export/ExportMP3.cpp
@@ -11089,7 +10944,7 @@ msgstr ""
 #: src/export/ExportPCM.cpp
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 
 #: src/export/ExportPCM.cpp
@@ -11098,7 +10953,7 @@ msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 
@@ -11138,7 +10993,7 @@ msgstr ""
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 
@@ -11147,7 +11002,7 @@ msgstr ""
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 
 #: src/import/Import.cpp
@@ -11156,7 +11011,7 @@ msgstr ""
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr ""
 
 #. i18n-hint: %s will be the filename
@@ -11164,9 +11019,9 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 
 #. i18n-hint: %s will be the filename
@@ -11174,7 +11029,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 
@@ -11183,7 +11038,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 
@@ -11192,7 +11047,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 
@@ -11202,8 +11057,8 @@ msgstr ""
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 
@@ -11212,7 +11067,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 
@@ -11221,9 +11076,9 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 
 #. i18n-hint: %s will be the filename
@@ -11231,7 +11086,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11242,7 +11097,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 
@@ -11251,7 +11106,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 
@@ -11260,7 +11115,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 
@@ -11269,7 +11124,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 
@@ -11282,7 +11137,7 @@ msgstr ""
 #: src/import/Import.cpp
 #, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11302,7 +11157,7 @@ msgstr ""
 #: src/import/Import.cpp
 #, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11330,7 +11185,7 @@ msgid ""
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 
 #: src/import/ImportAUP.cpp
@@ -11376,7 +11231,7 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr ""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr ""
 
 #: src/import/ImportAUP.cpp
@@ -11470,40 +11325,6 @@ msgstr ""
 
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr ""
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
 msgstr ""
 
 #: src/import/ImportLOF.cpp
@@ -12229,34 +12050,6 @@ msgid "Ext&ra"
 msgstr ""
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr ""
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr ""
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr ""
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr ""
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr ""
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr ""
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr ""
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr ""
 
@@ -12518,7 +12311,7 @@ msgid "&Getting Started"
 msgstr ""
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+msgid "&Manual"
 msgstr ""
 
 #: src/menus/HelpMenus.cpp
@@ -12543,10 +12336,6 @@ msgstr ""
 
 #: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
 msgid "Show &Log..."
-msgstr ""
-
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
 msgstr ""
 
 #: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
@@ -13452,7 +13241,7 @@ msgid "Created new label track"
 msgstr ""
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr ""
 
 #: src/menus/TrackMenus.cpp
@@ -13869,10 +13658,6 @@ msgid "So&ftware Playthrough (on/off)"
 msgstr ""
 
 #: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr ""
-
-#: src/menus/TransportMenus.cpp
 msgid "T&ransport"
 msgstr ""
 
@@ -14085,7 +13870,7 @@ msgid "Preferences for Application"
 msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -14289,7 +14074,7 @@ msgid "Directory %s is not writable"
 msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14374,11 +14159,11 @@ msgid "Plugin Options"
 msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+msgid "Check for updated plugins when Tenacity starts"
 msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+msgid "Rescan plugins next time Tenacity is started"
 msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14558,7 +14343,7 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+msgid "B&lend system and Tenacity theme"
 msgstr ""
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14734,7 +14519,7 @@ msgid ""
 msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14849,7 +14634,7 @@ msgstr ""
 
 #: src/prefs/LibraryPrefs.cpp
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 
@@ -14907,18 +14692,18 @@ msgstr ""
 
 #: src/prefs/ModulePrefs.cpp
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr ""
 
 #. i18n-hint preserve the leading spaces
@@ -14927,7 +14712,7 @@ msgid "  'New' means no choice has been made yet."
 msgstr ""
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr ""
 
 #: src/prefs/ModulePrefs.cpp
@@ -15081,6 +14866,14 @@ msgstr ""
 msgid "Move clip up/down between tracks"
 msgstr ""
 
+#: src/prefs/MousePrefs.cpp
+msgid "Alt-Left-Drag"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
 msgid "Change Amplification Envelope"
@@ -15204,7 +14997,7 @@ msgid "Always scrub un&pinned"
 msgstr ""
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+msgid "Tenacity Preferences"
 msgstr ""
 
 #: src/prefs/PrefsDialog.cpp
@@ -15339,39 +15132,6 @@ msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "System T&ime"
-msgstr ""
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr ""
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr ""
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr ""
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr ""
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr ""
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr ""
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr ""
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
 msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
@@ -15641,7 +15401,7 @@ msgid ""
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15936,15 +15696,23 @@ msgid "Stopped"
 msgstr ""
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr ""
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr ""
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
+msgstr ""
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr ""
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr ""
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
 msgstr ""
 
 #: src/toolbars/ControlToolBar.cpp
@@ -15957,14 +15725,6 @@ msgstr ""
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Append Record"
-msgstr ""
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr ""
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
 msgstr ""
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
@@ -16134,43 +15894,6 @@ msgstr ""
 msgid "&Playback Meter Toolbar"
 msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr ""
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr ""
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr ""
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr ""
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr ""
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr ""
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr ""
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr ""
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr ""
@@ -16332,7 +16055,7 @@ msgstr ""
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
 #, c-format
-msgid "Audacity %s Toolbar"
+msgid "Tenacity %s Toolbar"
 msgstr ""
 
 #: src/toolbars/ToolBar.cpp
@@ -16953,7 +16676,7 @@ msgstr ""
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
 msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
@@ -17885,16 +17608,11 @@ msgid "Paul Licameli"
 msgstr ""
 
 #: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
-#: plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny
-#: plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny
-#: plug-ins/crossfadetracks.ny plug-ins/delay.ny
-#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
-#: plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
 #: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
-#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny
-#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
-#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny
-#: plug-ins/vocoder.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr ""
 
@@ -17984,6 +17702,14 @@ msgstr ""
 #: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
 #: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
 msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
 msgstr ""
 
 #: plug-ins/StudioFadeOut.ny
@@ -18124,6 +17850,10 @@ msgstr ""
 
 #: plug-ins/beat.ny
 msgid "Finding beats..."
+msgstr ""
+
+#: plug-ins/beat.ny
+msgid "Audacity"
 msgstr ""
 
 #: plug-ins/beat.ny
@@ -18497,10 +18227,6 @@ msgstr ""
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
-msgstr ""
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
 msgstr ""
 
 #: plug-ins/label-sounds.ny

--- a/locale/tg.po
+++ b/locale/tg.po
@@ -9,11 +9,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-26 06:19+0000\n"
 "Last-Translator: Emily Mabrey <emilymabrey93@gmail.com>\n"
-"Language-Team: Tajik <https://hosted.weblate.org/projects/tenacity/tenacity/"
-"tg/>\n"
+"Language-Team: Tajik <https://hosted.weblate.org/projects/tenacity/tenacity/tg/>\n"
 "Language: tg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,42 +23,6 @@ msgstr ""
 "X-Poedit-Language: Tajik\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Баромад аз Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Маҷро(Канал)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Хатои кушодашавии файл"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Хатои кушодашавии файл"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Таблои %s Audacity"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Сабтшавӣ"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Муайяншавӣ номумкин аст"
@@ -69,9 +32,31 @@ msgstr "Муайяншавӣ номумкин аст"
 msgid "%s bytes"
 msgstr "байтҳо"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Тақвиятдиҳанда"
+
+#: libraries/lib-strings/Languages.cpp
+msgid "System"
+msgstr ""
 
 #: modules/mod-null/ModNullCallback.cpp
 msgid "1st Experimental Command..."
@@ -82,12 +67,68 @@ msgid "2nd Experimental Command"
 msgstr "Интихоби фармон"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Nyquist Workbench..."
+msgstr "Корбарии натиҷаи Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Undo\tCtrl+Z"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "&Redo\tCtrl+Y"
+msgstr "&Гузоштан"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cu&t\tCtrl+X"
+msgstr "&Гузоштан"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Copy\tCtrl+C"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Paste\tCtrl+V"
+msgstr "&Гузоштан"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Cle&ar\tCtrl+L"
 msgstr "&Гузоштан"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select A&ll\tCtrl+A"
 msgstr "Ҷудокунӣ"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Find...\tCtrl+F"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Matching Paren\tF8"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Top S-expr\tF9"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Higher S-expr\tF10"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Previous S-expr\tF11"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Next S-expr\tF12"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go to"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Select &Font..."
@@ -110,15 +151,37 @@ msgid "Show &Output"
 msgstr "Намоиши бурунӣ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Large Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Small Icons"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Toolbar"
 msgstr "Афзор"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&Go\tF5"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Stop\tF6"
 msgstr "Боздорӣ"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "&About"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Script"
+msgstr "Тағирёбанда"
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Индикатори баромад"
 
@@ -126,7 +189,20 @@ msgstr "Индикатори баромад"
 msgid "Load Nyquist script"
 msgstr "Дархости Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Script was not saved."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Огоҳӣ"
 
@@ -135,16 +211,59 @@ msgid "Save Nyquist script"
 msgstr "Дархости Nyquist..."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find dialog"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Tango Icon Gallery (toolbar icons)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "External Tenacity module which provides a simple IDE for writing effects."
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench"
 msgstr "Корбарии натиҷаи Nyquist..."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "No matches found"
+msgstr "Стереои муттаҳидшуда"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Code has been modified. Are you sure?"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Untitled"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Nyquist Effect Workbench - "
 msgstr "Корбарии натиҷаи Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Нав"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "New script"
+msgstr "Кушодани файлҳои Қаблӣ"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Open"
@@ -178,7 +297,8 @@ msgstr "Нусха"
 msgid "Copy to clipboard"
 msgstr "Буриш барои буфер"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Буридан"
 
@@ -186,7 +306,8 @@ msgstr "Буридан"
 msgid "Cut to clipboard"
 msgstr "Буриш барои буфер"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Гузоштан"
 
@@ -211,7 +332,8 @@ msgstr "Ҷудокунӣ"
 msgid "Select all text"
 msgstr "Ҷудокунӣ"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Барҳамдиҳӣ"
 
@@ -219,20 +341,70 @@ msgstr "Барҳамдиҳӣ"
 msgid "Undo last change"
 msgstr "Ивази Шакл"
 
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Redo"
+msgstr "&Такрор"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Redo previous change"
+msgstr "Ивази Шакл"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Find text"
+msgstr ""
+
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Match"
 msgstr "Баста"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to matching paren"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Top"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to top S-expr"
+msgstr "Нишона барои содирот ҷой надорад."
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Up"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to higher S-expr"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Previous"
 msgstr "Афзори Пешина"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "Go to previous S-expr"
+msgstr "Ҷойгузори Ботартиб ба Роҳчаи Пешина"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Next"
 msgstr "Афзори Навбатӣ"
 
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Go to next S-expr"
+msgstr ""
+
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Ибтидо"
 
@@ -240,7 +412,8 @@ msgstr "Ибтидо"
 msgid "Start script"
 msgstr "Дархости Nyquist..."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Боздорӣ"
 
@@ -248,31 +421,139 @@ msgstr "Боздорӣ"
 msgid "Stop script"
 msgstr "Дархости Nyquist..."
 
+#. i18n-hint: information about the program
+#: src/AboutDialog.cpp
+#, c-format
+msgid "About %s"
+msgstr ""
+
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "ОК"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp
+msgid "Build Information"
+msgstr ""
+
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Фаъол шуд"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Хомӯш карда шуд"
 
+#. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Фармон:"
+msgid "The Build"
+msgstr ""
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Version:"
+msgstr "Маъкусшавӣ"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Build type:"
+msgstr "Навъи хаш:"
+
+#: src/AboutDialog.cpp
+msgid "Compiler:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
+#. i18n-hint: The directory audacity is installed into (on *nix systems)
+#: src/AboutDialog.cpp
+msgid "Installation Prefix:"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Config folder:"
 msgstr "Танзимоти пӯша: "
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
+msgstr "Танзимоти пӯша: "
+
+#: src/AboutDialog.cpp
+msgid "File Format Support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Audio playback and recording"
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
 msgid "Sample rate conversion"
 msgstr "Табдилдиҳии басомади намуна"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP3 Importing"
+msgstr "Воридшавии хато"
+
+#: src/AboutDialog.cpp
+msgid "Ogg Vorbis Import and Export"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "ID3 tag support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FLAC import and export"
+msgstr "Насби вурудии FLAC"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "MP2 export"
+msgstr "Насби вуруди  MP2"
+
+#: src/AboutDialog.cpp
+msgid "Import via QuickTime"
+msgstr ""
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "FFmpeg Import/Export"
+msgstr "Хатои LOF"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Plug-in support"
+msgstr "Дастаҳои иттисоли %i ба %i"
+
+#: src/AboutDialog.cpp
+msgid "Sound card mixer support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Extreme Pitch and Tempo Change support"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "GPL License"
+msgstr ""
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -295,6 +576,18 @@ msgstr "Лифофа"
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
 #, c-format
+msgid "%s, system administration"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, co-founder and developer"
+msgstr "Лифофа"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
 msgid "%s, developer"
 msgstr "Лифофа"
 
@@ -306,9 +599,51 @@ msgstr "Лифофа"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support"
+msgstr "Лифофа"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
+msgstr "Лифофа"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, documentation and support, French"
+msgstr "Лифофа"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, quality assurance"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s, accessibility advisor"
+msgstr ""
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
 msgstr "Графики EQ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, composer"
+msgstr "Лифофа"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, tester"
+msgstr "Лифофа"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
@@ -329,8 +664,26 @@ msgid "%s, graphics"
 msgstr "Графики EQ"
 
 #: src/AboutDialog.cpp
+#, c-format
+msgid "%s (incorporating %s, %s, %s, %s and %s)"
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
+#. i18n-hint: The program's name substitutes for %s
+#: src/AboutDialog.cpp
+msgid "Free, open source, cross-platform audio recorder and editor."
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Ташаккур ба"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -348,6 +701,11 @@ msgstr "Ширкаткунандаҳои дигари лоиҳа"
 msgid "Tenacity Special thanks:"
 msgstr "Ташаккури махсус:"
 
+#: src/AboutDialog.cpp src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Libraries"
+msgstr "Рӯйхатҳо"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, c-format
@@ -361,14 +719,23 @@ msgid "%s Team Members"
 msgstr "Собиқ аъзоҳои гурӯҳи дигар"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Ширкаткунандаҳои дигари лоиҳа"
+
+#: src/AboutDialog.cpp
+msgid "Website and Graphics"
+msgstr ""
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Роҷер Ковакс, Виктор Ибрагимов, Акмал Саломов, Акбар Ватаншоев, Зарина Муродова, Сӯҳроб Рашидов, Абдураҳмон Холов. Почтаи электронӣ: youth_opportunities@tajikngo.org"
@@ -387,6 +754,26 @@ msgstr "Ташаккури махсус:"
 msgid "%s website: "
 msgstr "Аввал Audacity Бакордарорӣ"
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Ширкаткунандаҳои дигари лоиҳа"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Timeline actions disabled during recording"
+msgstr ""
+
 #: src/AdornedRulerPanel.cpp
 msgid "Click and drag to adjust, double-click to reset"
 msgstr "Пахш ва кашидан барои ба тартибоварии андозаи роҳчаҳои стереоӣ."
@@ -397,9 +784,15 @@ msgstr "Пахш ва кашидан барои ба тартибоварии а
 msgid "Record/Play head"
 msgstr "Сабтшавӣ"
 
+#: src/AdornedRulerPanel.cpp src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Timeline"
+msgstr "Дастаҳои иттисоли 1 ба %i"
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Барои таҳрири намунаҳо кашиш ва пахшро иҷро кунед"
@@ -407,12 +800,57 @@ msgstr "Барои таҳрири намунаҳо кашиш ва пахшро 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Пахш ва кашидан барои тағирдиҳии андозаи роҳча."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+msgid "Click & move to Scrub. Click & drag to Seek."
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Seek"
+msgstr "Ҷойгузории Ботартиб ба Роҳчаи Навбатӣ"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub"
+msgstr "Ҷойгузории Роҳча ба Поён"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release to stop seeking."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Drag to Seek. Release and move to Scrub."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Move to Scrub. Drag to Seek."
+msgstr "Пӯшидани роҳчаи фаъол"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Quick-Play disabled"
+msgstr " (хомӯш)"
+
+#: src/AdornedRulerPanel.cpp
+#, fuzzy
+msgid "Quick-Play enabled"
 msgstr " (хомӯш)"
 
 #: src/AdornedRulerPanel.cpp
@@ -420,14 +858,42 @@ msgid "Timeline Options"
 msgstr "Дастаҳои иттисоли 1 ба %i"
 
 #: src/AdornedRulerPanel.cpp
+msgid "Enable Quick-Play"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
 msgid "Enable dragging selection"
 msgstr "Иловаи нишонаҳо дар ҷудокунӣ"
+
+#: src/AdornedRulerPanel.cpp
+msgid "Update display while playing"
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp
+msgid "Lock Play Region"
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Pinned Play Head"
 msgstr "Сабтшавӣ"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp
+msgid ""
+"Cannot lock region beyond\n"
+"end of project."
+msgstr ""
+
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Хато"
 
@@ -437,8 +903,36 @@ msgid "Failed to remove %s"
 msgstr "'%s' тоза намешавад"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+msgid "Failed!"
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Reset Preferences?\n"
+"\n"
+"This is a one-time question, after an 'install' where you asked to have the Preferences reset."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Қисматҳои Audacity"
+
+#: src/AudacityApp.cpp
+#, c-format
+msgid ""
+"%s could not be found.\n"
+"\n"
+"It has been removed from the list of recent files."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "Block size must be within 256 to 100000000\n"
+msgstr ""
 
 #: src/AudacityApp.cpp
 #, fuzzy
@@ -457,6 +951,11 @@ msgstr "&Кушодан..."
 
 #: src/AudacityApp.cpp
 #, fuzzy
+msgid "Open &Recent..."
+msgstr "Кушодани файлҳои Қаблӣ"
+
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
+#, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Дар бораи Audacity..."
 
@@ -469,29 +968,33 @@ msgid "&File"
 msgstr "&Файл"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity наметавонад каталогро барои ба таври муваққатӣ нигоҳ доштани файлҳо ёбад.\n"
 "Каталоги мувофиқро дар равзанаи муколамавии барнома нишон диҳед."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity наметавонад каталогро барои ба таври муваққатӣ нигоҳ доштани файлҳо ёбад.\n"
 "Каталоги мувофиқро дар равзанаи муколамавии барнома нишон диҳед."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity барои баромадан омода аст.  Барнома барои истифодаи файлҳои муваққатии каталоги нав такроран бор карда шавад."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -500,38 +1003,111 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity наметавонад каталогро бо файлҳои муваққатӣ боз дорад.\n"
 "Имконияти истифодаи ин каталог бо нусхаи дигари Audacity мавҷуд аст.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Шумо то ҳол мехоҳед Audacity- ро ба кор дароред?"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "Error Locking Temporary Folder"
+msgstr "Хатои кушодашавии файл"
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Систем нусхаи дигари Audacity- ро бозхонд.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr "Фармонҳои «Сохтан» ё «Кушодан»-ро барои кор бо якчанд лоиҳа дар ин нусхаи Audacity истифода баред.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity аллакай бор шудааст"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+msgid ""
+"Unable to acquire semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Файлҳои лоиҳаи Audacity"
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to create semaphores.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire lock semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"Unable to acquire server semaphore.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid ""
+"The Tenacity IPC server failed to initialize.\n"
+"\n"
+"This is likely due to a resource shortage\n"
+"and a reboot may be required."
+msgstr ""
+
+#: src/AudacityApp.cpp
+msgid "An unrecoverable error has occurred during startup"
+msgstr ""
+
+#. i18n-hint: This controls the number of bytes that Audacity will
+#. *           use when writing files to the disk
+#: src/AudacityApp.cpp
+msgid "set max disk block size in bytes"
+msgstr ""
+
+#. i18n-hint: This displays a list of available options
+#: src/AudacityApp.cpp
+#, fuzzy
+msgid "this help message"
+msgstr "Фаъол шуд"
+
+#. i18n-hint: This runs a set of automatic tests on Audacity itself
+#: src/AudacityApp.cpp
+msgid "run self diagnostics"
+msgstr ""
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Хуш омадед ба тариқаи %s Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -541,9 +1117,10 @@ msgid "audio or project file name"
 msgstr "Лоиҳаи файлро кушода наметавонад"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -556,25 +1133,74 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Файлҳои лоиҳаи Audacity"
 
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
+#, fuzzy
+msgid "Message"
+msgstr "&Бознамунагузорӣ..."
+
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Давомнокии оҳанг:"
 
+#: src/AudacityFileConfig.cpp
+#, c-format
+msgid ""
+"The following configuration file could not be accessed:\n"
+"\n"
+"\t%s\n"
+"\n"
+"This could be caused by many reasons, but the most likely are that the disk is full or you do not have write permissions to the file. More information can be obtained by clicking the help button below.\n"
+"\n"
+"You can attempt to correct the issue and then click \"Retry\" to continue.\n"
+"\n"
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+msgstr ""
+
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Help"
+msgstr "&Мадад"
+
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Баромад аз Audacity"
 
+#: src/AudacityFileConfig.cpp
+msgid "&Retry"
+msgstr ""
+
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Таблои %s Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
 msgid "&Save..."
 msgstr "&Захира кардан..."
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#. i18n-hint: (verb)
+#: src/AudacityLogger.cpp src/Tags.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Cl&ear"
+msgstr ""
+
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Пӯшидан"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
+
+#: src/AudacityLogger.cpp
+#, fuzzy
+msgid "Save log to:"
+msgstr "Сабт ҳамчун..."
 
 #: src/AudacityLogger.cpp
 #, c-format
@@ -603,7 +1229,26 @@ msgid "Error Initializing Audio"
 msgstr "Хато дар вақти омодасозии овоз "
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+msgid "There was an error initializing the midi i/o layer.\n"
+msgstr ""
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid ""
+"You will not be able to play midi.\n"
+"\n"
+msgstr ""
+"Шумо садоро наметавонед сабт кунед ё ин ки боз хонед.\n"
+"\n"
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Error Initializing Midi"
+msgstr "Хато дар вақти омодасозии овоз "
+
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Таблои %s Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -613,10 +1258,27 @@ msgid ""
 "Error code: %s"
 msgstr "Хато ҳангоми кушодани афзори садо. "
 
+#: src/AudioIO.cpp
+msgid "Out of memory!"
+msgstr ""
+
+#: src/AudioIOBase.cpp
+msgid "Stream is active ... unable to gather information.\n"
+msgstr ""
+
 #: src/AudioIOBase.cpp
 #, c-format
 msgid "Default recording device number: %d\n"
 msgstr "Афзори вурудӣ\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Default playback device number: %d\n"
+msgstr "Афзори вурудӣ\n"
+
+#: src/AudioIOBase.cpp
+msgid "No devices found\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -654,8 +1316,18 @@ msgid "Low Recording Latency: %g\n"
 msgstr "Сабтшавӣ\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Low Playback Latency: %g\n"
+msgstr "Сабтшавӣ\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "High Recording Latency: %g\n"
+msgstr "Сабтшавӣ\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "High Playback Latency: %g\n"
 msgstr "Сабтшавӣ\n"
 
 #. i18n-hint: Supported, meaning made available by the system
@@ -669,37 +1341,40 @@ msgid "Selected recording device: %d - %s\n"
 msgstr "Афзори вурудӣ\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No recording device found for '%s'.\n"
+msgstr "Афзори вурудӣ\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected playback device: %d - %s\n"
 msgstr "Суръати иҷро\n"
 
 #: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Содирот номумкин аст\n"
+#, fuzzy, c-format
+msgid "No playback device found for '%s'.\n"
+msgstr "Суръати иҷро\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Сабтшавӣ\n"
+msgid "Cannot check mutual sample rates without both devices.\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, c-format
+msgid "Supports output: %d\n"
+msgstr ""
+
+#. i18n-hint: Supported, meaning made available by the system
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "Supports input: %d\n"
+msgstr "Содирот\n"
 
 #: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Бозигар\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Сабтшавӣ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Сабтшавӣ\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Бозигар\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Бозигар\n"
+#, c-format
+msgid "Opened: %d\n"
+msgstr ""
 
 #: src/AudioIOBase.cpp
 #, c-format
@@ -707,8 +1382,18 @@ msgid "Selected MIDI recording device: %d - %s\n"
 msgstr "Афзори вурудӣ\n"
 
 #: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI recording device found for '%s'.\n"
+msgstr "Афзори вурудӣ\n"
+
+#: src/AudioIOBase.cpp
 #, c-format
 msgid "Selected MIDI playback device: %d - %s\n"
+msgstr "Суръати иҷро\n"
+
+#: src/AudioIOBase.cpp
+#, fuzzy, c-format
+msgid "No MIDI playback device found for '%s'.\n"
 msgstr "Суръати иҷро\n"
 
 #: src/AutoRecoveryDialog.cpp
@@ -716,8 +1401,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -729,12 +1415,14 @@ msgid "Recoverable &projects"
 msgstr "Лоиҳаҳои барқароршаванда"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Ҷудокунӣ"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Ном"
 
@@ -747,8 +1435,19 @@ msgid "&Recover Selected"
 msgstr "Ҷудокунӣ"
 
 #: src/AutoRecoveryDialog.cpp
+msgid "&Skip"
+msgstr ""
+
+#: src/AutoRecoveryDialog.cpp
 msgid "No projects selected"
 msgstr "Ягон занҷира интихоб нашудааст"
+
+#: src/AutoRecoveryDialog.cpp
+msgid ""
+"Are you sure you want to discard the selected projects?\n"
+"\n"
+"Choosing \"Yes\" permanently deletes the selected projects immediately."
+msgstr ""
 
 #: src/BatchCommandDialog.cpp
 msgid "Select Command"
@@ -771,8 +1470,16 @@ msgid "&Parameters"
 msgstr "&Параметрҳо"
 
 #: src/BatchCommandDialog.cpp
+msgid "&Details"
+msgstr ""
+
+#: src/BatchCommandDialog.cpp
 msgid "Choose command"
 msgstr "И&нтихоби фармон"
+
+#: src/BatchCommands.cpp
+msgid "MP3 Conversion"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Fade Ends"
@@ -801,6 +1508,22 @@ msgstr "Нати&ҷа"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "&Таҳрири параметрҳо"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#: src/BatchCommands.cpp
+#, fuzzy
+msgid "Menu Command (No Parameters)"
+msgstr "&Таҳрири параметрҳо"
+
+#. i18n-hint: %s will be replaced by the name of an action, such as "Remove Tracks".
+#: src/BatchCommands.cpp src/CommonCommandFlags.cpp
+#, c-format
+msgid "\"%s\" requires one or more tracks to be selected."
+msgstr ""
 
 #: src/BatchCommands.cpp
 #, c-format
@@ -847,11 +1570,30 @@ msgstr "Ҳолати озмоиш"
 msgid "Apply %s"
 msgstr "Истифодаи %s"
 
+#: src/BatchProcessDialog.cpp
+msgid "Macros Palette"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp
+msgid "Manage Macros"
+msgstr ""
+
 #. i18n-hint: A macro is a sequence of commands that can be applied
 #. * to one or more audio files.
 #: src/BatchProcessDialog.cpp
 msgid "Select Macro"
 msgstr "Бознасбшуда"
+
+#. i18n-hint: This is the heading for a column in the edit macros dialog
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Macro"
+msgstr "&Нишонаҳо..."
+
+#: src/BatchProcessDialog.cpp
+#, fuzzy
+msgid "Apply Macro to:"
+msgstr "Истифодаи занҷир"
 
 #: src/BatchProcessDialog.cpp
 msgid "Apply macro to project"
@@ -907,13 +1649,43 @@ msgstr "&Бекор кардан"
 msgid "Remo&ve"
 msgstr "&Дигар кардан"
 
+#: src/BatchProcessDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Rename..."
+msgstr "&Бознамунагузорӣ..."
+
+#: src/BatchProcessDialog.cpp
+msgid "Re&store"
+msgstr ""
+
+#: src/BatchProcessDialog.cpp src/LabelDialog.cpp src/effects/Equalization.cpp
+#, fuzzy
+msgid "I&mport..."
+msgstr "&Воридот..."
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "E&xport..."
+msgstr "&Содирот..."
+
 #: src/BatchProcessDialog.cpp
 msgid "Edit Steps"
 msgstr "&Таҳрири параметрҳо"
 
+#. i18n-hint: This is the number of the command in the list
+#: src/BatchProcessDialog.cpp
+msgid "Num"
+msgstr ""
+
 #: src/BatchProcessDialog.cpp
 msgid "Command  "
 msgstr "&Фармон"
+
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#, fuzzy
+msgid "Parameters"
+msgstr "&Параметрҳо"
 
 #: src/BatchProcessDialog.cpp src/LabelDialog.cpp
 msgid "&Insert"
@@ -935,9 +1707,15 @@ msgstr "Ҳаракат &ба боло"
 msgid "Move &Down"
 msgstr "Ҳаракат &ба поён"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Захира кардан..."
+
+#. i18n-hint: The Shrink button makes the dialog smaller, with less in it
+#: src/BatchProcessDialog.cpp
+msgid "Shrin&k"
+msgstr ""
 
 #. i18n-hint: This is the last item in a list.
 #: src/BatchProcessDialog.cpp
@@ -983,11 +1761,38 @@ msgid "Benchmark"
 msgstr "&Боркунии Озмоишии..."
 
 #: src/Benchmark.cpp
+msgid "Disk Block Size (KB):"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Number of Edits:"
 msgstr "Миқдори вақтҳои такроршаванда: "
 
+#: src/Benchmark.cpp
+msgid "Test Data Size (MB):"
+msgstr ""
+
+#. i18n-hint: A "seed" is a number that initializes a
+#. pseudorandom number generating algorithm
+#: src/Benchmark.cpp
+msgid "Random Seed:"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each block file"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Show detailed info about each editing operation"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Run"
+msgstr ""
+
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Пӯшидан(бастан)"
 
@@ -1002,8 +1807,30 @@ msgid "Export Benchmark Data as:"
 msgstr "Содироти додаҳо ба монанди:"
 
 #: src/Benchmark.cpp
+msgid "Block size should be in the range 1 - 1024 KB."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Number of edits should be in the range 1 - 10000."
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Test data size should be in the range 1 - 2000 MB."
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Using %lld chunks of %lld samples each, for a total of %.1f MB.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
 msgid "Preparing...\n"
 msgstr "Омодасозии пешнамоиш\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Expected len %lld, track len %lld.\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 #, c-format
@@ -1012,17 +1839,109 @@ msgstr "Иҷрокунии такрор\n"
 
 #: src/Benchmark.cpp
 #, c-format
+msgid "Cut: %lld - %lld \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Trial %d\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Cut (%lld, %lld) failed.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
 msgid "Paste: %lld\n"
 msgstr "Гузоштан\n"
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"Trial %d\n"
+"Failed on Paste.\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to perform %d edits: %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Checking file pointer leaks:\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Track # blocks: %ld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Disk # blocks: \n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Doing correctness check...\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Bad: chunk %lld sample %lld\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Passed correctness check!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Errors in %d/%lld chunks\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data: %ld ms\n"
+msgstr ""
 
 #: src/Benchmark.cpp
 msgid "Reading data again...\n"
 msgstr "Давомнокии оҳанг:\n"
 
+#: src/Benchmark.cpp
+#, c-format
+msgid "Time to check all data (2): %ld ms\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+#, c-format
+msgid ""
+"At 44100 Hz, %d bytes per sample, the estimated number of\n"
+" simultaneous tracks that could be played at once: %.1f\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "TEST FAILED!!!\n"
+msgstr ""
+
+#: src/Benchmark.cpp
+msgid "Benchmark completed successfully.\n"
+msgstr ""
+
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Анҷоми Сана ва Вақт"
+msgid "No revision identifier was provided"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Debug build (debug level %d)"
+msgstr ""
+
+#: src/BuildInfo.h
+#, c-format
+msgid "Release build (debug level %d)"
+msgstr ""
 
 #: src/BuildInfo.h
 #, fuzzy
@@ -1038,9 +1957,58 @@ msgid ""
 "Ctrl + A selects all audio."
 msgstr "Аввал роҳчаро ҷудо кунед."
 
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Cmd + A to Select All) then try again."
+msgstr ""
+
+#. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid "Select the audio for %s to use (for example, Ctrl + A to Select All) then try again."
+msgstr ""
+
 #: src/CommonCommandFlags.cpp
 msgid "No Audio Selected"
 msgstr "Ягон занҷира интихоб нашудааст"
+
+#. i18n-hint: %s will be replaced by the name of an effect, usually 'Noise Reduction'.
+#: src/CommonCommandFlags.cpp
+#, c-format
+msgid ""
+"Select the audio for %s to use.\n"
+"\n"
+"1. Select audio that represents noise and use %s to get your 'noise profile'.\n"
+"\n"
+"2. When you have got your noise profile, select the audio you want to change\n"
+"and use %s to change that audio."
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+msgid ""
+"You can only do this when playing and recording are\n"
+"stopped. (Pausing is not sufficient.)"
+msgstr ""
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some stereo audio to perform this\n"
+"action. (You cannot use this with mono.)"
+msgstr "Аввал роҳчаро ҷудо кунед."
+
+#: src/CommonCommandFlags.cpp
+#, fuzzy
+msgid ""
+"You must first select some audio to perform this action.\n"
+"(Selecting other kinds of track won't work.)"
+msgstr "Аввал роҳчаро ҷудо кунед."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1057,9 +2025,28 @@ msgid "Checkpointing project"
 msgstr "Истифодаи ин &Лоиҳа"
 
 #: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Checkpointing %s"
+msgstr "Истифодаи ин &Лоиҳа"
+
+#: src/DBConnection.cpp src/ProjectFileIO.cpp
+msgid "This may take several seconds"
+msgstr ""
+
+#: src/DBConnection.cpp
 #, c-format
 msgid "Could not write to %s.\n"
 msgstr "Дар файл сабт намешавад: \n"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid ""
+"Disk is full.\n"
+"%s\n"
+"For tips on freeing up space, click the help button."
+msgstr ""
+"Audacity натавонист файлро сабт кунад:\n"
+"  %s."
 
 #: src/DBConnection.cpp
 #, c-format
@@ -1077,6 +2064,10 @@ msgid ""
 "%s"
 msgstr "'%s' тоза намешавад"
 
+#: src/DBConnection.cpp
+msgid "Database error.  Sorry, but we don't have more details."
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "Removing Dependencies"
 msgstr "Бастагиҳо бекор мешаванд"
@@ -1084,6 +2075,25 @@ msgstr "Бастагиҳо бекор мешаванд"
 #: src/Dependencies.cpp
 msgid "Copying audio data into project..."
 msgstr "Файлҳои савтӣ дар лоиҳа нусхабардорӣ шуда..."
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Project Depends on Other Audio Files"
+msgstr "Сабти лоиҳа вобаста ба дигар файлҳо"
+
+#: src/Dependencies.cpp
+msgid ""
+"Copying these files into your project will remove this dependency.\n"
+"This is safer, but needs more disk space."
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid ""
+"\n"
+"\n"
+"Files shown as MISSING have been moved or deleted and cannot be copied.\n"
+"Restore them to their original location to be able to copy into project."
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Project Dependencies"
@@ -1098,8 +2108,26 @@ msgid "Disk Space"
 msgstr "Фазои диск"
 
 #: src/Dependencies.cpp
+#, fuzzy
+msgid "Copy Selected Files"
+msgstr "Интихобкунӣ"
+
+#: src/Dependencies.cpp
 msgid "Cancel Save"
 msgstr "Бекорсозии сабт"
+
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Save Without Copying"
+msgstr "Нишона"
+
+#: src/Dependencies.cpp
+msgid "Do Not Copy"
+msgstr ""
+
+#: src/Dependencies.cpp
+msgid "Copy All Files (Safer)"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Whenever a project depends on other files:"
@@ -1111,9 +2139,32 @@ msgstr "Дар мавриде, ки дар лоиҳа файлҳои берун�
 msgid "Ask me"
 msgstr "Маро пурсед"
 
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+msgid "Always copy all files (safest)"
+msgstr ""
+
+#. i18n-hint: One of the choices of what you want Audacity to do when
+#. * Audacity finds a project depends on another file.
+#: src/Dependencies.cpp
+#, fuzzy
+msgid "Never copy any files"
+msgstr "Интихоби MIDI файл..."
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "MISSING %s"
+msgstr ""
+
 #: src/Dependencies.cpp
 msgid "&Copy Names to Clipboard"
 msgstr "Буриш барои буфер"
+
+#: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
 
 #: src/Dependencies.cpp
 msgid "Missing"
@@ -1124,10 +2175,22 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Агар идома диҳед лоиҳаи Шумо дар диск сабт намешавад. Шумо инро мехоҳед?"
 
 #: src/Dependencies.cpp
+msgid ""
+"Your project is self-contained; it does not depend on any external audio files. \n"
+"\n"
+"Some older Tenacity projects may not be self-contained, and care \n"
+"is needed to keep their external dependencies in the right place.\n"
+"New projects will be self-contained and are less risky."
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Dependency Check"
 msgstr "Санҷиши вобаста"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Ҳеҷ чиз"
 
@@ -1135,7 +2198,7 @@ msgstr "Ҳеҷ чиз"
 msgid "Rectangle"
 msgstr "Росткунҷа"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Секунҷа"
 
@@ -1147,28 +2210,167 @@ msgstr "Аз руи хаткашӣ"
 msgid "Rectangular"
 msgstr "Устувор"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg support not compiled in"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid ""
+"FFmpeg was configured in Preferences and successfully loaded before, \n"
+"but this time Tenacity failed to load it at startup. \n"
+"\n"
+"You may want to go back to Preferences > Libraries and re-configure it."
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg startup failed"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg library not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
+msgid "Locate FFmpeg"
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Location of '%s':"
+msgstr "Мавқеъи %s:"
+
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "To find '%s', click here -->"
+msgstr "Барои ёфтани %s --> пахш кунед"
+
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Баррасии..."
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
-msgstr ""
-"Audacity натавонист файлро сабт кунад:\n"
-"  %s."
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "To get a free copy of FFmpeg, click here -->"
+msgstr "Барои нусхабардории хато -->-ро пахш кунед "
 
-#: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#. i18n-hint: (verb)
+#: src/FFmpeg.cpp src/export/ExportMP3.cpp
+msgid "Download"
 msgstr ""
-"Audacity натавонист файлро сабт кунад:\n"
-"  %s."
 
-#: src/FileException.cpp
-#, c-format
+#. i18n-hint: It's asking for the location of a file, for
+#. example, "Where is lame_enc.dll?" - you could translate
+#. "Where would I find the file '%s'?" instead if you want.
+#: src/FFmpeg.cpp
+#, fuzzy, c-format
+msgid "Where is '%s'?"
+msgstr "%s дар куҷо ҷойгир аст?"
+
+#: src/FFmpeg.cpp
+msgid "FFmpeg not found"
+msgstr ""
+
+#: src/FFmpeg.cpp
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
+"but the libraries were not found.\n"
+"\n"
+"To use FFmpeg import, go to Edit > Preferences > Libraries\n"
+"to download or locate the FFmpeg libraries."
+msgstr ""
+
+#: src/FFmpeg.cpp
+#, fuzzy
+msgid "Do not show this warning again"
+msgstr "Ин огоҳиро дигар нишон надиҳед"
+
+#: src/FFmpeg.cpp
+msgid "Failed to find compatible FFmpeg libraries."
+msgstr ""
+
+#. i18n-hint: do not translate avformat.  Preserve the computer gibberish.
+#: src/FFmpeg.h
+msgid "Only avformat.dll"
+msgstr ""
+
+#: src/FFmpeg.h
+msgid "Only libavformat.so"
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
+msgstr ""
+"Audacity натавонист файлро сабт кунад:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
+msgstr ""
+"Audacity натавонист файлро сабт кунад:\n"
+"  %s."
+
+#: src/FileException.cpp
+#, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
+msgstr ""
+
+#: src/FileException.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1186,10 +2388,29 @@ msgid "Error (file may not have been written): %s"
 msgstr "Хато (файл сабт намешавад): %hs"
 
 #: src/FileFormats.cpp
+#, fuzzy
+msgid "&Copy uncompressed files into the project (safer)"
+msgstr "Файлҳои савтӣ дар лоиҳа нусхабардорӣ шуда..."
+
+#: src/FileFormats.cpp
+msgid "&Read uncompressed files from original location (faster)"
+msgstr ""
+
+#: src/FileFormats.cpp
 msgid "&Copy all audio into project (safest)"
 msgstr "Файлҳои савтӣ дар лоиҳа нусхабардорӣ шуда..."
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileFormats.cpp
+msgid "Do &not copy any audio"
+msgstr ""
+
+#: src/FileFormats.cpp
+msgid "As&k"
+msgstr ""
+
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Ҳамаи файлҳо (*)|*"
 
@@ -1200,6 +2421,14 @@ msgid "AUP3 project files"
 msgstr "Сабти додаҳои лоиҳа"
 
 #: src/FileNames.cpp
+msgid "Dynamically Linked Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Dynamic Libraries"
+msgstr ""
+
+#: src/FileNames.cpp
 msgid "Text files"
 msgstr "Номи файлҳо:"
 
@@ -1207,12 +2436,24 @@ msgstr "Номи файлҳо:"
 msgid "XML files"
 msgstr "Файлҳои MP2"
 
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
+
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
 #: src/FileNames.cpp
 #, c-format
 msgid "%s files"
 msgstr "Номи файлҳо:"
+
+#: src/FileNames.cpp
+msgid "The specified filename could not be converted due to Unicode character use."
+msgstr ""
+
+#: src/FileNames.cpp
+msgid "Specify New Filename:"
+msgstr ""
 
 #: src/FileNames.cpp
 #, c-format
@@ -1264,9 +2505,18 @@ msgstr "Басомади сабти воқеъӣ"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "дБ"
+
+#: src/FreqWindow.cpp
+msgid "Scroll"
+msgstr ""
 
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
@@ -1275,7 +2525,9 @@ msgstr "Калонкунӣ"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "Ҳертз"
 
@@ -1294,6 +2546,14 @@ msgid "Cursor:"
 msgstr "Курсори Чап"
 
 #: src/FreqWindow.cpp
+msgid "Peak:"
+msgstr ""
+
+#: src/FreqWindow.cpp
+msgid "&Grids"
+msgstr ""
+
+#: src/FreqWindow.cpp
 msgid "&Algorithm:"
 msgstr "Алгоритм:"
 
@@ -1308,6 +2568,10 @@ msgstr "&Содирот..."
 #: src/FreqWindow.cpp
 msgid "&Function:"
 msgstr "Амал"
+
+#: src/FreqWindow.cpp
+msgid "&Axis:"
+msgstr ""
 
 #: src/FreqWindow.cpp
 msgid "&Replot..."
@@ -1331,6 +2595,32 @@ msgstr "Додаҳо кам интихоб шуданд."
 msgid "s"
 msgstr "эс"
 
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "spectrum.txt"
 msgstr "спектрум.матн"
@@ -1339,7 +2629,8 @@ msgstr "спектрум.матн"
 msgid "Export Spectral Data As:"
 msgstr "Содироти додаҳо ба монанди:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Дар файл сабт намешавад: "
@@ -1356,6 +2647,22 @@ msgstr "Таъхири (сонияҳо)\tБасомад (Ҳертз)\tСатҳ"
 msgid "Plot Spectrum..."
 msgstr "&Кашидани тасвири Спектрум..."
 
+#: src/HelpText.cpp
+msgid "Welcome!"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Playing Audio"
+msgstr "Иҷро"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Recording Audio"
+msgstr "Аудиои Сабтшуда"
+
 #. i18n-hint: Title for a topic.
 #: src/HelpText.cpp
 msgid "Recording - Choosing the Recording Device"
@@ -1370,6 +2677,95 @@ msgstr "Сабтшавӣ"
 #: src/HelpText.cpp
 msgid "Recording - Setting the Recording Level"
 msgstr "Сабтшавӣ"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Editing and greyed out Menus"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Exporting an Audio File"
+msgstr "Берунсозии файл"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+#, fuzzy
+msgid "Saving an Audacity Project"
+msgstr "Кушодани Лоиҳаи Audacity"
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Support for Other Formats"
+msgstr ""
+
+#. i18n-hint: Title for a topic.
+#: src/HelpText.cpp
+msgid "Burn to CD"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "No Local Help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is an <b>Alpha test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "<br><br>The version of Audacity you are using is a <b>Beta test version</b>."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "How to get help"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "These are our support methods:"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
+msgstr ""
+
+#. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
+#: src/HelpText.cpp
+msgid " [[help:Main_Page|Manual]] - if not installed locally, [[https://manual.audacityteam.org/|view online]]"
+msgstr ""
+
+#: src/HelpText.cpp
+msgid " [[https://forum.audacityteam.org/|Forum]] - ask your question directly, online."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
+
+#: src/HelpText.cpp
+msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
+msgstr ""
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -1388,6 +2784,10 @@ msgid "Used Space"
 msgstr "Фазои диск"
 
 #: src/HistoryWindow.cpp
+msgid "&Total space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "&Undo levels available"
 msgstr "&Барҳамдиҳии сатҳҳои дастрас "
 
@@ -1401,6 +2801,10 @@ msgid "&Discard"
 msgstr "&Рад кардан"
 
 #: src/HistoryWindow.cpp
+msgid "Clip&board space used"
+msgstr ""
+
+#: src/HistoryWindow.cpp
 msgid "D&iscard"
 msgstr "&Рад кардан"
 
@@ -1408,15 +2812,39 @@ msgstr "&Рад кардан"
 msgid "&Compact"
 msgstr "&Фармон"
 
+#: src/HistoryWindow.cpp src/ProjectFileManager.cpp
+#, c-format
+msgid "Compacting actually freed %s of disk space."
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the various editing steps
 #. that have been taken.
 #: src/HistoryWindow.cpp
 msgid "&History..."
 msgstr "&Таърих..."
 
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error in %s at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
+#: src/InconsistencyException.cpp
+#, c-format
+msgid ""
+"Internal error at %s line %d.\n"
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
+msgstr ""
+
 #: src/InconsistencyException.h
 msgid "Internal Error"
 msgstr "(барномаи берунӣ)"
+
+#: src/LabelDialog.cpp
+#, fuzzy
+msgid "Edit Labels"
+msgstr "Нишонаҳои таҳриршуда"
 
 #. i18n-hint: (noun).  A track contains waves, audio etc.
 #: src/LabelDialog.cpp
@@ -1424,7 +2852,9 @@ msgid "Track"
 msgstr "Роҳча"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Нишона"
 
@@ -1481,19 +2911,47 @@ msgstr "Роҳчаи Нави Нишонавӣ"
 msgid "Enter track name"
 msgstr "Номи роҳчаро ворид кунед"
 
+#. i18n-hint: (noun) it's the name of a kind of track.
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Label track.
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Label Track"
+msgstr "&Нишонаи Роҳча"
+
+#: src/LabelTrack.cpp
+msgid "One or more saved labels could not be read."
+msgstr ""
+
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Аввал Audacity Бакордарорӣ"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Барои истифодабарии Audacity Забонро интихоб кунед:"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#. i18n-hint: The %s's are replaced by translated and untranslated
+#. * versions of language names.
+#: src/LangChoice.cpp
+#, c-format
+msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
+msgstr ""
+
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Тасдиқ шудан"
+
+#: src/Legacy.cpp
+#, fuzzy
+msgid "Error Converting Legacy Project File"
+msgstr "Дар файл сабт намешавад: "
 
 #: src/Legacy.cpp
 #, c-format
@@ -1505,8 +2963,19 @@ msgstr ""
 "Файли пешина бо номи '%s' сабт шуда буд"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Кушодани Лоиҳаи Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Ташаккури махсус:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "Баррасии..."
 
 #: src/Menus.cpp
 #, c-format
@@ -1526,6 +2995,17 @@ msgstr "&Такрори амалиёт %s"
 msgid "&Redo"
 msgstr "&Такрор"
 
+#: src/Menus.cpp
+msgid ""
+"There was a problem with your last action. If you think\n"
+"this is a bug, please tell us exactly where it occurred."
+msgstr ""
+
+#: src/Menus.cpp
+#, fuzzy
+msgid "Disallowed"
+msgstr "Хомӯш карда шуд"
+
 #. i18n-hint: noun, means a track, made by mixing other tracks
 #: src/Mix.cpp
 msgid "Mix"
@@ -1539,34 +3019,76 @@ msgstr "&Омезиш ва Пешниҳодкунӣ"
 msgid "Mixing and rendering tracks"
 msgstr "Омехтакунӣ ва муттаҳидсозии роҳчаҳо"
 
+#: src/MixerBoard.cpp
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
+msgstr "Сабти Замонсанҷи Audacity"
+
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Шиддат"
 
+#. i18n-hint: title of the MIDI Velocity slider
+#. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+msgid "Velocity"
+msgstr ""
+
+#: src/MixerBoard.cpp
+msgid "Musical Instrument"
+msgstr ""
+
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "панорама"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Бесадо"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Соло"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+msgid "Signal Level Meter"
+msgstr ""
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Ҷойивазшавии Идоракунандаҳои садо"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#, fuzzy
+msgid "Moved velocity slider"
+msgstr "Ҷойивазшавии Идоракунандаҳои садо"
+
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Ҷойивазшавии идоракунандаҳои садо"
+
+#: src/MixerBoard.cpp
+#, fuzzy
+msgid "&Mixer Board..."
+msgstr "Лавҳаи омезишӣ"
 
 #: src/ModuleManager.cpp
 #, c-format
@@ -1576,13 +3098,73 @@ msgid ""
 "Error: %s"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp
+#, fuzzy
+msgid "Module Unsuitable"
+msgstr "Фаъол шуд"
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide a version string.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" failed to initialize.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid "Module \"%s\" found."
+msgstr ""
+
+#: src/ModuleManager.cpp
+msgid ""
+"\n"
+"\n"
+"Only use modules from trusted sources"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+msgid "Yes"
+msgstr ""
+
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ҳеҷ чиз"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Таблои %s Audacity"
+
+#: src/ModuleManager.cpp
+msgid "Try and load this module?"
+msgstr ""
+
+#: src/ModuleManager.cpp
+#, c-format
+msgid ""
+"The module \"%s\" does not provide any of the required functions.\n"
+"\n"
+"It will not be loaded."
+msgstr ""
 
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Note track.
@@ -1592,18 +3174,126 @@ msgstr "Қайди Роҳча"
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
 msgid "G"
 msgstr "ГБ"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
 
 #. i18n-hint: Name of a musical note in the 12-tone chromatic scale
 #: src/PitchName.cpp
 msgid "B"
 msgstr "дБ"
 
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
+
 #: src/PluginManager.cpp
 #, c-format
 msgid "Overwrite the plug-in file %s?"
 msgstr "Бознависии файлҳои мавҷуда"
+
+#: src/PluginManager.cpp
+msgid "Plug-in already exists"
+msgstr ""
+
+#: src/PluginManager.cpp
+msgid "Plug-in file is in use. Failed to overwrite"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -1624,9 +3314,29 @@ msgstr[0] "Масрафсанҷи ғайрифаъол\n"
 msgid "Enable new plug-ins"
 msgstr "Масрафсанҷи ғайрифаъол"
 
+#: src/PluginManager.h
+#, fuzzy
+msgid "Nyquist Prompt"
+msgstr "Корбарии натиҷаи Nyquist..."
+
 #: src/PluginRegistrationDialog.cpp
 msgid "Manage Plug-ins"
 msgstr "Масрафсанҷи ғайрифаъол"
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Select effects, click the Enable or Disable button, then click OK."
+msgstr ""
+
+#. i18n-hint: This is before radio buttons selecting which effects to show
+#: src/PluginRegistrationDialog.cpp
+msgid "Show:"
+msgstr ""
+
+#. i18n-hint: Radio button to show all effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show all"
+msgstr "Фаъол шуд"
 
 #. i18n-hint: Radio button to show all effects
 #: src/PluginRegistrationDialog.cpp src/menus/SelectMenus.cpp
@@ -1653,6 +3363,25 @@ msgstr "Фаъол шуд"
 msgid "E&nabled"
 msgstr "Фаъол шуд"
 
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+#, fuzzy
+msgid "Show new"
+msgstr "Фаъол шуд"
+
+#. i18n-hint: Radio button to show just the newly discovered effects
+#: src/PluginRegistrationDialog.cpp
+msgid "Ne&w"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "State"
+msgstr ""
+
+#: src/PluginRegistrationDialog.cpp
+msgid "Path"
+msgstr ""
+
 #: src/PluginRegistrationDialog.cpp
 msgid "&Select All"
 msgstr "Ҷудокунӣ"
@@ -1661,7 +3390,8 @@ msgstr "Ҷудокунӣ"
 msgid "C&lear All"
 msgstr "&Тоза кардан"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "Фаъол шуд"
 
@@ -1700,6 +3430,14 @@ msgstr "Ҳангоми чоп хато ба амал омад."
 msgid "Print"
 msgstr "Чоп кардан"
 
+#: src/Project.cpp
+#, c-format
+msgid ""
+"There is very little free disk space left on %s\n"
+"Please select a bigger temporary directory location in\n"
+"Directories Preferences."
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 #, c-format
 msgid "Actual Rate: %d"
@@ -1715,6 +3453,21 @@ msgstr "Хато ҳангоми кушодани афзори савтӣ. Лут
 msgid "The tracks selected for recording must all have the same sampling rate"
 msgstr "Барои сохтани спектрум, ҳамаи роҳчаҳои интихобшуда бояд навъи якхела дошта бошанд."
 
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Mismatched Sampling Rates"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid ""
+"Too few tracks are selected for recording at this sample rate.\n"
+"(Tenacity requires two channels at the same sample rate for\n"
+"each stereo track)"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+msgid "Too Few Compatible Tracks Selected"
+msgstr ""
+
 #: src/ProjectAudioManager.cpp
 msgid "Recorded Audio"
 msgstr "Аудиои Сабтшуда"
@@ -1723,9 +3476,99 @@ msgstr "Аудиои Сабтшуда"
 msgid "Record"
 msgstr "Сабт"
 
+#. i18n-hint:  A name given to a track, appearing as its menu button.
+#. The translation should be short or else it will not display well.
+#. At most, about 11 Latin characters.
+#. Dropout is a loss of a short sequence of audio sample data from the
+#. recording
+#: src/ProjectAudioManager.cpp
+msgid "Dropouts"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid ""
+"Recorded audio was lost at the labeled locations. Possible causes:\n"
+"\n"
+"Other applications are competing with Tenacity for processor time\n"
+"\n"
+"You are saving directly to a slow external storage device\n"
+msgstr ""
+
+#: src/ProjectAudioManager.cpp
+msgid "Turn off dropout detection"
+msgstr ""
+
+#. i18n-hint: The audacity project file is XML and has 'tags' in it,
+#. rather like html tags <something>some stuff</something>.
+#. This error message is about the tags that hold the sequence information.
+#. The error message is confusing to users in English, and could just say
+#. "Found problems with <sequence> when checking project file."
+#: src/ProjectFSCK.cpp
+msgid "Project check read faulty Sequence tags."
+msgstr ""
+
 #: src/ProjectFSCK.cpp
 msgid "Close project immediately with no changes"
 msgstr "Лоиҳаро бе таъхир бе тағирот пӯшед"
+
+#: src/ProjectFSCK.cpp
+msgid "Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Problems Reading Sequence Tags"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Inspecting project file data"
+msgstr "Лоиҳаи файлро кушода наметавонад"
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing external audio file(s) \n"
+"('aliased files'). There is no way for Tenacity \n"
+"to recover these files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence. \n"
+"\n"
+"If you choose the third option, this will save the \n"
+"project in its current state, unless you \"Close \n"
+"project immediately\" on further error alerts."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Treat missing audio as silence (this session only)"
+msgstr "Барои додаҳои намоишии гумшуда аз рӯи хомӯшӣ пурра намоед [танҳо ин қисмат]"
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Aliased File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing alias (.auf) blockfile(s). \n"
+"Tenacity can fully regenerate these files \n"
+"from the current audio in the project."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Regenerate alias summary files (safe and recommended)"
+msgstr ""
 
 #: src/ProjectFSCK.cpp
 msgid "Fill in silence for missing display data (this session only)"
@@ -1735,11 +3578,87 @@ msgstr "Барои додаҳои намоишии гумшуда аз рӯи х
 msgid "Close project immediately with no further changes"
 msgstr "Лоиҳаро бе иловаи тағиротҳо, фавран пӯшонед"
 
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Alias Summary File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"detected %lld missing audio data (.au) blockfile(s), \n"
+"probably due to a bug, system crash, or accidental \n"
+"deletion. There is no way for Tenacity to recover \n"
+"these missing files automatically. \n"
+"\n"
+"If you choose the first or second option below, \n"
+"you can try to find and restore the missing files \n"
+"to their previous location. \n"
+"\n"
+"Note that for the second option, the waveform \n"
+"may not show silence."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Replace missing audio with silence (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Missing Audio Data Block File(s)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+#, c-format
+msgid ""
+"Project check of \"%s\" folder \n"
+"found %d orphan block file(s). These files are \n"
+"unused by this project, but might belong to other projects. \n"
+"They are doing no harm and are small."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Continue without deleting; ignore the extra files this session"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Delete orphan files (permanent immediately)"
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning - Orphan Block File(s)"
+msgstr ""
+
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Раванди иҷроиш"
+
+#: src/ProjectFSCK.cpp
+#, fuzzy
+msgid "Cleaning up unused directories in project data"
+msgstr "Раванди тозакунии феҳрист бо кеш"
+
+#: src/ProjectFSCK.cpp
+msgid ""
+"Project check found file inconsistencies during automatic recovery.\n"
+"\n"
+"Select 'Help > Diagnostics > Show Log...' to see details."
+msgstr ""
+
+#: src/ProjectFSCK.cpp
+msgid "Warning: Problems in Automatic Recovery"
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "Пурракунии лоиҳа"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -1778,11 +3697,96 @@ msgid ""
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy, c-format
+msgid ""
+"Failed to retrieve data from the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "'%s' тоза намешавад"
+
+#. i18n-hint: An error message.
+#: src/ProjectFileIO.cpp
+msgid ""
+"Project is in a read only directory\n"
+"(Unable to create the required temporary files)"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: An error message.  Don't translate inset or blockids.
+#: src/ProjectFileIO.cpp
+msgid "Unable to add 'inset' function (can't verify blockids)"
+msgstr ""
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is read only\n"
+"(Unable to work with the blockfiles)"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is locked\n"
+"(Unable to work with the blockfiles)"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is busy\n"
+"(Unable to work with the blockfiles)"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Project is corrupt\n"
+"(Unable to work with the blockfiles)"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Some permissions issue\n"
+"(Unable to work with the blockfiles)"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"A disk I/O error\n"
+"(Unable to work with the blockfiles)"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: An error message.  Don't translate blockfiles.
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid ""
+"Not authorized\n"
+"(Unable to work with the blockfiles)"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #. i18n-hint: An error message.  Don't translate blockfiles.
@@ -1791,12 +3795,38 @@ msgid "Unable to work with the blockfiles"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #: src/ProjectFileIO.cpp
+#, c-format
+msgid "Total orphan blocks deleted %d"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to rollback transaction during import"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Unable to attach destination database"
 msgstr "Тағйири номи '%s' ба '%s' номумкин аст"
 
 #: src/ProjectFileIO.cpp
+msgid "Unable to switch to fast journaling mode"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Failed to bind SQL parameter"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid ""
+"Failed to update the project file.\n"
+"The following command failed:\n"
+"\n"
+"%s"
+msgstr "'%s' тоза намешавад"
+
+#: src/ProjectFileIO.cpp
+msgid "Destination project could not be detached"
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Copying Project"
@@ -1807,9 +3837,9 @@ msgid "Error Writing to File"
 msgstr "Дар файл сабт намешавад: "
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -1820,8 +3850,17 @@ msgstr ""
 msgid "Compacting project"
 msgstr "Лоиҳаи нав эҷод карда шуд"
 
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
+#. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] Tenacity \"%s\""
+msgstr ""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
 msgstr "Таблои %s Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
@@ -1829,9 +3868,21 @@ msgstr "Таблои %s Tenacity"
 msgid "(Recovered)"
 msgstr "(Барқароршуда)"
 
+#. i18n-hint: %s will be replaced by the version number.
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
+msgstr ""
+
 #: src/ProjectFileIO.cpp
 msgid "Can't open project file"
 msgstr "Лоиҳаи файлро кушода наметавонад"
+
+#: src/ProjectFileIO.cpp
+msgid "Failed to remove the autosave information from the project file."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to bind to blob"
@@ -1846,14 +3897,62 @@ msgid "Unable to parse project information."
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #: src/ProjectFileIO.cpp
+msgid "The project's database failed to reopen, possibly because of limited space on the storage device."
+msgstr ""
+
+#: src/ProjectFileIO.cpp
 msgid "Saving project"
 msgstr "&Сабти Лоиҳа"
 
-#: src/ProjectFileManager.cpp
+#: src/ProjectFileIO.cpp src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Saving Project"
+msgstr "Натиҷаи корбурдашуда: %s"
+
+#: src/ProjectFileIO.cpp
+msgid "Syncing"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"The project failed to open, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid ""
+"Unable to remove autosave information, possibly due to limited space\n"
+"on the storage device.\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Backing up project"
+msgstr "&Сабти Лоиҳа"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
+msgstr ""
+"Қаблан баъзе лоиҳаҳо таҳрир ва нигоҳ дошта нашуда буданд \n"
+"бо Audacity кор мекарданд. Хушбахтона, баъзеи онҳоро барқарор сохтан мумкин аст:"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid ""
+"This project was not saved properly the last time Tenacity ran.\n"
+"\n"
+"It has been recovered to the last snapshot, but you must save it\n"
+"to preserve its contents."
 msgstr ""
 "Қаблан баъзе лоиҳаҳо таҳрир ва нигоҳ дошта нашуда буданд \n"
 "бо Audacity кор мекарданд. Хушбахтона, баъзеи онҳоро барқарор сохтан мумкин аст:"
@@ -1862,9 +3961,42 @@ msgstr ""
 msgid "Project Recovered"
 msgstr "Лоиҳа барқарор шуд"
 
+#: src/ProjectFileManager.cpp src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Projects cannot be saved to FAT drives."
+msgstr "Рӯйхатҳои файлҳои муваққатӣ"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Your project is now empty.\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Click 'No', Edit > Undo until all tracks\n"
+"are open, then File > Save Project.\n"
+"\n"
+"Save anyway?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Warning - Empty Project"
+msgstr "&Сабти Лоиҳа"
+
 #: src/ProjectFileManager.cpp
 msgid "Insufficient Disk Space"
 msgstr "Фазои диск"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"The project size exceeds the available free space on the target disk.\n"
+"\n"
+"Please select a different disk with more free space."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "The project exceeds the maximum size of 4GB when writing to a FAT32 formatted filesystem."
+msgstr ""
 
 #: src/ProjectFileManager.cpp src/commands/ScreenshotCommand.cpp
 #, c-format
@@ -1872,9 +4004,34 @@ msgid "Saved %s"
 msgstr "Сабт шуд %s"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the file name provided would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Project \"%s\" As..."
 msgstr "Сабти Лоиҳа &Ҳамчун..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"'Save Project' is for an Tenacity project, not an audio file.\n"
+"For an audio file that will open in other apps, use 'Export'.\n"
+msgstr ""
+
+#. i18n-hint: In each case, %s is the name
+#. of the file being overwritten.
+#: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"   Do you want to overwrite the project:\n"
+"\"%s\"?\n"
+"\n"
+"   If you select \"Yes\" the project\n"
+"\"%s\"\n"
+"   will be irreversibly overwritten."
+msgstr ""
 
 #. i18n-hint: Heading: A warning that a project is about to be overwritten.
 #: src/ProjectFileManager.cpp
@@ -1882,9 +4039,21 @@ msgid "Overwrite Project Warning"
 msgstr "Бознависии файлҳои мавҷуда"
 
 #: src/ProjectFileManager.cpp
+msgid ""
+"The project was not saved because the selected project is open in another window.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 #, c-format
 msgid "%sSave Copy of Project \"%s\" As..."
 msgstr "Сабти Лоиҳа &Ҳамчун..."
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Saving a copy must not overwrite an existing saved project.\n"
+"Please try again and select an original name."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Error Saving Copy of Project"
@@ -1907,6 +4076,23 @@ msgstr "Интихоби як ё якчанд файлҳои аудиои..."
 msgid "%s is already open in another window."
 msgstr "%s аллакай дар равзанаи дигар кушода шудааст."
 
+#: src/ProjectFileManager.cpp src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Error Opening Project"
+msgstr "Хатои кушодашавии файл"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"You are trying to open an automatically created backup file.\n"
+"Doing this may result in severe data loss.\n"
+"\n"
+"Please open the actual Tenacity project file instead."
+msgstr ""
+
+#: src/ProjectFileManager.cpp
+msgid "Warning - Backup File Detected"
+msgstr ""
+
 #: src/ProjectFileManager.cpp
 msgid "Error Opening File"
 msgstr "Хатои кушодашавии файл"
@@ -1923,6 +4109,17 @@ msgid ""
 msgstr ""
 "Файл нодуруст ё вайрон аст: \n"
 "%s"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error Opening File or Project"
+msgstr "Хатои кушодашавии файл"
+
+#: src/ProjectFileManager.cpp
+msgid ""
+"Project resides on FAT formatted drive.\n"
+"Copy it to another drive to open it."
+msgstr ""
 
 #: src/ProjectFileManager.cpp
 msgid "Project was recovered"
@@ -1950,12 +4147,33 @@ msgid "Error Importing"
 msgstr "Воридшавии хато"
 
 #: src/ProjectFileManager.cpp
+msgid "Cannot import AUP3 format.  Use File > Open instead"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compact Project"
 msgstr "&Сабти Лоиҳа"
 
 #: src/ProjectFileManager.cpp
+#, c-format
+msgid ""
+"Compacting this project will free up disk space by removing unused bytes within the file.\n"
+"\n"
+"There is %s of free disk space and this project is currently using %s.\n"
+"\n"
+"If you proceed, the current Undo/Redo History and clipboard contents will be discarded and you will recover approximately %s of disk space.\n"
+"\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/ProjectFileManager.cpp
 msgid "Compacted project file"
 msgstr "Лоиҳаи файлро кушода наметавонад"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Compact"
+msgstr "&Фармон"
 
 #: src/ProjectHistory.cpp
 msgid "Created new project"
@@ -1966,8 +4184,8 @@ msgid "Automatic database backup failed."
 msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Хуш омадед ба тариқаи %s Audacity"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -1981,9 +4199,23 @@ msgid "Save project before closing?"
 msgstr "Тағиротҳо пеш аз пӯшидан сабт шаванд?"
 
 #: src/ProjectManager.cpp
+msgid ""
+"\n"
+"If saved, the project will have no tracks.\n"
+"\n"
+"To save any previously open tracks:\n"
+"Cancel, Edit > Undo until all tracks\n"
+"are open, then File > Save Project."
+msgstr ""
+
+#: src/ProjectManager.cpp
 #, c-format
 msgid "Disk space remaining for recording: %s"
 msgstr "Фазои диск барои сабт %d дақиқа дорад."
+
+#: src/ProjectManager.cpp
+msgid "Less than 1 minute"
+msgstr ""
 
 #: src/ProjectManager.cpp
 #, c-format
@@ -1998,6 +4230,18 @@ msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
+
+#. i18n-hint: A time in hours and minutes. Only translate the "and".
+#: src/ProjectManager.cpp
+#, c-format
+msgid "%s and %s."
+msgstr ""
+
+#: src/ProjectSerializer.cpp
+msgid ""
+"This recovery file was saved by Audacity 2.3.0 or before.\n"
+"You need to run that version of Audacity to recover the project."
+msgstr ""
 
 #. i18n-hint: This is an experimental feature where the main panel in
 #. Audacity is put on a notebook tab, and this is the name on that tab.
@@ -2014,6 +4258,26 @@ msgstr "Стереои уфуқӣ"
 msgid "Vertical Scrollbar"
 msgstr "Стереои амудӣ"
 
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in group at %s was merged with a previously defined group"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in item at %s conflicts with a previously defined item and was discarded"
+msgstr ""
+
+#: src/Registry.cpp
+#, c-format
+msgid "Plug-in items at %s specify conflicting placements"
+msgstr ""
+
+#: src/Resample.cpp
+#, fuzzy
+msgid "Low Quality (Fastest)"
+msgstr "Сифат:"
+
 #: src/Resample.cpp
 msgid "Medium Quality"
 msgstr "Сифат"
@@ -2021,6 +4285,10 @@ msgstr "Сифат"
 #: src/Resample.cpp
 msgid "High Quality"
 msgstr "Сифат"
+
+#: src/Resample.cpp
+msgid "Best Quality (Slowest)"
+msgstr ""
 
 #. i18n-hint: Audio data bit depth (precision): 16-bit integers
 #: src/SampleFormat.cpp
@@ -2037,9 +4305,86 @@ msgstr "24-бит ПСМ"
 msgid "32-bit float"
 msgstr "32-бит float"
 
+#: src/SampleFormat.cpp
+msgid "Unknown format"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Screen Capture Frame"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose location to save files"
+msgstr "Барои вурудсозии файлҳо мавқеи онҳро интихоб кунед"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Save images to:"
+msgstr "Тағиротҳо сабт шаванд?"
+
 #: src/Screenshot.cpp src/export/ExportMultiple.cpp
 msgid "Choose..."
 msgstr "Интихоби..."
+
+#: src/Screenshot.cpp
+msgid "Capture entire window or screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Small"
+msgstr "Андоза"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Resize Large"
+msgstr "Андоза"
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'Blue'
+#: src/Screenshot.cpp
+msgid "Blue Bkgnd"
+msgstr ""
+
+#. i18n-hint: Bkgnd is short for background and appears on a small button
+#. * It is OK to just translate this item as if it said 'White'
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "White Bkgnd"
+msgstr "Сафед"
+
+#: src/Screenshot.cpp
+msgid "Capture Window Only"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Full Window"
+msgstr " равзана"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture Window Plus"
+msgstr "Намуди равзана:"
+
+#: src/Screenshot.cpp
+msgid "Capture Full Screen"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Wait 5 seconds and capture frontmost window/dialog"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Capture part of a project window"
+msgstr "Истифодаи ин &Лоиҳа"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "All Toolbars"
+msgstr "Афзор"
 
 #: src/Screenshot.cpp
 msgid "All Effects"
@@ -2053,7 +4398,13 @@ msgstr "Ҳамаи файлҳо (*)|*"
 msgid "All Preferences"
 msgstr "Қисматҳо..."
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "SelectionBar"
+msgstr "Интихобкунӣ"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Интихобкунӣ"
 
@@ -2061,47 +4412,153 @@ msgstr "Интихобкунӣ"
 msgid "Timer"
 msgstr "Вақти охир"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Абзорҳо"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "Transport"
+msgstr "Луғат"
+
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Омезишкунанда"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "масрафсанҷ"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Иҷрои масрафсанҷ"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Масрафсанҷи сабт"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Edit"
+msgstr "&Таҳрир"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Афзор"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Иҷро дар суръат"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub"
+msgstr "Лавҳаи таҳрирӣ"
 
 #: src/Screenshot.cpp src/TrackPanel.cpp
 msgid "Track Panel"
 msgstr "Лавҳаи Роҳча"
 
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+msgid "Ruler"
+msgstr ""
+
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Роҳчаҳо"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "First Track"
+msgstr "&Роҳчаҳо"
+
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Second Track"
+msgstr "Роҳчаи Нав"
+
+#: src/Screenshot.cpp src/prefs/SpectrumPrefs.cpp
+msgid "Scale"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "One Sec"
+msgstr "Хониши Якум Дуюм"
+
+#: src/Screenshot.cpp
+msgid "Ten Sec"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "Five Min"
+msgstr ""
+
+#: src/Screenshot.cpp
+msgid "One Hour"
+msgstr ""
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Short Tracks"
+msgstr "&Роҳчаҳо"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Medium Tracks"
+msgstr "&Роҳчаҳо"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Tall Tracks"
+msgstr "Роҳчаҳо"
+
+#: src/Screenshot.cpp
+#, fuzzy
+msgid "Choose a location to save screenshot images"
+msgstr "Барои вурудсозии файлҳо мавқеи онҳро интихоб кунед"
+
+#: src/Screenshot.cpp
+msgid "Capture failed!"
+msgstr ""
+
+#: src/Screenshot.cpp src/commands/CommandTargets.cpp
+#, fuzzy
+msgid "Long Message"
+msgstr "Фаъол шуд"
+
+#: src/Sequence.cpp
+#, c-format
+msgid ""
+"Sequence has block file exceeding maximum %s samples per block.\n"
+"Truncating to this maximum length."
+msgstr ""
+
+#: src/Sequence.cpp
+msgid "Warning - Truncating Overlong Block File"
+msgstr ""
 
 #: src/ShuttleGui.cpp src/effects/EffectUI.cpp
 msgid "&Preview"
@@ -2119,9 +4576,55 @@ msgstr "&Қисматҳо..."
 msgid "Debu&g"
 msgstr "&Ислоҳи хато"
 
+#: src/Snap.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "Off"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Nearest"
+msgstr ""
+
+#: src/Snap.cpp
+msgid "Prior"
+msgstr ""
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Sound Activated Record"
+msgstr "Сабти Замонсанҷи Audacity"
+
+#: src/SoundActivatedRecord.cpp
+#, fuzzy
+msgid "Activation level (dB):"
+msgstr "Тақвиятдиҳӣ (dB):"
+
+#: src/SplashDialog.cpp
+#, fuzzy
+msgid "Welcome to Tenacity!"
+msgstr "Хуш омадед ба тариқаи %s Audacity"
+
+#: src/SplashDialog.cpp
+#, fuzzy
+msgid "Don't show this again at start up"
+msgstr "Ин огоҳиро дигар нишон надиҳед"
+
 #: src/SqliteSampleBlock.cpp
 msgid "Connection to project file is null"
 msgstr "Лоиҳаи файлро кушода наметавонад"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Artist Name"
+msgstr "Ҷудокунӣ Аз рӯи Ном"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Track Title"
+msgstr "НамудиРоҳча"
+
+#: src/Tags.cpp
+msgid "Album Title"
+msgstr ""
 
 #: src/Tags.cpp
 msgid "Track Number"
@@ -2140,12 +4643,40 @@ msgid "Comments"
 msgstr "Шарҳ"
 
 #: src/Tags.cpp
+msgid "Use arrow keys (or ENTER key after editing) to navigate fields."
+msgstr ""
+
+#: src/Tags.cpp
+msgid "Tag"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Value"
+msgstr "Сатҳ:"
+
+#: src/Tags.cpp
 msgid "&Add"
 msgstr "&Илова кардан"
 
 #: src/Tags.cpp
 msgid "&Remove"
 msgstr "&Дигар кардан"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Genres"
+msgstr "Услуб"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "E&dit..."
+msgstr "&Таҳрир"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Rese&t..."
+msgstr "Бознасбшуда"
 
 #: src/Tags.cpp
 msgid "Template"
@@ -2156,26 +4687,100 @@ msgid "&Load..."
 msgstr "&Боргирии..."
 
 #: src/Tags.cpp
+#, fuzzy
+msgid "Set De&fault"
+msgstr "Но&баён"
+
+#: src/Tags.cpp
 msgid "Don't show this when exporting audio"
 msgstr "Ин огоҳиро дигар нишон надиҳед"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Edit Genres"
+msgstr "&Таҳрири параметрҳо"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to save genre file."
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/Tags.cpp
+msgid "Reset Genres"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Are you sure you want to reset the genre list to defaults?"
+msgstr "Шумо файлро бо аломати \" сабт кардан мехоҳед\n"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Unable to open genre file."
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/Tags.cpp
+msgid "Load Metadata As:"
+msgstr ""
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Loading Metadata"
+msgstr "Хатои кушодашавии файл"
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Save Metadata As:"
+msgstr "Сабти Лоиҳа &Ҳамчун..."
+
+#: src/Tags.cpp
+#, fuzzy
+msgid "Error Saving Tags File"
+msgstr "Хатои кушодашавии файл"
 
 #: src/TempDirectory.cpp
 msgid "Unsuitable"
 msgstr "Фаъол шуд"
 
-#: src/Theme.cpp
+#: src/TempDirectory.cpp
+#, fuzzy
+msgid ""
+"The temporary files directory is on a FAT formatted drive.\n"
+"Resetting to default location."
+msgstr "Рӯйхатҳои файлҳои муваққатӣ"
+
+#: src/TempDirectory.cpp
 #, c-format
 msgid ""
-"Audacity could not write file:\n"
+"%s\n"
+"\n"
+"For tips on suitable drives, click the help button."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity натавонист файлро сабт кунад:\n"
 "  %s."
 
+#. i18n-hint: A theme is a consistent visual style across an application's
+#. graphical user interface, including choices of colors, and similarity of images
+#. such as those on button controls.  Audacity can load and save alternative
+#. themes.
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Theme written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -2184,18 +4789,26 @@ msgstr ""
 "барои сабт."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity натавонист тасвирро дар файл сабт кунад:\n"
 "  %s."
 
+#. i18n-hint "Cee" means the C computer programming language
 #: src/Theme.cpp
 #, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Theme as Cee code written to:\n"
+"  %s."
+msgstr ""
+
+#: src/Theme.cpp
+#, fuzzy, c-format
+msgid ""
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -2205,9 +4818,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -2216,8 +4829,9 @@ msgstr ""
 "Шояд тариқаи пнг нодуруст аст?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity мавзуъро аз рӯи хомушӣ хонда натавонист.\n"
@@ -2255,18 +4869,40 @@ msgstr ""
 "аллакай мавҷуданд."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity файлро захира карда натавонист:\n"
 "  %s"
 
+#. i18n-hint: describing the "classic" or traditional
+#. appearance of older versions of Audacity
+#: src/Theme.cpp
+msgid "Classic"
+msgstr ""
+
 #. i18n-hint: Light meaning opposite of dark
 #: src/Theme.cpp
 msgid "Light"
 msgstr "Равшан"
+
+#: src/Theme.cpp
+msgid "Dark"
+msgstr ""
+
+#. i18n-hint: greater difference between foreground and
+#. background colors
+#: src/Theme.cpp
+msgid "High Contrast"
+msgstr ""
+
+#. i18n-hint: user defined
+#: src/Theme.cpp
+#, fuzzy
+msgid "Custom"
+msgstr "Номи Роҳча"
 
 #. i18n-hint: This string is used to configure the controls which shows the recording
 #. * duration. As such it is important that only the alphabetic parts of the string
@@ -2275,16 +4911,85 @@ msgstr "Равшан"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Давомнокӣ"
 
+#. i18n-hint: This is for screen reader software and indicates that
+#. this is a Time track.
+#: src/TimeTrack.cpp src/TrackPanelAx.cpp
+#, fuzzy
+msgid "Time Track"
+msgstr "&Роҳчаи Вақт"
+
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Сабти Замонсанҷи Audacity"
 
 #: src/TimerRecordDialog.cpp
 msgid "Save Timer Recording As"
+msgstr "Сабтшавӣ"
+
+#: src/TimerRecordDialog.cpp
+msgid ""
+"The selected file name could not be used\n"
+"for Timer Recording because it would overwrite another project.\n"
+"Please try again and select an original name."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error Saving Timer Recording Project"
+msgstr "Натиҷаи корбурдашуда: %s"
+
+#: src/TimerRecordDialog.cpp
+msgid "Duration is zero. Nothing will be recorded."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Duration"
+msgstr "Давомнокии оҳанг:"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Save path is invalid."
+msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Save"
+msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Automatic Export path is invalid."
+msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Error in Automatic Export"
+msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"You may not have enough free disk space to complete this Timer Recording, based on your current settings.\n"
+"\n"
+"Do you wish to continue?\n"
+"\n"
+"Planned recording duration:   %s\n"
+"Recording time remaining on disk:   %s"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Timer Recording Disk Space Warning"
 msgstr "Сабтшавӣ"
 
 #: src/TimerRecordDialog.cpp
@@ -2294,6 +4999,12 @@ msgstr "Истифодаи ин &Лоиҳа"
 #: src/TimerRecordDialog.cpp
 msgid "Recording start:"
 msgstr "Масрафсанҷи сабт"
+
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Duration:"
+msgstr "Давомнокӣ"
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording end:"
@@ -2309,6 +5020,11 @@ msgstr "Ба таври автоматӣ барқарорсозӣ баъди с�
 
 #: src/TimerRecordDialog.cpp
 msgid "Action after Timer Recording:"
+msgstr "Сабти Замонсанҷи Audacity"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Сабти Замонсанҷи Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -2328,12 +5044,44 @@ msgid ""
 msgstr "Масрафсанҷи сабт"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error saving recording."
+msgstr "Сабтшавӣ"
+
+#: src/TimerRecordDialog.cpp
 #, c-format
 msgid ""
 "%s\n"
 "\n"
 "Recording exported: %s"
 msgstr "Масрафсанҷи сабт"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"\n"
+"Error exporting recording."
+msgstr "Сабтшавӣ"
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled due to the error(s) noted above."
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"'%s' has been canceled as the recording was stopped."
+msgstr ""
 
 #: src/TimerRecordDialog.cpp src/menus/TransportMenus.cpp
 msgid "Timer Recording"
@@ -2354,16 +5102,32 @@ msgstr "0100 рӯз 024 с 060 д 060 с"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Оғози Сана ва Вақт "
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Start Date"
+msgstr "&Вақти оғоз"
 
 #: src/TimerRecordDialog.cpp
 msgid "End Date and Time"
 msgstr "Анҷоми Сана ва Вақт"
 
 #: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "End Date"
+msgstr "Анҷоми Сана ва Вақт"
+
+#: src/TimerRecordDialog.cpp
 msgid "Automatic Save"
+msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Enable &Automatic Save?"
 msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
 
 #: src/TimerRecordDialog.cpp
@@ -2386,7 +5150,8 @@ msgstr "Содирот номумкин аст"
 msgid "Export Project As:"
 msgstr "Воридоти НишонаҳоҲамчун:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Қисматҳо..."
 
@@ -2395,8 +5160,25 @@ msgid "After Recording completes:"
 msgstr "Масрафсанҷи сабт"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+msgid "Do nothing"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Баромад аз Audacity"
+
+#: src/TimerRecordDialog.cpp
+msgid "Restart system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Shutdown system"
+msgstr ""
+
+#: src/TimerRecordDialog.cpp
+msgid "Waiting to start recording at:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording duration:"
@@ -2406,11 +5188,24 @@ msgstr "Давомнокии оҳанг:"
 msgid "Scheduled to stop at:"
 msgstr "Интихоб ба Ибтидо"
 
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
+msgstr "Сабти Замонсанҷи Audacity"
+
 #. i18n-hint: "in" means after a duration of time,
 #. which is shown below this string
 #: src/TimerRecordDialog.cpp
 msgid "Recording will commence in:"
 msgstr "Масрафсанҷи сабт"
+
+#. i18n-hint: %s is one of "Do nothing", "Exit Audacity", "Restart system",
+#. or "Shutdown system", and
+#. "in" means after a duration of time, shown below this string
+#: src/TimerRecordDialog.cpp
+#, c-format
+msgid "%s in:"
+msgstr ""
 
 #: src/TimerRecordDialog.cpp
 msgid "Recording Saved:"
@@ -2421,8 +5216,19 @@ msgid "Recording Exported:"
 msgstr "Масрафсанҷи сабт"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Сабти Замонсанҷи Audacity"
+
+#: src/TrackInfo.cpp
+#, fuzzy
+msgid "Stereo, 999999Hz"
+msgstr "Стерео, "
+
+#. i18n-hint Esc is a key on the keyboard
+#: src/TrackPanel.cpp
+msgid "(Esc to cancel)"
+msgstr ""
 
 #: src/TrackPanelAx.cpp
 msgid "TrackView"
@@ -2452,6 +5258,15 @@ msgstr "Соло"
 #: src/TrackPanelAx.cpp
 msgid " Selected"
 msgstr "Ҷудокунӣ"
+
+#. i18n-hint: This is for screen reader software and indicates that
+#. this track is shown with a sync-locked icon.
+#. The absence of a dash between Sync and Locked is deliberate -
+#. if present, Jaws reads it as "dash".
+#: src/TrackPanelAx.cpp
+#, fuzzy
+msgid " Sync Locked"
+msgstr "Интихоби-овоз"
 
 #: src/TrackPanelAx.cpp
 msgid " Mute On"
@@ -2530,6 +5345,10 @@ msgstr "Ҷойгузории Роҳча ба Боло"
 msgid "Move Track Down"
 msgstr "Ҷойгузории Роҳча ба Поён"
 
+#: src/UndoManager.cpp
+msgid "Discarding undo/redo history"
+msgstr ""
+
 #. i18n-hint: Voice key is an experimental/incomplete feature that
 #. is used to navigate in vocal recordings, to move forwards and
 #. backwards by words.  So 'key' is being used in the sense of an index.
@@ -2575,21 +5394,80 @@ msgstr "Барои гузоштани интихоб пораи ҳофиза к�
 msgid "There is not enough room available to expand the cut line"
 msgstr "Барои густурдани хати буриш пораи ҳофиза кам аст"
 
+#: src/blockfile/NotYetAvailableException.cpp
+#, c-format
+msgid "This operation cannot be done until importation of %s completes."
+msgstr ""
+
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#, c-format
+msgid ""
+"%s: Could not load settings below. Default settings will be used.\n"
+"\n"
+"%s"
+msgstr ""
+
 #: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
 #, c-format
 msgid "Applying %s..."
 msgstr "Истифодабарӣ..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
+#: src/commands/AudacityCommand.h
+msgid "FAIL"
+msgstr ""
+
 #: src/commands/BatchEvalCommand.cpp
 msgid "Batch Command"
 msgstr "Интихоби фармон"
 
+#: src/commands/Command.cpp
+#, c-format
+msgid "%s is not a parameter accepted by %s"
+msgstr ""
+
+#: src/commands/Command.cpp
+#, c-format
+msgid "Invalid value for parameter '%s': should be %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Command"
+msgstr "&Фармон"
+
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Такрор %s"
+
+#: src/commands/CommandManager.cpp
+#, c-format
+msgid ""
+"\n"
+"* %s, because you have assigned the shortcut %s to %s"
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "The following commands have had their shortcuts removed, because their default shortcut is new or changed, and is the same shortcut that you have assigned to another command."
+msgstr ""
+
+#: src/commands/CommandManager.cpp
+msgid "Shortcuts have been removed"
+msgstr ""
 
 #: src/commands/CompareAudioCommand.cpp
 msgid "Compare Audio"
@@ -2599,6 +5477,15 @@ msgstr "Нусхабардории Нишонаҳо"
 msgid "Threshold:"
 msgstr "Остона:"
 
+#: src/commands/CompareAudioCommand.h
+#, fuzzy
+msgid "Compares a range on two tracks."
+msgstr "Созиши роҳчаи нави аудиоии нав"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr ""
+
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
 msgstr "Таваққуфи вақт (сонияҳо):"
@@ -2606,6 +5493,10 @@ msgstr "Таваққуфи вақт (сонияҳо):"
 #: src/commands/Demo.cpp
 msgid "Decay factor:"
 msgstr "Харобии омил:"
+
+#: src/commands/Demo.h
+msgid "Does the demo action."
+msgstr ""
 
 #: src/commands/DragCommand.cpp
 msgid "Drag"
@@ -2627,9 +5518,38 @@ msgstr "Роҳча"
 msgid "Track 1"
 msgstr "Роҳча"
 
+#. i18n-hint abbreviates "Identity" or "Identifier"
+#: src/commands/DragCommand.cpp
+msgid "Id:"
+msgstr ""
+
 #: src/commands/DragCommand.cpp
 msgid "Window Name:"
 msgstr "Намуди равзана:"
+
+#: src/commands/DragCommand.cpp
+msgid "From X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "From Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To X:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp
+msgid "To Y:"
+msgstr ""
+
+#: src/commands/DragCommand.cpp src/commands/SelectCommand.cpp
+msgid "Relative To:"
+msgstr ""
+
+#: src/commands/DragCommand.h
+msgid "Drags mouse from one place to another."
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Get Info"
@@ -2647,21 +5567,64 @@ msgstr "Ҳамаи файлҳо (*)|*"
 msgid "Preferences"
 msgstr "Қисматҳо..."
 
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Афзори Навбатӣ"
+
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Лифофа"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Нишонаҳо"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "Brief"
+msgstr ""
+
+#: src/commands/GetInfoCommand.cpp src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Type:"
+msgstr "масрафсанҷ"
+
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Қолаб:"
+
+#: src/commands/GetInfoCommand.h
+msgid "Gets information in JSON format."
+msgstr ""
 
 #: src/commands/GetTrackInfoCommand.cpp
 msgid "Get Track Info"
 msgstr "Ҷойгузории Роҳча ба Поён"
+
+#: src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Types:"
+msgstr "масрафсанҷ"
+
+#: src/commands/GetTrackInfoCommand.h
+msgid "Gets track values as JSON."
+msgstr ""
 
 #: src/commands/HelpCommand.cpp
 msgid "Comment"
@@ -2670,6 +5633,18 @@ msgstr "Шарҳ"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Фармон:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "Gives help on a command."
+msgstr ""
+
+#: src/commands/HelpCommand.h
+msgid "For comments in a macro."
+msgstr ""
 
 #: src/commands/ImportExportCommands.cpp
 msgid "Import2"
@@ -2688,6 +5663,11 @@ msgid "Number of Channels:"
 msgstr "Миқдори вақтҳои такроршаванда: "
 
 #: src/commands/ImportExportCommands.h
+#, fuzzy
+msgid "Imports from a file."
+msgstr "Вуруди бисёркарата"
+
+#: src/commands/ImportExportCommands.h
 msgid "Exports to a file."
 msgstr "Вуруди бисёркарата"
 
@@ -2695,9 +5675,31 @@ msgstr "Вуруди бисёркарата"
 msgid "Builtin Commands"
 msgstr "Интихоби фармон"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Гурӯҳи ташаббускори Audacity %s"
+
+#: src/commands/LoadCommands.cpp
+msgid "Provides builtin commands to Tenacity"
+msgstr ""
+
+#: src/commands/LoadCommands.cpp
+#, fuzzy
+msgid "Unknown built-in command name"
+msgstr "Анҷоми Сана ва Вақт"
+
+#: src/commands/MessageCommand.cpp src/commands/SetLabelCommand.cpp
+msgid "Text:"
+msgstr ""
+
+#: src/commands/MessageCommand.h
+#, fuzzy
+msgid "Echos a message."
+msgstr "Фаъол шуд"
 
 #: src/commands/OpenSaveCommands.cpp
 msgid "Open Project2"
@@ -2735,17 +5737,50 @@ msgstr "&Сабти Лоиҳа"
 msgid "Saves a copy of current project."
 msgstr "&Сабти Лоиҳа"
 
+#: src/commands/OpenSaveCommands.h
+msgid "Saves the log contents."
+msgstr ""
+
+#: src/commands/OpenSaveCommands.h
+msgid "Clears the log contents."
+msgstr ""
+
 #: src/commands/PreferenceCommands.cpp
 msgid "Get Preference"
 msgstr "Қисматҳо..."
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Ном"
 
 #: src/commands/PreferenceCommands.cpp
 msgid "Set Preference"
 msgstr "Қисматҳо..."
+
+#: src/commands/PreferenceCommands.cpp src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Value:"
+msgstr "Сатҳ:"
+
+#: src/commands/PreferenceCommands.cpp
+msgid "Reload"
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Gets the value of a single preference."
+msgstr ""
+
+#: src/commands/PreferenceCommands.h
+msgid "Sets the value of a single preference."
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+#, fuzzy
+msgid "Screenshot"
+msgstr "&Чоп кардан..."
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Window"
@@ -2760,8 +5795,18 @@ msgid "Window Plus"
 msgstr "Намуди равзана:"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Fullscreen"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 msgid "Toolbars"
 msgstr "Афзор"
+
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
+#, fuzzy
+msgid "Effects"
+msgstr "Нати&ҷа"
 
 #: src/commands/ScreenshotCommand.cpp
 msgid "Scriptables"
@@ -2803,6 +5848,10 @@ msgstr "Роҳчаҳо"
 msgid "All Tracks Plus"
 msgstr "Лавҳаи Роҳча"
 
+#: src/commands/ScreenshotCommand.cpp
+msgid "Blue"
+msgstr ""
+
 #. i18n-hint:  This really means the color, not as in "white noise"
 #: src/commands/ScreenshotCommand.cpp
 msgctxt "color"
@@ -2810,9 +5859,30 @@ msgid "White"
 msgstr "Сафед"
 
 #: src/commands/ScreenshotCommand.cpp
+msgid "Path:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Capture What:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Background:"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
+msgid "Bring To Top"
+msgstr ""
+
+#: src/commands/ScreenshotCommand.cpp
 #, c-format
 msgid "Error trying to save file: %s"
 msgstr "Дар файл сабт намешавад: "
+
+#: src/commands/ScreenshotCommand.h
+#, fuzzy
+msgid "Takes screenshots."
+msgstr "&Чоп кардан..."
 
 #: src/commands/SelectCommand.cpp
 msgid "Select Time"
@@ -2855,6 +5925,14 @@ msgid "Select Frequencies"
 msgstr "Басомад (Ҳз)"
 
 #: src/commands/SelectCommand.cpp
+msgid "High:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
+msgid "Low:"
+msgstr ""
+
+#: src/commands/SelectCommand.cpp
 msgid "Select Tracks"
 msgstr "&Роҳчаҳо"
 
@@ -2866,6 +5944,12 @@ msgstr "Ҷудокунӣ"
 #: src/commands/SelectCommand.cpp
 msgid "Add"
 msgstr "&Илова кардан"
+
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Remove"
+msgstr "&Дигар кардан"
 
 #: src/commands/SelectCommand.cpp
 msgid "First Track:"
@@ -2884,6 +5968,11 @@ msgid "Selects a time range."
 msgstr "Интихоби MIDI файл..."
 
 #: src/commands/SelectCommand.h
+#, fuzzy
+msgid "Selects a frequency range."
+msgstr "Интихоби MIDI файл..."
+
+#: src/commands/SelectCommand.h
 msgid "Selects a range of tracks."
 msgstr "Созиши роҳчаи нави аудиоии нав"
 
@@ -2895,9 +5984,37 @@ msgstr "Давомнокии хомӯшӣ:"
 msgid "Set Clip"
 msgstr "Афзори Навбатӣ"
 
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 0"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 1"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 2"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color 3"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp
+msgid "At:"
+msgstr ""
+
+#: src/commands/SetClipCommand.cpp src/commands/SetTrackInfoCommand.cpp
+msgid "Color:"
+msgstr ""
+
 #: src/commands/SetClipCommand.cpp src/commands/SetLabelCommand.cpp
 msgid "Start:"
 msgstr "Ибтидо"
+
+#: src/commands/SetClipCommand.h
+msgid "Sets various values for a clip."
+msgstr ""
 
 #: src/commands/SetEnvelopeCommand.cpp
 msgid "Set Envelope"
@@ -2916,9 +6033,14 @@ msgid "Edited Envelope"
 msgstr "Лифофа"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Лифофа"
+
+#: src/commands/SetEnvelopeCommand.h
+msgid "Sets an envelope point position."
+msgstr ""
 
 #: src/commands/SetLabelCommand.cpp
 msgid "Set Label"
@@ -2928,6 +6050,10 @@ msgstr "Аз рӯи нишонаҳо ҷудо карда шавад"
 msgid "Label Index"
 msgstr "Таҳрири Нишона"
 
+#: src/commands/SetLabelCommand.cpp
+msgid "End:"
+msgstr ""
+
 #: src/commands/SetLabelCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Selected"
 msgstr "Ҷудокунӣ"
@@ -2935,6 +6061,10 @@ msgstr "Ҷудокунӣ"
 #: src/commands/SetLabelCommand.cpp
 msgid "Edited Label"
 msgstr "Нишонаҳои таҳриршуда"
+
+#: src/commands/SetLabelCommand.h
+msgid "Sets various values for a label."
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Set Project"
@@ -2948,9 +6078,26 @@ msgstr "Насби Босуръат"
 msgid "Resize:"
 msgstr "Андоза"
 
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Width:"
+msgstr ""
+
 #: src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp
 msgid "Height:"
 msgstr "Равшан"
+
+#: src/commands/SetProjectCommand.h
+#, fuzzy
+msgid "Sets various values for a project."
+msgstr "&Сабти Лоиҳа"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Track Index:"
@@ -2965,6 +6112,10 @@ msgid "Set Track Status"
 msgstr "Номи Роҳча"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Unnamed"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Focused"
 msgstr "Таваққуф"
 
@@ -2977,10 +6128,17 @@ msgid "Gain:"
 msgstr "Шиддат"
 
 #: src/commands/SetTrackInfoCommand.cpp
+msgid "Pan:"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track Visuals"
 msgstr "&Роҳчаҳо"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Хатӣ"
 
@@ -2989,8 +6147,21 @@ msgid "Reset"
 msgstr "Бознасбшуда"
 
 #: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Вақти охир"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "HalfWave"
+msgstr ""
+
+#: src/commands/SetTrackInfoCommand.cpp
 msgid "Display:"
 msgstr "Намуд"
+
+#: src/commands/SetTrackInfoCommand.cpp
+msgid "Scale:"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom:"
@@ -3012,16 +6183,36 @@ msgstr "Танзимоти натиҷаҳо"
 msgid "Spectral Select"
 msgstr "Интихобкунӣ"
 
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
+
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
 msgstr "Роҳчаи Нав"
+
+#: src/commands/SetTrackInfoCommand.h
+#, fuzzy
+msgid "Sets various values for a track."
+msgstr "Созиши роҳчаи нави аудиоии нав"
 
 #: src/effects/Amplify.cpp
 msgid "Amplify"
 msgstr "Тақвият додан"
 
 #: src/effects/Amplify.cpp
+msgid "Increases or decreases the volume of the audio you have selected"
+msgstr ""
+
+#: src/effects/Amplify.cpp
 msgid "&Amplification (dB):"
+msgstr "Тақвиятдиҳӣ (dB):"
+
+#: src/effects/Amplify.cpp
+#, fuzzy
+msgid "Amplification dB"
 msgstr "Тақвиятдиҳӣ (dB):"
 
 #: src/effects/Amplify.cpp
@@ -3035,6 +6226,10 @@ msgstr "Иҷозати буриш"
 #: src/effects/AutoDuck.cpp
 msgid "Auto Duck"
 msgstr "Даки худкор"
+
+#: src/effects/AutoDuck.cpp
+msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
+msgstr ""
 
 #. i18n-hint: Auto duck is the name of an effect that 'ducks' (reduces the volume)
 #. * of the audio automatically when there is sound on another track.  Not as
@@ -3050,12 +6245,18 @@ msgstr "Шумо роҳчаеро интихоб кардед, ки аудио �
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Ба Auto Duck роҳчаи назоратие, ки аз поёни роҳча(ҳо)и интихобшуда ҷойгузор мешавад, лозим аст."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Миқдори Duck:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "сонияҳо"
 
@@ -3079,7 +6280,8 @@ msgstr "Норасоиҳои дохилии дарозии поёнӣ:"
 msgid "Inner &fade up length:"
 msgstr "Норасоиҳои дохилии дарозии боло:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "Остона:"
 
@@ -3088,8 +6290,17 @@ msgid "Preview not available"
 msgstr "Пештасвир дастрас нест"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass and Treble"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
 msgid "Simple tone control effect"
 msgstr "Интихоби Санади Чап"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Tone controls"
+msgstr "Остона:"
 
 #: src/effects/BassTreble.cpp
 msgid "Bass (dB):"
@@ -3100,12 +6311,30 @@ msgid "Ba&ss (dB):"
 msgstr "Баландкунӣ (dB):"
 
 #: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "Сатҳ:"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Treble"
+msgstr "Таҳрири Нишона"
+
+#: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
 msgstr "Сатҳ:"
 
 #: src/effects/BassTreble.cpp
 msgid "Level"
 msgstr "Сатҳ:"
+
+#: src/effects/BassTreble.cpp
+msgid "&Link Volume control to Tone controls"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "Change Pitch"
@@ -3116,13 +6345,35 @@ msgid "Changes the pitch of a track without changing its tempo"
 msgstr "Ивази сабти овоз бе ивази зарба"
 
 #: src/effects/ChangePitch.cpp
+#, fuzzy
+msgid "High Quality Pitch Change"
+msgstr "Сифат"
+
+#: src/effects/ChangePitch.cpp
 msgid "Change Pitch without Changing Tempo"
 msgstr "Ивази сабти овоз бе ивази зарба"
+
+#: src/effects/ChangePitch.cpp
+#, c-format
+msgid "Estimated Start Pitch: %s%d (%.3f Hz)"
+msgstr ""
 
 #. i18n-hint: (noun) Musical pitch.
 #: src/effects/ChangePitch.cpp
 msgid "Pitch"
 msgstr "Баландии садо (EAC)"
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing musical pitch "from" one value "to" another
+#: src/effects/ChangePitch.cpp
+msgctxt "change pitch"
+msgid "&from"
+msgstr ""
 
 #: src/effects/ChangePitch.cpp
 msgid "from Octave"
@@ -3156,13 +6407,40 @@ msgstr "Нимоҳангҳо (ним-қадамҳо):"
 msgid "Frequency"
 msgstr "Басомад (Ҳз)"
 
+#: src/effects/ChangePitch.cpp
+msgid "from (Hz)"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "f&rom"
+msgstr ""
+
+#: src/effects/ChangePitch.cpp
+msgid "to (Hz)"
+msgstr ""
+
 #: src/effects/ChangePitch.cpp src/effects/Loudness.cpp
 msgid "t&o"
 msgstr "ба"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Ивази Фоиз:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "Percent Change"
+msgstr "Ивази Фоиз:"
+
+#: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
+msgid "&Use high quality stretching (slow)"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "45"
@@ -3174,7 +6452,9 @@ msgstr "7"
 
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "д/н"
 
@@ -3193,6 +6473,32 @@ msgstr "Ивазшавии суръат ба зарба ва баландкун�
 #: src/effects/ChangeSpeed.cpp
 msgid "&Speed Multiplier:"
 msgstr "Вуруди бисёркарата"
+
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "From rpm"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
+#: src/effects/ChangeSpeed.cpp
+msgid "To rpm"
+msgstr ""
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #: src/effects/ChangeSpeed.cpp
@@ -3214,6 +6520,12 @@ msgstr ""
 msgid "Current length of selection."
 msgstr "Ҷудошудаҳои файл барои интихоб"
 
+#. i18n-hint: changing speed of audio "from" one value "to" another
+#: src/effects/ChangeSpeed.cpp
+msgctxt "change speed"
+msgid "from"
+msgstr ""
+
 #: src/effects/ChangeSpeed.cpp
 msgid "&New Length:"
 msgstr "Дарозӣ"
@@ -3233,8 +6545,33 @@ msgid "Changes the tempo of a selection without changing its pitch"
 msgstr "Ивазшавии зарба бе ивази баландкунӣ"
 
 #: src/effects/ChangeTempo.cpp
+#, fuzzy
+msgid "High Quality Tempo Change"
+msgstr "Сифат"
+
+#: src/effects/ChangeTempo.cpp
 msgid "Change Tempo without Changing Pitch"
 msgstr "Ивазшавии зарба бе ивази баландкунӣ"
+
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
+msgid "&from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgid "Beats per minute, to"
+msgstr ""
 
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
@@ -3249,6 +6586,12 @@ msgstr "Давомнокӣ (сония)"
 #. i18n-hint: changing tempo "from" one value "to" another
 #: src/effects/ChangeTempo.cpp
 msgctxt "change tempo"
+msgid "from"
+msgstr ""
+
+#. i18n-hint: changing tempo "from" one value "to" another
+#: src/effects/ChangeTempo.cpp
+msgctxt "change tempo"
 msgid "t&o"
 msgstr "ба"
 
@@ -3258,15 +6601,106 @@ msgid "Length in seconds from %s, to"
 msgstr "Давомнокӣ (сония)"
 
 #: src/effects/ClickRemoval.cpp
+#, fuzzy
+msgid "Click Removal"
+msgstr "Пахш бо ҷудошавии..."
+
+#: src/effects/ClickRemoval.cpp
+msgid "Click Removal is designed to remove clicks on audio tracks"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, fuzzy, c-format
+msgid "Selection must be larger than %d samples."
+msgstr "Ном набояд ҷои холӣ дошта бошад"
+
+#: src/effects/ClickRemoval.cpp
 msgid "&Threshold (lower is more sensitive):"
 msgstr "Остона барои хаш: "
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "Остона:"
 
 #: src/effects/ClickRemoval.cpp
 msgid "Max &Spike Width (higher is more sensitive):"
 msgstr "Остона барои хаш: "
 
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Фишордиҳандаи..."
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
+#: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
+#, fuzzy, c-format
+msgid "%.2f secs"
+msgstr "Ҳамлаи вақт: %.1f сон-ҳо"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f secs"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.0f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Ratio %.1f to 1"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Noise Floor:"
+msgstr "Навъи хаш:"
+
+#: src/effects/Compressor.cpp src/effects/Distortion.cpp
+#, fuzzy
+msgid "Noise Floor"
+msgstr "Навъи хаш:"
+
 #: src/effects/Compressor.cpp
 msgid "&Ratio:"
+msgstr "Давомнокӣ"
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Ratio"
 msgstr "Давомнокӣ"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
@@ -3277,16 +6711,48 @@ msgid "&Attack Time:"
 msgstr "Ҳамлаи вақт"
 
 #. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Ҳамлаи вақт"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
 #. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
 #. * sound dies away.
 #: src/effects/Compressor.cpp
 msgid "R&elease Time:"
 msgstr "Ҳамлаи вақт: %.1f сон-ҳо"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "Ҳамлаи вақт: %.1f сон-ҳо"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+msgid "C&ompress based on Peaks"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
 msgstr "Остона: %d dB"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Noise Floor %d dB"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -3299,33 +6765,301 @@ msgid "Release Time %.1f secs"
 msgstr "Ҳамлаи вақт: %.1f сон-ҳо"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "You can only measure one track at a time."
+msgstr "Созиши роҳчаи нави аудиоии нав"
+
+#: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Созиши роҳчаи нави аудиоии нав"
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Созиши роҳчаи нави аудиоии нав"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Интиҳо"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Volume    "
+msgstr "Сатҳ:"
+
+#: src/effects/Contrast.cpp
+msgid "&Foreground:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "&Measure selection"
 msgstr "Интихоб аз рӯи хомӯшӣ"
 
 #: src/effects/Contrast.cpp
+msgid "&Background:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "Анҷоми Сана ва Вақт"
+
+#: src/effects/Contrast.cpp
 msgid "Mea&sure selection"
 msgstr "Интихоб аз рӯи хомӯшӣ"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "R&eset"
 msgstr "Бознасбшуда"
 
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "Қисматҳо..."
+
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "&Мадад"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "zero"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Муайяншавӣ номумкин аст"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr ""
+"каталогро эҷод карда натавонист:\n"
+"  %s"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Воридоти НишонаҳоҲамчун:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "Filename = %s."
+msgstr "Ивази Номи '%s' ба '%s'"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "Такрор"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "&Аз рӯи хомӯшӣ"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Ҳарфҳо..."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Clipping"
+msgstr "Иҷозати буриш"
+
 #: src/effects/Distortion.cpp
 msgid "Soft Clipping"
 msgstr "Иҷозати буриш"
+
+#: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Expand and Compress"
@@ -3334,6 +7068,98 @@ msgstr "Фишордиҳандаи соҳаи пӯё"
 #: src/effects/Distortion.cpp
 msgid "Leveller"
 msgstr "Баробаркунанда"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Rectifier Distortion"
+msgstr "Давомнокӣ"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Limiter 1413"
+msgstr "Иҷозати буриш"
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Light, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Moderate, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavy, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heavier, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Leveller, Heaviest, -70dB noise floor"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Half-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Full-wave Rectifier (DC blocked)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Upper Threshold"
@@ -3356,8 +7182,16 @@ msgid "Distortion"
 msgstr "Давомнокӣ"
 
 #: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Distortion type:"
 msgstr "Зудии Синхронӣ бо Иловашавӣ"
+
+#: src/effects/Distortion.cpp
+msgid "DC blocking filter"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Threshold controls"
@@ -3372,8 +7206,26 @@ msgid "Clipping level"
 msgstr "Ба кор бурдани дараҷакунанда..."
 
 #: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Make-up Gain"
+msgstr "Истифодаи занҷир"
+
+#: src/effects/Distortion.cpp
 msgid "Clipping threshold"
 msgstr "Остона:"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion amount"
+msgstr "Давомнокӣ"
 
 #: src/effects/Distortion.cpp
 msgid "Output level"
@@ -3384,12 +7236,69 @@ msgid "Repeat processing"
 msgstr "Пардозиши Auto Duck..."
 
 #: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Degree of Levelling"
 msgstr "Дараҷаи баробаркунӣ"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "dB Limit"
+msgstr "Иҷозати буриш"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Суръати иҷро"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Residual level"
+msgstr "Суръати иҷро"
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr ""
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "Оҳангҳои &DTMF..."
+
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "DTMF &sequence:"
@@ -3399,7 +7308,9 @@ msgstr "басомади DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "Доманаи (0-1)"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "Давомнокӣ"
 
@@ -3412,12 +7323,29 @@ msgid "Duty cycle:"
 msgstr "Даври вазифавӣ:"
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Давомнокии оҳанг:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Давомнокии хомӯшӣ:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -3426,6 +7354,11 @@ msgstr "Инъикоси садо"
 #: src/effects/Echo.cpp
 msgid "Repeats the selected audio again and again"
 msgstr "Вуруди аудиоҳои ҷудошуда ба монанди Ог Ворбис"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
@@ -3436,6 +7369,10 @@ msgid "D&ecay factor:"
 msgstr "Харобии омил:"
 
 #: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
+
+#: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "Бознасбшуда"
 
@@ -3443,7 +7380,8 @@ msgstr "Бознасбшуда"
 msgid "Export Effect Parameters"
 msgstr "&Таҳрири параметрҳо"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Файлро \"%s\"-ро кушода натавонист"
@@ -3466,6 +7404,12 @@ msgstr "&Таҳрири параметрҳо"
 #, c-format
 msgid "%s: is not a valid presets file.\n"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст\n"
+
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
@@ -3505,6 +7449,11 @@ msgstr "Бознасбшуда"
 msgid "User Presets"
 msgstr "Танзимоти натиҷаҳо"
 
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Factory Presets"
+msgstr "&Аз рӯи хомӯшӣ"
+
 #: src/effects/EffectManager.cpp
 msgid "Current Settings"
 msgstr "Танзимоти натиҷаҳо"
@@ -3512,6 +7461,35 @@ msgstr "Танзимоти натиҷаҳо"
 #: src/effects/EffectManager.cpp
 msgid "Factory Defaults"
 msgstr "&Аз рӯи хомӯшӣ"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "Интихоб ба Интиҳо"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+msgid "Command failed to initialize"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Effects Rack"
@@ -3524,6 +7502,27 @@ msgstr "Истифодаи %s"
 #: src/effects/EffectUI.cpp
 msgid "Latency: 0"
 msgstr "Таваққуф"
+
+#: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Ҷобаҷогузошта"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Show/Hide Editor"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Move Up"
@@ -3542,6 +7541,24 @@ msgid "Move effect down in the rack"
 msgstr "Ҷойгузории муҳит барои роҳчаи дигар"
 
 #: src/effects/EffectUI.cpp
+msgid "Favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Remove effect from the rack"
+msgstr "Ҷойгузории муҳит барои роҳчаи дигар"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Name of the effect"
+msgstr "Номи нави занҷираро ворид кунед"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Latency: %4d"
 msgstr "Таваққуф"
@@ -3549,6 +7566,20 @@ msgstr "Таваққуф"
 #: src/effects/EffectUI.cpp
 msgid "Some Command"
 msgstr "Интихоби фармон"
+
+#: src/effects/EffectUI.cpp
+msgid "Manage presets and options"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "&Manage"
+msgstr "Идораи таърих"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Бозигар"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -3565,6 +7596,16 @@ msgid "&Preview effect"
 msgstr "Пеш&намоиш"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip backward"
+msgstr "Гузариш ба Ибтидо"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Skip &Backward"
+msgstr "Гузариш ба Ибтидо"
+
+#: src/effects/EffectUI.cpp
 msgid "Skip forward"
 msgstr "Гузариш ба Ибтидо"
 
@@ -3579,6 +7620,11 @@ msgstr "Фаъол шуд"
 #: src/effects/EffectUI.cpp
 msgid "Save Preset..."
 msgstr "Сабт ҳамчун..."
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Delete Preset"
+msgstr "Бознасбшуда"
 
 #: src/effects/EffectUI.cpp
 msgid "Defaults"
@@ -3597,9 +7643,24 @@ msgid "Options..."
 msgstr "Қисматҳо..."
 
 #: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Type: %s"
+msgstr "масрафсанҷ"
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Name: %s"
 msgstr "Ном"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Version: %s"
+msgstr "Маъкусшавӣ"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy, c-format
+msgid "Vendor: %s"
+msgstr "Хато: "
 
 #: src/effects/EffectUI.cpp
 #, c-format
@@ -3607,9 +7668,18 @@ msgid "Description: %s"
 msgstr "Луғат"
 
 #: src/effects/EffectUI.cpp
+msgid "About"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 #, c-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr "Шумо бовари доред, ки %s нест карда шавад?"
+
+#: src/effects/EffectUI.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Save Preset"
+msgstr "Сабт ҳамчун..."
 
 #: src/effects/EffectUI.cpp
 msgid "Preset name:"
@@ -3662,12 +7732,56 @@ msgid "Graphic EQ"
 msgstr "Графики EQ"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Садои баланди..."
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "Садои баланди..."
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Boost"
+msgstr "Таҳрири Нишона"
+
+#: src/effects/Equalization.cpp
 msgid "Treble Cut"
 msgstr "Таҳрири Нишона"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "To apply Equalization, all selected tracks must have the same sample rate."
@@ -3682,16 +7796,55 @@ msgid "Effect Unavailable"
 msgstr "Пештасвир дастрас нест"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "Макс dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "Миним dB"
 
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&EQ Type:"
+msgstr "масрафсанҷ"
+
 #: src/effects/Equalization.cpp
 msgid "Draw Curves"
 msgstr "Кашидани тавсирҳо"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Draw"
+msgstr "Тасвири афзор"
 
 #: src/effects/Equalization.cpp
 msgid "&Graphic"
@@ -3702,8 +7855,54 @@ msgid "Interpolation type"
 msgstr "Зудии Синхронӣ бо Иловашавӣ"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Басомади хаттӣ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Басомади хаттӣ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of &Filter:"
+msgstr "Ба кор бурдани дараҷакунанда..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Length of Filter"
+msgstr "Ба кор бурдани дараҷакунанда..."
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Select Curve:"
+msgstr "Бознасбшуда"
+
+#: src/effects/Equalization.cpp
 msgid "Select Curve"
 msgstr "Бознасбшуда"
+
+#: src/effects/Equalization.cpp
+msgid "S&ave/Manage Curves..."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Invert"
+msgstr "Табдилдиҳӣ"
+
+#: src/effects/Equalization.cpp
+msgid "Show grid lines"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Show g&rid lines"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Processing: "
@@ -3714,8 +7913,106 @@ msgid "D&efault"
 msgstr "&Аз рӯи хомӯшӣ"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "&Боркунии Озмоишии..."
+
+#. i18n-hint: name of the 'unnamed' custom curve
+#: src/effects/Equalization.cpp
+msgid "unnamed"
+msgstr ""
+
+#. i18n-hint: EQ stands for 'Equalization'.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid ""
+"Error Loading EQ Curves from file:\n"
+"%s\n"
+"Error message says:\n"
+"%s"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Loading EQ Curves"
+msgstr "Натиҷаи корбурдашуда: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Error Saving Equalization Curves"
+msgstr "Баробаркунии иҷроиш"
+
+#: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Curve not found"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Идораи таърих"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Кашидани тавсирҳо"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Curves"
+msgstr "Курсори Чап"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve Name"
+msgstr "Ном"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "D&elete..."
+msgstr "Нобудсозӣ"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Интихоби..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "Но&баён"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3723,14 +8020,42 @@ msgid "Rename '%s' to..."
 msgstr "Ивази Номи '%s' ба '%s'"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Rename..."
+msgstr "&Бознамунагузорӣ..."
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Rename '%s'"
 msgstr "Ивази Номи '%s' ба '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Ду&бора ном гузоштан"
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Overwrite existing curve '%s'?"
 msgstr "Бознависии файлҳои мавҷуда"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "Ҳаракат &ба поён"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Can't delete 'unnamed'"
+msgstr "Аудиоро дар %s ворид карда наметавонад"
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -3747,8 +8072,51 @@ msgid "Delete %d items?"
 msgstr "Тозакунии Нишонаҳо"
 
 #: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Файлҳои қаблии худсабт ҷойиваз карда нашуданд"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Содирот &Нишонаҳо..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Cannot Export 'unnamed'"
 msgstr "Аудиоро дар %s ворид карда наметавонад"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr "Масрафсанҷи сабт"
+
+#: src/effects/Equalization.cpp
+msgid "Curves exported"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "Нишона барои содирот ҷой надорад."
+
+#: src/effects/Equalization48x.cpp
+#, c-format
+msgid ""
+"Benchmark times:\n"
+"Original: %s\n"
+"Default Segmented: %s\n"
+"Default Threaded: %s\n"
+"SSE: %s\n"
+"SSE Threaded: %s\n"
+msgstr ""
 
 #: src/effects/Fade.cpp
 msgid "Fade In"
@@ -3762,13 +8130,76 @@ msgstr "Харобшавии мӯътадил"
 msgid "Applies a linear fade-in to the selected audio"
 msgstr "Барои ҷудокунии аудио пахш ва кашишро иҷро кунед"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-out to the selected audio"
+msgstr "Барои ҷудокунии аудио пахш ва кашишро иҷро кунед"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Find Clipping"
+msgstr "Иҷозати буриш"
+
+#: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "Clipping"
+msgstr "Иҷозати буриш"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "&Start threshold (samples):"
+msgstr "Остона: %d dB"
+
+#: src/effects/FindClipping.cpp
+#, fuzzy
+msgid "St&op threshold (samples):"
+msgstr "Остона: %d dB"
+
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "Барои гузоштани интихоб пораи ҳофиза кам аст"
+
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Табдилдиҳӣ"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Корбарии натиҷаи Nyquist..."
+
+#: src/effects/LoadEffects.cpp
+msgid "Provides builtin effects to Tenacity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+msgid "Unknown built-in effect name"
+msgstr ""
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Муққаррарӣ"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Loudness Normalization"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Sets the loudness of one or more tracks"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalizing Loudness...\n"
@@ -3787,6 +8218,31 @@ msgstr "Пардозиши Auto Duck..."
 #: src/effects/Loudness.cpp
 msgid "&Normalize"
 msgstr "Муққаррарӣ"
+
+#. i18n-hint: LUFS is a particular method for measuring loudnesss
+#: src/effects/Loudness.cpp
+msgid "Loudness LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "Normalize &stereo channels independently"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
+
+#: src/effects/Loudness.cpp src/effects/Normalize.cpp
+msgid "(Maximum 0dB)"
+msgstr ""
 
 #. i18n-hint: not a color, but "white noise" having a uniform spectrum
 #: src/effects/Noise.cpp
@@ -3812,6 +8268,10 @@ msgid "Noise"
 msgstr "Навъи хаш:"
 
 #: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
+
+#: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Навъи хаш:"
 
@@ -3824,16 +8284,73 @@ msgid "Second greatest"
 msgstr "сонияҳо"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "256 - аз рӯи хомушӣ"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "256 - аз рӯи хомушӣ"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Табдили хаш (dB):"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block are too few for the window types."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Steps per block cannot exceed the window size."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "All noise profile data must have the same sample rate."
 msgstr "Барои сохтани спектрум, ҳамаи роҳчаҳои интихобшуда бояд навъи якхела дошта бошанд."
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Selected noise profile is too short."
@@ -3841,6 +8358,11 @@ msgstr "Интихоб барои истифодаи калиди овоз хе�
 
 #: src/effects/NoiseReduction.cpp
 msgid "&Noise reduction (dB):"
+msgstr "Табдили хаш (dB):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise reduction"
 msgstr "Табдили хаш (dB):"
 
 #: src/effects/NoiseReduction.cpp
@@ -3871,6 +8393,11 @@ msgstr "Вақти такроршуда %d"
 msgid "&Frequency smoothing (bands):"
 msgstr "Суфтагии басомад (Hz):"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Суфтагии басомад (Hz):"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Sensiti&vity (dB):"
 msgstr "Қобилияти ҳис (эҳсос)"
@@ -3884,8 +8411,9 @@ msgid "Step 1"
 msgstr "Қадами 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Якчанд сония барои полоиши хаш ҷудо кунед, то ки Audacity дарк кунад, ки кадом амалиётро ичро карда истодааст,\n"
@@ -3907,6 +8435,27 @@ msgstr ""
 "Ҳамаи аудиоҳои полоишшавандаро ҷудо кунед,миқдори зарурии хашҳоро интихоб кунед\n"
 "ва баъдан -ро пахш кунед.\n"
 
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Noise:"
+msgstr "Навъи хаш:"
+
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Isolate"
+msgstr "Ҷойивазку&нии Роҳчаҳо"
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Андоза"
+
 #: src/effects/NoiseReduction.cpp
 msgid "Advanced Settings"
 msgstr "Қисматҳои омехтаи пешрафта"
@@ -3918,6 +8467,11 @@ msgstr "Намуди равзана:"
 #: src/effects/NoiseReduction.cpp
 msgid "Window si&ze:"
 msgstr "Намуди равзана:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "7"
 
 #: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
 msgid "16"
@@ -3931,17 +8485,63 @@ msgstr "2"
 msgid "64"
 msgstr "4"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "256 - аз рӯи хомушӣ"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
 msgstr "256 - аз рӯи хомушӣ"
 
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Ҷудосозии Хаш"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -3956,6 +8556,11 @@ msgid "Noise re&duction (dB):"
 msgstr "Табдили хаш (dB):"
 
 #: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "Қобилияти ҳис (эҳсос)"
+
+#: src/effects/NoiseRemoval.cpp
 msgid "Fr&equency smoothing (Hz):"
 msgstr "Суфтагии басомад (Hz):"
 
@@ -3963,13 +8568,70 @@ msgstr "Суфтагии басомад (Hz):"
 msgid "Attac&k/decay time (secs):"
 msgstr "Ҳуҷум/вақти хомушшавӣ (сон-ҳо):"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attack/decay time"
+msgstr "Ҳуҷум/вақти хомушшавӣ (сон-ҳо):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "&Дигар кардан"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Муққаррарӣ"
 
 #: src/effects/Normalize.cpp
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset and Normalizing...\n"
+msgstr "Тозашавии хаш\n"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset...\n"
 msgstr "Тозашавии хаш\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Normalizing without removing DC offset...\n"
+msgstr "Тозашавии хаш\n"
+
+#: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
 
 #: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
@@ -3979,9 +8641,23 @@ msgstr "Доманаи Нави Қулла (dB):"
 msgid "Peak amplitude dB"
 msgstr "Доманаи Нави Қулла (dB):"
 
+#: src/effects/Normalize.cpp
+msgid "N&ormalize stereo channels independently"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Харобии омил:"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "Харобии омил:"
@@ -3990,29 +8666,94 @@ msgstr "Харобии омил:"
 msgid "&Time Resolution (seconds):"
 msgstr "Таваққуфи вақт (сонияҳо):"
 
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Марҳиласоз"
 
 #: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
+
+#: src/effects/Phaser.cpp
 msgid "&Stages:"
 msgstr "Марҳилаҳо:"
+
+#: src/effects/Phaser.cpp
+#, fuzzy
+msgid "Stages"
+msgstr "Марҳилаҳо:"
+
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Freq&uency (Hz):"
 msgstr "Басомади LFO (Ҳертз):"
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO frequency in hertz"
+msgstr "Басомади LFO (Ҳертз):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO Sta&rt Phase (deg.):"
+msgstr "Ибтидои марҳилаи LFO (дараҷа):"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO start phase in degrees"
 msgstr "Ибтидои марҳилаи LFO (дараҷа):"
 
 #: src/effects/Phaser.cpp
 msgid "Dept&h:"
 msgstr "Амиқӣ:"
 
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
 #: src/effects/Phaser.cpp
 msgid "Feedbac&k (%):"
 msgstr "Бозгашт (%):"
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "&Output gain (dB):"
@@ -4027,6 +8768,10 @@ msgid "Repair"
 msgstr "Таъмир"
 
 #: src/effects/Repair.cpp
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr ""
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -4036,9 +8781,22 @@ msgstr ""
 "\n"
 "Намудро наздик созед ва пораи хурдтарини додаҳои савтиро интихоб кунед."
 
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Такрор"
+
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
 
 #: src/effects/Repeat.cpp
 msgid "&Number of repeats to add:"
@@ -4062,9 +8820,65 @@ msgstr "Интихоби нави дарозӣ: "
 msgid "New selection length: %s"
 msgstr "Интихоби нави дарозӣ: "
 
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Vocal I"
+msgstr "Ҷойгузории Роҳча"
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
 #: src/effects/Reverb.cpp
 msgid "Medium Room"
 msgstr "Муҳит"
+
+#: src/effects/Reverb.cpp
+msgid "Large Room"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Маъкус"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Room Size (%):"
+msgstr "Андоза"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "&Pre-delay (ms):"
+msgstr "Ҳуҷум/вақти хомушшавӣ (сон-ҳо):"
 
 #: src/effects/Reverb.cpp
 msgid "Rever&berance (%):"
@@ -4073,6 +8887,34 @@ msgstr "Бозгашт (%):"
 #: src/effects/Reverb.cpp
 msgid "Da&mping (%):"
 msgstr "Амиқӣ (%):"
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Tone &High (%):"
+msgstr "Амиқӣ (%):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "Шабакаҳои бурунӣ: %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "Шабакаҳои бурунӣ: %2d"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Stereo Wid&th (%):"
+msgstr "Стерео"
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
 
 #: src/effects/Reverb.cpp
 #, c-format
@@ -4087,13 +8929,98 @@ msgstr "Маъкус"
 msgid "Reverses the selected audio"
 msgstr "Вуруди аудиоҳои интихобшуда ба монанди FLAC"
 
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Highpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "&Боркунии Файл..."
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
 #: src/effects/ScienFilter.cpp
 msgid "To apply a filter, all selected tracks must have the same sample rate."
 msgstr "Барои сохтани спектрум, ҳамаи роҳчаҳои интихобшуда бояд навъи якхела дошта бошанд."
 
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "масрафсанҷ"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Subtype:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Cutoff (Hz)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Align MIDI to Audio"
 msgstr "Марказонидани Интиҳо бо Интихоби Интиҳо"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Давомнокӣ"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period"
+msgstr "Давомнокӣ"
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size:"
@@ -4102,6 +9029,14 @@ msgstr "Намуди равзана:"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Window Size"
 msgstr "Намуди равзана:"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
 
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Silence Threshold:"
@@ -4117,6 +9052,15 @@ msgstr "Остона:"
 #. It is OK to leave it in English.
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Presmooth Time:"
+msgstr "Ҷудокунӣ аз рӯи Вақт"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
 msgstr "Ҷудокунӣ аз рӯи Вақт"
 
 #. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
@@ -4155,15 +9099,28 @@ msgstr "&Аз рӯи хомӯшӣ"
 msgid "Restore Defaults"
 msgstr "&Аз рӯи хомӯшӣ"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
 msgid "Silence"
 msgstr "Хомушӣ"
 
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
 #: src/effects/StereoToMono.cpp
 msgid "Stereo To Mono"
 msgstr "&Стерео Ба Моно"
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
 
 #: src/effects/StereoToMono.cpp
 msgid "Resampling left channel"
@@ -4180,6 +9137,43 @@ msgstr "Корбарии стерео ба моно"
 #: src/effects/TimeScale.cpp
 msgid "Sliding Stretch"
 msgstr "Харобии омил:"
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Tempo Change (%)"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Initial Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(%) [-50 to 100]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Final Pitch Shift"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Logarithmic"
+msgstr "Зудии Синхронӣ бо Иловашавӣ"
 
 #: src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Sine"
@@ -4198,12 +9192,48 @@ msgid "Square, no alias"
 msgstr "Росткунҷаи бетахаллус"
 
 #: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
 msgid "&Waveform:"
 msgstr "Мавҷшакл:"
 
 #: src/effects/ToneGen.cpp
 msgid "&Frequency (Hz):"
 msgstr "Басомади (Ҳз):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Басомад (Ҳз)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz End"
+msgstr "Басомад (Ҳз)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Доманаи (0-1)"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude End"
+msgstr "Доманаи (0-1)"
 
 #: src/effects/ToneGen.cpp
 msgid "I&nterpolation:"
@@ -4214,14 +9244,62 @@ msgid "Truncate Detected Silence"
 msgstr "Бурриши қисматҳои хомӯш..."
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Truncate Silence"
+msgstr "Бурриши қисматҳои хомӯш..."
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Интихоби хомӯшӣ"
+
+#: src/effects/TruncSilence.cpp
+msgid "Tr&uncate to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Фишордиҳандаи..."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+msgid "Trunc&ate tracks independently"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "Нати&ҷа"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Феҳристи рамзгузошташудаи MP3-ро кушода натавонист!"
 
@@ -4229,8 +9307,32 @@ msgstr "Феҳристи рамзгузошташудаи MP3-ро кушода 
 msgid "VST Effect Options"
 msgstr "Танзимоти натиҷаҳо"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Buffer Size"
+msgstr "Дарозӣ"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
+msgstr "Таркиббандии калид"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
 msgstr "Таркиббандии калид"
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
@@ -4238,32 +9340,96 @@ msgid "Graphical Mode"
 msgstr "Графики EQ"
 
 #: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Enable &graphical interface"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Сабти Нутқ Ҳамчун:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Standard VST bank file"
+msgstr "Берунсозии файл"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Standard VST program file"
+msgstr "Берунсозии файл"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Файлҳои лоиҳаи Audacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Saving VST Presets"
+msgstr "Натиҷаи корбурдашуда: %s"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Load VST Preset:"
+msgstr "Бор кардани файлҳо"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "VST preset files"
 msgstr "Интихоби MIDI файл..."
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Error Loading VST Presets"
+msgstr "Натиҷаи корбурдашуда: %s"
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to load presets file."
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Танзимоти натиҷаҳо"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
 msgstr "Вах-Вах"
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Dept&h (%):"
@@ -4274,8 +9440,29 @@ msgid "Reso&nance:"
 msgstr "Зарбазанӣ:"
 
 #: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Зарбазанӣ:"
+
+#: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
 msgstr "Омезиши басомади Wah (%):"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Wah frequency offset in percent"
+msgstr "Омезиши басомади Wah (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Танзимоти натиҷаҳо"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr "Танзимоти натиҷаҳо"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Could not find component"
@@ -4290,16 +9477,42 @@ msgid "Audio Unit Effect Options"
 msgstr "Танзимоти натиҷаҳо"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
 msgstr "Робита"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
 msgstr "Интихоби Санади Чап"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Full"
+msgstr " равзана"
+
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Generic"
 msgstr "&Тавлид кардан"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Import Audio Unit Presets"
+msgstr "Берунсозии файл"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Presets (may select multiple)"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
@@ -4375,19 +9588,74 @@ msgid "Failed to retrieve preset content"
 msgstr "'%s' тоза намешавад"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Табдилдиҳии басомади намуна"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "'%s' тоза намешавад"
 
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "'%s' тоза намешавад"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "'%s' тоза намешавад"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Failed to set class info for \"%s\" preset"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Файли аудиоӣ"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Нати&ҷа"
 
 #: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "Provides LADSPA Effects"
+msgstr "Нати&ҷа"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effect Options"
 msgstr "Танзимоти натиҷаҳо"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
@@ -4395,6 +9663,7 @@ msgstr "Танзимоти натиҷаҳо"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.h
 msgid "LADSPA"
 msgstr "Нати&ҷа"
@@ -4403,13 +9672,59 @@ msgstr "Нати&ҷа"
 msgid "LV2 Effect Settings"
 msgstr "Танзимоти натиҷаҳо"
 
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Generator"
+msgstr "&Тавлид кардан"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Нати&ҷа"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/LoadNyquist.cpp
 msgid "Nyquist Effects"
 msgstr "Корбарии натиҷаи Nyquist..."
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
@@ -4425,6 +9740,24 @@ msgid "Ill-formed Nyquist plug-in header"
 msgstr "Буруни Nyquistы: "
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Audio selection required."
 msgstr "Ҷобаҷогузори бо интихоби интиҳо"
 
@@ -4437,12 +9770,36 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Бубахшед, аммо натиҷае, ки стереороҳчаҳое, ки роҳчаҳо мутобиқ нестанд, истифода намешавад."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Буруни Nyquistы: "
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Processing complete."
 msgstr "Пардозиши Auto Duck..."
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: "%s" is replaced by name of plug-in.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "nyx_error returned from %s.\n"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "plug-in"
@@ -4479,6 +9836,10 @@ msgid "Nyquist returned nil audio.\n"
 msgstr "Nyquist аудиоро барнагардонид.\n"
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Тариқаи Audacity бо дастгирии %s ҳамгардонӣ нашуда буд."
@@ -4487,10 +9848,37 @@ msgstr "Тариқаи Audacity бо дастгирии %s ҳамгардонӣ 
 msgid "Could not open file"
 msgstr "Файлро кушода натавонист: "
 
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Error in Nyquist code"
+msgstr ""
+
 #. i18n-hint: refers to programming "languages"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Could not determine language"
 msgstr "Файлро кушода натавонист: "
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
@@ -4511,6 +9899,21 @@ msgid "Lisp scripts"
 msgstr "Дархости Nyquist..."
 
 #: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "File could not be loaded"
+msgstr "Файлро кушода натавонист: "
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 #, c-format
 msgid ""
 "Value range:\n"
@@ -4529,17 +9932,72 @@ msgstr "Интихоби MIDI файл..."
 msgid "Save file as"
 msgstr "Сабти файлҳо"
 
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+msgid "untitled"
+msgstr ""
+
 #: src/effects/vamp/LoadVamp.cpp
 msgid "Vamp Effects"
 msgstr "Нати&ҷа"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
+msgstr "Бубахшед, аммо натиҷаҳои Plug-in дар стереороҳчаҳое, ки шабакаҳои индивидуалии мутобиқ надоранд истифода намешавад."
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, failed to load Vamp Plug-in."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+msgid "Sorry, Vamp Plug-in failed to initialize."
+msgstr ""
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Plugin Settings"
+msgstr "Дастаҳои иттисоли 1 ба %i"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Спектограммаҳо"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "No format specific options"
+msgstr "Танзимоти натиҷаҳо"
 
 #: src/export/Export.cpp
 msgid "Export Audio"
 msgstr "Берунсозии файл"
 
+#: src/export/Export.cpp src/export/ExportMultiple.cpp src/menus/EditMenus.cpp
+msgid "Edit Metadata Tags"
+msgstr ""
+
 #: src/export/Export.cpp
 msgid "Exported Tags"
 msgstr "Содирот"
+
+#: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
@@ -4613,6 +10071,11 @@ msgid "Output Channels: %2d"
 msgstr "Шабакаҳои бурунӣ: %2d"
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "Лавҳаи Роҳча"
+
+#: src/export/Export.cpp
 #, c-format
 msgid ""
 "Unable to export.\n"
@@ -4623,10 +10086,25 @@ msgstr "Содирот номумкин аст"
 msgid "Show output"
 msgstr "Намоиши бурунӣ"
 
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
 #. i18n-hint files that can be run as programs
 #: src/export/ExportCL.cpp
 msgid "Executables"
 msgstr "Тағирёбанда"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "Интихоби фармон"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -4657,18 +10135,174 @@ msgstr "Бурунсозии фармонҳо"
 msgid "&OK"
 msgstr "&ОК"
 
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "\"%s\" couldn't be found."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't determine format description for file \"%s\"."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg Error"
 msgstr "Хатои LOF"
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate output format context."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't add audio stream to output file \"%s\"."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't open output file \"%s\" to write. Error code is %d."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported a generic error (EPERM)"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
 #, c-format
 msgid "Exporting the audio as %s"
 msgstr "Вуруди аудиоҳои интихобшуда ба монанди FLAC"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Invalid sample rate"
+msgstr "Суръати намуна:"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Бознамунагирӣ"
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the current output\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the current output file format. "
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+msgid "You may resample to one of the rates below."
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Sample Rates"
+msgstr "Суръати намуна:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
@@ -4677,6 +10311,51 @@ msgstr "Суръати бит:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Сифат:"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "0"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "3"
+msgstr "2"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "6"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "10"
@@ -4691,6 +10370,10 @@ msgid "Constrained"
 msgstr "Доимӣ"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "&Аудио..."
 
@@ -4699,8 +10382,44 @@ msgid "Low Delay"
 msgstr "Намуди тугма"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Mediumband"
 msgstr "Муҳит"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Fullband"
@@ -4723,6 +10442,14 @@ msgid "Application:"
 msgstr "Истифодаи занҷир"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Current Format:"
 msgstr "Истифодаи ин &Лоиҳа"
 
@@ -4731,21 +10458,433 @@ msgid "Current Codec:"
 msgstr "Истифодаи ин &Лоиҳа"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Error Saving FFmpeg Presets"
+msgstr "Натиҷаи корбурдашуда: %s"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Бознависии файлҳои мавҷуда"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "Тасдиқ шудан"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Please select format before saving a profile"
+msgstr "Созиши роҳчаи нави аудиоии нав"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Рӯйхати %s мавҷуд нест. Сохта шавад?"
+
+#: src/export/ExportFFmpegDialogs.cpp
 #, c-format
 msgid "Replace preset '%s'?"
 msgstr "Ивази Номи '%s' ба '%s'"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Ч"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "Тасодуфан"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "Хатои LOF"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Сатҳ:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Сатҳ:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Сатҳ:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Preset:"
+msgstr "Бознасбшуда"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Load Preset"
+msgstr "Бор кардани файлҳо"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Import Presets"
+msgstr "Воридоти НишонаҳоҲамчун:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Export Presets"
+msgstr "Воридоти НишонаҳоҲамчун:"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Codec:"
+msgstr "Истифодаи ин &Лоиҳа"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Formats"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Show All Codecs"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Дастаҳои иттисоли 1 ба %i"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Забон:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Tag:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "Сифат:"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Суръати намуна:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Profile:"
+msgstr "Ҳамаи файлҳо (*)|*"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Муайян кардани қисматҳои FLAC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Compression level\n"
+"Required for FLAC\n"
+"-1 - automatic\n"
+"min - 0 (fast encoding, large output file)\n"
+"max - 10 (slow encoding, small output file)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "Фишордиҳандаи..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Frame size\n"
+"Optional\n"
+"0 - default\n"
+"min - 16\n"
+"max - 65535"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame:"
+msgstr "Ном"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"LPC coefficients precision\n"
+"Optional\n"
+"0 - default\n"
+"min - 1\n"
+"max - 15"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PdO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Min. PtO"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Max. PtO"
+msgstr ""
+
+#. i18n-hint:  Abbreviates "Linear Predictive Coding",
+#. but this text needs to be kept very short
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Use LPC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "MPEG container options"
+msgstr "Интихоб ба Интиҳо"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Насби Босуръат"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Packet Size:"
+msgstr "НамудиРоҳча"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't delete a preset without name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Delete preset '%s'?"
+msgstr "Ивази Номи '%s' ба '%s'"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "You can't save a preset without a name"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Select xml file with presets to import"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "No presets to export"
 msgstr "Нишона барои содирот ҷой надорад."
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Select xml file to export presets into"
+msgstr "Интихоби файл(ҳо) барои раванди дастаӣ..."
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to find the codec"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #: src/export/ExportFLAC.cpp
 msgid "16 bit"
@@ -4774,6 +10913,18 @@ msgstr "Амиқии бит:"
 #: src/export/ExportFLAC.cpp
 msgid "FLAC Files"
 msgstr "Файлҳои FLAC"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy, c-format
+msgid "FLAC export couldn't open %s"
+msgstr "Файлро \"%s\"-ро кушода натавонист"
+
+#: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
 
 #: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
@@ -4805,7 +10956,74 @@ msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
 msgid "Exporting the audio at %ld kbps"
 msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp
+msgid "220-260 kbps (Best Quality)"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "45-85 kbps (Smaller files)"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane, 320 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme, 220-260 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Standard, 170-210 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Medium, 145-185 kbps"
+msgstr ""
+
+#. i18n-hint: Slightly humorous - as in use an insane precision with MP3.
+#: src/export/ExportMP3.cpp
+msgid "Insane"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Extreme"
+msgstr ""
+
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Танзимшуда"
 
@@ -4846,14 +11064,19 @@ msgstr "Сифат"
 msgid "Channel Mode:"
 msgstr "Ҳолати шабака:"
 
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Force export to mono"
+msgstr "Хати Буриш Ҷой иваз шудааст"
+
 #. i18n-hint: LAME is the name of an MP3 converter and should not be translated
 #: src/export/ExportMP3.cpp
 msgid "Locate LAME"
 msgstr "Хатои ҷойшуда"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Файли %s ба Audacity барои сохтани MP3-ҳо лозим аст."
 
 #: src/export/ExportMP3.cpp
@@ -4881,6 +11104,38 @@ msgid "Where is %s?"
 msgstr "%s дар куҷо ҷойгир аст?"
 
 #: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only lame_enc.dll"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame64bit.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.dylib"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "Only libmp3lame.so.0"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Сабти додаҳои лоиҳа"
+
+#: src/export/ExportMP3.cpp
+msgid "Extended libraries"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "MP3 Files"
 msgstr "Файлҳои MP3"
 
@@ -4897,8 +11152,23 @@ msgid "Not a valid or supported MP3 encoding library!"
 msgstr "Феҳристи рамзгузошташудаи MP3 корношоям ё дастгиринашаванда асты!"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Unable to initialize MP3 stream"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with %s preset"
+msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio with %s preset"
+msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio with VBR quality %s"
 msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
 
 #: src/export/ExportMP3.cpp
@@ -4907,9 +11177,41 @@ msgid "Exporting the audio with VBR quality %s"
 msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio at %d Kbps"
+msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
+
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "Exporting the audio at %d Kbps"
 msgstr "Вуруди аудиоҳои интихобшуда дар %ld kbps"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "Error %ld returned from MP3 encoder"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) is not supported by the MP3\n"
+"file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"The project sample rate (%d) and bit rate (%d kbps) combination is not\n"
+"supported by the MP3 file format. "
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "MP3 export library not found"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
@@ -4920,8 +11222,18 @@ msgid "Cannot Export Multiple"
 msgstr "Вуруди бисёркарата"
 
 #: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Export files to:"
 msgstr "Мавқеи вуруд:"
+
+#: src/export/ExportMultiple.cpp
+msgid "Folder:"
+msgstr ""
 
 #: src/export/ExportMultiple.cpp
 msgid "Create"
@@ -4944,6 +11256,11 @@ msgid "First file name:"
 msgstr "Номи файли якум:"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "First file name"
+msgstr "Номи файли якум:"
+
+#: src/export/ExportMultiple.cpp
 msgid "Name files:"
 msgstr "Номи файлҳо:"
 
@@ -4952,7 +11269,22 @@ msgid "Using Label/Track Name"
 msgstr "Истифодаи нишона/Номи роҳча"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Истифодаи нишона/Номи роҳча"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Пешванди номи файл:"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "Пешванди номи файл:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "Пешванди номи файл:"
 
 #: src/export/ExportMultiple.cpp
@@ -4970,6 +11302,31 @@ msgstr "Барои вурудсозии файлҳо мавқеи онҳро и�
 
 #: src/export/ExportMultiple.cpp
 #, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, c-format
 msgid ""
 "\"%s\" doesn't exist.\n"
 "\n"
@@ -4983,9 +11340,60 @@ msgstr ""
 msgid "Continue to export remaining files?"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "Сабт ҳамчун..."
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis Files"
+msgstr "Ин файли Ogg Vorbis нест"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - rate or quality problem"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #: src/export/ExportOGG.cpp
 msgid "Unable to export - problem with file"
@@ -4999,6 +11407,14 @@ msgstr "Вуруди аудиоҳои ҷудошуда ба монанди Ог 
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Вуруди аудиоҳои ҷудошуда ба монанди Ог Ворбис"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Сарлавҳа:"
@@ -5008,12 +11424,52 @@ msgid "Encoding:"
 msgstr "Рамзгузорӣ:"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "Интихоби файлҳои аудиоии ғайрифишурдаи..."
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Воридшавии хато"
 
 #: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
 msgstr "Аудиро дар ин шакл вуруд карда наметавонад."
+
+#: src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the selected audio as %s"
+msgstr "Вуруди аудиоҳои интихобшуда ба монанди FLAC"
+
+#. i18n-hint: %s will be the error message from libsndfile, which
+#. * is usually something unhelpful (and untranslated) like "system
+#. * error"
+#: src/export/ExportPCM.cpp
+#, c-format
+msgid ""
+"Error while writing %s file (disk full?).\n"
+"Libsndfile says \"%s\""
+msgstr ""
 
 #: src/import/Import.cpp
 msgid "All supported files"
@@ -5021,8 +11477,184 @@ msgstr "Содирот"
 
 #: src/import/Import.cpp
 #, c-format
-msgid "This version of Audacity was not compiled with %s support."
+msgid ""
+"\"%s\" \n"
+"is a MIDI file, not an audio file. \n"
+"Tenacity cannot open this type of file for playing, but you can\n"
+"edit it by clicking File > Import > MIDI."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
+msgstr ""
+
+#: src/import/Import.cpp
+#, fuzzy
+msgid "Select stream(s) to import"
+msgstr "Интихоб ба Интиҳо"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Тариқаи Audacity бо дастгирии %s ҳамгардонӣ нашуда буд."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an audio CD track. \n"
+"Tenacity cannot open audio CDs directly. \n"
+"Extract (rip) the CD tracks to an audio format that \n"
+"Tenacity can import, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a playlist file. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
+"You may be able to open it in a text editor and download the actual audio files."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Windows Media Audio file. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a RealPlayer media file. \n"
+"Tenacity cannot open this proprietary format. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a notes-based file, not an audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"Try converting it to an audio file such as WAV or AIFF and \n"
+"then import it, or record it into Tenacity."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Musepack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
+"and try importing it again. Otherwise you need to convert it to a supported audio \n"
+"format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Wavpack audio file. \n"
+"Tenacity cannot open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a Dolby Digital audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is an Ogg Speex audio file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
+msgstr ""
+
+#: src/import/Import.cpp
+#, c-format
+msgid "File \"%s\" not found."
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity did not recognize the type of the file '%s'.\n"
+"\n"
+"%sFor uncompressed files, also try File > Import > Raw Data."
+msgstr ""
+
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s, %s"
+msgstr ""
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, c-format
+msgid ""
+"Tenacity recognized the type of the file '%s'.\n"
+"Importers supposedly supporting such files are:\n"
+"%s,\n"
+"but none of them understood this file format."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "AUP project files (*.aup)"
+msgstr "Сабти додаҳои лоиҳа"
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5039,13 +11671,123 @@ msgid "Import Project"
 msgstr "Воридоти НишонаҳоҲамчун:"
 
 #: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid "Invalid project '%s' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'vpos' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'h' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'zoom' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel0' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'sel1' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selLow' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid project 'selHigh' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 #, c-format
 msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Лоиҳаи додаи пӯша ёфт нашуд: \"%s\""
 
 #: src/import/ImportAUP.cpp
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
 msgid "Project Import"
 msgstr "Суръати лоиҳа (Hz):"
+
+#: src/import/ImportAUP.cpp
+msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -5062,17 +11804,20 @@ msgstr "Кушодан/сохтани файлҳои санҷишӣ номумк
 msgid "Unable to read %lld samples from %s"
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Тағйири номи '%s' ба '%s' номумкин аст"
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
 
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+#: src/import/ImportFLAC.cpp
+#, fuzzy
+msgid "FLAC files"
+msgstr "Файлҳои FLAC"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -5126,6 +11871,29 @@ msgstr "Файлро кушода натавонист: "
 msgid "Could not open file %s."
 msgstr "Файлро \"%s\"-ро кушода натавонист"
 
+#: src/import/ImportMP3.cpp
+#, fuzzy
+msgid "MP3 files"
+msgstr "Файлҳои MP3"
+
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
+#: src/import/ImportOGG.cpp
+#, fuzzy
+msgid "Ogg Vorbis files"
+msgstr "Ин файли Ogg Vorbis нест"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
 msgstr "Хатои хониши додаҳо"
@@ -5151,12 +11919,120 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF ва дигар намунаҳои фишурданашуда"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 8 bit PCM"
+msgstr "16-бит ПСM"
+
+#: src/import/ImportPCM.cpp
 msgid "Signed 16 bit PCM"
 msgstr "16-бит ПСM"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 24 bit PCM"
 msgstr "24-бит ПСМ"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Signed 32 bit PCM"
+msgstr "24-бит ПСМ"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "Unsigned 8 bit PCM"
+msgstr "16-бит ПСM"
 
 #: src/import/ImportPCM.cpp
 msgid "32 bit float"
@@ -5167,6 +12043,39 @@ msgid "64 bit float"
 msgstr "32-бит float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "12 bit DWVW"
+msgstr "16 бит"
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DWVW"
 msgstr "16 бит"
 
@@ -5175,12 +12084,63 @@ msgid "24 bit DWVW"
 msgstr "24 бит"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-бит ПСM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "16-бит ПСM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
+#: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
+#, fuzzy, c-format
+msgid "Importing %s"
+msgstr "Вориди '%s'"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "QuickTime files"
+msgstr "Номи файлҳо:"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Муайяншавӣ номумкин аст"
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime render quality"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to set QuickTime discrete channels property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+msgid "Unable to get QuickTime sample size property"
+msgstr ""
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to retrieve stream description"
+msgstr "'%s' тоза намешавад"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Import Raw"
+msgstr "Вуруди додаи Raw"
 
 #: src/import/ImportRaw.cpp
 msgid "Import Raw Data"
@@ -5223,6 +12183,15 @@ msgstr "2 Шабака (Стерео)"
 msgid "%d Channels"
 msgstr "%d Шабакаҳо"
 
+#: src/import/ImportRaw.cpp
+msgid "Byte order:"
+msgstr ""
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Маҷро(Канал)"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
@@ -5240,6 +12209,15 @@ msgstr "Миқдори вуруд:"
 #: src/import/ImportRaw.cpp
 msgid "Sample rate:"
 msgstr "Суръати намуна:"
+
+#: src/import/ImportRaw.cpp src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Import"
+msgstr "Воридот"
+
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
 
 #. i18n-hint: given the name of a track, specify its left channel
 #: src/menus/ClipMenus.cpp
@@ -5261,6 +12239,7 @@ msgstr "рост"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -5284,6 +12263,7 @@ msgstr "Интиҳо"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -5303,12 +12283,35 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Вақти роҳчаҳо/клип %s %.02f сония ҷойгардонӣ шудаст"
+
+#: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the left"
 msgstr "Вақти роҳчаҳо/клип %s %.02f сония ҷойгардонӣ шудаст"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Вақт-Ҷойгардонӣ"
+
+#: src/menus/ClipMenus.cpp
+msgid "clip not moved"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "Ибтидо ба интихоб"
 
 #: src/menus/ClipMenus.cpp
 msgid "Previo&us Clip"
@@ -5325,6 +12328,26 @@ msgstr "Афзори Навбатӣ"
 #: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Афзори Навбатӣ"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Pre&vious Clip Boundary"
+msgstr "Афзори Пешина"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "Истифодаи ин &Лоиҳа"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Ne&xt Clip Boundary"
+msgstr "Афзори Навбатӣ"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "Ибтидо ба интихоб"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time Shift &Left"
@@ -5358,6 +12381,11 @@ msgstr "Буриш барои буфер"
 #, c-format
 msgid "Deleted %.2f seconds at t=%.2f"
 msgstr "Тозашавӣ %.2f аз сонияи t=%.2f"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pasting one type of track into another is not allowed."
+msgstr "Нусхабардории стерео ба аудио иҷозат дода намешавад."
 
 #: src/menus/EditMenus.cpp
 msgid "Copying stereo audio into a mono track is not allowed."
@@ -5404,7 +12432,13 @@ msgstr "Хомушӣ"
 msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
 msgstr "Дар роҳчаҳои ҷудокардашуда навишта шудааст %.2f нишонагузорӣ аз сонияи %.2f"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "Бур&иши қолабӣ"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Ҷудокунӣ"
 
@@ -5424,6 +12458,20 @@ msgstr "Якҷоя карда шудааст %.2fсаршавӣ бо сония�
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "Муттаҳидсозӣ"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Тозашавӣ %.2f аз сонияи t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Metadata Tags"
+msgstr "Таҳрири З&анҷираҳо..."
 
 #: src/menus/EditMenus.cpp
 msgid "&Edit"
@@ -5453,6 +12501,11 @@ msgstr "&Гузоштан"
 msgid "Duplic&ate"
 msgstr "Нусхабард&орӣ"
 
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "R&emove Special"
+msgstr "Ҷойивазку&нии Роҳчаҳо"
+
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
 msgid "Spl&it Cut"
@@ -5462,6 +12515,12 @@ msgstr "Пор&акунӣ Буридан"
 #: src/menus/EditMenus.cpp
 msgid "Split D&elete"
 msgstr "Поракунӣ Т&озакунӣ"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "Нишонаҳои Аз рӯи хомушӣ пурра кардашуда"
 
 #. i18n-hint: (verb)
 #: src/menus/EditMenus.cpp
@@ -5482,9 +12541,19 @@ msgstr "Поракунии На&в"
 msgid "&Join"
 msgstr "&Муттаҳидсозӣ"
 
+#: src/menus/EditMenus.cpp src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detac&h at Silences"
+msgstr "Интихоби хомӯшӣ"
+
 #: src/menus/EditMenus.cpp
 msgid "&Metadata..."
 msgstr "Таҳрири З&анҷираҳо..."
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Pre&ferences..."
+msgstr "&Параметрҳо..."
 
 #: src/menus/EditMenus.cpp
 msgid "&Delete Key"
@@ -5495,32 +12564,8 @@ msgid "Delete Key&2"
 msgstr "Калиди Поккунандаи2"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Лавҳаи омезишӣ"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "Бозигар"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Бозигар"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Бозигар"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "Сабтшавӣ"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Сабтшавӣ"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Сабтшавӣ"
+msgid "Ext&ra"
+msgstr ""
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -5541,6 +12586,17 @@ msgstr "Кэширонидани додаҳои садоӣ"
 #: src/menus/ExtraMenus.cpp
 msgid "Change Recording Cha&nnels..."
 msgstr "Ивази сабти овоз"
+
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, c-format
+msgid ""
+"Cannot create directory '%s'. \n"
+"File already exists that is not a directory"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
@@ -5564,12 +12620,28 @@ msgid "Please select a Note Track."
 msgstr "Созиши роҳчаи нави аудиоии нав"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI As:"
+msgstr "&Содирот..."
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI file"
 msgstr "Интихоби MIDI файл..."
 
 #: src/menus/FileMenus.cpp
 msgid "Allegro file"
 msgstr "Ҳамаи файлҳо (*)|*"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MIDI"
+msgstr "&Содирот..."
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -5583,6 +12655,11 @@ msgstr "Воридоти Нишонаҳо"
 #: src/menus/FileMenus.cpp
 msgid "Select a MIDI file"
 msgstr "Интихоби MIDI файл..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI and Allegro files"
+msgstr "Ҳамаи файлҳо (*)|*"
 
 #: src/menus/FileMenus.cpp
 msgid "MIDI files"
@@ -5600,6 +12677,12 @@ msgstr "Сабт ҳамчун..."
 #: src/menus/FileMenus.cpp
 msgid "Open Recent"
 msgstr "Кушодани файлҳои Қаблӣ"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "Сабти файлҳо"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -5658,6 +12741,11 @@ msgid "&Labels..."
 msgstr "&Нишонаҳо..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "&Содирот..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Маълумоти коркардношудаи..."
 
@@ -5674,6 +12762,10 @@ msgstr "&Чоп кардан..."
 #: src/menus/FileMenus.cpp
 msgid "E&xit"
 msgstr "Б&аромад"
+
+#: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
@@ -5698,8 +12790,17 @@ msgid "Fix"
 msgstr "Омехта"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "&Мадад"
+
+#: src/menus/HelpMenus.cpp
 msgid "Nothing to do"
 msgstr "Барҳамдиҳӣ ҷой надорад"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Clocks on the Tracks"
@@ -5714,6 +12815,18 @@ msgid "Recording stops and starts"
 msgstr "Масрафсанҷи сабт"
 
 #: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Audio Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "MIDI Device Info"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Quick Fix..."
 msgstr "&Мадад"
 
@@ -5722,7 +12835,8 @@ msgid "&Getting Started"
 msgstr "Ибтидои интихоб:"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
+#, fuzzy
+msgid "&Manual"
 msgstr "Таблои %s Audacity"
 
 #: src/menus/HelpMenus.cpp
@@ -5730,12 +12844,34 @@ msgid "&Quick Help..."
 msgstr "&Мадад"
 
 #: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Дар бораи Audacity..."
+msgid "&Manual..."
+msgstr ""
 
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/HelpMenus.cpp
+msgid "&Diagnostics"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "Au&dio Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&MIDI Device Info..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp src/widgets/ErrorDialog.cpp
+msgid "Show &Log..."
+msgstr ""
+
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Нишонаҳои иловашуда"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Text to New Label"
+msgstr "Ҷойгузории Ботартиб ба Роҳчаи Навбатӣ"
 
 #. i18n-hint: (verb) past tense.  Audacity has just cut the labeled audio
 #. regions.
@@ -5851,6 +12987,15 @@ msgid "Add Label at &Playback Position"
 msgstr "Иловаи Нишона Дар &Мавқеъи Хониш"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Paste Te&xt to New Label"
+msgstr "Ҷойгузории Ботартиб ба Роҳчаи Навбатӣ"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
 msgid "La&beled Audio"
 msgstr "Аудиои Сабтшуда"
 
@@ -5885,6 +13030,11 @@ msgid "Label Split Delete"
 msgstr "Ҷудокунӣ бо Тозакунӣ"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "Нишонаҳои Аз рӯи хомушӣ пурра кардашуда"
+
+#: src/menus/LabelMenus.cpp
 msgid "Label Silence"
 msgstr "Хомушӣ"
 
@@ -5909,6 +13059,23 @@ msgstr "Таҳрири Нишона"
 #: src/menus/LabelMenus.cpp
 msgid "Label Join"
 msgstr "Таҳрири Нишона"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr "Ҷойгузории Ботартиб ба Роҳчаи Навбатӣ"
 
 #: src/menus/NavigationMenus.cpp
 msgid "Move F&orward from Toolbars to Tracks"
@@ -5947,8 +13114,16 @@ msgid "Toggle Focuse&d Track"
 msgstr "Банизомдарории Роҳчаи Дупоя"
 
 #: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "..."
 msgstr "Нав..."
+
+#: src/menus/PluginMenus.cpp
+msgid "Unknown"
+msgstr ""
 
 #: src/menus/PluginMenus.cpp
 #, c-format
@@ -5965,6 +13140,10 @@ msgid "&Generate"
 msgstr "&Тавлид кардан"
 
 #: src/menus/PluginMenus.cpp
+msgid "Add / Remove Plug-ins..."
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
 msgid "Repeat Last Generator"
 msgstr "Муваллиди оҳанг"
 
@@ -5973,8 +13152,18 @@ msgid "Effe&ct"
 msgstr "Нати&ҷа"
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "Муваллиди оҳанг"
+
+#: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&Таҳлил"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Analyzer"
+msgstr "Муваллиди оҳанг"
 
 #: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
 msgid "T&ools"
@@ -6012,6 +13201,10 @@ msgstr "&Боркунии Озмоишии..."
 msgid "Simulate Recording Errors"
 msgstr "Сабтшавӣ"
 
+#: src/menus/PluginMenus.cpp
+msgid "Detect Upstream Dropouts"
+msgstr ""
+
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
@@ -6032,6 +13225,16 @@ msgstr "Ҷудокунӣ"
 #: src/menus/PluginMenus.cpp
 msgid "Set Track Status..."
 msgstr "Номи Роҳча"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Audio..."
+msgstr "Давомнокии хомӯшӣ:"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "&Роҳчаҳо"
 
 #: src/menus/PluginMenus.cpp
 msgid "Get Preference..."
@@ -6057,9 +13260,20 @@ msgstr "&Тағйири нишона"
 msgid "Set Project..."
 msgstr "Сабти Лоиҳа &Ҳамчун..."
 
+#. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Scripta&bles II"
+msgstr "Тағирёбанда"
+
 #: src/menus/PluginMenus.cpp
 msgid "Set Track..."
 msgstr "&Роҳчаҳо"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Info..."
+msgstr "Иттилоот"
 
 #: src/menus/PluginMenus.cpp
 msgid "Message..."
@@ -6085,6 +13299,33 @@ msgstr "Интихоби..."
 msgid "Compare Audio..."
 msgstr "Фишордиҳандаи..."
 
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Screenshot (short format)..."
+msgstr "&Чоп кардан..."
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Насби нуқтаи ҷудокунӣ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Мавқеи аудио:"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Насби нуқтаи ҷудокунӣ"
+
+#. i18n-hint: (verb) It's an item on a menu.
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Select"
+msgstr "Ҷудокунӣ"
+
 #: src/menus/SelectMenus.cpp
 msgid "&None"
 msgstr "&Ягонто"
@@ -6098,8 +13339,21 @@ msgid "&Tracks"
 msgstr "&Роҳчаҳо"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "In All &Tracks"
+msgstr "Роҳчаҳо"
+
+#: src/menus/SelectMenus.cpp
+msgid "In All &Sync-Locked Tracks"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Sync-Locked"
 msgstr "Интихоби-овоз"
+
+#: src/menus/SelectMenus.cpp
+msgid "R&egion"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
@@ -6118,8 +13372,18 @@ msgid "Set Selection Right at Play Position"
 msgstr "Аз мавқеъи рости хониш"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Track &Start to Cursor"
+msgstr "Интихоб ба Ибтидо"
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Track Start to Cursor"
 msgstr "Интихоб ба Ибтидо"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor to Track &End"
+msgstr "Номи Роҳча"
 
 #: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Track End"
@@ -6158,8 +13422,17 @@ msgid "Next &Lower Peak Frequency"
 msgstr "Басомади хаттӣ"
 
 #: src/menus/SelectMenus.cpp
+msgid "Cursor to Stored &Cursor Position"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Select Cursor to Stored"
 msgstr "Интихоб ба Ибтидо"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Store Cursor Pos&ition"
+msgstr "Мавқеи аудио:"
 
 #: src/menus/SelectMenus.cpp
 msgid "At &Zero Crossings"
@@ -6172,6 +13445,18 @@ msgstr "Ёфтани &Нуқтаҳлии наздиктарин"
 #: src/menus/SelectMenus.cpp
 msgid "&Selection"
 msgstr "Интихобкунӣ"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Off"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Nearest"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection to &Start"
@@ -6284,6 +13569,40 @@ msgstr "Курсори Чап"
 #: src/menus/SelectMenus.cpp
 msgid "Cursor Long Ju&mp Right"
 msgstr "Курсори Рост"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
+msgid "See&k"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
+#: src/menus/ToolbarMenus.cpp
+#, fuzzy
+msgid "&Toolbars"
+msgstr "Афзор"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
@@ -6435,6 +13754,15 @@ msgid "Align Together"
 msgstr "Марказонидани Якҷояи Роҳчаҳо"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Synchronize MIDI with Audio"
+msgstr "Марказонидани Интиҳо бо Интихоби Интиҳо"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
 msgstr "Шиддати муратабшуда"
 
@@ -6459,10 +13787,21 @@ msgid "Created new label track"
 msgstr "Созиши нишонаи нави роҳча"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Созиши вақти роҳчаи нав"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "New sample rate (Hz):"
+msgstr "Суръати намуна:"
+
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Ифодаи воридшуда нодуруст аст"
 
@@ -6482,6 +13821,25 @@ msgstr "Бознамунагирии Роҳча"
 #: src/menus/TrackMenus.cpp
 msgid "Please select at least one audio track and one MIDI track."
 msgstr "Созиши роҳчаи нави аудиоии нав"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync MIDI with Audio"
+msgstr "Марказонидани Интиҳо бо Интихоби Интиҳо"
+
+#: src/menus/TrackMenus.cpp
+#, c-format
+msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
@@ -6504,6 +13862,11 @@ msgid "Can't delete track with active audio"
 msgstr "Роҳчаро бо аудиои фаъол тоза карда наметавонад"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Add &New"
+msgstr "&Нав"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mono Track"
 msgstr "Ҷойивазшавии Роҳча"
 
@@ -6520,8 +13883,18 @@ msgid "&Time Track"
 msgstr "&Роҳчаи Вақт"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x"
+msgstr "Лавҳаи омезишӣ"
+
+#: src/menus/TrackMenus.cpp
 msgid "Mix Stereo Down to &Mono"
 msgstr "Корбарии стерео ба моно"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mi&x and Render"
+msgstr "&Омезиш ва Пешниҳодкунӣ"
 
 #: src/menus/TrackMenus.cpp
 msgid "Mix and Render to Ne&w Track"
@@ -6540,6 +13913,11 @@ msgid "M&ute/Unmute"
 msgstr "Хомӯшкунӣ/Баргардонидани роҳчаи садогӣ "
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Mute All Tracks"
+msgstr "К&ушодани Ҳамаи Роҳчаҳо"
+
+#: src/menus/TrackMenus.cpp
 msgid "&Unmute All Tracks"
 msgstr "К&ушодани Ҳамаи Роҳчаҳо"
 
@@ -6550,6 +13928,10 @@ msgstr "&Роҳчаҳо"
 #: src/menus/TrackMenus.cpp
 msgid "U&nmute Tracks"
 msgstr "К&ушодани Ҳамаи Роҳчаҳо"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "&Left"
@@ -6574,6 +13956,11 @@ msgstr "Марказ"
 #: src/menus/TrackMenus.cpp
 msgid "Pan Center"
 msgstr "Марказ"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "Роҳчаҳо"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Align End to End"
@@ -6602,6 +13989,11 @@ msgstr "&Вақти оғоз"
 #: src/menus/TrackMenus.cpp
 msgid "By &Name"
 msgstr "Ном"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "Ҷойгузории муҳит барои роҳчаи дигар"
 
 #: src/menus/TrackMenus.cpp
 msgid "&Track"
@@ -6673,7 +14065,9 @@ msgstr "Иҷро"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Сабтшавӣ"
 
@@ -6686,8 +14080,27 @@ msgid "no label track at or below focused track"
 msgstr "Мувофиқаткунӣ дар роҳчаи фаъол"
 
 #: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
 msgid "no labels in label track"
 msgstr "Созиши нишонаи нави роҳча"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -6716,9 +14129,34 @@ msgstr "Луғат"
 msgid "Pl&aying"
 msgstr "Иҷро"
 
+#. i18n-hint: (verb) Start or Stop audio playback
+#: src/menus/TransportMenus.cpp
+msgid "Pl&ay/Stop"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "Иҷро дар суръат"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Pause"
+msgstr "Таваққуф"
+
 #: src/menus/TransportMenus.cpp
 msgid "&Recording"
 msgstr "Сабтшавӣ"
+
+#. i18n-hint: (verb)
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Record"
+msgstr "Сабт"
 
 #: src/menus/TransportMenus.cpp
 msgid "&Append Record"
@@ -6729,8 +14167,71 @@ msgid "Record &New Track"
 msgstr "Ҷойивазку&нии Роҳчаҳо"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Сабтшавӣ"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Pla&y Region"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Lock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "&Unlock"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "R&escan Audio Devices"
+msgstr "Масрафсанҷи сабт"
+
+#: src/menus/TransportMenus.cpp
 msgid "Transport &Options"
 msgstr "Луғат"
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound Activation Le&vel..."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Сабтшавӣ"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid "So&ftware Playthrough (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "Луғат"
+
+#. i18n-hint: (verb) Start playing audio
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pl&ay"
+msgstr "Иҷро"
+
+#. i18n-hint: (verb) Stop playing audio
+#: src/menus/TransportMenus.cpp
+msgid "Sto&p"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Play &One Second"
@@ -6848,6 +14349,11 @@ msgid "&Fit to Width"
 msgstr "&Равзанаи муносиб"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Fit to &Height"
+msgstr "&Равзанаи муносиб"
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Печонидани Ҳамаи Роҳчаҳо"
 
@@ -6872,12 +14378,57 @@ msgid "Skip to Selection End"
 msgstr "Интиҳо ба интихоб"
 
 #: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
 msgstr "Иҷозати буриш"
+
+#: src/menus/ViewMenus.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Show Effects Rack"
+msgstr "Нати&ҷа"
 
 #: src/menus/WindowMenus.cpp
 msgid "&Window"
 msgstr " равзана"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
+#: src/ondemand/ODComputeSummaryTask.h
+msgid "Import complete. Calculating waveform"
+msgstr ""
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Масрафсанҷи сабт"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -6885,7 +14436,7 @@ msgstr "Қисматҳо..."
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Баромад аз Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -6905,6 +14456,15 @@ msgstr "Қисматҳо..."
 msgid "Behaviors"
 msgstr "Рафтор"
 
+#: src/prefs/BatchPrefs.cpp
+msgid "&Don't apply effects in batch mode"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Devices"
+msgstr "Афзор"
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Preferences for Device"
 msgstr "Қисматҳо..."
@@ -6915,11 +14475,17 @@ msgctxt "device"
 msgid "Interface"
 msgstr "Робита"
 
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "Истифодаи:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Бозигар"
 
@@ -6939,7 +14505,8 @@ msgstr "Маҷро(Канал)"
 msgid "Latency"
 msgstr "Таваққуф"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "миллисония"
 
@@ -6952,6 +14519,15 @@ msgid "&Latency compensation:"
 msgstr "Таркиббандии калид"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Роҳча(ҳо)и аудиоии ҷобаҷогузошташуда"
+
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "No devices found"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
 msgid "1 (Mono)"
 msgstr "1 (Моно)"
 
@@ -6960,17 +14536,37 @@ msgid "2 (Stereo)"
 msgstr "2 (Стерео)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Рӯйхатҳо"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Лоиҳаҳоро барқарор созед"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Default directories"
 msgstr "Рӯйхатҳо"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "&Browse..."
 msgstr "Баррасии..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "B&rowse..."
@@ -7001,6 +14597,11 @@ msgid "Temporary files directory"
 msgstr "Рӯйхатҳои файлҳои муваққатӣ"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Location:"
+msgstr "Амал"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory cannot be on a FAT drive."
 msgstr "Рӯйхатҳои файлҳои муваққатӣ"
 
@@ -7017,8 +14618,17 @@ msgid "Choose a location to place the temporary directory"
 msgstr "Интихоби ҷой барои ҷойкунии рӯйхати муваққатӣ"
 
 #: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location"
 msgstr "И&нтихоби фармон"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, c-format
+msgid "Directory %s is not suitable (at risk of being cleaned out)"
+msgstr ""
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -7035,8 +14645,14 @@ msgid "Directory %s is not writable"
 msgstr "Рӯйхати %s навишта намешавад"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Тағиротҳо ба рӯйхати муваққатӣ то аз навборкунии Audacity натиҷагирӣ намешаванд"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Рӯйхати нави муваққатӣ"
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Preferences for Effects"
@@ -7046,11 +14662,36 @@ msgstr "Қисматҳо..."
 msgid "Sorted by Effect Name"
 msgstr "Ҷудокунӣ Аз рӯи Ном"
 
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Publisher and Effect Name"
+msgstr "Ҷудокунӣ Аз рӯи Ном"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Type and Effect Name"
+msgstr "Ҷудокунӣ Аз рӯи Ном"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/prefs/EffectsPrefs.cpp
 msgid "&LADSPA"
 msgstr "Нати&ҷа"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
 
 #. i18n-hint: "Nyquist" is an embedded interpreted programming language in
 #. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
@@ -7060,17 +14701,141 @@ msgstr "Нати&ҷа"
 msgid "N&yquist"
 msgstr "Оҳанг"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Enable Effects"
+msgstr "Нати&ҷа"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Effect Options"
 msgstr "Танзимоти натиҷаҳо"
 
 #: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Maximum effects per group (0 to disable):"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "Plugin Options"
 msgstr "Дастаҳои иттисоли 1 ба %i"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Rescan plugins next time Tenacity is started"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Instruction Set"
+msgstr "Зудии Синхронӣ бо Иловашавӣ"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Use SSE/SSE2/.../AVX"
+msgstr ""
+
+#. i18n-hint:  Title of dialog governing "Extended", or "advanced,"
+#. * audio file import options
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Extended Import"
+msgstr "Воридот"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Preferences for ExtImport"
 msgstr "Қисматҳо..."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Rules to choose import filters"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Mime-types"
+msgstr "Навъи хаш:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Importer order"
+msgstr "Воридоти НишонаҳоҲамчун:"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Ҳаракат &ба боло"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Ҳаракат &ба поён"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "Ҳаракат &ба боло"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Ҳаракат &ба поён"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Тозакунии Нишонаҳои ҷудокардашуда"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Мавқеи вуруд:"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Spaces detected"
+msgstr "Ҷудокунӣ"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "Шумо бовари доред, ки %s нест карда шавад?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Давомнокии оҳанг:"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
@@ -7095,6 +14860,11 @@ msgid "-48 dB (PCM range of 8 bit samples)"
 msgstr "-48 dB (соҳаи PCM аз намунаҳаи 8 бита)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-60 dB (PCM range of 10 bit samples)"
+msgstr "-96 dB (соҳаи PCM аз намунаҳои 16 бита)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-72 dB (PCM range of 12 bit samples)"
 msgstr "-96 dB (соҳаи PCM аз намунаҳои 16 бита)"
 
@@ -7114,9 +14884,100 @@ msgstr "-120 dB (ҳудуди шунавоӣ)"
 msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (соҳаи PCM намунаҳои 24 бита)"
 
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Local"
+msgstr "Амал"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "From Internet"
+msgstr ""
+
 #: src/prefs/GUIPrefs.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.cpp
 msgid "Display"
 msgstr "Намуд"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "&Language:"
+msgstr "Забон:"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "Мавқеъи %s:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Meter dB &range:"
+msgstr "Мавҷшакл (dB)"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show 'How to Get &Help' at launch"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show e&xtra menus"
+msgstr "Фаъол шуд"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Show alternative &styling (Mac vs PC)"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "&Beep on completion of longer activities"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Show Timeline Tooltips"
+msgstr "Дастаҳои иттисоли 1 ба %i"
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Show Scrub Ruler"
+msgstr "Масрафсанҷи ғайрифаъол"
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Import / Export"
+msgstr "Воридоти НишонаҳоҲамчун:"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Preferences for ImportExport"
+msgstr "Қисматҳо..."
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "&Mix down to Stereo or Mono"
@@ -7131,6 +14992,10 @@ msgid "S&tandard"
 msgstr "Танзимшуда"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "E&xtended (with frequency ranges)"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "&Seconds"
 msgstr "сонияҳо"
 
@@ -7139,8 +15004,29 @@ msgid "&Beats"
 msgstr "Такрор"
 
 #: src/prefs/ImportExportPrefs.cpp
+msgid "When exporting tracks to an audio file"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "S&how Metadata Tags editor before export"
+msgstr ""
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "Exported Label Style:"
 msgstr "Воридоти НишонаҳоҲамчун:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.h
+msgid "IMPORT EXPORT"
+msgstr ""
 
 #. i18n-hint: as in computer keyboard (not musical!)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -7152,6 +15038,18 @@ msgid "Preferences for KeyConfig"
 msgstr "Қисматҳо..."
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Тугмаҳои фаъол"
 
@@ -7160,12 +15058,49 @@ msgid "View by:"
 msgstr "&Намуд"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "Ном"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Намуд"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Намуд"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Намуд"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Searc&h:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Bindings"
 msgstr "Тугмаҳои фаъол"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Short cut"
+msgstr ""
+
+#. i18n-hint: (verb)
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "&Set"
+msgstr "&Қисматҳо..."
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Note: Pressing Cmd+Q will quit. All other keys are valid."
@@ -7180,7 +15115,15 @@ msgid "&Defaults"
 msgstr "&Аз рӯи хомӯшӣ"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Интихоби файли XML, ки дорои тугмаҳои фаъоли саҳфакалиди Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -7189,8 +15132,21 @@ msgstr "Вуруди таркиббандии саҳфакалид ҳамчун:
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "%d миёнбури саҳфакалид бор карда шудааст\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -7204,6 +15160,38 @@ msgstr "Вуруди таркиббандии саҳфакалид ҳамчун:
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Вуруди таркиббандии саҳфакалид ҳамчун:"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
 #: src/prefs/KeyConfigPrefs.h
 msgid "Key Config"
 msgstr "Таркиббандии калид"
@@ -7213,12 +15201,72 @@ msgid "Preferences for Library"
 msgstr "Қисматҳо..."
 
 #: src/prefs/LibraryPrefs.cpp
+msgid "LAME MP3 Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "MP3 Library Version:"
 msgstr "Тариқаи феҳристи MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg Import/Export Library"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "No compatible FFmpeg library was found"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "FFmpeg support is not compiled in"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library Version:"
+msgstr "Тариқаи феҳристи MP3:"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg Library:"
+msgstr "Хатои LOF"
+
+#: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "Loca&te..."
+msgstr "&Захира кардан..."
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Dow&nload"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.h
+msgid "Library"
+msgstr ""
+
+#. i18n-hint: untranslatable acronym for "Musical Instrument Device Interface"
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "MIDI Devices"
+msgstr "Интихоби MIDI файл..."
 
 #: src/prefs/MidiIOPrefs.cpp
 msgid "Preferences for MidiIO"
 msgstr "Қисматҳо..."
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Робита"
 
 #. i18n-hint Software interface to MIDI
 #: src/prefs/MidiIOPrefs.cpp
@@ -7226,17 +15274,77 @@ msgctxt "MIDI"
 msgid "Interface"
 msgstr "Робита"
 
+#: src/prefs/MidiIOPrefs.cpp
+msgid "Using: PortMidi"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Имконияти камтари басомад бояд бузургии тағирёбанда бошад"
+
+#: src/prefs/MidiIOPrefs.h
+msgid "Midi IO"
+msgstr ""
+
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
+#: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
 #: src/prefs/ModulePrefs.cpp
 msgid "Preferences for Module"
 msgstr "Қисматҳо..."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+msgid ""
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
+"and know what you are doing."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Тағиротҳо ба рӯйхати муваққатӣ то аз навборкунии Audacity натиҷагирӣ намешаванд"
 
 #: src/prefs/ModulePrefs.cpp
 msgid "Ask"
 msgstr "Маро пурсед"
+
+#: src/prefs/ModulePrefs.cpp
+msgid "Failed"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+msgid "No modules were found"
+msgstr ""
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -7278,13 +15386,26 @@ msgstr "Тугмаи чап -кашидашавӣ "
 msgid "Set Selection Range"
 msgstr "Интихоби насби соҳа"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-Left-Пахшкунӣ"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Extend Selection Range"
 msgstr "Васеъкунии соҳаи интихоб"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Left-Double-Click"
+msgstr "Alt-Left-Пахш"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Select Clip or Entire Track"
+msgstr "Интихоб ба Интиҳо"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
@@ -7323,6 +15444,26 @@ msgid "same as left-drag"
 msgstr "ҳамон як кашиши чап"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Drag"
+msgstr "Shift-Left-кашиш"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom out on a Range"
+msgstr "Наздиккунӣ дар соҳа"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Middle-Click"
+msgstr "Пахши чап"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Zoom default"
+msgstr "&Аз рӯи хомӯшӣ"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Move clip left/right or between tracks"
 msgstr "Ҷойгузорӣ ба боло/поён байни роҳчаҳо"
 
@@ -7341,6 +15482,15 @@ msgstr "Тугмаи чап -кашидашавӣ "
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Ҷойгузорӣ ба боло/поён байни роҳчаҳо"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "Тугмаи чап -кашидашавӣ "
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -7392,6 +15542,11 @@ msgid "Scroll tracks up or down"
 msgstr "Чархиш ба боло ё поён"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Shift-Wheel-Rotate"
+msgstr "Чархиши чарх"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Scroll waveform"
 msgstr "Мавҷшакл"
 
@@ -7428,9 +15583,46 @@ msgstr "Дарозӣ"
 msgid "Cut Preview"
 msgstr "Буриши пешнамоиш"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Before cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&After cut region:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Seek Time when playing"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Қисматҳои Audacity"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -7439,6 +15631,11 @@ msgstr "Қисматҳо..."
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Қисматҳо..."
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -7457,12 +15654,32 @@ msgid "Default Sample &Format:"
 msgstr "Қолаби намуна аз рӯи хомушӣ:"
 
 #: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Табдилдиҳии басомади намуна"
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Con&verter:"
 msgstr "Табдилдиҳии басомади намуна"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
+
+#: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "High-quality Conversion"
+msgstr "Интерполятсияи баландсифати синхронӣ"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Conver&ter:"
 msgstr "Табдилдиҳии басомади намуна"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
 
 #: src/prefs/QualitySettings.cpp
 msgid "16-bit"
@@ -7477,8 +15694,30 @@ msgid "Preferences for Recording"
 msgstr "Қисматҳо..."
 
 #: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "&Software playthrough of input"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Record on a new track"
 msgstr "Роҳчаи Нав"
+
+#. i18n-hint: Dropout is a loss of a short sequence audio sample data from the recording
+#: src/prefs/RecordingPrefs.cpp
+msgid "Detect dropouts"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Сабтшавӣ"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
@@ -7489,9 +15728,19 @@ msgstr "Сатҳ:"
 msgid "Name newly recorded tracks"
 msgstr "Омехтакунӣ ва муттаҳидсозии роҳчаҳо"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+msgid "With:"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Номи Роҳча"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Таҳрири Нишона"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Recorded_Audio"
@@ -7501,11 +15750,67 @@ msgstr "Аудиои Сабтшуда"
 msgid "&Track Number"
 msgstr "Рақами роҳча"
 
+#: src/prefs/RecordingPrefs.cpp
+msgid "System &Date"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "System T&ime"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Қисматҳо..."
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Cross&fade:"
+msgstr "Қайди Роҳча"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
 #. i18n-hint: New color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
 msgctxt "spectrum prefs"
 msgid "Color (default)"
 msgstr "256 - аз рӯи хомушӣ"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "256 - аз рӯи хомушӣ"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "Хатӣ"
 
 #. i18n-hint: Inverse grayscale color scheme for spectrograms
 #: src/prefs/SpectrogramSettings.cpp
@@ -7517,14 +15822,42 @@ msgstr "Хатӣ"
 msgid "Frequencies"
 msgstr "Басомад (Ҳз)"
 
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
+
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Pitch (EAC)"
 msgstr "Баландии садо (EAC)"
 
 #: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Maximum frequency must be 100 Hz or above"
+msgstr "Имконияти камтари басомад бояд 0 Hz бошад"
+
+#: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "Имконияти камтари басомад бояд 0 Hz бошад"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Имконияти камтари басомад бояд 0 Hz бошад"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "Имконияти камтари басомад бояд 0 Hz бошад"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -7543,6 +15876,10 @@ msgstr "Қисматҳо..."
 msgid "&Use Preferences"
 msgstr "Қисматҳо..."
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+msgid "S&cale:"
+msgstr ""
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "Басомади камтарин (Ҳз):"
@@ -7550,6 +15887,24 @@ msgstr "Басомади камтарин (Ҳз):"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "Басомади бештарин (Ҳз):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Colors"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "Шабакаҳои бурунӣ: %2d"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Баландкунӣ (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -7572,12 +15927,52 @@ msgid "1024 - default"
 msgstr "256 - аз рӯи хомушӣ"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "32768 - most narrowband"
+msgstr "8 - бештар паҳнохат"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Window &type:"
 msgstr "Намуди равзана:"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Zero padding factor:"
+msgstr "Харобии омил:"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Ena&ble Spectral Selection"
 msgstr "Интихобкунӣ"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Show a grid along the &Y-axis"
+msgstr ""
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+msgid "FFT Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Minimum Amplitude (dB):"
+msgstr "Доманаи Нави Қулла (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "Max. Number of Notes (1..128):"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Find Notes"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "&Quantize Notes"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Global settings"
@@ -7594,6 +15989,36 @@ msgstr "Имконияти бештари басомад бояд бузурги
 #: src/prefs/SpectrumPrefs.cpp
 msgid "The minimum frequency must be an integer"
 msgstr "Имконияти камтари басомад бояд бузургии тағирёбанда бошад"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Имконияти бештари басомад бояд бузургии тағирёбанда бошад"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Имконияти бештари басомад бояд бузургии тағирёбанда бошад"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Имконияти бештари басомад бояд бузургии тағирёбанда бошад"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The minimum amplitude (dB) must be an integer"
+msgstr "Имконияти камтари басомад бояд бузургии тағирёбанда бошад"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Имконияти бештари басомад бояд бузургии тағирёбанда бошад"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Имконияти бештари басомад бояд бузургии тағирёбанда бошад"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
@@ -7612,13 +16037,14 @@ msgid "Info"
 msgstr "Иттилоот"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -7637,6 +16063,12 @@ msgstr ""
 "[Танҳо рангҳо ва сутуни абзор дар роҳчаи мавҷдор фаъоланд\n"
 "ҳато агар тасвири файл \n"
 " дигар расмҳоро нишон диҳад.]"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
 #. * so keep it as is
@@ -7674,6 +16106,11 @@ msgid "Preferences for TracksBehaviors"
 msgstr "Рафтор"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Simple"
+msgstr "намунаҳо"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Multi-track"
 msgstr "Бисёр"
 
@@ -7691,8 +16128,33 @@ msgid "Enable &dragging selection edges"
 msgstr "Иловаи нишонаҳо дар ҷудокунӣ"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Enable scrolling left of &zero"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Advanced &vertical zooming"
 msgstr "Қисматҳои омехтаи пешрафта"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Тугма"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Logarithmic (dB)"
@@ -7706,6 +16168,14 @@ msgstr "Мавҷшакл"
 msgid "Spectrogram"
 msgstr "Спектограммаҳо"
 
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Fit to Width"
 msgstr "&Равзанаи муносиб"
@@ -7717,6 +16187,10 @@ msgstr "&Тағири тасвир барои интихоб"
 #: src/prefs/TracksPrefs.cpp
 msgid "Zoom Default"
 msgstr "&Аз рӯи хомӯшӣ"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Minutes"
+msgstr ""
 
 #: src/prefs/TracksPrefs.cpp plug-ins/sample-data-export.ny
 msgid "Seconds"
@@ -7739,6 +16213,16 @@ msgid "50ths of Seconds"
 msgstr "сонияҳо"
 
 #: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "100ths of Seconds"
+msgstr "сонияҳо"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "500ths of Seconds"
+msgstr "сонияҳо"
+
+#: src/prefs/TracksPrefs.cpp
 msgid "MilliSeconds"
 msgstr "миллисония"
 
@@ -7746,7 +16230,12 @@ msgstr "миллисония"
 msgid "Samples"
 msgstr "намунаҳо"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Калонкунӣ"
 
@@ -7755,12 +16244,42 @@ msgid "Preferences for Tracks"
 msgstr "Қисматҳо..."
 
 #: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Сабтшавӣ"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
 msgid "Default &view mode:"
 msgstr "Басомади намуна аз рӯи пешфарз:"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default Waveform scale:"
 msgstr "Қолаби намуна аз рӯи хомушӣ:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "намунаҳо"
 
 #: src/prefs/TracksPrefs.cpp
 msgid "Default audio track &name:"
@@ -7783,9 +16302,46 @@ msgstr "Бознасбшуда"
 msgid "Preset 2:"
 msgstr "Бознасбшуда"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "Огоҳӣ"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Preferences for Warnings"
 msgstr "Қисматҳо..."
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Show Warnings/Prompts for"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &projects"
+msgstr "&Сабти Лоиҳа"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Saving &empty project"
+msgstr "&Сабти Лоиҳа"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &mono during export"
+msgstr "Корбарии стерео ба моно"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Mixing down to &stereo during export"
+msgstr "Корбарии стерео ба моно"
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
 
 #. i18n-hint: A waveform is a visual representation of vibration
 #: src/prefs/WaveformPrefs.cpp
@@ -7808,16 +16364,24 @@ msgid "Stopped"
 msgstr "Боздорӣ"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Таваққуф"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Гузариш ба Ибтидо"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Гузариш ба Интиҳо"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Таваққуф"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Интихоб ба Ибтидо"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Интихоб ба Интиҳо"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -7831,20 +16395,24 @@ msgstr "Роҳчаи Нав"
 msgid "Append Record"
 msgstr "Сабт"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Интихоб ба Интиҳо"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Интихоб ба Ибтидо"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "Таваққуф"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Лавҳаи Рӯйнависӣ"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -7855,6 +16423,11 @@ msgstr "Суръати иҷро"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Масрафсанҷи сабт"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "Мавқеи аудио:"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -7877,8 +16450,18 @@ msgid "Select Playback Device"
 msgstr "Суръати иҷро"
 
 #: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "Давомнокии хомӯшӣ:"
+
+#: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
 msgstr "Шабакаи чап рост"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Device information is not available."
+msgstr "Пештасвир дастрас нест\n"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that manages devices
@@ -7902,11 +16485,22 @@ msgstr "Буриши ҳамаи ғайриҷудошудаҳо"
 msgid "Silence audio selection"
 msgstr "Интихоб аз рӯи хомӯшӣ"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "&Роҳчаҳо"
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Калонкунӣ"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Хурдкунӣ"
 
@@ -7917,6 +16511,11 @@ msgstr "Пурракунии интихоб дар равзана"
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "Пурракунии лоиҳа дар равзана"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "Нати&ҷа"
 
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
@@ -7969,38 +16568,24 @@ msgstr "Лавҳаи чароғакҳо"
 msgid "&Playback Meter Toolbar"
 msgstr "Иҷрои масрафсанҷ"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Сабтшавӣ"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Бозигар"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Масрафсанҷи ғайрифаъол"
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Сабтшавӣ"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Бозигар"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Бозигар"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Лавҳаи омезишӣ"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Дархости Nyquist..."
 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Дархости Nyquist..."
@@ -8008,6 +16593,7 @@ msgstr "Дархости Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Дархости Nyquist..."
@@ -8015,9 +16601,24 @@ msgstr "Дархости Nyquist..."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Seeking"
+msgstr "Ибтидои мазмун"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Ибтидои мазмун"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Hide Scrub Ruler"
+msgstr "Масрафсанҷи ғайрифаъол"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. that enables Scrub or Seek playback and Scrub Ruler
@@ -8028,6 +16629,10 @@ msgstr "Лавҳаи таҳрирӣ"
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "Суръати лоиҳа (Hz):"
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap-To"
+msgstr ""
 
 #: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
 msgid "Audio Position"
@@ -8049,13 +16654,36 @@ msgstr "Интиҳо ба интихоб"
 msgid "Length and Center of Selection"
 msgstr "Ҷудошудаҳои файл барои интихоб"
 
+#: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
+msgid "Show"
+msgstr ""
+
+#: src/toolbars/SelectionBar.cpp
+msgid "Snap To"
+msgstr ""
+
 #: src/toolbars/SelectionBar.cpp
 msgid "Length"
 msgstr "Дарозӣ"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Марказ"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -8082,6 +16710,10 @@ msgstr "Баландкунии Басомади  "
 msgid "Center Frequency"
 msgstr "Басомади хаттӣ"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
@@ -8100,8 +16732,8 @@ msgstr "Лавҳаи таҷҳизот"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Таблои %s Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -8128,7 +16760,8 @@ msgstr "Вақти Интихоби Афзор"
 msgid "Zoom Tool"
 msgstr "Тағирдиҳии андозаи Афзор"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Тасвири афзор"
 
@@ -8204,11 +16837,13 @@ msgstr "Кашидани як ё якчанд сарҳадҳои нишонаҳ�
 msgid "Drag label boundary."
 msgstr "Кашидани як ё якчанд сарҳадҳои нишонаҳо"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Тағиротҳои Нишонавӣ"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Таҳрири Нишона"
 
@@ -8228,6 +16863,12 @@ msgstr "Нишонаи Қалам(шрифт)и Роҳча"
 #. i18n-hint: (noun) The name of the typeface
 #: src/tracks/labeltrack/ui/LabelTrackControls.cpp
 msgid "Face name"
+msgstr "Ду&бора ном гузоштан"
+
+#. i18n-hint: (noun) The size of the typeface
+#: src/tracks/labeltrack/ui/LabelTrackControls.cpp
+#, fuzzy
+msgid "Face size"
 msgstr "Ду&бора ном гузоштан"
 
 #: src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -8258,31 +16899,42 @@ msgstr "Нишонаҳои таҳриршуда"
 msgid "New label"
 msgstr "Нишонаҳои иловашуда"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Актаваи Боло"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Актаваи Поён"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Барои наздиксозии амудӣ пахшро иҷро кунед, Shift-ро барои дурсозӣ ва Drag-ро барои сохтани наздиксозии муҳити махсус истифода кунед."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Пахши рост"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Хурдкунӣ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-Left-Пахшкунӣ"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Shift-Left-Пахшкунӣ"
 
@@ -8305,10 +16957,28 @@ msgid "Stretch"
 msgstr "Харобии омил:"
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#, fuzzy
+msgid "Merged Clips"
+msgstr "Иҷозати буриш"
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Merge"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Expanded Cut Line"
 msgstr "Васеъшавии Хати Буриш"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Васеъкунӣ"
 
@@ -8321,12 +16991,21 @@ msgid "Click and drag to edit the samples"
 msgstr "Барои таҳрири намунаҳо кашиш ва пахшро иҷро кунед"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+msgid "To use Draw, zoom in further until you can see the individual samples."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Moved Samples"
 msgstr "Намунаи Ҷойивазшуда"
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Намунаи Таҳрир"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -8335,6 +17014,16 @@ msgstr "Наздиккунӣ бо нуқта"
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "&Spectrogram"
 msgstr "Спектограммаҳо"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 msgid "S&pectrogram Settings..."
@@ -8360,7 +17049,8 @@ msgstr "Пардозиши Auto Duck..."
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' ба %s тағйир дода шуд"
@@ -8374,7 +17064,60 @@ msgid "Rat&e"
 msgstr "Насби Босуръат"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "8000 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "22050 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "44100 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "48000 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "88200 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "96000 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "176400 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "192000 Hz"
+msgstr "0100 с 060 д 060>01000 с"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "384000 Hz"
 msgstr "0100 с 060 д 060>01000 с"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -8395,7 +17138,8 @@ msgstr "Ивази Басомад"
 msgid "Set Rate"
 msgstr "Насби Босуръат"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Бисёр"
 
@@ -8487,6 +17231,27 @@ msgstr "Чап, "
 msgid "Right, %dHz"
 msgstr "Рост, "
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.0f%% Left"
+msgstr ""
+
+#. i18n-hint: Stereo pan setting
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.0f%% Right"
+msgstr "рост"
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "Пахш ва кашидан барои ба тартибоварии андозаи роҳчаҳои стереоӣ."
@@ -8494,6 +17259,15 @@ msgstr "Пахш ва кашидан барои ба тартибоварии а
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to rearrange sub-views"
 msgstr "Барои ҷойивазкунии роҳча пахш ва кашишро иҷро кунед"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Rearrange sub-views"
+msgstr "Барои ҷойивазкунии роҳча пахш ва кашишро иҷро кунед"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom x1/2"
@@ -8503,6 +17277,10 @@ msgstr "Калонкунӣ"
 msgid "Zoom x2"
 msgstr "Калонкунӣ"
 
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+msgid "Half Wave"
+msgstr ""
+
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "Wa&veform"
 msgstr "Мавҷшакл"
@@ -8510,6 +17288,11 @@ msgstr "Мавҷшакл"
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "&Wave Color"
 msgstr "Мавҷшакл"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, c-format
+msgid "Instrument %i"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 msgid "WaveColor Change"
@@ -8542,16 +17325,37 @@ msgid "Set Range"
 msgstr "Насби Суръат"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Display"
 msgstr "Намуд"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Set Interpolation"
 msgstr "Зудии Синхронӣ бо Иловашавӣ"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Linear scale"
 msgstr "Хатӣ"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Зудии Синхронӣ бо Иловашавӣ"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "&Range..."
@@ -8563,9 +17367,8 @@ msgstr "Зудии Синхронӣ бо Иловашавӣ"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Барои ҷойивазкунии роҳча пахш ва кашишро иҷро кунед"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -8616,6 +17419,21 @@ msgstr "Ба тартибории лифофавӣ."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Лавҳаи таҳрирӣ"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Seeking"
+msgstr "Ибтидои мазмун"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Масрафсанҷи ғайрифаъол"
@@ -8631,6 +17449,16 @@ msgstr "Пӯшидани роҳчаи фаъол"
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Move mouse pointer to Scrub"
 msgstr "Ҷойгузории Роҳча ба Поён"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Дархости Nyquist..."
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Гузариш ба Ибтидо"
 
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub For&wards"
@@ -8683,6 +17511,11 @@ msgstr "Барои ҷудокунии аудио пахш ва кашишро и
 msgid "Click and drag to select audio"
 msgstr "Барои ҷудокунии аудио пахш ва кашишро иҷро кунед"
 
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
+
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Барои ҷойивазкунии роҳча пахш ва кашишро иҷро кунед"
@@ -8704,6 +17537,10 @@ msgstr "Дар роҳчаҳои ҷудокардашуда навишта шуд
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Дар роҳчаҳои ҷудокардашуда навишта шудааст %.2f нишонагузорӣ аз сонияи %.2f"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -8730,6 +17567,12 @@ msgstr "&Фармон"
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Ctrl+Click"
 msgstr "Пахши чап"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "Созиши роҳчаи нави аудиоии нав"
 
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
@@ -8788,6 +17631,20 @@ msgstr "Ч"
 msgid "R"
 msgstr "Р"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"\"%s\" вуҷуд надорад.\n"
+"\n"
+"Шумо онро сохтан мехоҳад?"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Please choose an existing file."
 msgstr " Лутфан, амалиётро интихоб намоед "
@@ -8811,6 +17668,34 @@ msgstr "Контакткунанда"
 #: src/widgets/Grid.cpp
 msgid "Empty"
 msgstr "Холӣ"
+
+#: src/widgets/HelpSystem.cpp
+msgid "Backwards"
+msgstr ""
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Гузариш ба Ибтидо"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+msgid "Help on the Internet"
+msgstr ""
+
+#: src/widgets/KeyView.cpp
+#, fuzzy
+msgid "Menu"
+msgstr "Ҳамаи файлҳо (*)|*"
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -8849,6 +17734,13 @@ msgid "Refresh Rate"
 msgstr "Насби Босуръат"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "Масрафсанҷи басомади навшуда дар сония [1-100]: "
 
@@ -8861,12 +17753,21 @@ msgid "Meter Style"
 msgstr "масрафсанҷ"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "масрафсанҷ"
 
 #: src/widgets/Meter.cpp
 msgid "Orientation"
 msgstr "Давомнокӣ"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Ба таври автоматӣ барқарорсозӣ баъди садама"
 
 #: src/widgets/Meter.cpp
 msgid "Horizontal"
@@ -8879,6 +17780,33 @@ msgstr "Идоракунандаи амудӣ"
 #: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr "Мазмуни охирин"
+
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+msgid "Show Log for Details"
+msgstr ""
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Созиши роҳчаи нави аудиоии нав"
 
 #. i18n-hint: Format string for displaying time in seconds. Change the comma
 #. * in the middle to the 1000s separator for your locale, and the 'seconds'
@@ -8918,6 +17846,25 @@ msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 рӯз 024 с 060 д 060 с"
 
 #. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "сс:дд:сс + мисолҳо"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 с 060 д 060>01000 с"
+
+#. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
@@ -8954,6 +17901,7 @@ msgstr "0100 с 060 д 060 с+># мисолҳо"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "намунаҳо"
@@ -9115,6 +18063,10 @@ msgstr "01000,01000 кадр|75"
 msgid "010,01000>0100 Hz"
 msgstr "0100 с 060 д 060>01000 с"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows frequency in kilohertz
 #: src/widgets/NumericTextCtrl.cpp
 msgid "kHz"
@@ -9127,6 +18079,10 @@ msgstr "kҲертз"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000>01000 kHz|0.001"
 msgstr "0100 с 060 д 060>01000 с"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
 
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
@@ -9142,15 +18098,76 @@ msgstr "Актаваи Поён"
 msgid "100>01000 octaves|1.442695041"
 msgstr "01000,01000 кадрҳо|24"
 
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
 #. i18n-hint: Format string for displaying log of frequency in decades.
 #. * Change the decimal points for your locale. Don't change the numbers.
 #: src/widgets/NumericTextCtrl.cpp
 msgid "10>01000 decades|0.434294482"
 msgstr "01000,01000 кадрҳо|24"
 
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "(Use context menu to change format.)"
 msgstr "Барои иваз намудани қолаб тугмаи рости мушро ё калиди матниро истифода баред"
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "centiseconds"
+msgstr "сонияҳо"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Ҳамлаи вақт: %.1f сон-ҳо"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Remaining Time:"
+msgstr "Вақти охир"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Cancel"
+msgstr "&Бекор кардан"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Are you sure you wish to cancel?"
@@ -9182,6 +18199,11 @@ msgstr "Тасдиқ шудан"
 msgid "Unable to write files to directory: %s."
 msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -9199,14 +18221,44 @@ msgstr "Лоиҳаҳоро барқарор созед"
 msgid "Don't show this warning again"
 msgstr "Ин огоҳиро дигар нишон надиҳед"
 
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "Infinity"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
+msgid "-Infinity"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
 #: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Холӣ"
 
 #: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Malformed number"
+msgstr "Сабт"
+
+#: src/widgets/valnum.cpp
 #, c-format
 msgid "Not in range %d to %d"
 msgstr "Наздиккунӣ дар соҳа"
+
+#: src/widgets/valnum.cpp
+#, fuzzy
+msgid "Value overflow"
+msgstr "Хатои LOF"
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
 
 #: src/widgets/valnum.cpp
 #, c-format
@@ -9224,12 +18276,31 @@ msgid "Value must not be greater than %s"
 msgstr "Ном набояд ҷои холӣ дошта бошад"
 
 #: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
+
+#: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Лоиҳаи нав эҷод карда шуд"
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Directory Dialog"
 msgstr "Рӯйхатҳо"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "Рӯйхатҳо"
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Error: %s at line %lu"
+msgstr "Хато: "
+
+#: src/xml/XMLFileReader.cpp
+#, fuzzy, c-format
+msgid "Could not load file: \"%s\""
+msgstr "Файлро \"%s\"-ро кушода натавонист"
 
 #: src/xml/XMLFileReader.cpp
 msgid "Could not parse XML"
@@ -9239,16 +18310,49 @@ msgstr "Файлро кушода натавонист: "
 msgid "Spectral edit multi tool"
 msgstr "Интихобкунӣ"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Дарозӣ"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "Басомад (Ҳз)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Хато"
@@ -9263,8 +18367,34 @@ msgstr "Шабакаҳои бурунӣ: %2d"
 
 #: plug-ins/SpectralEditParametricEQ.ny
 #, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
 msgid "~aCenter frequency must be above 0 Hz."
 msgstr "Имконияти камтари басомад бояд 0 Hz бошад"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
 
 #: plug-ins/SpectralEditShelves.ny
 msgid "Spectral edit shelves"
@@ -9277,6 +18407,28 @@ msgstr "Харобшавии мӯътадил"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Истифодабарӣ..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Adjustable Fade"
@@ -9303,8 +18455,16 @@ msgid "S-Curve Down"
 msgstr "Ҳаракат &ба поён"
 
 #: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Start/End as"
 msgstr "Ибтидо"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "dB Gain"
@@ -9313,6 +18473,14 @@ msgstr "Шиддат"
 #: plug-ins/adjustable-fade.ny
 msgid "Start (or end)"
 msgstr "Ибтидо"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Handy Presets (override controls)"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "None Selected"
@@ -9325,6 +18493,14 @@ msgstr "Хатӣ"
 #: plug-ins/adjustable-fade.ny
 msgid "Linear Out"
 msgstr "Хатӣ"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
 
 #: plug-ins/adjustable-fade.ny
 msgid "Logarithmic In"
@@ -9363,6 +18539,24 @@ msgstr "Ҳаракат &ба поён"
 msgid "Error~%~%"
 msgstr "Хато"
 
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
+
 #: plug-ins/beat.ny
 msgid "Beat Finder"
 msgstr "Такрор"
@@ -9370,6 +18564,10 @@ msgstr "Такрор"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Буридашавии қисматҳои хомӯшӣ..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Таблои %s Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -9383,6 +18581,23 @@ msgstr "Курсори Рост"
 msgid "Reconstructing clips..."
 msgstr "Ҷойивазсозии пахшҳо ва мусиқаҳо..."
 
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Threshold of Clipping (%)"
+msgstr "Остона: %d dB"
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
 #: plug-ins/crossfadeclips.ny
 msgid "Crossfade Clips"
 msgstr "Қайди Роҳча"
@@ -9390,6 +18605,21 @@ msgstr "Қайди Роҳча"
 #: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
 msgid "Crossfading..."
 msgstr "Қайди Роҳча"
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
 
 #: plug-ins/crossfadetracks.ny
 msgid "Crossfade Tracks"
@@ -9423,6 +18653,19 @@ msgstr "Номи Роҳча"
 msgid "Fade direction"
 msgstr "Интихобкунӣ"
 
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
 #: plug-ins/delay.ny
 msgid "Delay"
 msgstr "Намуди тугма"
@@ -9440,6 +18683,19 @@ msgid "Regular"
 msgstr "Устувор"
 
 #: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay level per echo (dB)"
+msgstr "Табдили хаш (dB):"
+
+#: plug-ins/delay.ny
 msgid "Delay time (seconds)"
 msgstr "Таваққуфи вақт (сонияҳо):"
 
@@ -9452,12 +18708,24 @@ msgid "Pitch/Tempo"
 msgstr "Баландии садо (EAC)"
 
 #: plug-ins/delay.ny
+msgid "Low-quality Pitch Shift"
+msgstr ""
+
+#: plug-ins/delay.ny
 msgid "Pitch change per echo (semitones)"
 msgstr "Пеш&намоиш"
 
 #: plug-ins/delay.ny
 msgid "Number of echoes"
 msgstr "Миқдори вақтҳои такроршаванда: "
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
@@ -9472,18 +18740,40 @@ msgid "XML file"
 msgstr "Файлҳои MP2"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+msgid "If output text file exists"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Append number"
 msgstr "Сабт"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%Unable to open file~%~s"
 msgstr "Хатои кушодашавии файл"
 
+#. i18n-hint: Do not translate "~a".txt
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy, lisp-format
+msgid "Error.~%File overwrite disallowed:~%\"~a.txt\""
+msgstr "Хато (файл сабт намешавад): %hs"
+
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
 msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Хато (файл сабт намешавад): %hs"
+
+#: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
 
 #. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
 #: plug-ins/equalabel.ny
@@ -9514,18 +18804,67 @@ msgstr "Давомнокӣ (сония)"
 msgid "Length of label region (seconds)"
 msgstr "Давомнокӣ (сония)"
 
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Таҳрири Нишона"
 
 #: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "None - Text Only"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (Before Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "1 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "2 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "3 (After Label)"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Message on completion"
 msgstr "Таркиббандии калид"
 
 #: plug-ins/equalabel.ny
+msgid "Details"
+msgstr ""
+
+#: plug-ins/equalabel.ny
 msgid "Warnings only"
 msgstr "Огоҳӣ"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
 
 #. i18n-hint:  Type of label
 #: plug-ins/equalabel.ny
@@ -9535,6 +18874,17 @@ msgstr "Муттаҳидшавии Нишонаҳо "
 #: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "Муттаҳидшавии Нишонаҳо "
+
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
 
 #: plug-ins/highpass.ny
 msgid "High-Pass Filter"
@@ -9548,13 +18898,46 @@ msgstr "Баробаркунии иҷроиш"
 msgid "Dominic Mazzoni"
 msgstr "Ҷудосозии Хаш бо ёрии Доминик Мазони"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Басомад (Ҳз)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
 msgstr "Имконияти камтари басомад бояд 0 Hz бошад"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
 
 #. i18n-hint: Name of effect that labels sounds
 #: plug-ins/label-sounds.ny
@@ -9578,6 +18961,11 @@ msgid "Average level"
 msgstr "Миёна"
 
 #: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "RMS level"
+msgstr "Суръати иҷро"
+
+#: plug-ins/label-sounds.ny
 msgid "Minimum silence duration"
 msgstr "Давомнокии хомӯшӣ:"
 
@@ -9598,14 +18986,57 @@ msgid "Point after sound"
 msgstr "Стереои муттаҳидшуда"
 
 #: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Region between sounds"
+msgstr "Стереои муттаҳидшуда"
+
+#: plug-ins/label-sounds.ny
 msgid "Maximum leading silence"
 msgstr "Буридашавии қисматҳои хомӯшӣ..."
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Maximum trailing silence"
+msgstr "Буридашавии қисматҳои хомӯшӣ..."
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
 
 #. i18n-hint: '~a' will be replaced by a time duration
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Error.~%Selection must be less than ~a."
 msgstr "Ном набояд ҷои холӣ дошта бошад"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Limiter"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Limiting..."
@@ -9633,8 +19064,25 @@ msgid "Hard Clip"
 msgstr "Иҷозати буриш"
 
 #: plug-ins/limiter.ny
+msgid ""
+"Input Gain (dB)\n"
+"mono/Left"
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid ""
+"Input Gain (dB)\n"
+"Right channel"
+msgstr "Шабакаи чап рост"
+
+#: plug-ins/limiter.ny
 msgid "Limit to (dB)"
 msgstr "Сатҳ:"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
 
 #: plug-ins/limiter.ny
 msgid "Apply Make-up Gain"
@@ -9655,6 +19103,14 @@ msgstr "Навъи хаш:"
 #: plug-ins/noisegate.ny
 msgid "Select Function"
 msgstr "Интихобкунӣ"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
 
 #: plug-ins/noisegate.ny
 msgid "Stereo Linking"
@@ -9688,6 +19144,44 @@ msgstr "Ҳуҷум/вақти хомушшавӣ (сон-ҳо):"
 msgid "Decay (ms)"
 msgstr "Ҳуҷум/вақти хомушшавӣ (сон-ҳо):"
 
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr "Ном набояд ҷои холӣ дошта бошад"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "Ба кор бурдани дараҷакунанда..."
@@ -9695,6 +19189,22 @@ msgstr "Ба кор бурдани дараҷакунанда..."
 #: plug-ins/notch.ny
 msgid "Applying Notch Filter..."
 msgstr "Ба кор бурдани дараҷакунанда..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Nyquist Plug-in Installer"
@@ -9717,7 +19227,8 @@ msgstr "Номи файлҳо:"
 msgid "HTML file"
 msgstr "Файлҳои MP2"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Номи файлҳо:"
 
@@ -9734,9 +19245,24 @@ msgid "Disallow"
 msgstr "Хомӯш карда шуд"
 
 #: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow"
+msgstr "Хомӯш карда шуд"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Warning.~%Failed to copy some files:~%"
 msgstr "'%s' тоза намешавад"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -9747,16 +19273,58 @@ msgid "Files copied to plug-ins folder:"
 msgstr "Интихоби MIDI файл..."
 
 #: plug-ins/nyquist-plug-in-installer.ny
+msgid "Not found or cannot be read:"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Unsupported file type:"
 msgstr "Мавқеи вуруд:"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Files already installed ('Allow Overwriting' disabled):"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Cannot be written to plug-ins folder:"
+msgstr "Интихоби MIDI файл..."
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Error.~%No file selected."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Муваллиди оҳанг"
 
 #: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Fade-out type"
 msgstr "Навъи хаш:"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Duration (60s max)"
@@ -9771,8 +19339,40 @@ msgid "Generating Rhythm..."
 msgstr "Муваллиди набз"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Beats per bar"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Number of bars"
 msgstr "Миқдори вақтҳои такроршаванда: "
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Rhythm track duration"
@@ -9795,12 +19395,54 @@ msgid "Beat sound"
 msgstr "Такрор"
 
 #: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Тозашавии хаш"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Noise Click"
 msgstr "Навъи хаш:"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Risset Drum"
@@ -9811,12 +19453,25 @@ msgid "Generating Risset Drum..."
 msgstr "Муваллиди хаш"
 
 #: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
 msgstr "Таваққуфи вақт (сонияҳо):"
 
 #: plug-ins/rissetdrum.ny
 msgid "Center frequency of noise (Hz)"
 msgstr "Басомади хаттӣ"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amount of noise in mix (percent)"
+msgstr "Басомад (Ҳз)"
 
 #: plug-ins/rissetdrum.ny
 msgid "Amplitude (0 - 1)"
@@ -9829,6 +19484,10 @@ msgstr "Содирот номумкин аст"
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
 msgstr "Истифодабарӣ..."
+
+#: plug-ins/sample-data-export.ny
+msgid "Limit output to first"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "Measurement scale"
@@ -9847,6 +19506,10 @@ msgid "HTML files"
 msgstr "Файлҳои MP2"
 
 #: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Sample Count"
 msgstr "Намунаи Таҳрир"
 
@@ -9855,8 +19518,34 @@ msgid "Time Indexed"
 msgstr "Таҳрири Нишона"
 
 #: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "All"
 msgstr "&Ҳама"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
 
 #. i18n-hint: L for Left
 #: plug-ins/sample-data-export.ny
@@ -9871,6 +19560,11 @@ msgstr "Фаъол шуд"
 msgid "Errors Only"
 msgstr "Хато: "
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "Left Channel.~%~%"
@@ -9883,6 +19577,46 @@ msgstr "Шабакаи чап рост"
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
 msgid "~a samples."
 msgstr "намунаҳо"
 
@@ -9890,6 +19624,43 @@ msgstr "намунаҳо"
 #, lisp-format
 msgid "~a seconds."
 msgstr "сонияҳо"
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 msgid "sample data"
@@ -9908,6 +19679,10 @@ msgid "Value (dB)"
 msgstr "Сатҳ:"
 
 #: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "Left (linear)"
 msgstr "Хатӣ"
 
@@ -9924,6 +19699,14 @@ msgid "Right (dB)"
 msgstr "Рост, "
 
 #: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
 msgid "linear"
 msgstr "Хатӣ"
 
@@ -9934,6 +19717,40 @@ msgstr "2 Шабака (Стерео)"
 #: plug-ins/sample-data-export.ny
 msgid "1 channel (mono)"
 msgstr "1 Шабака (Моно)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Error.~%\"~a\" cannot be written."
+msgstr "Хато (файл сабт намешавад): %hs"
 
 #: plug-ins/sample-data-import.ny
 msgid "Sample Data Import"
@@ -9948,8 +19765,40 @@ msgid "Select file"
 msgstr "Интихоби MIDI файл..."
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 msgid "Throw Error"
 msgstr "Хато"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
 
 #: plug-ins/sample-data-import.ny
 #, lisp-format
@@ -9959,6 +19808,15 @@ msgstr "Хатои кушодашавии файл"
 #: plug-ins/spectral-delete.ny
 msgid "Spectral Delete"
 msgstr "Интихобкунӣ"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
 
 #: plug-ins/tremolo.ny
 msgid "Applying Tremolo..."
@@ -9976,9 +19834,21 @@ msgstr "Дандоншакл"
 msgid "Starting phase (degrees)"
 msgstr "Ибтидои марҳилаи LFO (дараҷа):"
 
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
 #: plug-ins/vocalrediso.ny
 msgid "Applying Action..."
 msgstr "Истифодабарӣ..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
@@ -10020,9 +19890,96 @@ msgstr "&Таҳлил"
 msgid "Strength"
 msgstr "Дарозӣ"
 
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Пардозиши Auto Duck..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Output choice"
@@ -10056,6 +20013,105 @@ msgstr "Басомад (Ҳз)"
 msgid "Frequency of Radar Needles (Hz)"
 msgstr "Басомад (Ҳз)"
 
+#: plug-ins/vocoder.ny
+#, lisp-format
+msgid "Error.~%Stereo track required."
+msgstr ""
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Баромад аз Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Маҷро(Канал)"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Таблои %s Audacity"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Сабтшавӣ"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Фармон:"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Содирот номумкин аст\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Сабтшавӣ\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Бозигар\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Сабтшавӣ\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Сабтшавӣ\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Бозигар\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Бозигар\n"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Тағйири номи '%s' ба '%s' номумкин аст"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "Бозигар"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Бозигар"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Бозигар"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "Сабтшавӣ"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Сабтшавӣ"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Сабтшавӣ"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Дар бораи Audacity..."
+
+#~ msgid "Recording Volume"
+#~ msgstr "Сабтшавӣ"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Бозигар"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Сабтшавӣ"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Бозигар"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Бозигар"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Барои ҷойивазкунии роҳча пахш ва кашишро иҷро кунед"
+
 #~ msgid "Program build date:"
 #~ msgstr "Санаи эҷоди барнома: "
 
@@ -10066,10 +20122,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Unknown exception"
 #~ msgstr "Қи"
-
-#, fuzzy
-#~ msgid "Failed to send crash report"
-#~ msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #, fuzzy
 #~ msgid "available"
@@ -10099,14 +20151,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Failed to copy tags"
 #~ msgstr "'%s' тоза намешавад"
-
-#, fuzzy
-#~ msgid "Select any uncompressed audio file"
-#~ msgstr "Интихоби файлҳои аудиоии ғайрифишурдаи..."
-
-#, fuzzy
-#~ msgid "decode an autosave file"
-#~ msgstr "Файлҳои қаблии худсабт ҷойиваз карда нашуданд"
 
 #, fuzzy
 #~ msgid "Error Decoding File"
@@ -10158,10 +20202,6 @@ msgstr "Басомад (Ҳз)"
 #~ "/%s/%s.%s"
 #~ msgstr "Сабтшавӣ"
 
-#, fuzzy
-#~ msgid "Export recording"
-#~ msgstr "Сабтшавӣ"
-
 #~ msgid "Ogg Vorbis support is not included in this build of Audacity"
 #~ msgstr "Дастгирии Ogg Vorbis дари ин ҳамбастии Audacity ворид нашудааст"
 
@@ -10181,9 +20221,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Cleaning up after failed save"
 #~ msgstr "Раванди тозакунии файлҳои мувақкатӣ"
-
-#~ msgid "Cleaning up cache directories"
-#~ msgstr "Раванди тозакунии феҳрист бо кеш"
 
 #~ msgid "%s-old%d"
 #~ msgstr "%s-кӯҳна%d"
@@ -10220,10 +20257,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Файлҳои қаблии худсабт ҷойиваз карда нашуданд"
 
 #, fuzzy
-#~ msgid "Compress"
-#~ msgstr "Фишордиҳандаи..."
-
-#, fuzzy
 #~ msgid ""
 #~ "MP3 Decoding Failed:\n"
 #~ "\n"
@@ -10247,9 +20280,6 @@ msgstr "Басомад (Ҳз)"
 
 #~ msgid "Audio cache"
 #~ msgstr "Аудиокэш"
-
-#~ msgid "When saving a project that depends on other audio files"
-#~ msgstr "Сабти лоиҳа вобаста ба дигар файлҳо"
 
 #, fuzzy
 #~ msgid "Silence Finder"
@@ -10282,10 +20312,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Audacity Team Members"
 #~ msgstr "Гурӯҳи кории Audacity %s"
-
-#, fuzzy
-#~ msgid "Unable to open/create test file."
-#~ msgstr "Кушодан/сохтани файлҳои санҷишӣ номумкин аст"
 
 #, fuzzy
 #~ msgid "Unable to remove '%s'."
@@ -10347,10 +20373,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Disable dragging selection"
 #~ msgstr "Интихоб аз рӯи хомӯшӣ"
-
-#, fuzzy
-#~ msgid "Disable Scrub Ruler"
-#~ msgstr "Масрафсанҷи ғайрифаъол"
 
 #, fuzzy
 #~ msgid "Enable Scrub Ruler"
@@ -10418,10 +20440,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Созиши файли худсабт номумкин аст: "
 
 #, fuzzy
-#~ msgid "Vocal Remover"
-#~ msgstr "Ҷойгузории Роҳча"
-
-#, fuzzy
 #~ msgid "Removing center-panned audio..."
 #~ msgstr "Ҷойивазсозии пахшҳо ва мусиқаҳо..."
 
@@ -10452,18 +20470,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Current settings returned the original audio."
 #~ msgstr "Ny"
-
-#, fuzzy
-#~ msgid "AudioUnit"
-#~ msgstr "Файли аудиоӣ"
-
-#, fuzzy
-#~ msgid "Nyquist Effects Prompt"
-#~ msgstr "Корбарии натиҷаи Nyquist..."
-
-#, fuzzy
-#~ msgid "Unable to save device info"
-#~ msgstr "Муайяншавӣ номумкин аст"
 
 #, fuzzy
 #~ msgid "Unable to save MIDI device info"
@@ -10520,10 +20526,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Таҳрири З&анҷираҳо..."
 
 #, fuzzy
-#~ msgid "Tra&nscription Toolbar"
-#~ msgstr "Лавҳаи Рӯйнависӣ"
-
-#, fuzzy
 #~ msgid "&Tools"
 #~ msgstr "Абзорҳо"
 
@@ -10545,10 +20547,6 @@ msgstr "Басомад (Ҳз)"
 #~ "Error opening sound device.\n"
 #~ "Try changing the audio host, recording device and the project sample rate."
 #~ msgstr "Хато ҳангоми кушодани афзори савтӣ. Лутфан, насби берунаи афзор ва суръати намунаи лоиҳаро санҷед."
-
-#, fuzzy
-#~ msgid "Slider Recording"
-#~ msgstr "Сабтшавӣ"
 
 #, fuzzy
 #~ msgid "Slider Playback"
@@ -10582,10 +20580,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Trans&cription"
 #~ msgstr "Луғат"
-
-#, fuzzy
-#~ msgid "Scru&b"
-#~ msgstr "Лавҳаи таҳрирӣ"
 
 #, fuzzy
 #~ msgid "Ext-Co&mmand"
@@ -10650,10 +20644,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Дарозӣ"
 
 #, fuzzy
-#~ msgid "Selection options"
-#~ msgstr "Интихоб ба Интиҳо"
-
-#, fuzzy
 #~ msgid "Start - Length - End"
 #~ msgstr "Интиҳо ба интихоб"
 
@@ -10712,10 +20702,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Ивази Фоиз:"
 
 #, fuzzy
-#~ msgid "AttackTime"
-#~ msgstr "Ҳамлаи вақт"
-
-#, fuzzy
 #~ msgid "Repeats"
 #~ msgstr "Такрор"
 
@@ -10726,14 +20712,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "Duty Cycle"
 #~ msgstr "Даври вазифавӣ:"
-
-#, fuzzy
-#~ msgid "Amplitude"
-#~ msgstr "Доманаи (0-1)"
-
-#, fuzzy
-#~ msgid "CurveName"
-#~ msgstr "Ном"
 
 #, fuzzy
 #~ msgid "InterpolateLin"
@@ -10785,10 +20763,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Бозгашт (%):"
 
 #, fuzzy
-#~ msgid "RoomSize"
-#~ msgstr "Андоза"
-
-#, fuzzy
 #~ msgid "Reverberance"
 #~ msgstr "Бозгашт (%):"
 
@@ -10803,14 +20777,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "DryGain"
 #~ msgstr "Шиддат"
-
-#, fuzzy
-#~ msgid "StereoWidth"
-#~ msgstr "Стерео"
-
-#, fuzzy
-#~ msgid "FilterType"
-#~ msgstr "масрафсанҷ"
 
 #, fuzzy
 #~ msgid "RatePercentChangeStart"
@@ -10835,10 +20801,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "StartAmp"
 #~ msgstr "Ибтидо"
-
-#, fuzzy
-#~ msgid "Version"
-#~ msgstr "Маъкусшавӣ"
 
 #~ msgid ""
 #~ "The keyboard shortcut '%s' is already assigned to:\n"
@@ -10938,10 +20900,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Шабакаи чап рост"
 
 #, fuzzy
-#~ msgid "&Bass (dB):"
-#~ msgstr "Баландкунӣ (dB):"
-
-#, fuzzy
 #~ msgid "&Enable level control"
 #~ msgstr "Масрафсанҷи ғайрифаъол"
 
@@ -10952,10 +20910,6 @@ msgstr "Басомад (Ҳз)"
 #, fuzzy
 #~ msgid "-Left-Click"
 #~ msgstr "Пахши чап"
-
-#, fuzzy
-#~ msgid "-Left-Double-Click"
-#~ msgstr "Alt-Left-Пахш"
 
 #~ msgid "Time shift clip or move up/down between tracks"
 #~ msgstr "Вақти таконхурӣ ё ҷунбиш ба боло/поён байни роҳчаҳо"
@@ -10994,12 +20948,6 @@ msgstr "Басомад (Ҳз)"
 #~ "  %s"
 
 #, fuzzy
-#~ msgid "Current directory:"
-#~ msgstr ""
-#~ "каталогро эҷод карда натавонист:\n"
-#~ "  %s"
-
-#, fuzzy
 #~ msgid "Directory doesn't exist."
 #~ msgstr "Рӯйхати %s мавҷуд нест. Сохта шавад?"
 
@@ -11033,17 +20981,8 @@ msgstr "Басомад (Ҳз)"
 #~ msgid "Command Line Export Setup"
 #~ msgstr "Воридсозии насби хатҳои фармоишӣ"
 
-#~ msgid "Specify FLAC Options"
-#~ msgstr "Муайян кардани қисматҳои FLAC"
-
-#~ msgid "FLAC Export Setup"
-#~ msgstr "Насби вурудии FLAC"
-
 #~ msgid "Specify MP2 Options"
 #~ msgstr "Муайянкунии қисматҳои MP2"
-
-#~ msgid "MP2 Export Setup"
-#~ msgstr "Насби вуруди  MP2"
 
 #~ msgid "Specify MP3 Options"
 #~ msgstr "Муайянкунии қисматҳои MP3"
@@ -11089,9 +21028,6 @@ msgstr "Басомад (Ҳз)"
 
 #~ msgid "&Audio Track"
 #~ msgstr "&Роҳчаи Аудиои"
-
-#~ msgid "High-quality Sinc Interpolation"
-#~ msgstr "Интерполятсияи баландсифати синхронӣ"
 
 #~ msgid "Fast Sinc Interpolation"
 #~ msgstr "Зудии Синхронӣ бо Иловашавӣ"
@@ -11143,9 +21079,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgid "Change Tempo..."
 #~ msgstr "Ивазшавии зарбаи..."
 
-#~ msgid "Click Removal..."
-#~ msgstr "Пахш бо ҷудошавии..."
-
 #~ msgid "Applying Dynamic Range Compression..."
 #~ msgstr "Корфармоии фишордиҳандаи соҳаи пӯёи..."
 
@@ -11173,9 +21106,6 @@ msgstr "Басомад (Ҳз)"
 
 #~ msgid "Equalization..."
 #~ msgstr "Баробаркунии..."
-
-#~ msgid "Performing Equalization"
-#~ msgstr "Баробаркунии иҷроиш"
 
 #~ msgid "Fading In"
 #~ msgstr "Харобшавӣ дар"
@@ -11226,20 +21156,8 @@ msgstr "Басомад (Ҳз)"
 #~ msgstr "Ду&бора ном гузоштан"
 
 #, fuzzy
-#~ msgid "Load preset:"
-#~ msgstr "Бор кардани файлҳо"
-
-#, fuzzy
 #~ msgid "Change name to:"
 #~ msgstr "Тағйири номи роҳча ба:"
-
-#, fuzzy
-#~ msgid "Reverb..."
-#~ msgstr "Маъкус"
-
-#, fuzzy
-#~ msgid "Classic Filters..."
-#~ msgstr "&Боркунии Файл..."
 
 #, fuzzy
 #~ msgid "Silence..."
@@ -11257,9 +21175,6 @@ msgstr "Басомад (Ҳз)"
 #~ msgid "Chirp Generator"
 #~ msgstr "Муваллиди набз"
 
-#~ msgid "Truncate Silence..."
-#~ msgstr "Бурриши қисматҳои хомӯш..."
-
 #, fuzzy
 #~ msgid "Buffer Delay Compensation"
 #~ msgstr "Таркиббандии калид"
@@ -11275,9 +21190,6 @@ msgstr "Басомад (Ҳз)"
 
 #~ msgid "Author: "
 #~ msgstr "Муаллиф: "
-
-#~ msgid "Sorry, Plug-in Effects cannot be performed on stereo tracks where the individual channels of the track do not match."
-#~ msgstr "Бубахшед, аммо натиҷаҳои Plug-in дар стереороҳчаҳое, ки шабакаҳои индивидуалии мутобиқ надоранд истифода намешавад."
 
 #, fuzzy
 #~ msgid "Recording Level (Click to monitor.)"

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -13,82 +13,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-09 14:18+0000\n"
 "Last-Translator: Göktuğ Kayaalp <self@gkayaalp.com>\n"
-"Language-Team: Turkish <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/tr/>\n"
+"Language-Team: Turkish <https://hosted.weblate.org/projects/tenacity/tenacity/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.8-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Audacity uygulamasını güncelle"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&Atla"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Güncellemeyi kur"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Değişim günlüğü"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "GitHub üzerinden bilgi alın"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Güncelleme denetlenirken sorun çıktı"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Audacity güncelleme sunucusu ile bağlantı kurulamadı."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Güncelleme verileri bozuk."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Güncelleme indirilirken sorun çıktı."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Audacity indirme bağlantısı açılamadı."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Audacity %s yayınlanmış!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "Kayıt"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -98,6 +32,24 @@ msgstr "Belirlenemedi"
 #, c-format
 msgid "%s bytes"
 msgstr "%s bayt"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -224,7 +176,8 @@ msgid "Script"
 msgstr "Betik"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Çıkış"
 
@@ -240,7 +193,12 @@ msgstr "Nyquist betikleri (*.ny)|*.ny|Lisp betikleri (*.lsp)|*.lsp|Tüm dosyalar
 msgid "Script was not saved."
 msgstr "Betik kaydedilemedi."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Uyarı"
 
@@ -253,11 +211,24 @@ msgid "Find dialog"
 msgstr "Arama penceresi"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr "Harvey Lubin (amblem)"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango Icon Gallery (araç çubuğu simgeleri)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr "(C) 2009 Luland Lucius tarafından"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Yazma etkileri için basit bir IDE oluşturan dış Audacity modülü."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -280,7 +251,8 @@ msgstr "Başlıksız"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist Etkisi Tezgahı - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Yeni"
 
@@ -320,7 +292,8 @@ msgstr "Kopyala"
 msgid "Copy to clipboard"
 msgstr "Panoya kopyala"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Kes"
 
@@ -328,7 +301,8 @@ msgstr "Kes"
 msgid "Cut to clipboard"
 msgstr "Panoya kes"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Yapıştır"
 
@@ -353,7 +327,8 @@ msgstr "Tümünü Seç"
 msgid "Select all text"
 msgstr "Tüm metni seç"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Geri Al"
 
@@ -361,7 +336,8 @@ msgstr "Geri Al"
 msgid "Undo last change"
 msgstr "Son değişikliği geri al"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Yinele"
 
@@ -418,7 +394,8 @@ msgid "Go to next S-expr"
 msgstr "Sonraki S-expr git"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Başlangıç"
 
@@ -426,7 +403,8 @@ msgstr "Başlangıç"
 msgid "Start script"
 msgstr "Betiği başlat"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Durdur"
 
@@ -441,7 +419,8 @@ msgid "About %s"
 msgstr "%s Hakkında"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Tamam"
 
@@ -449,11 +428,13 @@ msgstr "Tamam"
 msgid "Build Information"
 msgstr "Yapım Bilgileri"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Etkin"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Devre Dışı"
 
@@ -463,8 +444,9 @@ msgid "The Build"
 msgstr "Yapım"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Gönderim Kodu:"
+#, fuzzy
+msgid "Version:"
+msgstr "Sürüm: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -474,22 +456,28 @@ msgstr "Sürüm türü:"
 msgid "Compiler:"
 msgstr "Derleyici:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Kurulum Ön Eki:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Ayarlar klasörü:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Ayarlar klasörü:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Dosya Biçimi Desteği"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Platformlar arası GUI kitaplığı"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -503,7 +491,6 @@ msgstr "Örnekleme hızı dönüşümü"
 msgid "MP3 Importing"
 msgstr "MP3 İçe Aktarma"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis İçe ve Dışa Aktarma"
@@ -512,7 +499,6 @@ msgstr "Ogg Vorbis İçe ve Dışa Aktarma"
 msgid "ID3 tag support"
 msgstr "ID3 etiket desteği"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC içe ve dışa aktarma"
@@ -530,14 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg İçe ve Dışa Aktarma"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "GStreamer ile içe aktarma"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Özellikler"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Uygulama eki desteği"
 
@@ -552,6 +530,10 @@ msgstr "Perde ve Tempo Değiştirme desteği"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Aşırı Perde ve Tempo Değiştirme desteği"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Özellikler"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -595,13 +577,13 @@ msgstr "%s, Audacity geliştiricisi"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
-#, c-format, fuzzy
+#, fuzzy, c-format
 msgid "%s, developer and support"
 msgstr "%s, Audacity geliştiricisi ve destek elemanı"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
-#, c-format, fuzzy
+#, fuzzy, c-format
 msgid "%s, documentation and support"
 msgstr "%s, Audacity dökümantasyonu ve destek"
 
@@ -670,15 +652,22 @@ msgstr "%s, Audacity görselleri"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (%s, %s, %s, %s ve %s ile birlikte)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
-msgstr ""
-"Özgür, açık kaynaklı, çok-platformlu ses düzenleme ve kaydetme uygulaması."
+msgstr "Özgür, açık kaynaklı, çok-platformlu ses düzenleme ve kaydetme uygulaması."
 
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Emeği Geçenler"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Lütfen isimlerin önem sırasına göre değil, alfabetik sıraya göre sıralandığını unutmayın."
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -728,6 +717,7 @@ msgstr "Audacity Web sitesi ve Görselleri"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Çevirmenler"
@@ -745,6 +735,22 @@ msgstr "Audacity'den özel teşekkürler:"
 #, c-format
 msgid "%s website: "
 msgstr "%s web sitesi: "
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s katkıda bulunanlar"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Audacity%s ticari markası bu yazılımda yalnızca belirleyici ve bilgilendirme amaçlı kullanılmaktadır."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity, MuseCY SM Ltd. veya Dominic M Mazzoni tarafından üretilmemekte veya desteklenmemektedir."
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -767,6 +773,7 @@ msgstr "Zaman Akışı"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Taramayı başlatmak için tıklayın ya da sürükleyin"
@@ -774,6 +781,7 @@ msgstr "Taramayı başlatmak için tıklayın ya da sürükleyin"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Sarmayı başlatmak için tıklayın ya da sürükleyin"
@@ -781,6 +789,7 @@ msgstr "Sarmayı başlatmak için tıklayın ya da sürükleyin"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Sarmak için tıklayıp taşıyın. Taramak için tıklayıp sürükleyin."
@@ -788,6 +797,7 @@ msgstr "Sarmak için tıklayıp taşıyın. Taramak için tıklayıp sürükleyi
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Taramaya Taşı"
@@ -795,6 +805,7 @@ msgstr "Taramaya Taşı"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Sarmaya Taşı"
@@ -851,7 +862,17 @@ msgstr ""
 "Daha ileri bölge kilitlenemiyor\n"
 "projenin sonu."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Sorun"
 
@@ -875,7 +896,8 @@ msgstr ""
 "Bu seçenek 'kurulumdan' sonra ayarları sıfırlamak için bir kez sorulur."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Audacity Ayarlarını Sıfırla"
 
 #: src/AudacityApp.cpp
@@ -890,7 +912,8 @@ msgstr ""
 "Geçmiş dosyalar listesinden kaldırıldı."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite kitaplığı hazırlanamadı.  Audacity devam edemiyor."
 
 #: src/AudacityApp.cpp
@@ -915,7 +938,7 @@ msgstr "&Aç..."
 msgid "Open &Recent..."
 msgstr "&Son Kullanılanlar..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "Ten&acity Hakkında..."
 
@@ -928,9 +951,10 @@ msgid "&File"
 msgstr "&Dosya"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity geçici dosyaları kaydedecek bir yer bulamadı.\n"
@@ -938,20 +962,23 @@ msgstr ""
 "Lütfen ayarlar bölümünden uygun bir klasör seçin."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity geçici dosyaları kaydedecek bir yer bulamadı.\n"
 "Lütfen ayarlar bölümünden uygun bir klasör seçin."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity şimdi kapanacak. Yeni geçici klasörü kullanmak için yeniden başlatmalısınız."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -960,15 +987,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity geçici dosyalar klasörünü kilitleyemedi.\n"
 "Bu klasör çalışan başka bir Audacity kopyası tarafından kullanılıyor olabilir.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Audacity gene de başlatılsın mı?"
 
 #: src/AudacityApp.cpp
@@ -976,19 +1005,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Geçici Klasör Kilitlenirken Sorun Çıktı"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Sistem başka bir Audacity kopyasının çalıştığını algıladı.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Aynı anda birden fazla projeyi açmak için çalışmakta olan\n"
 "Audacity içinden Yeni ya da Aç komutlarını kullanın.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity zaten çalışıyor"
 
 #: src/AudacityApp.cpp
@@ -1004,7 +1036,8 @@ msgstr ""
 "yeniden başlatma gerekebilir."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity Açılışı Tamamlanamadı"
 
 #: src/AudacityApp.cpp
@@ -1044,8 +1077,9 @@ msgstr ""
 "yeniden başlatma gerekebilir."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1077,7 +1111,8 @@ msgstr "kendi kendini sına"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "Audacity sürümünü görüntüle"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1087,9 +1122,10 @@ msgid "audio or project file name"
 msgstr "ses ya da proje dosyasının adı"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1102,16 +1138,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity Proje Dosyaları"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "İleti"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Audacity Yapılandırma Sorunu"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1121,7 +1159,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Şu yapılandırma dosyasına erişilemedi:\n"
 "\n"
@@ -1133,12 +1171,15 @@ msgstr ""
 "\n"
 "\"Audacity Uygulamasından Çık\" üzerine tıklarsanız, projeniz kaydedilmemiş bir durumda kalır ve bir sonraki açışınızda kurtarılır."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Yardım"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "A&udacity'den Çık"
 
 #: src/AudacityFileConfig.cpp
@@ -1146,7 +1187,8 @@ msgid "&Retry"
 msgstr "&Yeniden Dene"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Audacity Günlüğü"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1158,9 +1200,14 @@ msgstr "&Kaydet..."
 msgid "Cl&ear"
 msgstr "T&emizle"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "Kapa&t"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr "log.txt"
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1209,7 +1256,8 @@ msgid "Error Initializing Midi"
 msgstr "MIDI Hazırlanırken Sorun Çıktı"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Audacity Ses"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1224,37 +1272,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Bellek doldu!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Daha fazla iyileştirme yapmak olanaksız. Hala çok yüksek."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Kayıt düzeyi otomatik olarak ayarlanarak ses düzeyi %f olarak azaltıldı."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Daha fazla iyileştirme yapmak olanaksız. Hala çok düşük."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Kayıt düzeyi otomatik olarak ayarlanarak ses düzeyi %.2f. olarak arttırıldı."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Kabul edilebilir bir ses düzeyi bulunamadan toplam inceleme sayısı aşıldı. Hala çok yüksek."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Kabul edilebilir bir ses düzeyi bulunamadan toplam inceleme sayısı aşıldı. Hala çok düşük."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. %.2f. kabul edilebilir bir ses düzeyi olarak görünüyor."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1353,43 +1370,6 @@ msgstr "'%s' için bir oynatma aygıtı bulunamadı.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "İki aygıtın örnekleme hızları karşılıklı olarak denetlenemedi.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Aygıtlar açılırken %d alındı\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Portmixer açılamadı\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Kullanılabilecek karıştırıcılar:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Kullanılabilecek kayıt aygıtları:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Kullanılabilecek oynatma ses düzeyleri:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Kayıt ses düzeyi taklit ediliyor\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Kayıt ses düzeyi doğal\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Oynatma ses düzeyi taklit ediliyor\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Oynatma ses düzeyi doğal\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1432,8 +1412,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Otomatik Çökme Kurtarması"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1446,12 +1427,14 @@ msgid "Recoverable &projects"
 msgstr "Kurtarılabilir &projeler"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Seç"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Ad"
 
@@ -1537,6 +1520,11 @@ msgstr "Etki"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Menü Komutu (Parametreler ile)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1682,7 +1670,8 @@ msgstr "K&urtar"
 msgid "I&mport..."
 msgstr "&Al..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "V&er..."
 
@@ -1723,7 +1712,8 @@ msgstr "Y&ukarı Taşı"
 msgid "Move &Down"
 msgstr "&Aşağı Taşı"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Kaydet"
 
@@ -1806,9 +1796,16 @@ msgid "Run"
 msgstr "Çalıştır"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Kapat"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+msgid "benchmark.txt"
+msgstr "benchmark.txt"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1946,10 +1943,6 @@ msgid "No revision identifier was provided"
 msgstr "Herhangi bir değişiklik belirteci belirtilmemiş"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "Bilinmeyen tarih ve saat"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Hata ayıklama yapımı (hata ayıklama düzeyi %d)"
@@ -2032,6 +2025,11 @@ msgid ""
 msgstr ""
 "Bu işlemi yapabilmek için önce bazı sesler\n"
 "seçmelisiniz. (Başka iz türleri ile kullanılamaz)."
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2194,6 +2192,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Adları Panoya &Kopyala"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Eksik"
 
@@ -2202,10 +2205,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "İşleme devam ederseniz, projeniz diske kaydedilmeyecek. Ne yapmak istersiniz?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2219,7 +2223,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Bağımlılık Denetimi"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Yok"
 
@@ -2227,7 +2234,7 @@ msgstr "Yok"
 msgid "Rectangle"
 msgstr "Dikdörtgen"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Üçgen"
 
@@ -2238,6 +2245,36 @@ msgstr "Şekilli"
 #: src/FFT.cpp
 msgid "Rectangular"
 msgstr "Dikdörtgensel"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
 
 #. i18n-hint a mathematical function named for C. F. Gauss
 #: src/FFT.cpp
@@ -2259,17 +2296,17 @@ msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg desteği derlenmemiş"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
 "FFmpeg, Ayarlardan yapılandırılmış ve daha önce sorunsuz yüklenmiş,\n"
 "ancak bu kez Tenacity başlatılırken yüklenemedi.\n"
 "\n"
-"Ayarlar > Kütüphaneler bölümüne giderek yeniden yapılandırmak "
-"isteyebilirsiniz."
+"Ayarlar > Kütüphaneler bölümüne giderek yeniden yapılandırmak isteyebilirsiniz."
 
 #: src/FFmpeg.cpp
 msgid "FFmpeg startup failed"
@@ -2284,11 +2321,9 @@ msgid "Locate FFmpeg"
 msgstr "FFmpeg konumu"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
-msgstr ""
-"Tenacity, sesleri FFmpeg aracılığıyla içe ve dışa aktarmak için '%s' "
-"dosyasına gerek duyuyor."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
+msgstr "Tenacity, sesleri FFmpeg aracılığıyla içe ve dışa aktarmak için '%s' dosyasına gerek duyuyor."
 
 #: src/FFmpeg.cpp
 #, c-format
@@ -2300,7 +2335,8 @@ msgstr "'%s' konumu:"
 msgid "To find '%s', click here -->"
 msgstr "'%s' ögesini bulmak için, buraya tıklayın -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Gözat..."
 
@@ -2326,8 +2362,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg bulunamadı"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2357,24 +2394,24 @@ msgid "Only libavformat.so"
 msgstr "Yalnız libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity %s içindeki bir dosyayı açamadı."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity %s içindeki bir dosyayı okuyamadı."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity %s içindeki bir dosyayı yazdı ancak %s olarak yeniden adlandıramadı."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2412,7 +2449,9 @@ msgstr "&Hiç bir ses kopyalanmasın"
 msgid "As&k"
 msgstr "&Sorulsun"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Tüm dosyalar"
 
@@ -2437,6 +2476,10 @@ msgstr "Metin dosyaları"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML dosyaları"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2501,6 +2544,17 @@ msgstr "Doğrusal frekans"
 msgid "Log frequency"
 msgstr "Günlükleme sıklığı"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr "dB"
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Kaydır"
@@ -2508,6 +2562,15 @@ msgstr "Kaydır"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Yakınlaştır"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2568,6 +2631,23 @@ msgstr "Çok fazla ses seçilmiş. Sesin sadece ilk %.1f saniyesi çözümlenece
 msgid "Not enough data selected."
 msgstr "Yeterli veri seçilmemiş."
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, fuzzy, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %d dB"
+
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
@@ -2583,10 +2663,15 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f saniye (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+msgid "spectrum.txt"
+msgstr "spectrum.txt"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Spektral Veriyi Şu Şekilde Dışa Aktar:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Dosya yazılamadı: %s"
@@ -2776,19 +2861,19 @@ msgid "&History..."
 msgstr "&Geçmiş..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s içinde %s konumunda %d satırında bir sorun çıktı.\n"
 "Lütfen https://forum.audacityteam.org/ adresinden Audacity ekibini bilgilendirin."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s konumunda %d satırında bir sorun çıktı.\n"
 "Lütfen https://forum.audacityteam.org/ adresinden Audacity ekibini bilgilendirin."
@@ -2807,7 +2892,9 @@ msgid "Track"
 msgstr "İz"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Etiket"
 
@@ -2867,7 +2954,8 @@ msgstr "İz adını yazın"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Etiket İzi"
 
@@ -2878,11 +2966,13 @@ msgstr "Kaydedilmiş bir ya da bir kaç etiket okunamadı."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Audacity İlk Kez Çalıştırıldı"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Audacity içinde kullanacağınız dili seçin:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2892,7 +2982,8 @@ msgstr "Audacity içinde kullanacağınız dili seçin:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Seçtiğiniz %s (%s) dili, %s (%s) sistem diliniz, ile aynı değil."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Onaylayın"
 
@@ -2910,8 +3001,19 @@ msgstr ""
 "Eski dosya '%s' olarak kaydedildi"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Audacity Projesi Açılıyor"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Tenacity Karaokesi%s"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "&Göz at..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2957,19 +3059,23 @@ msgid "Mixing and rendering tracks"
 msgstr "İzler karıştırılıp çevriliyor"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Audacity Karıştırıcı Panosu %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Kazanç"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Hız"
 
@@ -2978,28 +3084,42 @@ msgid "Musical Instrument"
 msgstr "Muzik Enstrumanı"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Terazi"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Kıs"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "İşaret Düzeyi Ölçer"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Kazanç düğmesi oynatıldı"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Hız düğmesi oynatıldı"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Pan düğmesi oynatıldı"
 
@@ -3034,9 +3154,9 @@ msgstr ""
 "Bu nedenle yüklenmeyecek."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3070,16 +3190,19 @@ msgstr ""
 "\n"
 "Yalnız güvenilir kaynaklardan sağlanan modülleri kullanın"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Evet"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Hayır"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Audacity Modül Yükleyici"
 
 #: src/ModuleManager.cpp
@@ -3102,6 +3225,117 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Not İzi"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+#, fuzzy
+msgid "B"
+msgstr "dB"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3211,7 +3445,8 @@ msgstr "Tümünü &Seç"
 msgid "C&lear All"
 msgstr "Tümünü &Bırak"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Etkinleştir"
 
@@ -3291,9 +3526,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Örnekleme Hızları Uyumlu Değil"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Bu örnekleme hızında kayıt için çok az sayıda iz seçilmiş.\n"
@@ -3322,10 +3558,11 @@ msgid "Dropouts"
 msgstr "Kesintiler"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3365,11 +3602,11 @@ msgid "Inspecting project file data"
 msgstr "Proje dosyası verisi araştırılıyor"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3411,11 +3648,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Dikkat - Kayıp Takma Adlı Dosyalar: (%s)"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Proje denetimi \"%s\" klasöründe \n"
@@ -3440,12 +3677,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Dikkat - Kayıp Takma Adlı Özet Dosyaları"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3505,7 +3742,8 @@ msgstr "Dikkat - Sahipsiz Blok Dosyaları"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "İşlem"
 
@@ -3530,6 +3768,11 @@ msgstr "Dikkat: Otomatik Kurtarma Sırasında Sorun Çıktı"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<adsız>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Proje %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3599,12 +3842,14 @@ msgstr ""
 "(Gerekli geçici dosyalar oluşturulamaz)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Bu bir Audacity projesi dosyası değil"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3736,9 +3981,9 @@ msgid "Error Writing to File"
 msgstr "Dosyaya Yazılırken Sorun Çıktı"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3752,9 +3997,16 @@ msgstr "Proje sıkıştırılıyor"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Proje %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Hız"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3763,10 +4015,10 @@ msgstr "(Kurtarılan)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Bu dosya Audacity %s sürümü kullanarak kaydedilmiş.\n"
 "Audacity %s sürümünü kullanıyorsunuz. Bu dosyayı açmak için daha yeni bir sürüme yükseltmelisiniz."
@@ -3837,8 +4089,9 @@ msgid "Backing up project"
 msgstr "Proje yedekleniyor"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3846,8 +4099,9 @@ msgstr ""
 "Son yedekleme noktası geri yüklendi."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3925,8 +4179,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sProjeyi Farklı \"%s\" Kaydet..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "'Projeyi Kaydet' komutu, ses dosyaları için değil Audacity projeleri için kullanılır.\n"
@@ -4003,11 +4258,12 @@ msgid "Error Opening Project"
 msgstr "Proje Açılırken Sorun Çıktı"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Otomatik olarak oluşturulmuş bir yedek dosyasını açmayı deniyorsunuz.\n"
 "Bu işlem ciddi büyüklükte veri kaybına neden olabilir.\n"
@@ -4116,8 +4372,8 @@ msgid "Automatic database backup failed."
 msgstr "Veritabanı otomatik olarak yedeklenemedi."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Audacity %s sürümüne hoş geldiniz"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4229,6 +4485,18 @@ msgstr "Yüksek Kalite"
 msgid "Best Quality (Slowest)"
 msgstr "En İyi Kalite (En Yavaş)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "16-bit PCM"
+msgstr "İmzalanmış 16 bit PCM"
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+#, fuzzy
+msgid "24-bit PCM"
+msgstr "İmzalanmış 24 bit PCM"
+
 #. i18n-hint: Audio data bit depth (precision): 32-bit floating point
 #: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
 msgid "32-bit float"
@@ -4322,7 +4590,8 @@ msgstr "Tüm Ayarlar"
 msgid "SelectionBar"
 msgstr "Seçim Çubuğu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Spektral Seçim"
 
@@ -4330,46 +4599,55 @@ msgstr "Spektral Seçim"
 msgid "Timer"
 msgstr "Zamanlayıcı"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Araçlar"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Hareket"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Karıştırıcı"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Ölçer"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Oynatma Ölçeri"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Kayıt Ölçeri"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Düzenle"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Aygıt"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Seçilmiş hızda oynat"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Sarma"
 
@@ -4384,7 +4662,10 @@ msgstr "Cetvel"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "İzler"
 
@@ -4494,7 +4775,8 @@ msgid "Activation level (dB):"
 msgstr "Etkinleşme düzeyi (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Audacity Programına Hoş Geldiniz!"
 
 #: src/SplashDialog.cpp
@@ -4641,9 +4923,9 @@ msgstr ""
 "Uygun sürücüler ile ilgili ipuçları için yardım düğmesine tıklayın."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity dosyaya yazamadı:\n"
@@ -4663,9 +4945,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4674,9 +4956,9 @@ msgstr ""
 "dosyasını yazmak için açamadı."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity görüntüleri şu dosyaya yazamadı:\n"
@@ -4693,9 +4975,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4705,9 +4987,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4716,8 +4998,9 @@ msgstr ""
 "Bozuk png biçimi olabilir mi?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity varsayılan temayı okuyamadı.\n"
@@ -4755,9 +5038,9 @@ msgstr ""
 "içinde zaten var. Üzerine yazılsın mı?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity dosyayı kaydedemedi:\n"
@@ -4796,7 +5079,11 @@ msgstr "Özel"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Süre"
 
@@ -4807,7 +5094,8 @@ msgid "Time Track"
 msgstr "Zaman İzi"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Audacity Zamanlanmış Kayıt"
 
 #: src/TimerRecordDialog.cpp
@@ -4881,7 +5169,8 @@ msgstr "Geçerli Proje"
 msgid "Recording start:"
 msgstr "Kayıt başlangıcı:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Süre:"
 
@@ -4902,7 +5191,8 @@ msgid "Action after Timer Recording:"
 msgstr "Zamanlama Kayıt Sonrasında Yapılacak İşlem:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Audacity Zamanlanmış Kayıt İlerlemesi"
 
 #: src/TimerRecordDialog.cpp
@@ -4998,6 +5288,7 @@ msgstr "099 gün 024 sa 060 dk 060 sn"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Başlangıç Tarihi ve Zamanı"
@@ -5042,7 +5333,8 @@ msgstr "&Otomatik Dışa Aktarma Kullanılsın mı?"
 msgid "Export Project As:"
 msgstr "Projeyi Şu Şekilde Dışa Aktar:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Seçenekler"
 
@@ -5055,7 +5347,8 @@ msgid "Do nothing"
 msgstr "Hiç bir şey yapılmasın"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Audacity kapatılsın"
 
 #: src/TimerRecordDialog.cpp
@@ -5079,7 +5372,8 @@ msgid "Scheduled to stop at:"
 msgstr "Ayarlanan durma zamanı:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Audacity Zamanlanmış Kayıt - Başlamak için bekliyor"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5105,7 +5399,8 @@ msgid "Recording Exported:"
 msgstr "Kayıt Dışa Aktarıldı:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Audacity Zamanlanmış Kayıt - Bekliyor"
 
 #: src/TrackInfo.cpp
@@ -5301,6 +5596,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "%s uygulanıyor..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "(%d): %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "TAMAMLANAMADI"
@@ -5319,13 +5624,15 @@ msgstr "%s %s tarafından kabul edilen bir parametre değil"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "'%s' parametresinin değeri geçersiz: %s olmalı"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Komut"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "%s yinele"
@@ -5452,13 +5759,24 @@ msgstr "Parçalar"
 msgid "Envelopes"
 msgstr "Zarflar"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Etiketler"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Kutular"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5468,7 +5786,8 @@ msgstr "Kısa"
 msgid "Type:"
 msgstr "Tür:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Biçim:"
 
@@ -5495,6 +5814,10 @@ msgstr "Yorum"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Komut:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5532,12 +5855,17 @@ msgstr "Bilgileri bir dosyaya dışa aktarır."
 msgid "Builtin Commands"
 msgstr "İç Komutlar"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Audacity Takımı"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Audacity için iç komutları sağlar"
 
 #: src/commands/LoadCommands.cpp
@@ -5600,7 +5928,10 @@ msgstr "Günlük kayıtlarını temizler."
 msgid "Get Preference"
 msgstr "Ayarı Al"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Ad:"
 
@@ -5648,7 +5979,8 @@ msgstr "Tam Ekran"
 msgid "Toolbars"
 msgstr "Araç Çubukları"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Etkiler"
 
@@ -5788,7 +6120,8 @@ msgstr "Ayarla"
 msgid "Add"
 msgstr "Ekle"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Kaldır"
 
@@ -5873,7 +6206,8 @@ msgid "Edited Envelope"
 msgstr "Düzenlenen zarf"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Kılıf"
 
@@ -5916,6 +6250,14 @@ msgstr "Hız:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Yeniden Adlandır:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5965,7 +6307,10 @@ msgstr "Kaydırma:"
 msgid "Set Track Visuals"
 msgstr "İz Görsellerini Ayarla"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Doğrusal"
 
@@ -6069,12 +6414,18 @@ msgstr "Ses içermeyen bir iz seçtiniz. Otomatik kısma yalnız ses izleri üze
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Otomatik kısma, seçilmiş izlerin altına yerleştirilecek bir denetim izine gerek duyar."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "Kısma &miktarı:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "saniye"
 
@@ -6098,7 +6449,8 @@ msgstr "İç &azalarak çıkma uzunluğu:"
 msgid "Inner &fade up length:"
 msgstr "İç artarak girme &uzunluğu:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Eşik:"
 
@@ -6236,11 +6588,13 @@ msgstr "bitiş (Hz)"
 msgid "t&o"
 msgstr "ş&una"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "&Yüzde Değişim:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Yüzde Değişim"
 
@@ -6248,9 +6602,23 @@ msgstr "Yüzde Değişim"
 msgid "&Use high quality stretching (slow)"
 msgstr "Yüksek &kaliteli germe kullanılsın (yavaş)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "yok"
 
@@ -6278,6 +6646,7 @@ msgstr "Standart Plak Devri:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Başlangıç Devri"
@@ -6290,6 +6659,7 @@ msgstr "ş&undan"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Bitiş Devri"
@@ -6432,6 +6802,12 @@ msgstr "Sıkıştırıcı"
 msgid "Compresses the dynamic range of audio"
 msgstr "Sesin devingen aralığını sıkıştırır"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6441,6 +6817,20 @@ msgstr "%.2f saniye"
 #, c-format
 msgid "%.1f secs"
 msgstr "%.1f saniye"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
 
 #: src/effects/Compressor.cpp
 #, c-format
@@ -6557,7 +6947,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Karşıtlık Çözümleyici, seçilmiş iki sesin, ortalama ses düzeyleri arasındaki farkları ölçmek içindir."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Bitiş"
 
@@ -6617,6 +7008,18 @@ msgstr "&Fark:"
 msgid "&Help"
 msgstr "&Yardım"
 
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "sıfır"
@@ -6624,6 +7027,13 @@ msgstr "sıfır"
 #: src/effects/Contrast.cpp
 msgid "indeterminate"
 msgstr "belirsiz"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
 
 #. i18n-hint: dB abbreviates decibels
 #: src/effects/Contrast.cpp
@@ -6677,6 +7087,12 @@ msgstr "Geçerli fark"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "Ölçülen ön alan düzeyi"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f saniye"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -7030,7 +7446,9 @@ msgstr "DTMF &sırası:"
 msgid "&Amplitude (0-1):"
 msgstr "&Genlik (0-1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Süre:"
 
@@ -7043,12 +7461,29 @@ msgid "Duty cycle:"
 msgstr "Doluluk oranı:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f saniye"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Ton süresi:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Sessizlik süresi:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7058,7 +7493,8 @@ msgstr "Yankı"
 msgid "Repeats the selected audio again and again"
 msgstr "Seçilmiş sesi üstüste yineler"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "İstenilen değer bellek kapasitesini aşıyor."
 
@@ -7082,7 +7518,8 @@ msgstr "Hazır Ayarlar"
 msgid "Export Effect Parameters"
 msgstr "Etki Parametrelerini Dışa Aktar"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Dosya açılamadı: \"%s\""
@@ -7119,6 +7556,15 @@ msgstr "Ön izleme hazırlanıyor"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Ön izleniyor"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Nyquist Sorunu"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7451,6 +7897,10 @@ msgid "Low rolloff for speech"
 msgstr "Konuşma için alçak yuvarlanma"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Telefon"
 
@@ -7487,12 +7937,41 @@ msgid "Effect Unavailable"
 msgstr "Etki Kullanılamıyor"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "En Fazla dB"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "En Az dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7567,8 +8046,16 @@ msgid "D&efault"
 msgstr "&Varsayılan"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE &Dişli"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7813,7 +8300,8 @@ msgid "Builtin Effects"
 msgstr "İç Etkiler"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Audacity için iç etkileri sağlar"
 
 #: src/effects/LoadEffects.cpp
@@ -7823,6 +8311,10 @@ msgstr "Etkinin iç adı bilinmiyor"
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "algılanan ses yüksekliği"
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -7854,6 +8346,14 @@ msgstr "&Normalleştir"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "Güçlendirme LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -7923,7 +8423,17 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (varsayılan)"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "Blackman"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
+msgstr "Hamming, yok"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
 msgstr "Hamming, yok"
 
 #: src/effects/NoiseReduction.cpp
@@ -8023,8 +8533,9 @@ msgid "Step 1"
 msgstr "1. adım"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Yalnızca gürültünün olduğu bir kaç saniyeyi seçin. Böylece Audacity neyi süzeceğini bilir,\n"
@@ -8076,13 +8587,62 @@ msgstr "&Pencere türleri:"
 msgid "Window si&ze:"
 msgstr "Pencere &boyutu:"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (varsayılan)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Bir &penceredeki adım sayısı:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8198,12 +8758,18 @@ msgid "N&ormalize stereo channels independently"
 msgstr "Çift &kanalı birbirinden bağımsız olarak normalleştir"
 
 #: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "Paulstretch"
+msgstr "Esnetme"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "Paulstretch yalnız zaman germe ya da \"statis\" etkisinde kullanılır"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "&Gerilme Çarpanı:"
@@ -8485,6 +9051,11 @@ msgstr "Seçilmiş sesi tersine çevirir"
 msgid "SBSMS Time / Pitch Stretch"
 msgstr "SBSMS Süresi / Perde Gerdirme"
 
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
 #. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
 #: src/effects/ScienFilter.cpp
 msgid "Chebyshev Type I"
@@ -8640,6 +9211,11 @@ msgstr "Varsayılanları Kullan"
 #: src/effects/ScoreAlignDialog.cpp
 msgid "Restore Defaults"
 msgstr "Varsayılanları Geri Yükle"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
 
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
@@ -8799,6 +9375,10 @@ msgstr "Sessizliği Algıla"
 msgid "Tr&uncate to:"
 msgstr "Şuna &buda:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "Şuna &sıkıştır:"
@@ -8812,7 +9392,8 @@ msgid "VST Effects"
 msgstr "VST Etkileri"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Audacity içinde VST etkilerinin kullanılabilmesini sağlar."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8824,7 +9405,8 @@ msgstr "VST Kabuğu Taranıyor"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "%d / %d kaydediliyor: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Kitaplık yüklenemedi"
 
@@ -8844,7 +9426,8 @@ msgstr "Ara bellek boyutu, her yinelemede etkiye gönderilen örneklerin sayıs�
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "&Ara Bellek Boyutu (8 - 1048576 örnek):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Gecikme Dengelemesi"
 
@@ -8852,7 +9435,8 @@ msgstr "Gecikme Dengelemesi"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "İşlemlerinin bir parçası olarak, bazı VST etkilerinin Audacity üzerine geri döndürülen sesi geciktirmesi gerekir. Bu gecikmeyi dengelemezseniz, sese küçük sessizliklerin eklendiğini fark edersiniz. Bu seçenek etkinleştirildiğinde bu dengeleme yapılır, ancak tüm VST etkileri için çalışmayabilir."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "D&engeleme kullanılsın"
 
@@ -8886,7 +9470,8 @@ msgid "Standard VST program file"
 msgstr "Standart VST program dosyası"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Audacity hazır VST ayarları dosyası"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8913,7 +9498,8 @@ msgstr "Hazır VST Ayarları Yüklenirken Sorun Çıktı"
 msgid "Unable to load presets file."
 msgstr "Hazır ayarlar dosyası yüklenemedi."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Etki Ayarları"
 
@@ -8929,6 +9515,16 @@ msgstr "Hazır ayarlar dosyası okunamadı."
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Bu parametre dosyası %s ile kaydedilmiş. Devam edilsin mi?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
@@ -8960,7 +9556,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio Unit Etkileri"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Audacity için Audio Unit etkileri desteği sağlar"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -8976,7 +9573,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio Unit Etkileri Ayarları"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "İşlemlerinin bir parçası olarak, bazı Ses Birimi etkilerinin Audacity üzerine geri döndürülen sesi geciktirmesi gerekir. Bu gecikmeyi dengelemezseniz, sese küçük sessizliklerin eklendiğini fark edersiniz. Bu seçenek etkinleştirildiğinde bu dengeleme yapılır, ancak tüm Audio Unit etkileri için çalışmayabilir."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9112,8 +9710,16 @@ msgstr "Hazır ayar için özellik listesi oluşturulamadı"
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "\"%s\" hazır ayarı için sınıf bilgileri ayarlanamadı"
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Audio Unit Etkileri"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA Etkileri"
@@ -9123,7 +9729,8 @@ msgid "Provides LADSPA Effects"
 msgstr "LADSPA Etkileri Sağlar"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity artık vst-bridge kullanmıyor"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9131,12 +9738,30 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA Etkisi Ayarları"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "İşlemlerinin bir parçası olarak, bazı LADSPA etkilerinin Audacity üzerine geri döndürülen sesi geciktirmesi gerekir. Bu gecikmeyi dengelemezseniz, sese küçük sessizliklerin eklendiğini fark edersiniz. Bu seçenek etkinleştirildiğinde bu dengeleme yapılır, ancak tüm LADSPA etkileri için çalışmayabilir."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "Şu sürede %s:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Etki Çıkışı"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA Etkileri"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9148,7 +9773,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "&Ara Bellek Boyutu (8 - %d) örnekleri:"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "İşlemlerinin bir parçası olarak, bazı LV2 etkilerinin Audacity üzerine geri döndürülen sesi geciktirmesi gerekir. Bu gecikmeyi dengelemezseniz, sese küçük sessizliklerin eklendiğini fark edersiniz. Bu seçenek etkinleştirildiğinde bu dengeleme yapılır, ancak tüm LV2 etkileri için çalışmayabilir."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9173,12 +9799,19 @@ msgstr "%s için desteklenmeyen %s seçeneği gerekli\n"
 msgid "Generator"
 msgstr "Üreteç"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 Etkileri"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Audacity için LV2 etkileri desteği sağlar"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9186,7 +9819,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist Etkileri"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Audacity için Nyquist etkileri desteği sağlar"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9414,7 +10048,8 @@ msgstr "Bir dosya seçin"
 msgid "Save file as"
 msgstr "Dosyayı farklı kaydet"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "adsız"
 
@@ -9423,7 +10058,8 @@ msgid "Vamp Effects"
 msgstr "Vamp Etkileri"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Audacity için Vamp etkileri desteği sağlar"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9441,6 +10077,17 @@ msgstr "Maalesef Vamp uygulama eki hazırlanamadı."
 #: src/effects/vamp/VampEffect.cpp
 msgid "Plugin Settings"
 msgstr "Eklenti Ayarları"
+
+#: src/effects/vamp/VampEffect.cpp
+#, fuzzy
+msgid "Program"
+msgstr "Spektrogram"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9741,7 +10388,8 @@ msgstr "Ses %s olarak dışa aktarılıyor"
 msgid "Invalid sample rate"
 msgstr "Örnekleme hızı geçersiz"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Yeniden Örnekle"
 
@@ -9771,6 +10419,14 @@ msgstr "Aşağıdaki hızlardan biriyle yeniden örnekleyebilirsiniz."
 msgid "Sample Rates"
 msgstr "Örnekleme Hızları"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Bit Hızı:"
@@ -9778,6 +10434,48 @@ msgstr "Bit Hızı:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "Kalite (kbps):"
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f saniye"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9788,12 +10486,40 @@ msgid "Constrained"
 msgstr "Kısıtlı"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "Ses"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "Düşük Gecikme"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -9880,8 +10606,16 @@ msgid "Replace preset '%s'?"
 msgstr "'%s' hazır ayarının üzerine yazılsın mı?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Ana"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -9989,6 +10723,10 @@ msgstr "Dil:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Bit Deposu"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10122,6 +10860,11 @@ msgstr ""
 "0 - varsayılan\n"
 "En az - 1\n"
 "En çok - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "LPC Kullan"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10302,6 +11045,16 @@ msgid "Failed to find the codec"
 msgstr "Kodlayıcı-çözücü bulunamadı"
 
 #: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "16 bit"
+msgstr ", 64 bit"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "24 bit"
+msgstr ", 64 bit"
+
+#: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
 msgstr "0 (en hızlı)"
 
@@ -10370,6 +11123,42 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (En İyi Kalite)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Aşırı, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "Standart, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "Orta, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "Orta, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (Daha küçük dosyalar)"
 
@@ -10399,7 +11188,8 @@ msgstr "Çılgın"
 msgid "Extreme"
 msgstr "Ekstrem"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Standart"
 
@@ -10450,8 +11240,8 @@ msgid "Locate LAME"
 msgstr "LAME Konumu"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity MP3 oluşturmak için %s dosyasına gerek duyuyor."
 
 #: src/export/ExportMP3.cpp
@@ -10479,10 +11269,10 @@ msgid "Where is %s?"
 msgstr "%s nerede?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Lame_enc.dll v%d.%d sürümüne bağlanıyorsunuz. Bu sürüm Audacity %d.%d.%d sürümü ile uyumlu değil.\n"
 "Lütfen en son 'Audacity için LAME' sürümünü indirin."
@@ -10787,6 +11577,14 @@ msgstr "Seçilmiş ses Ogg Vorbis olarak dışa aktarılıyor"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Ses Ogg Vorbis olarak dışa aktarılıyor"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Başlık Bilgisi:"
@@ -10800,9 +11598,10 @@ msgid "Other uncompressed files"
 msgstr "Diğer sıkıştırılmamış dosyalar"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "4GB boyutundan büyük bir WAV ya da AIFF dosyasını dışa aktarmak istediniz.\n"
 "Audacity bu işlemi yapamaz, dışa aktarma işlemi iptal edildi."
@@ -10812,8 +11611,9 @@ msgid "Error Exporting"
 msgstr "Dışa Aktarılırken Sorun Çıktı"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Audacity, 4GB boyutundan büyük dosyaları dışa aktaramayacağından\n"
@@ -10853,11 +11653,11 @@ msgid "All supported files"
 msgstr "Tüm desteklenen dosyalar"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10866,11 +11666,11 @@ msgstr ""
 "Dosya > İçe Aktar > MIDI seçeneği ile düzenleyebilirsiniz."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\" \n"
 "bir ses dosyası değil. \n"
@@ -10881,18 +11681,18 @@ msgid "Select stream(s) to import"
 msgstr "İçe aktarılacak akışları seçin"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Bu Audacity sürümü %s desteği ile derlenmemiş."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir CD ses izi. \n"
 "Audacity ses CDlerini doğrudan açamaz. \n"
@@ -10901,10 +11701,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" bir oynatma listesi dosyası. \n"
@@ -10913,10 +11713,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir Windows Media ses dosyası. \n"
@@ -10925,10 +11725,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir Gelişmiş Ses Kodlama dosyası. \n"
@@ -10937,12 +11737,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir şifrelenmiş ses dosyası. \n"
@@ -10953,10 +11753,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir RealPlayer ortam dosyası. \n"
@@ -10965,12 +11765,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" bir nota tabanlı dosya, bir ses dosyası değil. \n"
 "Audacity bu türdeki dosyaları açamaz. \n"
@@ -10979,10 +11779,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -10995,10 +11795,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir Wavpack ses dosyası. \n"
@@ -11007,10 +11807,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir Dolby Sayısal ses dosyası. \n"
@@ -11019,10 +11819,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir Ogg Spex ses dosyası. \n"
@@ -11031,10 +11831,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" bir görüntü dosyası. \n"
@@ -11048,9 +11848,9 @@ msgstr "\"%s\" dosyası bulunamadı."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11066,11 +11866,16 @@ msgstr ""
 "FFmpeg kurulmaya çalışılıyor.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, Audacity deneme kullanıcısı"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11100,12 +11905,13 @@ msgid "Import Project"
 msgstr "Projeyi İçe Aktar"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Bu proje Audacity 1.0 ya da öncesindeki bir sürüm ile kaydedilmiş. \n"
 "Dosya biçimi değiştiğinden bu Audacity sürümü projeyi içe aktaramıyor.\n"
@@ -11156,7 +11962,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "\"%s\" proje veri klasörü bulunamadı"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Proje dosyasında MIDI izleri bulundu ancak bu Audacity sürümünde MIDI desteği olmadığından iz atlanıyor."
 
 #: src/import/ImportAUP.cpp
@@ -11261,40 +12068,6 @@ msgstr "Belirteç[%02x] Kodlayıcı-çözücü[%s], Dil[%s], Bithızı[%s], Kana
 msgid "FLAC files"
 msgstr "FLAC dosyaları"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer uyumlu dosyalar"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Kod çözücü işlem akışına eklenemedi"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer İçe Aktarıcı"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Akış durumu duraklatılmış olarak ayarlanamadı."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Dizin[%02d], Tür[%s], Kanallar[%d], Hız[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "Dosyada herhangi bir ses akışı bulunamadı."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Dosya içe aktarılamadı, durum değiştirilemedi."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer Sorunu: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Temel metin biçimindeki dosyaların listesi"
@@ -11397,12 +12170,97 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF ve diğer sıkıştırılmamış türler"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG kapsayıcı biçimi)"
 
 #: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (üst bilgisiz)"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11431,6 +12289,64 @@ msgstr "32 bit kayan"
 #: src/import/ImportPCM.cpp
 msgid "64 bit float"
 msgstr "64 bit kayan"
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "16 bit DPCM"
+msgstr "İmzalanmış 16 bit PCM"
+
+#: src/import/ImportPCM.cpp
+#, fuzzy
+msgid "8 bit DPCM"
+msgstr "İmzalanmış 8 bit PCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11479,6 +12395,19 @@ msgstr "Ham Veri İçe Aktarma"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Endiansızlık yok"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Big-endian"
+msgstr "Medyan"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -11553,6 +12482,7 @@ msgstr "%s sağ"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11576,6 +12506,7 @@ msgstr "bitiş"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11602,7 +12533,8 @@ msgstr "Zamanı sağa ötelenmiş parçalar"
 msgid "Time shifted clips to the left"
 msgstr "Zamanı sola ötelenmiş parçalar"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Zaman Kaydırması"
 
@@ -11740,7 +12672,8 @@ msgstr "Seçilmiş izleri %.2f ile %.2f saniyeleri arasında buda"
 msgid "Trim Audio"
 msgstr "Sesi Buda"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Ayır"
 
@@ -11865,34 +12798,6 @@ msgid "Ext&ra"
 msgstr "Ek Çu&buklar"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "&Karıştırıcı"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "&Oynatma Ses Düzeyini Ayarla..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "Oynatma Ses Düzeyini &Arttır"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "Oynatma Ses Düzeyini A&zalt"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "&Kayıt Ses Düzeyini Ayarla..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "Kayıt Ses Düzeyi&ni Arttır"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "Kayıt S&es Düzeyini Azalt"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "Ay&gıt"
 
@@ -11928,6 +12833,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Seçilmiş Sesi Dışa Aktar"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Etiket metni"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -12061,6 +12972,11 @@ msgid "&Labels..."
 msgstr "&Etiketler..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "&MIDI Dışa Aktar..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "&Ham Veri..."
 
@@ -12149,8 +13065,9 @@ msgid "&Getting Started"
 msgstr "&Başlarken"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Audacity &Kılavuzu"
+#, fuzzy
+msgid "&Manual"
+msgstr "&Belgeler..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12176,11 +13093,8 @@ msgstr "&MIDI Aygıtı Bilgileri..."
 msgid "Show &Log..."
 msgstr "Gün&lüğü Görüntüle..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Audacity Hakkında..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Etiket eklendi"
 
@@ -12428,6 +13342,11 @@ msgstr "&Odaklanılan İzi Değiştir"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "Kategorisiz"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Yeni..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12866,6 +13785,7 @@ msgstr "İ&mleci Sağa Doğru Uzun Atlat"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "A&ra"
@@ -13077,18 +13997,21 @@ msgid "Created new label track"
 msgstr "Yeni etiket izi oluşturuldu"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "Bu Audacity sürümünde her proje penceresinde yalnız bir zaman izi kullanılabilir."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Yeni zaman izi oluşturuldu"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Yeni örnekleme hızı (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Yazdığınız değer geçersiz"
 
@@ -13345,7 +14268,9 @@ msgstr "Oynatılıyor"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Kaydetme"
 
@@ -13494,10 +14419,6 @@ msgstr "&Bindirme (aç/kapat)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "&Yazılımsal Oynarken Kaydet (aç/kapat)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "Otomatik Kayıt &Düzeyi Ayarlaması (aç/kapat)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13713,7 +14634,7 @@ msgstr "Kalite Ayarları"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Audacity uygulamasını güncelle"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13760,7 +14681,8 @@ msgstr "&Sunucu:"
 msgid "Using:"
 msgstr "Şunu Kullanarak:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Oynatma"
 
@@ -13780,7 +14702,8 @@ msgstr "Ka&nallar:"
 msgid "Latency"
 msgstr "Gecikme"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "milisaniye"
 
@@ -13809,7 +14732,8 @@ msgid "2 (Stereo)"
 msgstr "2 (Çift Kanallı)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Klasörler"
 
@@ -13917,7 +14841,8 @@ msgid "Directory %s is not writable"
 msgstr "%s klasörü yazılabilir değil"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Geçici klasör değişikliğinin geçerli olması için Audacity programını yeniden başlatmalısınız"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -13948,6 +14873,40 @@ msgstr "Yayıncıya Göre Gruplu"
 msgid "Grouped by Type"
 msgstr "Türe Göre Gruplu"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Nyquist Sorunu"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Etkileri Etkinleştir"
@@ -13969,11 +14928,13 @@ msgid "Plugin Options"
 msgstr "Eklenti Ayarları"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Audacity başlatıldığında eklenti güncellemeleri denetlensin"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Audacity başlatıldığında eklentileri yeniden tara"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14153,7 +15114,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "Seçim e&tikete denk gelirse etiketler korunsun"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "Sistem ve Audacity teması karıştırı&lsın"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14331,7 +15293,8 @@ msgstr ""
 "   *   \"%s\"  ('%s' kısayolu \"%s\" tarafından kullanıldığından)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Audacity tuş takımı kısayollarını içeren bir XML dosyası seçin..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14464,8 +15427,9 @@ msgid "Dow&nload"
 msgstr "İ&ndir"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity uygun FFmpeg kitaplıkları buldu.\n"
@@ -14524,8 +15488,9 @@ msgid "Preferences for Module"
 msgstr "Modül Ayarları"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Bu modüller deneysel olduğundan, yalnız Audacity belgelerini okuduysanız ve\n"
@@ -14533,12 +15498,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr " 'Sor': Audacity her başlatıldığında modülün yüklenip yüklenmeyeceğinin sorulacağı anlamına gelir."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr " 'Başarısız': Audacity modülün bozuk olduğunu düşündüğünden çalıştırılmayacağı anlamına gelir."
 
 #. i18n-hint preserve the leading spaces
@@ -14547,7 +15514,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr " 'Yeni': Henüz bir seçim yapılmamış olduğu anlamına gelir."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Bu ayarlarda yapılan değişiklikler yalnız Audacity başlatılırken geçerli olur."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14565,6 +15533,10 @@ msgstr "Herhangi bir modül bulunamadı"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Modül"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14606,7 +15578,10 @@ msgstr "Sol Tuş ile Sürükleme"
 msgid "Set Selection Range"
 msgstr "Seçim Aralığını Ayarla"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift ile Sol Tıklama"
 
@@ -14693,6 +15668,15 @@ msgstr "-Sol-Sürükleme"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Parçaları izler arasında yukarı/aşağı taşı"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Sol-Sürükleme"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14817,7 +15801,8 @@ msgid "Always scrub un&pinned"
 msgstr "Her &zaman sabitlenmemiş olarak sar"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Audacity Ayarları"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14831,6 +15816,11 @@ msgstr "Ayarlar:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Kalite Ayarları"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -14873,6 +15863,14 @@ msgstr "Örnek Hızı Dönüş&türücü:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Dit&her:"
 msgstr "Titr&eme:"
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
@@ -14942,39 +15940,6 @@ msgid "System T&ime"
 msgstr "Sistem &Saati"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Kayıt Düzeyinin Otomatik Olarak Ayarlanması"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Kayıt Düzeyi Otomatik Olarak Ayarlansın."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Hedef Tepe:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "İçinde:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Çözümleme Süresi:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "milisaniye (bir çözümleme süresi)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Birbirini izleyen çözümleme sayısı:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 sonsuz anlamına gelir"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "İşaretle ve Kaydı Sürdür"
 
@@ -14985,6 +15950,16 @@ msgstr "Ön &sarma:"
 #: src/prefs/RecordingPrefs.cpp
 msgid "Cross&fade:"
 msgstr "Çapraz &geçiş:"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
 
 #. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
 #: src/prefs/SpectrogramSettings.cpp
@@ -15124,6 +16099,10 @@ msgid "1024 - default"
 msgstr "1024 - varsayılan"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - en darbant"
 
@@ -15221,13 +16200,14 @@ msgid "Info"
 msgstr "Bilgi"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15410,7 +16390,8 @@ msgstr "Örnekler"
 msgid "4 Pixels per Sample"
 msgstr "Örnek Başına 4 Piksel"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "En Büyük Yakınlaştırma"
 
@@ -15532,16 +16513,24 @@ msgid "Stopped"
 msgstr "Durduruldu"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Duraklat"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Başlangıca Git"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Bitişe Git"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Duraklat"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Başlangıca Kadar Seç"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Bitişe Kadar Seç"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15555,20 +16544,17 @@ msgstr "Yeni İz Kaydet"
 msgid "Append Record"
 msgstr "Kayıt Ekle"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Bitişe Kadar Seç"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Başlangıca Kadar Seç"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s duraklatıldı."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15648,11 +16634,17 @@ msgstr "Seçilmiş Sesi Sustur"
 msgid "Sync-Lock Tracks"
 msgstr "Eş Kilitlenmiş İzler"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Yakınlaştır"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Uzaklaştır"
 
@@ -15719,43 +16711,6 @@ msgstr "&Kayıt Ölçüm Çubuğu"
 msgid "&Playback Meter Toolbar"
 msgstr "&Oynatma Ölçüm Çubuğu"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Kayıt Düzeyi"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Oynatma Düzeyi"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Kayıt Düzeyi: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Kayıt Düzeyi (denetlenemiyor; sistem karıştırıcısını kullanın)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Oynatma Ses Düzeyi: %.2f (taklit edilen)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Oynatma Ses Düzeyi: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Oynatma Düzeyi (denetlenemiyor; sistem karıştırıcısını kullanın)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Karış&tırıcı Çubuğu"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Tarama"
@@ -15771,6 +16726,7 @@ msgstr "Sarma"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Sarmayı Durdur"
@@ -15778,6 +16734,7 @@ msgstr "Sarmayı Durdur"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Sarmayı Başlat"
@@ -15785,6 +16742,7 @@ msgstr "Sarmayı Başlat"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Taramayı Durdur"
@@ -15792,6 +16750,7 @@ msgstr "Taramayı Durdur"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Taramayı Başlat"
@@ -15846,7 +16805,9 @@ msgstr "Şuna Uy"
 msgid "Length"
 msgstr "Uzunluk"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Orta"
 
@@ -15910,8 +16871,8 @@ msgstr "&Zaman Araç Çubuğu"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Audacity %s Araç Çubuğu"
 
 #: src/toolbars/ToolBar.cpp
@@ -15938,7 +16899,8 @@ msgstr "Zaman Kaydırma Aracı"
 msgid "Zoom Tool"
 msgstr "Yakınlaştırma Aracı"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Çizim Aracı"
 
@@ -16014,11 +16976,13 @@ msgstr "Bir ya da daha fazla etiket sınırını sürükleyin."
 msgid "Drag label boundary."
 msgstr "Etiket sınırını sürükleyin."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Düzenlenmiş etiket"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Etiket Düzenle"
 
@@ -16073,31 +17037,42 @@ msgstr "Etiketler düzenlendi"
 msgid "New label"
 msgstr "Etiket ekle"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Ü&st Oktav"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "Alt Okta&v"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Dikey olarak yakınlaştırmak için tıklayın, uzaklaştırmak için Shift ile Tıklayın, Yakınlaştırma aralığını seçmek için sürükleyin."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Menüyü açmak için sağ tıklayın."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Yakınlaştırmayı Sıfırla"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift ile Sağ Tıklama"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Sol Tıklama/Sol Sürükleme"
 
@@ -16139,7 +17114,8 @@ msgstr "Birleştir"
 msgid "Expanded Cut Line"
 msgstr "Kesim Hattını Genişlet"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Genişlet"
 
@@ -16162,6 +17138,11 @@ msgstr "Taşınan Örnekler"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Örnek Düzenleme"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16207,7 +17188,8 @@ msgstr "İşleniyor...   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "'%s' %s olarak değiştirildi"
@@ -16219,6 +17201,54 @@ msgstr "Biçim Değişimi"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Rat&e"
 msgstr "&Oran"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16238,7 +17268,8 @@ msgstr "Hız Değişimi"
 msgid "Set Rate"
 msgstr "Oranı Ayarla"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "Ç&oklu görünüm"
 
@@ -16330,14 +17361,23 @@ msgstr "Sol, %dHz"
 msgid "Right, %dHz"
 msgstr "Sağ, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Sola"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Sağa"
@@ -16455,9 +17495,8 @@ msgstr "Logaritmik A&radeğerleme"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "İzi zamanda taşımak için tıklayıp sürükleyin"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16508,6 +17547,7 @@ msgstr "Ayarlanmış kılıf."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "&Sar"
@@ -16519,6 +17559,7 @@ msgstr "Taranıyor"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Sarma &Cetveli"
@@ -16702,6 +17743,24 @@ msgstr "Basın"
 msgid "Button"
 msgstr "Düğme"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16735,9 +17794,19 @@ msgstr "Boş"
 msgid "Backwards"
 msgstr "Geriye"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "İleriye"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16950,6 +18019,7 @@ msgstr "0100 sa 060 da 060 sn+>örnek sayısı"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "örnekler"
@@ -17103,8 +18173,36 @@ msgstr "CDDA kareleri (75 fps)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 kare|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "0100 sa 060 da 060>0100 sn"
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centihertz"
+msgstr "santihertz"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "kHz"
+msgstr "Hz"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hertz"
 msgstr "santihertz"
 
 #. i18n-hint: Name of display format that shows log of frequency
@@ -17171,6 +18269,11 @@ msgstr "(Biçimi değiştirmek için kısa yol menüsünü kullanın)"
 msgid "centiseconds"
 msgstr "santisaniye"
 
+#: src/widgets/PopupMenuTable.h
+#, fuzzy, c-format
+msgid "%s (%s)"
+msgstr "(%s)"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Geçen Süre:"
@@ -17212,6 +18315,11 @@ msgstr "Kapatmayı Onayla"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Hazır ayar \"%s\" konumundan okunamadı"
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -17316,15 +18424,27 @@ msgstr "XML işlenemedi"
 msgid "Spectral edit multi tool"
 msgstr "Spektral düzenleme çoklu araç"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Süzülüyor..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "GNU Genel Kamu Lisansı 2. sürüm koşulları altında yayınlanmıştır"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aLütfen frekansları seçin."
@@ -17351,7 +18471,8 @@ msgstr ""
 "                      Alt frekans bağlantısı değerini arttırmayı~%~\n"
 "                      ya da süzgeç 'Genişliğini' arttırmayı deneyin."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Sorun.~%"
@@ -17412,6 +18533,25 @@ msgstr "Stüdyo Azalarak Çık"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Kısma Uygulanıyor..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "&Varsayılan Ayarla"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "GNU Genel Kamu Lisansı 2 ve üzeri sürümlerin koşulları altında yayınlanmıştır."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17555,6 +18695,11 @@ msgstr "Vuruş Bulucu"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Vuruşlar bulunuyor..."
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Audacity Günlüğü"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -17879,13 +19024,38 @@ msgstr "Yüksek Geçiren Süzgeç"
 msgid "Performing High-Pass Filter..."
 msgstr "Yüksek Geçiren Süzgeç Uygulanıyor..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Frekans (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "Roll-off (dB her oktav için)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -17906,10 +19076,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Sesleri Etiketle"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "GNU Genel Kamu Lisansı 2 ve üzeri sürümlerin koşulları altında yayınlanmıştır."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18209,7 +19375,8 @@ msgstr "Lisp dosyası"
 msgid "HTML file"
 msgstr "HTML dosyası"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Metin dosyası"
 
@@ -18274,12 +19441,20 @@ msgid "Error.~%No file selected."
 msgstr "Hata.~%Herhangi bir dosya seçilmemiş."
 
 #: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Generating pluck sound..."
 msgstr "Pluck sesi üretiliyor..."
 
 #: plug-ins/pluck.ny
 msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "C notaları için MIDI değerleri: 36, 48, 60 [orta C], 72, 84, 96."
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
 
 #: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
@@ -18310,6 +19485,10 @@ msgid "Generating Rhythm..."
 msgstr "Ritim Üretiliyor..."
 
 #: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "30 - 300 beats/minute"
 msgstr "30 - 300 vuruş/dakika"
 
@@ -18324,6 +19503,10 @@ msgstr "1 - 20 vuruş/ölçüm"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "Salınım miktarı"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18394,6 +19577,10 @@ msgid "MIDI pitch of strong beat"
 msgstr "Güçlü vuruş MIDI tonu"
 
 #: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "MIDI pitch of weak beat"
 msgstr "Zayıf vuruş MIDI tonu"
 
@@ -18412,6 +19599,10 @@ msgstr "Risset Davulu"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Risset Davulu Üretiliyor..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18514,6 +19705,11 @@ msgstr "İletileri görüntüle"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Yalnız Sorunlar"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -18814,6 +20010,10 @@ msgid "Applying Action..."
 msgstr "İşlem Uygulanıyor..."
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "Vokalleri Kaldır: Tek kanallıya"
 
@@ -18954,8 +20154,16 @@ msgid "This plug-in works only with stereo tracks."
 msgstr "Bu uygulama eki yalnız çift kanallı izlerde çalışır."
 
 #: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Processing Vocoder..."
 msgstr "Vocoder İşleniyor..."
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
 
 #: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
@@ -18997,6 +20205,230 @@ msgstr "Radar Antenlerinin Frekansı (Hz)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "Sorun.~%Çift kanallı iz gereklidir."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Audacity uygulamasını güncelle"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&Atla"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Güncellemeyi kur"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Değişim günlüğü"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "GitHub üzerinden bilgi alın"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Güncelleme denetlenirken sorun çıktı"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Audacity güncelleme sunucusu ile bağlantı kurulamadı."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Güncelleme verileri bozuk."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Güncelleme indirilirken sorun çıktı."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Audacity indirme bağlantısı açılamadı."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Audacity %s yayınlanmış!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Kayıt"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Gönderim Kodu:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Platformlar arası GUI kitaplığı"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "GStreamer ile içe aktarma"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Daha fazla iyileştirme yapmak olanaksız. Hala çok yüksek."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Kayıt düzeyi otomatik olarak ayarlanarak ses düzeyi %f olarak azaltıldı."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Daha fazla iyileştirme yapmak olanaksız. Hala çok düşük."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Kayıt düzeyi otomatik olarak ayarlanarak ses düzeyi %.2f. olarak arttırıldı."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Kabul edilebilir bir ses düzeyi bulunamadan toplam inceleme sayısı aşıldı. Hala çok yüksek."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. Kabul edilebilir bir ses düzeyi bulunamadan toplam inceleme sayısı aşıldı. Hala çok düşük."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Kayıt düzeyinin otomatik olarak ayarlanması durduruldu. %.2f. kabul edilebilir bir ses düzeyi olarak görünüyor."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Aygıtlar açılırken %d alındı\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Portmixer açılamadı\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Kullanılabilecek karıştırıcılar:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Kullanılabilecek kayıt aygıtları:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Kullanılabilecek oynatma ses düzeyleri:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Kayıt ses düzeyi taklit ediliyor\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Kayıt ses düzeyi doğal\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Oynatma ses düzeyi taklit ediliyor\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Oynatma ses düzeyi doğal\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "Bilinmeyen tarih ve saat"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer uyumlu dosyalar"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Kod çözücü işlem akışına eklenemedi"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer İçe Aktarıcı"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Akış durumu duraklatılmış olarak ayarlanamadı."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Dizin[%02d], Tür[%s], Kanallar[%d], Hız[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "Dosyada herhangi bir ses akışı bulunamadı."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Dosya içe aktarılamadı, durum değiştirilemedi."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer Sorunu: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "&Karıştırıcı"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "&Oynatma Ses Düzeyini Ayarla..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "Oynatma Ses Düzeyini &Arttır"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "Oynatma Ses Düzeyini A&zalt"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "&Kayıt Ses Düzeyini Ayarla..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "Kayıt Ses Düzeyi&ni Arttır"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "Kayıt S&es Düzeyini Azalt"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Audacity &Kılavuzu"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Audacity Hakkında..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "Otomatik Kayıt &Düzeyi Ayarlaması (aç/kapat)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Kayıt Düzeyinin Otomatik Olarak Ayarlanması"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Kayıt Düzeyi Otomatik Olarak Ayarlansın."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Hedef Tepe:"
+
+#~ msgid "Within:"
+#~ msgstr "İçinde:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Çözümleme Süresi:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "milisaniye (bir çözümleme süresi)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Birbirini izleyen çözümleme sayısı:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 sonsuz anlamına gelir"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Kayıt Düzeyi"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Oynatma Düzeyi"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Kayıt Düzeyi: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Kayıt Düzeyi (denetlenemiyor; sistem karıştırıcısını kullanın)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Oynatma Ses Düzeyi: %.2f (taklit edilen)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Oynatma Ses Düzeyi: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Oynatma Düzeyi (denetlenemiyor; sistem karıştırıcısını kullanın)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Karış&tırıcı Çubuğu"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "İzi zamanda taşımak için tıklayıp sürükleyin"
 
 #~ msgid "Program build date:"
 #~ msgstr "Uygulama oluşturulma tarihi:"
@@ -19078,155 +20510,6 @@ msgstr "Sorun.~%Çift kanallı iz gereklidir."
 #~ msgid "Gra&yscale"
 #~ msgstr "&Gri Tonlamalı"
 
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
 #, c-format
-msgid "%s KB"
-msgstr "%s kB"
-
-#. i18n-hint: Benchmark means a software speed test;
-#. leave untranslated file extension .txt
-#: src/Benchmark.cpp
-msgid "benchmark.txt"
-msgstr "benchmark.txt"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#: src/AudacityLogger.cpp
-msgid "log.txt"
-msgstr "log.txt"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Tenacity, MuseCY SM Ltd. veya Dominic M Mazzoni tarafından üretilmemekte "
-"veya desteklenmemektedir."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Audacity%s ticari markası bu yazılımda yalnızca belirleyici ve bilgilendirme "
-"amaçlı kullanılmaktadır."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s katkıda bulunanlar"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Lütfen isimlerin önem sırasına göre değil, alfabetik sıraya göre "
-"sıralandığını unutmayın."
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "(C) 2009 by Leland Lucius"
-msgstr "(C) 2009 Luland Lucius tarafından"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Harvey Lubin (logo)"
-msgstr "Harvey Lubin (amblem)"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
-msgid "Solo"
-msgstr "Solo"
-
-#: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
-msgstr "Tenacity Karaokesi%s"
-
-#: src/FreqWindow.cpp
-msgid "spectrum.txt"
-msgstr "spectrum.txt"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#. i18n-hint: abbreviates decibels
-#. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
-msgid "dB"
-msgstr "dB"
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -9,86 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-12 13:54+0000\n"
 "Last-Translator: mondstern <mondstern@snopyta.org>\n"
-"Language-Team: Ukrainian <https://hosted.weblate.org/projects/tenacity/"
-"tenacity/uk/>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/tenacity/tenacity/uk/>\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 "
-"? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > "
-"14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % "
-"100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 "X-Generator: Weblate 4.8-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "Оновити Audacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "Проп&устити"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "&Встановити оновлення"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "Журнал змін"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "Прочитати більше на GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "Помилка під час перевірки оновлень"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "Не вдалося встановити з'єднання із сервером оновлення Audacity."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "Дані оновлення пошкоджено."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "Помилка під час отримання оновлення."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "Не вдалося відкрити посилання для отримання Audacity."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Випущено Audacity %s!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Запис"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -242,7 +172,8 @@ msgid "Script"
 msgstr "Скрипт"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Виведення"
 
@@ -258,7 +189,12 @@ msgstr "скрипти Nyquist (*.ny)|*.ny|скрипти Lisp (*.lsp)|*.lsp|у�
 msgid "Script was not saved."
 msgstr "Скрипти не збережено."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Попередження"
 
@@ -279,11 +215,16 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Галерея піктограм Tango (піктограми панелі інструментів)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Leland Lucius"
+msgstr "Ліланд Люціус"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "(C) 2009 by Leland Lucius"
 msgstr "© Leland Lucius, 2009"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Зовнішній модуль Audacity, який забезпечує роботу простого комплексного середовища розробки для створення ефектів."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -306,7 +247,8 @@ msgstr "Без назви"
 msgid "Nyquist Effect Workbench - "
 msgstr "Стенд ефектів Nyquist – "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "Новий"
 
@@ -346,7 +288,8 @@ msgstr "Копіювати"
 msgid "Copy to clipboard"
 msgstr "Скопіювати до буфера"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Вирізати"
 
@@ -354,7 +297,8 @@ msgstr "Вирізати"
 msgid "Cut to clipboard"
 msgstr "Вирізати до буфера"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Вставити"
 
@@ -379,7 +323,8 @@ msgstr "Позначити все"
 msgid "Select all text"
 msgstr "Позначити увесь текст"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Скасувати"
 
@@ -387,7 +332,8 @@ msgstr "Скасувати"
 msgid "Undo last change"
 msgstr "Скасувати останню зміну"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Повторити"
 
@@ -444,7 +390,8 @@ msgid "Go to next S-expr"
 msgstr "Перейти до наступного S-виразу"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Початок"
 
@@ -452,7 +399,8 @@ msgstr "Початок"
 msgid "Start script"
 msgstr "Запустити скрипт"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Зупинити"
 
@@ -467,7 +415,8 @@ msgid "About %s"
 msgstr "Про %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "Гаразд"
 
@@ -475,11 +424,13 @@ msgstr "Гаразд"
 msgid "Build Information"
 msgstr "Інформація про випуск"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Вимкнено"
 
@@ -489,8 +440,9 @@ msgid "The Build"
 msgstr "Збірка"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Ід. внеску:"
+#, fuzzy
+msgid "Version:"
+msgstr "Версія: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -500,22 +452,28 @@ msgstr "Тип випуску:"
 msgid "Compiler:"
 msgstr "Компілятор:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Префікс встановлення:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Тека з параметрами:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Тека з параметрами:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Підтримка форматів файлів"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Бібліотека для побудови графічних інтерфейсів на різних платформах"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -529,7 +487,6 @@ msgstr "Зміна частоти дискретизації"
 msgid "MP3 Importing"
 msgstr "Імпортування MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Імпорт та експорт файлів Ogg Vorbis"
@@ -538,7 +495,6 @@ msgstr "Імпорт та експорт файлів Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Підтримка міток ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Імпорт та експорт файлів FLAC"
@@ -556,14 +512,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Імпортування/Експортування даних FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "Імпорт за допомогою GStreamer"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Можливості"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Підтримка додатків"
 
@@ -578,6 +526,10 @@ msgstr "Підтримка зміни кроку і темпу"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Підтримка екстремальної зміни такту і темпу"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Можливості"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -696,6 +648,10 @@ msgstr "%s, графіка"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (із включеними %s, %s, %s, %s та %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -705,6 +661,10 @@ msgstr "%s — вільне програмне забезпечення з ві�
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Подяки"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "Будь ласка, зверніть увагу, що імена відсортовані в алфавітному порядку, а не в порядку важливості."
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -755,6 +715,7 @@ msgstr "Сайт та графіка"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -777,6 +738,22 @@ msgstr "Особливі подяки:"
 msgid "%s website: "
 msgstr "Сайт %s: "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s вкладники"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Торгова марка Audacity %s використовується в цьому програмному забезпеченні тільки в описових та інформаційних цілях."
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Завзятість не виробляється і не схвалено MuseCY SM Ltd. або Домініком м. Маццоні."
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "Дії з монтажним столом вимкнено на час запису"
@@ -798,6 +775,7 @@ msgstr "Монтажний стіл"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Клацання або перетягування — почати позиціювання"
@@ -805,6 +783,7 @@ msgstr "Клацання або перетягування — почати по
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Клацання або перетягування — почати прокручування"
@@ -812,6 +791,7 @@ msgstr "Клацання або перетягування — почати пр
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Клацання з пересуванням — прокручування, клацання з перетягуванням — позиціювання."
@@ -819,6 +799,7 @@ msgstr "Клацання з пересуванням — прокручуван�
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Пересування — позиціювання"
@@ -826,6 +807,7 @@ msgstr "Пересування — позиціювання"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Пересування — прокручування"
@@ -882,7 +864,17 @@ msgstr ""
 "Не можна блокувати область за\n"
 "кінцевою точкою проєкту."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Помилка"
 
@@ -906,7 +898,8 @@ msgstr ""
 "Це питання буде задано лише один раз, після встановлення, де програма запитувала вас щодо відновлення початкових значень налаштувань."
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Відновити налаштування Audacity"
 
 #: src/AudacityApp.cpp
@@ -921,7 +914,8 @@ msgstr ""
 "Його вилучено зі списку нещодавніх файлів."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Не вдалося ініціалізувати бібліотеку SQLite. Неможливо продовжити роботу Audacity."
 
 #: src/AudacityApp.cpp
@@ -947,7 +941,7 @@ msgstr "&Відкрити…"
 msgid "Open &Recent..."
 msgstr "Відкрити &недавні…"
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Про Audacity…"
@@ -961,9 +955,10 @@ msgid "&File"
 msgstr "&Файл"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Програмі не вдалося знайти безпечне місце для зберігання тимчасових файлів.\n"
@@ -971,20 +966,23 @@ msgstr ""
 "Вкажіть відповідний каталог у діалоговому вікні уподобань."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Програмі не вдається знайти каталог для зберігання тимчасових файлів.\n"
 "Вкажіть відповідний каталог у діалоговому вікні уподобань."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Audacity готується до завершення. Повторно завантажте програму для використання нової теки тимчасових файлів."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -993,15 +991,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity не може заблокувати теку з тимчасовими файлами.\n"
 "Можливо цю теку вже використовує інша копія Audacity.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Досі бажаєте запустити Audacity?"
 
 #: src/AudacityApp.cpp
@@ -1009,12 +1009,14 @@ msgid "Error Locking Temporary Folder"
 msgstr "Помилка при блокуванні теки тимчасових фалів"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Система визначила, що вже запущено іншу копію Audacity.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Щоб відкрити одночасно декілька проєктів використовуйте\n"
@@ -1022,7 +1024,8 @@ msgstr ""
 "Audacity, що зараз виконується.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity вже запущено"
 
 #: src/AudacityApp.cpp
@@ -1038,7 +1041,8 @@ msgstr ""
 "і може знадобитися перезавантаження системи."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Помилка під час запуску Audacity"
 
 #: src/AudacityApp.cpp
@@ -1078,8 +1082,9 @@ msgstr ""
 "і може знадобитися перезавантаження системи."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1111,7 +1116,8 @@ msgstr "запуск самодіагностики"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "показати версію Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1121,9 +1127,10 @@ msgid "audio or project file name"
 msgstr "назва файла звукових даних або проєкту"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1136,16 +1143,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Файли проєктів Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Повідомлення"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Помилка у налаштуваннях Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1155,7 +1164,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Не вдалося отримати доступ до цього файла налаштувань:\n"
 "\n"
@@ -1167,12 +1176,15 @@ msgstr ""
 "\n"
 "Якщо ви натиснете кнопку «Вийти з Audacity», ваш проєкт може залишитися у незбереженому стані — програма намагатиметься його відновити під час наступного запуску."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Довідка"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "Ви&йти з Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1180,7 +1192,8 @@ msgid "&Retry"
 msgstr "&Повторити"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Журнал Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1192,9 +1205,14 @@ msgstr "З&берегти…"
 msgid "Cl&ear"
 msgstr "Спорожн&ити"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Закрити"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1243,7 +1261,8 @@ msgid "Error Initializing Midi"
 msgstr "Помилка при ініціалізації MIDI"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Звук Audacity"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1258,37 +1277,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Не вистачає пам'яті!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Роботу інструменту автоматичного виправлення рівня запису зупинено. Рівень вже неможливо покращити. Рівень гучності зависокий."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Інструмент встановлення автоматичної гучності запису знизив гучність до %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Роботу інструменту автоматичного виправлення рівня запису зупинено. Рівень вже неможливо покращити. Рівень гучності занизький."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Інструмент автоматичного визначення гучності запису збільшив гучність до %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Роботу інструменту автоматичного визначення гучності запису зупинено. Перевищено загальну кількість точок аналізу, прийнятного рівня гучності не знайдено. Гучність залишається занадто високою."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Роботу інструменту автоматичного визначення гучності запису зупинено. Перевищено загальну кількість точок аналізу, прийнятного рівня гучності не знайдено. Гучність залишається занадто низькою."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Роботу інструменту автоматичного виправлення рівня запису зупинено. Визначено прийнятну гучність — %.2f."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1387,48 +1375,6 @@ msgstr "Не знайдено пристрою відтворення для «%
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Неможливо перевірити взаємні частоти дискретизації без обох пристроїв.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Отримано %d під час спроби відкрити пристрій\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Не вдалося відкрити Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Доступні мікшери:\n"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d – %s\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Доступні джерела для запису:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Доступні гучності відтворення.:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Гучність запису є емульованою\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Гучність запису є природною\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Гучність відтворення є емульованою\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Гучність відтворення є природною\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1471,8 +1417,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Автоматичне відновлення після краху"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1485,12 +1432,14 @@ msgid "Recoverable &projects"
 msgstr "Придатні до відновлення &проєкти"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Позначення"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Назва"
 
@@ -1576,6 +1525,11 @@ msgstr "Ефект"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Команда меню (з параметрами)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1721,7 +1675,8 @@ msgstr "Від&новити"
 msgid "I&mport..."
 msgstr "І&мпортувати…"
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Експортувати…"
 
@@ -1762,7 +1717,8 @@ msgstr "В&гору"
 msgid "Move &Down"
 msgstr "В&низ"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Зберегти"
 
@@ -1845,7 +1801,8 @@ msgid "Run"
 msgstr "Виконати"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Закрити"
 
@@ -1991,11 +1948,6 @@ msgid "No revision identifier was provided"
 msgstr "Не надано ідентифікатора модифікації"
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Дата і час кінця"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Діагностична збірка (рівень діагностики %d)"
@@ -2079,6 +2031,11 @@ msgid ""
 msgstr ""
 "Для виконання цієї дії спочатку треба позначити область звукових даних.\n"
 "(Позначення інших типів доріжки не працюватиме.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2254,10 +2211,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Якщо продовжити, проєкт не буде збережено на диск. Ви цього хочете?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2271,7 +2229,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Перевірка залежностей"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Немає"
 
@@ -2279,7 +2240,7 @@ msgstr "Немає"
 msgid "Rectangle"
 msgstr "Прямокутник"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Трикутник"
 
@@ -2341,9 +2302,10 @@ msgid "FFmpeg support not compiled in"
 msgstr "Програму зібрано без підтримки FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2365,8 +2327,8 @@ msgid "Locate FFmpeg"
 msgstr "Вказати адресу FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity потребує файла «%s» для імпортування та експортування звукових даних за допомогою FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2379,7 +2341,8 @@ msgstr "Розташування «%s»:"
 msgid "To find '%s', click here -->"
 msgstr "Щоб знайти «%s», клацніть тут —>"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Огляд…"
 
@@ -2405,8 +2368,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg не знайдено"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2436,24 +2400,24 @@ msgid "Only libavformat.so"
 msgstr "Лише libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity не вдалося відкрити файл у %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity не вдалося прочитати дані з файла у %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity вдалося успішно записати файл до %s, але не вдалося перейменувати його на %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2491,7 +2455,9 @@ msgstr "Не к&опіювати ніякого аудіо"
 msgid "As&k"
 msgstr "За&питати"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "усі файли"
 
@@ -2516,6 +2482,10 @@ msgstr "текстові файли"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "файли XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2557,6 +2527,14 @@ msgstr "Середньоквадратична кореляція"
 msgid "Enhanced Autocorrelation"
 msgstr "Розширена автокореляція"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Спектр"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2575,7 +2553,12 @@ msgstr "Частота запису журналу"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "дБ"
 
@@ -2590,7 +2573,9 @@ msgstr "Масштабування"
 #. i18n-hint: This is the abbreviation for "Hertz", or
 #. cycles per second.
 #. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "Hz"
 msgstr "Гц"
 
@@ -2685,10 +2670,16 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f сек (%d Гц) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Спектр"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Експортувати результати спектрального аналізу у файл:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Не вдалося записати дані до цього файла: %s"
@@ -2878,19 +2869,19 @@ msgid "&History..."
 msgstr "&Журнал змін…"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Внутрішня помилка у %s, %s, рядок %d.\n"
 "Будь ласка, повідомте про цю помилку команду розробників Audacity за допомогою форуму: https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Внутрішня помилка у %s, рядок %d.\n"
 "Будь ласка, повідомте про цю помилку команду розробників Audacity за допомогою форуму: https://forum.audacityteam.org/."
@@ -2909,7 +2900,9 @@ msgid "Track"
 msgstr "Доріжка"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Мітка"
 
@@ -2969,7 +2962,8 @@ msgstr "Введіть назву доріжки"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Позначити доріжку"
 
@@ -2980,11 +2974,13 @@ msgstr "Одну або декілька збережених міток не в
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Перший запуск Audacity"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Виберіть мову інтерфейсу для Audacity:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2994,7 +2990,8 @@ msgstr "Виберіть мову інтерфейсу для Audacity:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Вибрана вами мова, %s (%s), не збігається з мовою, встановленою у системі, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Підтвердити"
 
@@ -3012,12 +3009,13 @@ msgstr ""
 "Старий файл збережено з назвою «%s»"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Відкривається проєкт Audacity"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Audacity Караоке%s"
 
 #: src/LyricsWindow.cpp
@@ -3068,19 +3066,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Мікшування та зведення доріжок"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Панель мікшера Audacity%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Гучність"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Швидкість"
 
@@ -3089,17 +3091,23 @@ msgid "Musical Instrument"
 msgstr "Музичний інструмент"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Панорама"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Тиша"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "Соло"
 
@@ -3107,15 +3115,18 @@ msgstr "Соло"
 msgid "Signal Level Meter"
 msgstr "Індикатор рівня сигналу"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Регулятор рівня переміщено"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Пересунуто повзунок швидкості"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Регулятор панорами переміщено"
 
@@ -3150,9 +3161,9 @@ msgstr ""
 "Його не буде завантажено."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3186,16 +3197,19 @@ msgstr ""
 "\n"
 "Використовуйте лише модулі з надійних джерел"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Так"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Ні"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Завантажувач модулів Audacity"
 
 #: src/ModuleManager.cpp
@@ -3218,6 +3232,117 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Доріжка приміток"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+#, fuzzy
+msgid "B"
+msgstr "дБ"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3329,7 +3454,8 @@ msgstr "&Позначити усі"
 msgid "C&lear All"
 msgstr "З&няти позначення з усіх"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Увімкнути"
 
@@ -3409,9 +3535,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Невідповідні частоти дискретизації"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Позначено надто мало доріжок для запису із цією частотою дискретизації.\n"
@@ -3440,10 +3567,11 @@ msgid "Dropouts"
 msgstr "Провали"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3483,11 +3611,11 @@ msgid "Inspecting project file data"
 msgstr "Вивчення даних файла проєкту"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3530,11 +3658,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Попередження: не знайдено приєднаних файлів"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Перевірка теки «%s» виявила %lld пропущених приєднаних файлів (auf)\n"
@@ -3558,12 +3686,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Попередження: не вистачає приєднаних файлів резюме"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3620,7 +3748,8 @@ msgstr "Попередження: зайві блок-файли"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Поступ"
 
@@ -3645,6 +3774,11 @@ msgstr "Попередження: проблеми з автоматичним �
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<без назви>"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Проєкт %02i] Audacity «%s»"
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3714,12 +3848,14 @@ msgstr ""
 "(Неможливо створити необхідні тимчасові файли)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Цей файл не є файлом проєкту Audacity"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3851,9 +3987,9 @@ msgid "Error Writing to File"
 msgstr "Помилка під час спроби запису файла"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3867,9 +4003,16 @@ msgstr "Ущільнення проєкту"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Проєкт %02i] Audacity «%s»"
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Швидкість"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3878,10 +4021,10 @@ msgstr "(Відновлено)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Файл збережений програмою Audacity версії %s.\n"
 "Ви використовуєте Audacity версії %s. Щоб відкрити цей файл, слід оновити  версію програми."
@@ -3953,8 +4096,9 @@ msgid "Backing up project"
 msgstr "Резервне копіювання проєкту"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3963,8 +4107,9 @@ msgstr ""
 "Його відновлено з останнього зробленого знімка."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -4044,8 +4189,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%sЗберегти проєкт «%s» як…"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "Дію «Зберегти проєкт» призначено для проєкту Audacity, а не файла звукових даних.\n"
@@ -4122,11 +4268,12 @@ msgid "Error Opening Project"
 msgstr "Помилка під час відкриття файла проєкту"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Ви намагаєтеся відкрити файл резервної копії, створений у автоматичному режимі.\n"
 "Подібна дія може призвести до критичної втрати даних.\n"
@@ -4235,8 +4382,8 @@ msgid "Automatic database backup failed."
 msgstr "Не вдалося виконати автоматичне резервне копіювання бази даних."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Ласкаво просимо до Audacity версії %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4456,7 +4603,8 @@ msgstr "Усі налаштування"
 msgid "SelectionBar"
 msgstr "Панель вибору"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Спектральний вибір"
 
@@ -4464,46 +4612,55 @@ msgstr "Спектральний вибір"
 msgid "Timer"
 msgstr "Таймер"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Інструменти"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Керування"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Мікшер"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Індикатор"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Індикатор програвання"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Індикатор запису"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Редагування"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Пристрій"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Відтворити на швидкості"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Прокрутити"
 
@@ -4518,7 +4675,10 @@ msgstr "Лінійка"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Доріжки"
 
@@ -4628,7 +4788,8 @@ msgid "Activation level (dB):"
 msgstr "Рівень активації (дБ):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Ласкаво просимо до Audacity!"
 
 #: src/SplashDialog.cpp
@@ -4775,9 +4936,9 @@ msgstr ""
 "Щоб отримати підказки щодо належних дисків, натисніть кнопку «Довідка»."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity не може записати файл:\n"
@@ -4797,9 +4958,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4808,9 +4969,9 @@ msgstr ""
 "для запису."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity не може записати зображення у файл:\n"
@@ -4827,9 +4988,9 @@ msgstr ""
 "  %s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4839,9 +5000,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4850,8 +5011,9 @@ msgstr ""
 "Можливо неправильний формат png?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity не може прочитати свою типову тему.\n"
@@ -4889,9 +5051,9 @@ msgstr ""
 "вже були наявні. Перезаписати їх?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Audacity не може зберегти файл:\n"
@@ -4930,7 +5092,11 @@ msgstr "Нетипова"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Тривалість"
 
@@ -4941,7 +5107,8 @@ msgid "Time Track"
 msgstr "Доріжка часу"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Таймер запису Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5015,7 +5182,8 @@ msgstr "Поточний проєкт"
 msgid "Recording start:"
 msgstr "Початок запису:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Тривалість:"
 
@@ -5036,7 +5204,8 @@ msgid "Action after Timer Recording:"
 msgstr "Дія після записування за таймером:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Поступ запису за таймером Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5132,6 +5301,7 @@ msgstr "099 днів 024 г 060 хв 060 с"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Дата та час початку"
@@ -5176,7 +5346,8 @@ msgstr "Увімкнути автоматичне &експортування?"
 msgid "Export Project As:"
 msgstr "Експортувати проєкт як:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Параметри"
 
@@ -5189,7 +5360,8 @@ msgid "Do nothing"
 msgstr "Нічого не робити"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Вийти з Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5213,7 +5385,8 @@ msgid "Scheduled to stop at:"
 msgstr "Заплановано зупинку о:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Запис за таймером Audacity — Очікування початку"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5239,7 +5412,8 @@ msgid "Recording Exported:"
 msgstr "Запис експортовано:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Запис за таймером Audacity — очікування"
 
 #: src/TrackInfo.cpp
@@ -5435,6 +5609,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Застосовуємо %s…"
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%s: %s"
+msgstr "(%d): %s"
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "ПОМИЛКА"
@@ -5453,13 +5637,15 @@ msgstr "%s не є прийнятним параметром для %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "Некоректне значення параметра «%s»: має бути %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Команда"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Повторити %s"
@@ -5586,13 +5772,24 @@ msgstr "Кліпи"
 msgid "Envelopes"
 msgstr "Конверти"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Мітки"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "Блоки"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5602,7 +5799,8 @@ msgstr "Коротко"
 msgid "Type:"
 msgstr "Тип:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Формат:"
 
@@ -5629,6 +5827,10 @@ msgstr "Коментар"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Команда:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5666,12 +5868,17 @@ msgstr "Експортує дані до файла."
 msgid "Builtin Commands"
 msgstr "Вбудовані команди"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Команда Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "Надає вбудовані команди Audacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5734,7 +5941,10 @@ msgstr "Вилучає вміст журналу."
 msgid "Get Preference"
 msgstr "Отримати налаштування"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Назва:"
 
@@ -5782,7 +5992,8 @@ msgstr "На весь екран"
 msgid "Toolbars"
 msgstr "Панелі інструментів"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Ефекти"
 
@@ -5922,7 +6133,8 @@ msgstr "Встановити"
 msgid "Add"
 msgstr "Додати"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Вилучити"
 
@@ -6007,7 +6219,8 @@ msgid "Edited Envelope"
 msgstr "Редагована обгортка"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Обвідна"
 
@@ -6050,6 +6263,14 @@ msgstr "Частота"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Змінити розмір:"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -6099,7 +6320,10 @@ msgstr "Панорамування:"
 msgid "Set Track Visuals"
 msgstr "Встановлення візуальних ефектів доріжки"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Лінійна"
 
@@ -6212,7 +6436,9 @@ msgid "Duck &amount:"
 msgstr "Величина пригл&ушення:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "секунд"
 
@@ -6236,7 +6462,8 @@ msgstr "Внутрішня довжина з&гасання:"
 msgid "Inner &fade up length:"
 msgstr "Внутрішня дов&жина наростання:"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "По&ріг:"
 
@@ -6374,11 +6601,13 @@ msgstr "до (у Гц)"
 msgid "t&o"
 msgstr "д&о"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "З&міна у відсотках:"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Зміна у відсотках"
 
@@ -6386,9 +6615,24 @@ msgstr "Зміна у відсотках"
 msgid "&Use high quality stretching (slow)"
 msgstr "Використовувати високо&якісне розтягування (повільно)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+#, fuzzy
+msgid "78"
+msgstr "Б"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "не вказано"
 
@@ -6416,6 +6660,7 @@ msgstr "Стандартне значення об/хв. платівки:"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "З об./хв."
@@ -6428,6 +6673,7 @@ msgstr "&від"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "До об./хв."
@@ -6586,6 +6832,20 @@ msgstr "%.2f секунд"
 msgid "%.1f secs"
 msgstr "%.1f секунд"
 
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "%.0f:1"
+msgstr "%.0f мс"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
@@ -6701,7 +6961,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "Аналізатор контрастності для вимірювання відносної різниці у гучності між двома ділянками звукової доріжки."
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Кінець"
 
@@ -7199,7 +7460,9 @@ msgstr "Пос&лідовність DTMF:"
 msgid "&Amplitude (0-1):"
 msgstr "&Амплітуда (0 — 1):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "&Тривалість:"
 
@@ -7210,6 +7473,11 @@ msgstr "Від&ношення сигнал/тиша:"
 #: src/effects/DtmfGen.cpp
 msgid "Duty cycle:"
 msgstr "Робочий цикл:"
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%+.1f дБ"
 
 #: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
@@ -7239,7 +7507,8 @@ msgstr "Луна"
 msgid "Repeats the selected audio again and again"
 msgstr "Циклічно повторює відтворення позначених звукових даних"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "Вказане значення перевищує обсяг доступної пам’яті."
 
@@ -7263,7 +7532,8 @@ msgstr "Шаблони"
 msgid "Export Effect Parameters"
 msgstr "Експортувати параметри ефекту"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Не вдалося відкрити файл: «%s»"
@@ -7640,6 +7910,10 @@ msgid "Low rolloff for speech"
 msgstr "Спадання низьких частот для голосових даних"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "Телефон"
 
@@ -7704,6 +7978,12 @@ msgstr "%d Гц"
 #: src/effects/Equalization.cpp
 #, c-format
 msgid "%g kHz"
+msgstr "%g кГц"
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%gk"
 msgstr "%g кГц"
 
 #: src/effects/Equalization.cpp
@@ -7779,8 +8059,16 @@ msgid "D&efault"
 msgstr "&Типовий"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE з &потоками"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -8025,7 +8313,8 @@ msgid "Builtin Effects"
 msgstr "Вбудовані ефекти"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "Надає підтримку вбудованих ефектів у Audacity"
 
 #: src/effects/LoadEffects.cpp
@@ -8070,6 +8359,10 @@ msgstr "&Нормалізувати"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "LUFS гучності"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "RMS dB"
@@ -8251,8 +8544,9 @@ msgid "Step 1"
 msgstr "Крок 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Позначте декілька секунд чистого шуму, щоб Audacity знала, що фільтрувати,\n"
@@ -8308,13 +8602,58 @@ msgstr "&Розмір вікна:"
 msgid "8"
 msgstr "Б"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048 (типово)"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "Кроків &на вікно:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8440,6 +8779,7 @@ msgstr "Надзвичайне уповільнення призначено л�
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "&Коефіцієнт видовження:"
@@ -8883,6 +9223,11 @@ msgstr "Типові значення"
 msgid "Restore Defaults"
 msgstr "Відновити типові"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -9041,6 +9386,10 @@ msgstr "Виявлення тиші"
 msgid "Tr&uncate to:"
 msgstr "О&брізати до:"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "С&тиснути до:"
@@ -9054,7 +9403,8 @@ msgid "VST Effects"
 msgstr "Ефекти VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "Додає можливість використання ефектів VST у Audacity."
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9066,7 +9416,8 @@ msgstr "Пошук оболонки VST"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "Реєструємо %d з %d: %-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Не вдалося завантажити бібліотеку"
 
@@ -9086,7 +9437,8 @@ msgstr "Розмір буфера керує кількістю фрагмент
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "Розмір &буфера (від 8 до 1048576 семплів):"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "Компенсація латентності"
 
@@ -9094,7 +9446,8 @@ msgstr "Компенсація латентності"
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
 msgstr "У межах частини процедури обробки, деякі ефекти VST мають затримати повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього пункту надасть змогу компенсувати затримку, але таке компенсування працює не для усіх ефектів VST."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "Увімкнути &компенсацію"
 
@@ -9128,7 +9481,8 @@ msgid "Standard VST program file"
 msgstr "Стандартний файл програми VST"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Файли набору шаблонів VST Audacity"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9155,7 +9509,8 @@ msgstr "Помилка під час завантаження шаблонів V
 msgid "Unable to load presets file."
 msgstr "Не вдалося завантажити файл набору шаблонів."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Параметри ефекту"
 
@@ -9171,6 +9526,12 @@ msgstr "Не вдалося прочитати файл набору шабло�
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "Цей файл параметрів було збережено у %s. Продовжити?"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -9206,7 +9567,8 @@ msgid "Audio Unit Effects"
 msgstr "Ефекти Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "Надає підтримку ефектів Audio Unit у Audacity"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9222,7 +9584,8 @@ msgid "Audio Unit Effect Options"
 msgstr "Параметри ефектів Audio Unit"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
 msgstr "У межах частини процедури обробки, деякі ефекти Audio Unit мають затримати повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього пункту надасть змогу компенсувати затримку, але таке компенсування працює не для усіх ефектів Audio Unit."
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9366,6 +9729,7 @@ msgstr "Звуковий модуль"
 
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "Ефекти LADSPA"
@@ -9375,7 +9739,8 @@ msgid "Provides LADSPA Effects"
 msgstr "Забезпечує роботу ефектів LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Audacity більше не використовує vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9383,12 +9748,30 @@ msgid "LADSPA Effect Options"
 msgstr "Параметри ефектів LADSPA"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
 msgstr "У межах частини процедури обробки, деякі ефекти LADSPA мають затримати повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього пункту надасть змогу компенсувати затримку, але таке компенсування працює не для усіх ефектів LADSPA."
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s тут:"
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Результат ефекту"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "Ефекти LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9400,7 +9783,8 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "Розмір &буфера (від 8 до %d семплів):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
 msgstr "У межах частини процедури обробки, деякі ефекти LV2 мають затримати повернення даних до Audacity. Якщо не компенсувати цю затримку, ви помітите, що до звукових даних вставляються невеличкі фрагменти тиші. Позначення цього пункту надасть змогу компенсувати затримку, але таке компенсування працює не для усіх ефектів LV2."
 
 #: src/effects/lv2/LV2Effect.cpp
@@ -9425,12 +9809,19 @@ msgstr "%s потребує непідтримуваного параметра 
 msgid "Generator"
 msgstr "Генератор"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Ефекти LV2"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "Надає підтримку ефектів LV2 у Audacity"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9438,7 +9829,8 @@ msgid "Nyquist Effects"
 msgstr "Ефекти Nyquist"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "Надає підтримку ефектів Nyquist у Audacity"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9665,7 +10057,8 @@ msgstr "Виберіть файл"
 msgid "Save file as"
 msgstr "Зберегти файл як"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "без назви"
 
@@ -9674,7 +10067,8 @@ msgid "Vamp Effects"
 msgstr "Ефекти Vamp"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "Надає підтримку ефектів Vamp у Audacity"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9696,6 +10090,12 @@ msgstr "Параметри додатка"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "Програма"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9996,7 +10396,8 @@ msgstr "Експорт звукових даних у форматі %s"
 msgid "Invalid sample rate"
 msgstr "Некоректна частота дискретизації"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Змінити частоту"
 
@@ -10028,7 +10429,8 @@ msgstr "Частоти дискретизації"
 
 #. i18n-hint kbps abbreviates "thousands of bits per second"
 #. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
 #, c-format
 msgid "%d kbps"
 msgstr "%d кбіт/с"
@@ -10046,6 +10448,42 @@ msgstr "Якість (кбіт/с):"
 #, c-format
 msgid "%.2f kbps"
 msgstr "%.2f кбіт/с"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -10176,8 +10614,17 @@ msgid "Replace preset '%s'?"
 msgstr "Замінити шаблон «%s»?"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LC"
+msgstr "Л"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Main"
 msgstr "Основний"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "M4A (AAC) Files (FFmpeg)"
@@ -10285,6 +10732,10 @@ msgstr "Мова:"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Bit Reservoir"
 msgstr "Буфер бітів"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
@@ -10418,6 +10869,11 @@ msgstr ""
 "0 — типова\n"
 "min — 1\n"
 "max — 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Використовувати LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10735,7 +11191,8 @@ msgstr "Надзвичайна"
 msgid "Extreme"
 msgstr "Висока"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Стандартна"
 
@@ -10786,8 +11243,8 @@ msgid "Locate LAME"
 msgstr "Знайти LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity потребує файла %s для створення MP3."
 
 #: src/export/ExportMP3.cpp
@@ -10815,10 +11272,10 @@ msgid "Where is %s?"
 msgstr "Де знаходиться %s?"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "Було здійснено спробу з’єднатися з бібліотекою lame_enc.dll v%d.%d. Ця версія бібліотеки не є сумісною з Audacity %d.%d.%d.\n"
 "Будь ласка, звантажте найостаннішу версію бібліотеки LAME для Audacity."
@@ -11123,6 +11580,14 @@ msgstr "Експортуємо позначені звукові дані у ф�
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "Експортуємо звукові дані у форматі Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "Заголовок:"
@@ -11136,9 +11601,10 @@ msgid "Other uncompressed files"
 msgstr "Інші нестиснуті файли"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "Вами зроблено спробу експортувати файл WAV або AIFF, розмір якого перевищує 4 ГБ.\n"
 "Audacity не зможе виконати потрібну вам дію. Експортування було скасовано."
@@ -11148,8 +11614,9 @@ msgid "Error Exporting"
 msgstr "Помилка під час експортування"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "Експортований вами файл WAV було обрізано, оскільки Audacity не може експортувати\n"
@@ -11189,11 +11656,11 @@ msgid "All supported files"
 msgstr "всі файли, що підтримуються"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "«%s» \n"
@@ -11201,11 +11668,11 @@ msgstr ""
 "Audacity не може відкривати цей тип файлів для відтворення, але ви можете редагувати їх, якщо виберете пункт меню Файл > Імпорт > MIDI."
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "«%s» \n"
 "не є файлом звукових даних. \n"
@@ -11216,18 +11683,18 @@ msgid "Select stream(s) to import"
 msgstr "Оберіть потоки для імпортування"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Ця версія Audacity була зібрана без підтримки %s."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "«%s» є доріжкою аудіо-КД. \n"
 "Audacity не може відкрити аудіо-КД напряму. \n"
@@ -11236,10 +11703,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "«%s» є файлом списку програвання.\n"
@@ -11248,10 +11715,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» є файлом Windows Media Audio. \n"
@@ -11260,10 +11727,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» є файлом вдосконаленого аудіокодування (AAC). \n"
@@ -11272,12 +11739,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "«%s» є шифрованим аудіофайлом. \n"
@@ -11288,10 +11755,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» є файлом RealPlayer. \n"
@@ -11300,12 +11767,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "«%s» є нотним файлом, а не файлом аудіо. \n"
 "Audacity не може відкривати цей тип файлів. \n"
@@ -11314,10 +11781,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11330,10 +11797,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» є файлом аудіоформату Wavpack. \n"
@@ -11342,10 +11809,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» є файлом аудіоформату Dolby Digital. \n"
@@ -11354,10 +11821,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "«%s» є файлом аудіо Ogg Speex. \n"
@@ -11366,10 +11833,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "«%s» є файлом відео. \n"
@@ -11383,9 +11850,9 @@ msgstr "Файла «%s» не знайдено."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11401,11 +11868,16 @@ msgstr ""
 "Спробуйте встановити FFmpeg.\n"
 "\n"
 
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, тестувальник"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11435,12 +11907,13 @@ msgid "Import Project"
 msgstr "Імпортувати проєкт"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "Цей проєкт було збережено у версії 1.0 Audacity або старішій версії. З того часу,\n"
 "формат було змінено, і ця версія Audacity не може імпортувати дані проєкту.\n"
@@ -11491,7 +11964,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Не вдалося знайти теку з даними проєкту: «%s»"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "У файлі проєкту виявлено доріжки MIDI, але у цій збірці Audacity не передбачено підтримки MIDI. Пропускаємо доріжку."
 
 #: src/import/ImportAUP.cpp
@@ -11596,40 +12070,6 @@ msgstr "Індекс[%02x] Кодек[%s], Мова[%s], Бітова швидк
 msgid "FLAC files"
 msgstr "Файли FLAC"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "Сумісні з GStreamer файли"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "Не вдалося додати декодувальник до конвеєра"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Засіб імпортування GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Не вдалося перевести стан потоку у значення «призупинено»."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "Індекс[%02d], тип[%s], канали[%d], частота[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "У файлі не міститься звукових даних."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Не вдалося імпортувати файл, оскільки не вдалося змінити стан."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Помилка GStreamer: %s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "Перелік файлів у звичайному текстовому форматі"
@@ -11731,22 +12171,98 @@ msgstr "Внутрішня логічна помилка"
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, та інші типи без стискання"
 
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/import/ImportPCM.cpp
 msgid "FLAC (FLAC Lossless Audio Codec)"
 msgstr "FLAC (FLAC, кодек зберігання звуку без втрат)"
 
 #: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (формат контейнера OGG)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "RAW (header-less)"
 msgstr "RAW (без заголовка)"
 
 #: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "SDS (Midi Sample Dump Standard)"
 msgstr "SDS (MIDI Sample Dump Standard)"
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11777,6 +12293,26 @@ msgid "64 bit float"
 msgstr "64-бітовий float"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "32kbs G721 ADPCM"
 msgstr "32кбіт/с G721 ADPCM"
 
@@ -11797,12 +12333,20 @@ msgid "24 bit DWVW"
 msgstr "24-бітовий DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16-бітовий DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8-бітовий DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11851,6 +12395,18 @@ msgstr "Імпорту raw-файлі"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Без урахування порядку байтів"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr "Літтл-эндиан"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Big-endian"
+msgstr "Біг-эндиан"
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -11925,6 +12481,7 @@ msgstr "%s, правий"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d of %d clip %s"
@@ -11950,6 +12507,7 @@ msgstr "кінець"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11980,7 +12538,8 @@ msgstr "Кліпи зі зсувом за часом праворуч"
 msgid "Time shifted clips to the left"
 msgstr "Кліпи зі зсувом за часом ліворуч"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Зсув у часі"
 
@@ -12118,7 +12677,8 @@ msgstr "Обрізати позначені звукові доріжки з %.2
 msgid "Trim Audio"
 msgstr "Обрізати звук"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Розділити"
 
@@ -12243,34 +12803,6 @@ msgid "Ext&ra"
 msgstr "Д&одаткові"
 
 #: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "Мік&шер"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "С&коригувати гучність відтворення…"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "З&більшити гучність відтворення"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "З&меншити гучність відтворення"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "С&коригувати гучність запису…"
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "З&більшити гучність запису"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "З&меншити гучність запису"
-
-#: src/menus/ExtraMenus.cpp
 msgid "De&vice"
 msgstr "Пр&истрій"
 
@@ -12306,6 +12838,12 @@ msgstr ""
 #: src/menus/FileMenus.cpp
 msgid "Export Selected Audio"
 msgstr "Експортувати позначені звукові дані"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Текст мітки"
 
 #: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
@@ -12531,8 +13069,9 @@ msgid "&Getting Started"
 msgstr "По&чаток роботи"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "&Підручник з Audacity"
+#, fuzzy
+msgid "&Manual"
+msgstr "Під&ручник…"
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12558,11 +13097,8 @@ msgstr "Дані &щодо пристрою MIDI…"
 msgid "Show &Log..."
 msgstr "Показати &журнал…"
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Про Audacity…"
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Мітку додано"
 
@@ -13252,6 +13788,7 @@ msgstr "Довгий п&ерехід курсора праворуч"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "Пози&ціювати"
@@ -13463,18 +14000,21 @@ msgid "Created new label track"
 msgstr "Створено нову доріжку для позначок"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "У цій версії Audacity можна використовувати лише по одній доріжці у кожному з вікон проєкту."
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Створено нову доріжку часу"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Нова частота дискретизації (Гц):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Введене значення є некоректним"
 
@@ -13731,7 +14271,9 @@ msgstr "Відтворення"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Запис"
 
@@ -13880,10 +14422,6 @@ msgstr "&Накладення (увімкн./вимкн.)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "&Програмне відтворення (увімкн./вимкн.)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "А&втоматичне виправлення рівня запису (увімкн./вимкн.)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -14099,7 +14637,7 @@ msgstr "Налаштування якості"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Оновити Audacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -14146,7 +14684,8 @@ msgstr "&Вузол:"
 msgid "Using:"
 msgstr "Використовується:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Відтворення"
 
@@ -14166,7 +14705,8 @@ msgstr "&Канали:"
 msgid "Latency"
 msgstr "Затримка"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "мілісекунд"
 
@@ -14195,7 +14735,8 @@ msgid "2 (Stereo)"
 msgstr "2 (стерео)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Каталоги"
 
@@ -14303,7 +14844,8 @@ msgid "Directory %s is not writable"
 msgstr "Немає прав на запис у каталог %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Зміни каталогу для зберігання тимчасових файлів не наберуть сили, доки програму Audacity не буде перезавантажено."
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14334,6 +14876,40 @@ msgstr "Згруповано за розповсюджувачем"
 msgid "Grouped by Type"
 msgstr "Згруповано за типом"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Найквіст"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Увімкнути ефекти"
@@ -14355,11 +14931,13 @@ msgid "Plugin Options"
 msgstr "Параметри додатків"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "Шукати оновлення додатків під час запуску Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Виконати повторний пошук додатків під час наступного запуску Audacity"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14539,7 +15117,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "З&берігати мітки, якщо позначення прилипає до мітки"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "О&б'єднати загальносистемну тему та тему Audacity"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14717,7 +15296,8 @@ msgstr ""
 "   *   «%s»  (оскільки скорочення «%s» вже використано для «%s»)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Виберіть XML-файл, що містить комбінації клавіш Audacity…"
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14849,8 +15429,9 @@ msgid "Dow&nload"
 msgstr "Зва&нтажити"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Audacity було у автоматичному режимі визначено належні бібліотеки FFmpeg.\n"
@@ -14909,8 +15490,9 @@ msgid "Preferences for Module"
 msgstr "Налаштування модуля"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "Ці модулі є недостатньо перевіреними. Вмикайте їх, лише якщо ви ознайомилися\n"
@@ -14918,12 +15500,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  «Запитувати» — під час кожного запуску запитувати, чи слід завантажувати модуль."
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  «Помилка» — модуль непрацездатний, він не завантажуватиметься."
 
 #. i18n-hint preserve the leading spaces
@@ -14932,7 +15516,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  «Новий» означає, що вибору ще не було зроблено."
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "Зміни цих параметрів набудуть чинності лише після перезапуску Audacity."
 
 #: src/prefs/ModulePrefs.cpp
@@ -14950,6 +15535,10 @@ msgstr "Модулів не знайдено"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "Модуль"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14991,7 +15580,10 @@ msgstr "← — Перетягування"
 msgid "Set Selection Range"
 msgstr "Встановити область вибору"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift — ← — Клацання"
 
@@ -15078,6 +15670,15 @@ msgstr "-перетягування лівою"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Пересунути ділянку вгору або вниз між доріжками"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-перетягування лівою"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -15202,7 +15803,8 @@ msgid "Always scrub un&pinned"
 msgstr "Завжди витирати непри&шпилене"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Параметри Audacity"
 
 #: src/prefs/PrefsDialog.cpp
@@ -15338,39 +15940,6 @@ msgstr "&Дата у системі"
 #: src/prefs/RecordingPrefs.cpp
 msgid "System T&ime"
 msgstr "&Час у системі"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "Автоматичне виправлення рівня запису"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Увімкнути автоматичне виправлення рівня запису."
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "Вихідне пікове значення:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "У межах:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "Тривалість зразка:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "мілісекунд (тривалість одного зразка)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "Кількість послідовних зразків:"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 означає без кінця"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
@@ -15532,6 +16101,10 @@ msgid "1024 - default"
 msgstr "1024 — типово"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 — найточніше"
 
@@ -15629,13 +16202,14 @@ msgid "Info"
 msgstr "Інформація"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15818,7 +16392,8 @@ msgstr "семпли"
 msgid "4 Pixels per Sample"
 msgstr "4 пікселі на семпл"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Макс. масштаб"
 
@@ -15940,16 +16515,24 @@ msgid "Stopped"
 msgstr "Зупинено"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Призупинити"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "Перейти на початок доріжки"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "Перейти на кінець доріжки"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Призупинити"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Позначити до початку"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Позначити до кінця"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15963,20 +16546,17 @@ msgstr "Записати нову доріжку"
 msgid "Append Record"
 msgstr "Долучити запис"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Позначити до кінця"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Позначити до початку"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s призупинено."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -16056,11 +16636,17 @@ msgstr "Замінити позначене тишею"
 msgid "Sync-Lock Tracks"
 msgstr "Синхронізація-прив’язка доріжок"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Збільшити"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Зменшити"
 
@@ -16127,43 +16713,6 @@ msgstr "Панель індикаторів &запису"
 msgid "&Playback Meter Toolbar"
 msgstr "Панель індикаторів &відтворення"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Гучність запису"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Гучність відтворення"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "Гучність запису: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "Гучність запису (недоступна, скористайтеся мікшером системи)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Гучність відтворення: %.2f (емуляція)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Гучність відтворення: %.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "Гучність відтворення (недоступна, скористайтеся мікшером системи)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Панель мік&шера"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "Позиціювання"
@@ -16179,6 +16728,7 @@ msgstr "Прокручування"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "Зупинити прокручування"
@@ -16186,6 +16736,7 @@ msgstr "Зупинити прокручування"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "Почати прокручування"
@@ -16193,6 +16744,7 @@ msgstr "Почати прокручування"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "Зупинити позиціювання"
@@ -16200,6 +16752,7 @@ msgstr "Зупинити позиціювання"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "Почати позиціювання"
@@ -16254,7 +16807,9 @@ msgstr "Прив'язка"
 msgid "Length"
 msgstr "Тривалість"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Центр"
 
@@ -16318,8 +16873,8 @@ msgstr "Панель &часу"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Панель інструментів Audacity %s"
 
 #: src/toolbars/ToolBar.cpp
@@ -16346,7 +16901,8 @@ msgstr "Зсув у часі"
 msgid "Zoom Tool"
 msgstr "Масштабування"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Зміна хвилі"
 
@@ -16422,11 +16978,13 @@ msgstr "Перетягнути одну чи більше меж позначо�
 msgid "Drag label boundary."
 msgstr "Перетягнути межу мітки."
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Мітку змінено"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Редагування мітки"
 
@@ -16481,31 +17039,42 @@ msgstr "Змінені мітки"
 msgid "New label"
 msgstr "Нова мітка"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "Октаво&ю вище"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "О&ктавою нижче"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Клацання — вертикальне збільшення, Shift+клацання — зменшення, перетягування — визначення області масштабування."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "Меню викликається клацанням правою кнопкою."
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Відновити початковий масштаб"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift — Клацання правою"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "Клацання лівою/Перетягування лівою"
 
@@ -16547,7 +17116,8 @@ msgstr "Об'єднати"
 msgid "Expanded Cut Line"
 msgstr "Розширена лінія розрізу"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Розгорнути"
 
@@ -16620,7 +17190,8 @@ msgstr "Обробка…   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "«%s» змінено на %s"
@@ -16699,7 +17270,8 @@ msgstr "Змінити частоту"
 msgid "Set Rate"
 msgstr "Встановити частоту дискретизації"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "&Мультиперегляд"
 
@@ -16792,19 +17364,22 @@ msgid "Right, %dHz"
 msgstr "Правий, %dГц"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%+.1f дБ"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% лівий"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% правий"
@@ -16922,9 +17497,8 @@ msgstr "Логарифмічна &інтерполяція"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-#, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Натисніть кнопку миші і перетягніть, щоб пересунути доріжку у часі"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16975,6 +17549,7 @@ msgstr "Обвідна скорегована."
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "П&рокрутити"
@@ -16986,6 +17561,7 @@ msgstr "Позиціювання"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "Лінійка про&кручування"
@@ -17181,6 +17757,12 @@ msgstr "Л"
 msgid "R"
 msgstr "П"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.2fx"
+msgstr "%.2f дБ"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -17214,9 +17796,19 @@ msgstr "Порожній"
 msgid "Backwards"
 msgstr "Назад"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "Вперед"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -17345,6 +17937,13 @@ msgstr "Будь ласка, вкажіть дію"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 секунд"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "дд:гг:хх:сс"
+
 #. i18n-hint: Format string for displaying time in hours, minutes and
 #. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
@@ -17423,6 +18022,7 @@ msgstr "0100 г 060 х 060 с+<# семплів"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "семпли"
@@ -17669,6 +18269,11 @@ msgstr "(Скористайтеся контекстним меню, щоб зм
 msgid "centiseconds"
 msgstr "сантисекунди"
 
+#: src/widgets/PopupMenuTable.h
+#, fuzzy, c-format
+msgid "%s (%s)"
+msgstr "(%s)"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "Час, що минув:"
@@ -17710,6 +18315,11 @@ msgstr "Підтвердження закриття"
 #, fuzzy, c-format
 msgid "Unable to write files to directory: %s."
 msgstr "Не вдалося прочитати набір шаблонів з «%s»."
+
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
 
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
@@ -17814,15 +18424,27 @@ msgstr "Не вдалося обробити XML"
 msgid "Spectral edit multi tool"
 msgstr "Універсальний інструмент редагування спектра"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "Фільтрування…"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "Випущено за умов дотримання Загальної громадської ліцензії GNU (GPL) версії 2"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aБудь ласка, виберіть частоти."
@@ -17849,7 +18471,8 @@ msgstr ""
 "                      Спробуйте збільшити обмеження за нижньою частотою~%~\n"
 "                      або зменшити значення фільтра «Ширина»."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Помилка.~%"
@@ -17910,6 +18533,25 @@ msgstr "Студійне спадання"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "Застосовуємо спадання…"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Зробити &типовими"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "Випущено за умов дотримання Загальної громадської ліцензії GNU (GPL) версії 2 або новішої версії."
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -18053,6 +18695,11 @@ msgstr "Пошук бітів"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "Шукаємо біти…"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Журнал Audacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18377,7 +19024,12 @@ msgstr "Фільтр високих частот"
 msgid "Performing High-Pass Filter..."
 msgstr "Виконуємо фільтрування високих частот…"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Частота (Гц)"
 
@@ -18424,10 +19076,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "Позначення звуків"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "Випущено за умов дотримання Загальної громадської ліцензії GNU (GPL) версії 2 або новішої версії."
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18727,7 +19375,8 @@ msgstr "файли Lisp"
 msgid "HTML file"
 msgstr "файли HTML"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "текстовий файл"
 
@@ -18856,6 +19505,10 @@ msgid "Swing amount"
 msgstr "Розмах"
 
 #: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
 msgstr "Встановіть кількість тактів у нуль, щоб скористатися пунктом «Тривалість доріжки ритму»."
 
@@ -18946,6 +19599,10 @@ msgstr "Барабан Ріссе"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "Створюємо звук барабана Ріссе…"
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -19048,6 +19705,11 @@ msgstr "Показувати повідомлення"
 #: plug-ins/sample-data-export.ny
 msgid "Errors Only"
 msgstr "Лише помилки"
+
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -19348,6 +20010,10 @@ msgid "Applying Action..."
 msgstr "Застосовуємо дію…"
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "Вилучення вокалу: моно"
 
@@ -19540,6 +20206,236 @@ msgstr "Частота голок радару (у Гц)"
 msgid "Error.~%Stereo track required."
 msgstr "Помилка.~%Потрібна стереодоріжка."
 
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "Оновити Audacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "Проп&устити"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "&Встановити оновлення"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "Журнал змін"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "Прочитати більше на GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "Помилка під час перевірки оновлень"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "Не вдалося встановити з'єднання із сервером оновлення Audacity."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "Дані оновлення пошкоджено."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "Помилка під час отримання оновлення."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "Не вдалося відкрити посилання для отримання Audacity."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Випущено Audacity %s!"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Запис"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Ід. внеску:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Бібліотека для побудови графічних інтерфейсів на різних платформах"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "Імпорт за допомогою GStreamer"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Роботу інструменту автоматичного виправлення рівня запису зупинено. Рівень вже неможливо покращити. Рівень гучності зависокий."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Інструмент встановлення автоматичної гучності запису знизив гучність до %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Роботу інструменту автоматичного виправлення рівня запису зупинено. Рівень вже неможливо покращити. Рівень гучності занизький."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Інструмент автоматичного визначення гучності запису збільшив гучність до %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Роботу інструменту автоматичного визначення гучності запису зупинено. Перевищено загальну кількість точок аналізу, прийнятного рівня гучності не знайдено. Гучність залишається занадто високою."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Роботу інструменту автоматичного визначення гучності запису зупинено. Перевищено загальну кількість точок аналізу, прийнятного рівня гучності не знайдено. Гучність залишається занадто низькою."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Роботу інструменту автоматичного виправлення рівня запису зупинено. Визначено прийнятну гучність — %.2f."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Отримано %d під час спроби відкрити пристрій\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Не вдалося відкрити Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Доступні мікшери:\n"
+
+#, c-format
+#~ msgid "%d - %s\n"
+#~ msgstr "%d – %s\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Доступні джерела для запису:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Доступні гучності відтворення.:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Гучність запису є емульованою\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Гучність запису є природною\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Гучність відтворення є емульованою\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Гучність відтворення є природною\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Дата і час кінця"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "Сумісні з GStreamer файли"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "Не вдалося додати декодувальник до конвеєра"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Засіб імпортування GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Не вдалося перевести стан потоку у значення «призупинено»."
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "Індекс[%02d], тип[%s], канали[%d], частота[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "У файлі не міститься звукових даних."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Не вдалося імпортувати файл, оскільки не вдалося змінити стан."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Помилка GStreamer: %s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "Мік&шер"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "С&коригувати гучність відтворення…"
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "З&більшити гучність відтворення"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "З&меншити гучність відтворення"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "С&коригувати гучність запису…"
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "З&більшити гучність запису"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "З&меншити гучність запису"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "&Підручник з Audacity"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Про Audacity…"
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "А&втоматичне виправлення рівня запису (увімкн./вимкн.)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "Автоматичне виправлення рівня запису"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Увімкнути автоматичне виправлення рівня запису."
+
+#~ msgid "Target Peak:"
+#~ msgstr "Вихідне пікове значення:"
+
+#~ msgid "Within:"
+#~ msgstr "У межах:"
+
+#~ msgid "Analysis Time:"
+#~ msgstr "Тривалість зразка:"
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "мілісекунд (тривалість одного зразка)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "Кількість послідовних зразків:"
+
+#~ msgid "0 means endless"
+#~ msgstr "0 означає без кінця"
+
+#~ msgid "Recording Volume"
+#~ msgstr "Гучність запису"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Гучність відтворення"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "Гучність запису: %.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "Гучність запису (недоступна, скористайтеся мікшером системи)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Гучність відтворення: %.2f (емуляція)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Гучність відтворення: %.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "Гучність відтворення (недоступна, скористайтеся мікшером системи)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Панель мік&шера"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Натисніть кнопку миші і перетягніть, щоб пересунути доріжку у часі"
+
 #~ msgid "Program build date:"
 #~ msgstr "Дата компіляції програми:"
 
@@ -19669,55 +20565,3 @@ msgstr "Помилка.~%Потрібна стереодоріжка."
 
 #~ msgid "Select any uncompressed audio file"
 #~ msgstr "Виберіть будь-який нестиснений звуковий файл"
-
-#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
-#. know the correct technical word.
-#: src/import/ImportRaw.cpp
-msgid "Big-endian"
-msgstr "Біг-эндиан"
-
-#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
-#. know the correct technical word.
-#: src/import/ImportRaw.cpp
-msgid "Little-endian"
-msgstr "Літтл-эндиан"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr ""
-"Завзятість не виробляється і не схвалено MuseCY SM Ltd. або Домініком м. "
-"Маццоні."
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr ""
-"Торгова марка Audacity %s використовується в цьому програмному забезпеченні "
-"тільки в описових та інформаційних цілях."
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s вкладники"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr ""
-"Будь ласка, зверніть увагу, що імена відсортовані в алфавітному порядку, а "
-"не в порядку важливості."
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Ліланд Люціус"

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-07-24 09:29+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/tenacity/tenacity/vi/>\n"
@@ -24,20 +24,6 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "&bỏ qua"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-#, fuzzy
-msgctxt "preference"
-msgid "Recording"
-msgstr "Đang ghi âm"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "Không quyết định được"
@@ -47,6 +33,24 @@ msgstr "Không quyết định được"
 msgid "%s bytes"
 msgstr "%sbytes"
 
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr ""
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr ""
+
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
 msgstr "Tối giản hóa"
@@ -54,6 +58,14 @@ msgstr "Tối giản hóa"
 #: libraries/lib-strings/Languages.cpp
 msgid "System"
 msgstr "Hệ thống"
+
+#: modules/mod-null/ModNullCallback.cpp
+msgid "1st Experimental Command..."
+msgstr ""
+
+#: modules/mod-null/ModNullCallback.cpp
+msgid "2nd Experimental Command"
+msgstr ""
 
 #: modules/mod-nyq-bench/NyqBench.cpp
 msgid "&Nyquist Workbench..."
@@ -164,7 +176,8 @@ msgid "Script"
 msgstr "Script - Tập lệnh"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "Đầu ra"
 
@@ -180,7 +193,12 @@ msgstr "Tập lệnh Nyquist (*.ny)|*.ny|kịch bàn Lisp (*.lsp)|*.lsp|All file
 msgid "Script was not saved."
 msgstr "Tập lệnh chưa lưu."
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "Cảnh báo"
 
@@ -193,11 +211,24 @@ msgid "Find dialog"
 msgstr "Tìm hộp thoại"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
+msgid "Harvey Lubin (logo)"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
 msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Bộ biểu tượng Tango (biểu tượng thanh công cụ)"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr ""
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "Mô-đun ngoài của Audacity cung cấp bộ IDE đơn giản về hiểu ứng chữ viết."
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -220,7 +251,8 @@ msgstr "Chưa có tên"
 msgid "Nyquist Effect Workbench - "
 msgstr "Workbench - Bàn làm việc hiệu ứng Nyquist"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "&Mới"
 
@@ -260,7 +292,8 @@ msgstr "Chép"
 msgid "Copy to clipboard"
 msgstr "Sao chép vào bộ nhớ sao chép Clipboard "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "Cắt"
 
@@ -268,7 +301,8 @@ msgstr "Cắt"
 msgid "Cut to clipboard"
 msgstr "Cắt vào bộ nhớ sao chép Clipboard"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "Dán"
 
@@ -293,7 +327,8 @@ msgstr "Chọn tất cả"
 msgid "Select all text"
 msgstr "Chọn tất cả văn bản"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "Huỷ bỏ"
 
@@ -301,7 +336,8 @@ msgstr "Huỷ bỏ"
 msgid "Undo last change"
 msgstr "Hoàn tác vụ gần đây nhất"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "Làm lại"
 
@@ -358,7 +394,8 @@ msgid "Go to next S-expr"
 msgstr "Chuyển đến S-expr &Tiếp theo"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "Bắt đầu"
 
@@ -366,7 +403,8 @@ msgstr "Bắt đầu"
 msgid "Start script"
 msgstr "Bắt đầu Tập lệnh"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "Dừng"
 
@@ -380,15 +418,23 @@ msgstr "Dừng Tập lệnh"
 msgid "About %s"
 msgstr "Về %s"
 
+#. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+msgid "OK"
+msgstr ""
+
 #: src/AboutDialog.cpp
 msgid "Build Information"
 msgstr "Thông tin biên dịch"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "Đã bật"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "Đã Tắt"
 
@@ -398,8 +444,9 @@ msgid "The Build"
 msgstr "kiến trúc"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Nhập Id:"
+#, fuzzy
+msgid "Version:"
+msgstr "Phiên bản: %s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -409,22 +456,28 @@ msgstr "Dựng kiểu:"
 msgid "Compiler:"
 msgstr "Trình biên dịch:"
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "Cài đặt tiền tố:"
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "Thư mục cài đặt:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "Thư mục cài đặt:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "Hỗ trợ định dạng tệp"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "Thư viện hệ thống GUI (Giao diện người dùng đồ họa)"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -438,7 +491,6 @@ msgstr "Chuyển đổi tốc độ lấy mẫu"
 msgid "MP3 Importing"
 msgstr "Nhập MP3"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Xuất và nhập Ogg Vorbis"
@@ -447,7 +499,6 @@ msgstr "Xuất và nhập Ogg Vorbis"
 msgid "ID3 tag support"
 msgstr "Thẻ hỗ trợ ID3"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "Xuất và nhập FLAC"
@@ -465,10 +516,6 @@ msgid "FFmpeg Import/Export"
 msgstr "Nhập/ Xuất FFmpeg"
 
 #: src/AboutDialog.cpp
-msgid "Features"
-msgstr "Các tính năng"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "Hỗ trợ trình bổ sung"
 
@@ -483,6 +530,10 @@ msgstr "Hỗ trợ thay đổi nhịp độ và cao độ"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "Hỗ trợ thay đổi âm tần và tốc độ cực trị"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "Các tính năng"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -526,8 +577,20 @@ msgstr "%s, lập trình phát triển"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
 #: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, developer and support"
+msgstr "%stài liệu và hỗ trợ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
 #, c-format
 msgid "%s, documentation and support"
+msgstr "%stài liệu và hỗ trợ"
+
+#. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s, QA tester, documentation and support"
 msgstr "%stài liệu và hỗ trợ"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper name
@@ -589,6 +652,10 @@ msgstr "%s, đồ họa"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (bao gồm %s, %s, %s, %s và %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr ""
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -598,6 +665,10 @@ msgstr "%sphần mềm miễn phí, mã nguồn mở, đa nền tảng để ghi
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "Công trạng"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr ""
 
 #: src/AboutDialog.cpp
 #, fuzzy
@@ -632,6 +703,10 @@ msgid "%s Team Members"
 msgstr "%sThành viên nhóm"
 
 #: src/AboutDialog.cpp
+msgid "Emeritus:"
+msgstr ""
+
+#: src/AboutDialog.cpp
 msgid "Contributors"
 msgstr "Những người đóng góp"
 
@@ -644,6 +719,7 @@ msgstr "Trang mạng và đồ họa"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "Vietnamese translation by  Brad 'Bảo' Hirsch, and Cuong and Ha Mien, and Mersoid, and Nguyễn Đình Trung"
@@ -661,6 +737,22 @@ msgstr "Rất cám ơn:"
 #, c-format
 msgid "%s website: "
 msgstr "%s trang mạng:"
+
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, fuzzy, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "Những người đóng góp"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr ""
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr ""
 
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
@@ -683,6 +775,7 @@ msgstr "Thời gian biểu"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "Nhấp chuột và kéo để Seek (tua ngắt quãng)"
@@ -690,6 +783,7 @@ msgstr "Nhấp chuột và kéo để Seek (tua ngắt quãng)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "Nhấp chuột và kéo để Scrub (tua rê chuột)"
@@ -697,6 +791,7 @@ msgstr "Nhấp chuột và kéo để Scrub (tua rê chuột)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "Nhấp chuột & rê chuột để Scrub (tua rê). Nhấp & kéo thả để Seek (tua ngắt quãng)"
@@ -704,6 +799,7 @@ msgstr "Nhấp chuột & rê chuột để Scrub (tua rê). Nhấp & kéo thả 
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "Rê chuột để Seek (tua rê)"
@@ -711,6 +807,7 @@ msgstr "Rê chuột để Seek (tua rê)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "Rê chuột để Scrub (tua ngắt quãng)"
@@ -767,7 +864,17 @@ msgstr ""
 "Không thể khóa được vùng tua nhạc nằm ngoài \n"
 "kết thúc của dự án."
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "Lỗi"
 
@@ -791,7 +898,8 @@ msgstr ""
 "Câu hỏi này chỉ được thực hiện một lần sau khi \"cài đặt\" xong, khi bạn được hỏi để cài đặt lại Cài đặt Uu tiên"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "Khởi động lại Cài đặt Ưu tiên của Audacity"
 
 #: src/AudacityApp.cpp
@@ -806,7 +914,8 @@ msgstr ""
 "Tệp tin đã bị loại bỏ trong danh sách các tệp gần đây."
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Audacity không thể chạy tiếp. thư viện SQLite bị lỗi."
 
 #: src/AudacityApp.cpp
@@ -832,7 +941,7 @@ msgstr "&Mở..."
 msgid "Open &Recent..."
 msgstr "Mở &Gần đây..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 #, fuzzy
 msgid "&About Tenacity..."
 msgstr "&Thông tin về Audacity..."
@@ -846,9 +955,10 @@ msgid "&File"
 msgstr "&Tập tin"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity đã không tìm thấy nơi an toàn nào để chứa các tệp tin tạm thời.\n"
@@ -856,20 +966,23 @@ msgstr ""
 "Hãy nhập vào một địa chỉ thư mục trong các hộp thoại cài đặt ưu tiên."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Audacity không tìm được nơi nào để chứa các tập tin tạm thời.\n"
 "Xin hãy nhập vào địa chỉ thích hợp và chọn thư mục chứa các tập tin tạm thời."
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "Đang thoát Audacity. Thư mục tạm thời mới sẽ được dùng trong lần chạy kế tiếp."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -878,15 +991,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Audacity không thể sử dụng thư mục chứa các tệp tạm thời,\n"
 "có lẽ thư mục này đang được sử dùng bỡi 1 bản Audacity khác.\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "Bạn vẫn muốn khởi động Audacity?"
 
 #: src/AudacityApp.cpp
@@ -894,19 +1009,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "Gặp lỗi Khóa Thư mục Tạm thời"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "Hệ thống phát hiện ra một bản Audacity khác đang chạy.\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "Dùng lệnh Mới hoặc Mở trên bản Audacity đang chạy \n"
 "để mở nhiều dự án cùng lúc.\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Audacity đang hoạt động từ trước..."
 
 #: src/AudacityApp.cpp
@@ -922,7 +1040,8 @@ msgstr ""
 "Bạn có thể thử khởi động lại chương trình."
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Audacity Khởi động KHÔNG Thành công"
 
 #: src/AudacityApp.cpp
@@ -962,8 +1081,9 @@ msgstr ""
 "Bạn có thể thử khởi động lại chương trình."
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -995,7 +1115,8 @@ msgstr "chạy tác vụ tự chẩn đoán"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "hiện phiên bản Audacity"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1005,9 +1126,10 @@ msgid "audio or project file name"
 msgstr "tên tập âm thanh hoặc dự án"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1019,16 +1141,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tập tin Dự án Audacity"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "Tin nhắn"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Lỗi cấu trúc Audacity"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1038,7 +1162,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "Không thể truy cập vào tập tin cấu trúc :\n"
 "\n"
@@ -1050,12 +1174,15 @@ msgstr ""
 "\n"
 "Nếu bạn click vào \"thoát Audacity. dự án của bạn sẽ được tạm thời lưu vào hệ thống, nó sẽ được khôi phục ở lần tiếp theo bạn mở Audacity."
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "Trợ giúp"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "&Thoát Audacity"
 
 #: src/AudacityFileConfig.cpp
@@ -1063,7 +1190,8 @@ msgid "&Retry"
 msgstr "&Thử lại"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tập nhật ký của Audacity"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1075,9 +1203,14 @@ msgstr "&Lưu..."
 msgid "Cl&ear"
 msgstr "&Xoá"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "&Đóng"
+
+#: src/AudacityLogger.cpp
+msgid "log.txt"
+msgstr ""
 
 #: src/AudacityLogger.cpp
 msgid "Save log to:"
@@ -1123,6 +1256,11 @@ msgstr ""
 msgid "Error Initializing Midi"
 msgstr "Lỗi khởi chạy MIDI"
 
+#: src/AudioIO.cpp
+#, fuzzy
+msgid "Tenacity Audio"
+msgstr "chọn Audio."
+
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
 #, c-format
 msgid ""
@@ -1135,37 +1273,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "Đã hết dung lượng lưu trữ!"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã dừng hoạt động. Không thể tối ưu hóa thêm. Cấp độ còn quá cao."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã giảm âm lượng xuống %f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã dừng hoạt động. Không thể tối ưu hóa thêm nữa. Cấp độ còn quá thấp."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã tăng âm lượng lên %.2f."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã đừng. Tổng số phân tích đã vượt quá mức và mức âm lượng phù hợp vẫn chưa được tìm thấy. Vẫn còn quá cao."
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã đừng. Tổng số phân tích đã vượt quá mức và mức âm lượng phù hợp vẫn chưa được tìm thấy. Vẫn còn quá thấp."
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã dừng. %.2f được xem là mức âm lượng vừa phải."
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1264,43 +1371,6 @@ msgstr "Không tìm thấy thiết bị phát âm thanh cho '%s'.\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "Không thể kiểm tra được tỷ lệ tốc độ lấy mẫu chung khi không có đủ cả hai thiết bị.\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "Nhận %d khi mở thiết bị \n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "Không mở được bộ phối cổng (Portmixer)\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "Các bộ phối mixer hợp lệ:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "Các nguồn thu âm hợp lệ:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "Các âm lượng phát tiếng hợp lệ:\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "Âm lượng thu âm được giả lập\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "Âm lượng thu âm gốc\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "Âm lượng phát tiếng được giả lập\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "Âm lượng phát tiếng gốc\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1343,8 +1413,9 @@ msgid "Automatic Crash Recovery"
 msgstr "Tự động khôi phục lỗi"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1357,12 +1428,14 @@ msgid "Recoverable &projects"
 msgstr "Có thể khôi phục &dự án"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "Chọn"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "Tên"
 
@@ -1448,6 +1521,11 @@ msgstr "Hiệu ứng"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "Lệnh thanh Menu (Có Tham số)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr ""
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1593,7 +1671,8 @@ msgstr "&Hồi phục"
 msgid "I&mport..."
 msgstr "&Nhập..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "&Xuất..."
 
@@ -1634,7 +1713,8 @@ msgstr "Chuyển lên &trên"
 msgid "Move &Down"
 msgstr "Chuyển &xuống dưới"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "&Lưu..."
 
@@ -1717,9 +1797,17 @@ msgid "Run"
 msgstr "Chạy"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "Đóng"
+
+#. i18n-hint: Benchmark means a software speed test;
+#. leave untranslated file extension .txt
+#: src/Benchmark.cpp
+#, fuzzy
+msgid "benchmark.txt"
+msgstr "Đối chuẩn"
 
 #: src/Benchmark.cpp
 msgid "Export Benchmark Data as:"
@@ -1855,11 +1943,6 @@ msgid "No revision identifier was provided"
 msgstr "Không có nhận dạng sửa đổi nào được cung cấp."
 
 #: src/BuildInfo.h
-#, fuzzy
-msgid "Unknown date and time"
-msgstr "Ngày giờ kết thúc"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "Thiết lập sửa lỗi (mức sửa lỗi %d)"
@@ -1868,6 +1951,10 @@ msgstr "Thiết lập sửa lỗi (mức sửa lỗi %d)"
 #, c-format
 msgid "Release build (debug level %d)"
 msgstr "thiết lập phát hành (mức sửa lỗi %d)"
+
+#: src/BuildInfo.h
+msgid ", 64 bits"
+msgstr ""
 
 #. i18n-hint: %s will be replaced by the name of an action, such as Normalize, Cut, Fade.
 #: src/CommonCommandFlags.cpp
@@ -1934,6 +2021,21 @@ msgid ""
 msgstr ""
 "Bạn cần phải chọn audio để thực hiện tác vụ này.\n"
 "(Không lựa chọn đoạn âm dạng khác.)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr ""
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Failed to set safe mode on primary connection to %s"
+msgstr "Lỗi lượt bỏ kết nối"
+
+#: src/DBConnection.cpp
+#, fuzzy, c-format
+msgid "Failed to set safe mode on checkpoint connection to %s"
+msgstr "Lỗi phục hồi kết nối"
 
 #: src/DBConnection.cpp
 msgid "Checkpointing project"
@@ -2086,6 +2188,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "Sao &Chép tên vào bộ nhớ sao chép Clipboard "
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr ""
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "Mất tích"
 
@@ -2094,10 +2201,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "Dự án của bạn sẽ không được lưu lại vào đĩa. Bạn có muốn thế không?"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2111,7 +2219,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "Kiểm tra tính phụ thuộc"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "Không có gì"
 
@@ -2119,7 +2230,7 @@ msgstr "Không có gì"
 msgid "Rectangle"
 msgstr "Chữ nhật"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "Tam giác"
 
@@ -2131,14 +2242,61 @@ msgstr "Có hình dạng"
 msgid "Rectangular"
 msgstr "Chữ nhật"
 
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr ""
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr ""
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+#, fuzzy
+msgid "Welch"
+msgstr "Xin chào!"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr ""
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr ""
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "Hỗ trợ FFmpeg đã không được tích hợp"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2160,8 +2318,8 @@ msgid "Locate FFmpeg"
 msgstr "Tìm thấy FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Audacity cần tập tin '%s' để nhập và xuất ra audio thôn gqua FFmpeg."
 
 #: src/FFmpeg.cpp
@@ -2174,7 +2332,8 @@ msgstr "Địa điểm '%s':"
 msgid "To find '%s', click here -->"
 msgstr "Để tìm '%s'  click vào đây -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "Duyệt..."
 
@@ -2200,8 +2359,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg không tìm được"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2230,24 +2390,24 @@ msgid "Only libavformat.so"
 msgstr "Chỉ libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Audacity không mở được tập tin %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Audacity không đọc được tập tin   %s."
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity đã thành công trong việc tạo tập tin tại %s nhưng đã không thành công trong việc đổi tên thành %s."
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2285,7 +2445,9 @@ msgstr "Đừ&ng sao chép bất kỳ âm thanh"
 msgid "As&k"
 msgstr "&Hỏi"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "Tất cả tập tin"
 
@@ -2310,6 +2472,10 @@ msgstr "Tập tin văn bản"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "Tập tin XML"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ""
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2351,6 +2517,14 @@ msgstr "Tự tương quan căn bậc ba"
 msgid "Enhanced Autocorrelation"
 msgstr "Tự tương quan tăng"
 
+#. i18n-hint: This is a technical term, derived from the word
+#. * "spectrum".  Do not translate it unless you are sure you
+#. * know the correct technical word in your language.
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "Cepstrum"
+msgstr "Phổ"
+
 #. i18n-hint: This refers to a "window function",
 #. * such as Hann or Rectangular, used in the
 #. * Frequency analyze dialog box.
@@ -2367,6 +2541,17 @@ msgstr "Tần số tuyến tính"
 msgid "Log frequency"
 msgstr "Tần số logarit"
 
+#. i18n-hint: abbreviates decibels
+#. i18n-hint: short form of 'decibels'.
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+msgid "dB"
+msgstr ""
+
 #: src/FreqWindow.cpp
 msgid "Scroll"
 msgstr "Cuộn chuột "
@@ -2374,6 +2559,15 @@ msgstr "Cuộn chuột "
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "Thu phóng"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr ""
 
 #: src/FreqWindow.cpp
 #, fuzzy
@@ -2434,11 +2628,48 @@ msgstr "Quá nhiều Audio đã được lựa chọn. Chỉ %.1f giây đầu c
 msgid "Not enough data selected."
 msgstr "Chưa chọn đủ data (dữ liệu)"
 
+#. i18n-hint: short form of 'seconds'.
+#: src/FreqWindow.cpp src/effects/AutoDuck.cpp
+msgid "s"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %f"
+msgstr ""
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%.4f sec (%d Hz) (%s) = %.3f"
+msgstr ""
+
+#: src/FreqWindow.cpp
+#, fuzzy
+msgid "spectrum.txt"
+msgstr "Phổ"
+
 #: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "Xuất dữ liệu phổ thành:"
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "Không thể viết vào tập tin:  %s"
@@ -2632,19 +2863,19 @@ msgid "&History..."
 msgstr "Đã &làm..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Lỗi %s ở %s line %d.\n"
 "Vui lòng thông báo cho nhóm Audacity: https://forum.audacityteam.org/."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "Lỗi ở %s line %d.\n"
 "Vui lòng thông báo cho nhóm Audacity: https://forum.audacityteam.org/."
@@ -2663,7 +2894,9 @@ msgid "Track"
 msgstr "Track - Đoạn âm"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "Nhãn"
 
@@ -2723,7 +2956,8 @@ msgstr "Nhập tên đoạn âm"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "Nhãn đoạn âm"
 
@@ -2734,11 +2968,13 @@ msgstr "Không xác thực được một hoặc nhiều nhãn đã lưu."
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Chạy Audacity lần đầu tiên"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "Chọn ngôn ngữ sẽ dùng:"
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2748,7 +2984,8 @@ msgstr "Chọn ngôn ngữ sẽ dùng:"
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "Ngôn ngữ bạn đã chọn, %s (%s), không giống với ngôn ngữ hệ thống, %s (%s)."
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "Xác nhận"
 
@@ -2766,8 +3003,19 @@ msgstr ""
 "Tập tin cũ đã được lưu thành '%s'"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "Mở dự án của Audacity"
+
+#: src/LyricsWindow.cpp
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
+msgstr "Rất cám ơn:"
+
+#: src/LyricsWindow.cpp
+#, fuzzy
+msgid "&Karaoke..."
+msgstr "&Lưu..."
 
 #: src/Menus.cpp
 #, c-format
@@ -2813,19 +3061,23 @@ msgid "Mixing and rendering tracks"
 msgstr "Trộn và kết xuất đoạn âm"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Bảng Mixer Audacity %s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "Độ khuếch đại"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "Vận tốc"
 
@@ -2834,28 +3086,43 @@ msgid "Musical Instrument"
 msgstr "Nhạc cụ"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "Cân bằng trái/phải"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "Tắt tiếng"
+
+#. i18n-hint: This is on a button that will silence all the other tracks.
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#, fuzzy
+msgid "Solo"
+msgstr "Solo"
 
 #: src/MixerBoard.cpp
 msgid "Signal Level Meter"
 msgstr "Thước đo Mức Tín hiệu"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "Đã di chuyển thanh trượt khuếch đại"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "Đã di chuyển thanh trượt vận tốc "
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "Đã di chuyển thanh trượt cân bằng trái/phải"
 
@@ -2890,9 +3157,9 @@ msgstr ""
 "Không tải được Mô-đun."
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -2926,16 +3193,19 @@ msgstr ""
 "\n"
 "Chỉ dùng các mô-đun đến từ nguồn có tín"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "Có"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "Không"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tải mô-đun Audacity"
 
 #: src/ModuleManager.cpp
@@ -2958,6 +3228,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "Đặt ghi chú cho dải âm"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr ""
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr ""
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr ""
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3064,7 +3444,8 @@ msgstr "Chọn tất cả"
 msgid "C&lear All"
 msgstr "&Xoá  hết"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "&Bật lên"
 
@@ -3142,9 +3523,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "Tốc độ lấy mẫu không phù hợp"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "Quá ít đoạn âm được lựa chọn để ghi tỷ lệ tốc độ mẫu này.\n"
@@ -3173,10 +3555,11 @@ msgid "Dropouts"
 msgstr "Hụt tiếng"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3216,11 +3599,11 @@ msgid "Inspecting project file data"
 msgstr "Đang kiểm tra dữ liệu tệp dự án"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3263,11 +3646,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "Cảnh báo - không tìm thấy (các) tập tin biệt hiệu."
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "Kiểm tra thư mục \"%s\"\n"
@@ -3292,12 +3675,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "Cách báo - không tìm thấy (các) tập tin tổng hợp biệt hiệu"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3355,7 +3738,8 @@ msgstr "Cảnh báo - Các khối tập tin mồ côi "
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "Đang tiến hành"
 
@@ -3376,6 +3760,16 @@ msgstr ""
 #: src/ProjectFSCK.cpp
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "Cảnh báo: có lỗi trong quá trình khôi phục tự động"
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "<untitled>"
+msgstr "Chưa có tên"
+
+#: src/ProjectFileIO.cpp
+#, fuzzy, c-format
+msgid "[Project %02i] "
+msgstr "[Dự án %02i] Audacity \"%s\""
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3445,8 +3839,16 @@ msgstr ""
 "(không thể tạo các tập tin tạm được yêu câu)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "Đây không phải tập tin dự án của Audacity"
+
+#: src/ProjectFileIO.cpp
+msgid ""
+"This project was created with a newer version of Tenacity.\n"
+"\n"
+"You will need to upgrade to open it."
+msgstr ""
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to initialize the project file"
@@ -3572,9 +3974,9 @@ msgid "Error Writing to File"
 msgstr "Lỗi khi cố gắng lưu tập tin"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3588,9 +3990,16 @@ msgstr "Đang nén dự án"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[Dự án %02i] Audacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Vận tốc"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3599,10 +4008,10 @@ msgstr "(Đã phục hồi)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "Tập tin này được lưu lại bởi Audicity bản %s.\n"
 "Bạn đang dùng Audacity bản %s. Bạn có thể nâng cấp lên phien bản mới hơn để mở tập tin này."
@@ -3614,6 +4023,11 @@ msgstr "Không mở được tập tin dự án"
 #: src/ProjectFileIO.cpp
 msgid "Failed to remove the autosave information from the project file."
 msgstr "Không thể xóa thông tin lưu tự động từ tập tin dự án."
+
+#: src/ProjectFileIO.cpp
+#, fuzzy
+msgid "Unable to bind to blob"
+msgstr "Không tìm thấy codec"
 
 #: src/ProjectFileIO.cpp
 msgid "Unable to decode project document"
@@ -3670,8 +4084,9 @@ msgid "Backing up project"
 msgstr "Đang phục hồi dự án"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3680,8 +4095,9 @@ msgstr ""
 "Nó đã được phục hồi ở thao tác cuối cùng được lưu."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3759,8 +4175,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%s Lưu lại Dự án \"%s\" thành..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "Lưu lại Dự án' dành cho dự án Audacity, không phải là tập tin audio.\n"
@@ -3815,6 +4232,16 @@ msgstr ""
 msgid "Error Saving Copy of Project"
 msgstr "Lỗi khi lưu bản sao dự án"
 
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Can't open new empty project"
+msgstr "Không mở được tập tin dự án"
+
+#: src/ProjectFileManager.cpp
+#, fuzzy
+msgid "Error opening a new empty project"
+msgstr "Lỗi khi mở tập tin hoặc dự án"
+
 #: src/ProjectFileManager.cpp src/effects/nyquist/Nyquist.cpp
 msgid "Select one or more files"
 msgstr "Chọn một hoặc nhiều tập tin âm thanh"
@@ -3829,11 +4256,12 @@ msgid "Error Opening Project"
 msgstr "Lỗi khi mở dự án"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "Bạn đang mở một tập tin phục hồi được tạo tự động.\n"
 "điều này có thể dẫn đến mất dữ liệu gốc.\n"
@@ -3940,8 +4368,8 @@ msgid "Automatic database backup failed."
 msgstr "Lỗi quá trình phục hồi tự động."
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "Chào bạn, bạn đang dùng Audacity phiên bản %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4051,6 +4479,21 @@ msgstr "Chất lượng cao"
 msgid "Best Quality (Slowest)"
 msgstr "Chất lượng cao nhất (Chậm nhất)"
 
+#. i18n-hint: Audio data bit depth (precision): 16-bit integers
+#: src/SampleFormat.cpp
+msgid "16-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 24-bit integers
+#: src/SampleFormat.cpp
+msgid "24-bit PCM"
+msgstr ""
+
+#. i18n-hint: Audio data bit depth (precision): 32-bit floating point
+#: src/SampleFormat.cpp src/prefs/QualitySettings.cpp
+msgid "32-bit float"
+msgstr ""
+
 #: src/SampleFormat.cpp
 msgid "Unknown format"
 msgstr "Đuôi tập tin không xác định"
@@ -4139,7 +4582,8 @@ msgstr "Tất cả tuỳ thích"
 msgid "SelectionBar"
 msgstr "Thanh lựa chọn"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "Lựa chọn quang phổ"
 
@@ -4147,46 +4591,55 @@ msgstr "Lựa chọn quang phổ"
 msgid "Timer"
 msgstr "Bấm giờ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "Công cụ"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "Chuyển đổi"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "Bộ trộn"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "Bộ đo"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "Bộ đo phát"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "Bộ đo thu"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "Chỉnh sửa"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "Thiết bị"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "Tốc độ phát"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "Hủy bỏ "
 
@@ -4201,7 +4654,10 @@ msgstr "Thước đo"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "Các Đoạn âm"
 
@@ -4311,7 +4767,8 @@ msgid "Activation level (dB):"
 msgstr "Mức độ kích hoạt (dB):"
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "Xin chào!"
 
 #: src/SplashDialog.cpp
@@ -4458,9 +4915,9 @@ msgstr ""
 "Để xem các mẹo chọn ổ đĩa, click vào nút trợ giúp."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Audacity không ghi được tập tin:\n"
@@ -4480,9 +4937,9 @@ msgstr ""
 "%s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4491,9 +4948,9 @@ msgstr ""
 "để ghi."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Audacity không thể ghi ảnh minh hoạ vào tập tin:\n"
@@ -4510,9 +4967,9 @@ msgstr ""
 "%s."
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4522,9 +4979,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4533,8 +4990,9 @@ msgstr ""
 "Có lẽ do lỗi định dạng png?"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Audacity không hiển thị được sắc thái giao diện mặc định.\n"
@@ -4572,9 +5030,9 @@ msgstr ""
 "Đã sẵn sàng. bạn có muốn ghi đè không?"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Không lưu được tập tin: \n"
@@ -4613,7 +5071,11 @@ msgstr "Tùy chỉnh"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "Độ dài"
 
@@ -4624,7 +5086,8 @@ msgid "Time Track"
 msgstr "Thời gian đoạn âm"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Bộ thu âm định thời của Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4697,7 +5160,8 @@ msgstr "Dự án hiện hành"
 msgid "Recording start:"
 msgstr "Bắt đầu ghi âm:"
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "Độ dài:"
 
@@ -4718,7 +5182,8 @@ msgid "Action after Timer Recording:"
 msgstr "Hoạt động sau bộ ghi thời gian:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Tiến độ ghi âm định thời gian của Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4799,11 +5264,24 @@ msgstr ""
 msgid "Timer Recording"
 msgstr "Bộ ghi Thời gian"
 
+#. i18n-hint a format string for hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 h 060 m 060 s"
+msgstr "0100 ngày 024 h 060 m 060 s"
+
+#. i18n-hint a format string for days, hours, minutes, and seconds
+#: src/TimerRecordDialog.cpp
+#, fuzzy
+msgid "099 days 024 h 060 m 060 s"
+msgstr "0100 ngày 024 h 060 m 060 s"
+
 #. i18n-hint: This string is used to configure the controls for times when the recording is
 #. * started and stopped. As such it is important that only the alphabetic parts of the string
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "Ngày giờ bắt đầu"
@@ -4848,7 +5326,8 @@ msgstr "Bật Xuất thành tập tin Tự động"
 msgid "Export Project As:"
 msgstr "Xuất dự án thành:"
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "Tùy chọn"
 
@@ -4861,7 +5340,8 @@ msgid "Do nothing"
 msgstr "Không làm gì cả"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "Thoát Audacity"
 
 #: src/TimerRecordDialog.cpp
@@ -4885,7 +5365,8 @@ msgid "Scheduled to stop at:"
 msgstr "Đặt lịch dừng tại:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Bộ ghi thời gian Audacity - đang chờ khởi động"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -4911,8 +5392,13 @@ msgid "Recording Exported:"
 msgstr "Thu âm đã xuất:"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Bộ ghi thời gian Audacity - đang chờ "
+
+#: src/TrackInfo.cpp
+msgid "Stereo, 999999Hz"
+msgstr ""
 
 #. i18n-hint Esc is a key on the keyboard
 #: src/TrackPanel.cpp
@@ -5103,6 +5589,16 @@ msgstr ""
 msgid "Applying %s..."
 msgstr "Đang áp dụng %s..."
 
+#. i18n-hint: An item name followed by a value, with appropriate separating punctuation
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%s: %s"
+msgstr ""
+
 #: src/commands/AudacityCommand.h
 msgid "FAIL"
 msgstr "FAIL - không thành"
@@ -5121,13 +5617,15 @@ msgstr "%skhông phải là tham số công nhận bỡi %s"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "giá trị tham số '%s': không hợp lệ: giá trị đề nghị là %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "Lệnh"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "Lặp lại %s"
@@ -5238,17 +5736,41 @@ msgstr "Đọc Thông Tin"
 msgid "Commands"
 msgstr "Lệnh"
 
+#: src/commands/GetInfoCommand.cpp
+msgid "Menus"
+msgstr ""
+
 #: src/commands/GetInfoCommand.cpp src/commands/ScreenshotCommand.cpp
 msgid "Preferences"
 msgstr "Tuỳ chọn:"
+
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Clips"
+msgstr "Đặt clip"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Envelopes"
 msgstr "Đường bao biên độ"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "Các nhãn"
+
+#: src/commands/GetInfoCommand.cpp
+msgid "Boxes"
+msgstr ""
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr ""
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5258,7 +5780,8 @@ msgstr "bản tóm tắt"
 msgid "Type:"
 msgstr "Loại:"
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "Định dạng:"
 
@@ -5285,6 +5808,10 @@ msgstr "Ghi chú"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "Lệnh:"
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr ""
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5322,12 +5849,17 @@ msgstr "Xuất ra vào tập tin."
 msgid "Builtin Commands"
 msgstr "Lệnh nội trang"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Nhóm hỗ trợ Audacity"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "cung cấp lệnh nội trang cho Audacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5390,7 +5922,10 @@ msgstr "Xóa nội dung nhật ký."
 msgid "Get Preference"
 msgstr "Đọc Tuỳ Chọn:"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "Tên:"
 
@@ -5438,7 +5973,8 @@ msgstr "Fullscreen - Toàn bộ ành màn hình"
 msgid "Toolbars"
 msgstr "Thanh công cụ"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "Hiệu ứng"
 
@@ -5578,7 +6114,8 @@ msgstr "Đặt "
 msgid "Add"
 msgstr "Thêm"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "Xoá bỏ"
 
@@ -5658,8 +6195,14 @@ msgstr "Thời gian:"
 msgid "Delete"
 msgstr "Xoá"
 
+#: src/commands/SetEnvelopeCommand.cpp
+#, fuzzy
+msgid "Edited Envelope"
+msgstr "đặt đường biên độ"
+
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "Đường bao biên độ"
 
@@ -5683,6 +6226,11 @@ msgstr "Kết thúc:"
 msgid "Selected"
 msgstr "Được chọn"
 
+#: src/commands/SetLabelCommand.cpp
+#, fuzzy
+msgid "Edited Label"
+msgstr "Đã sửa nhãn"
+
 #: src/commands/SetLabelCommand.h
 msgid "Sets various values for a label."
 msgstr "đặt giá trị cho nhãn"
@@ -5698,6 +6246,14 @@ msgstr "Tốc độ:"
 #: src/commands/SetProjectCommand.cpp
 msgid "Resize:"
 msgstr "Chỉnh kích thước lại"
+
+#: src/commands/SetProjectCommand.cpp
+msgid "X:"
+msgstr ""
+
+#: src/commands/SetProjectCommand.cpp
+msgid "Y:"
+msgstr ""
 
 #: src/commands/SetProjectCommand.cpp
 msgid "Width:"
@@ -5747,13 +6303,21 @@ msgstr "Cân bằng:"
 msgid "Set Track Visuals"
 msgstr "đặt tầm nhìn đoạn âm "
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "Tuyến tính"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Reset"
 msgstr "Thiết lập lại"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "Times 2"
+msgstr "Bấm giờ"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "HalfWave"
@@ -5766,6 +6330,11 @@ msgstr "Hiển thị:"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Scale:"
 msgstr "gam:"
+
+#: src/commands/SetTrackInfoCommand.cpp
+#, fuzzy
+msgid "VZoom:"
+msgstr "Thu phóng"
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "VZoom Top:"
@@ -5782,6 +6351,12 @@ msgstr "dùng các Pref đặc biệt"
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Spectral Select"
 msgstr "Chọn quang phổ"
+
+#. i18n-hint Scheme refers to a color scheme for spectrogram colors
+#: src/commands/SetTrackInfoCommand.cpp src/prefs/SpectrumPrefs.cpp
+msgctxt "spectrum prefs"
+msgid "Sche&me"
+msgstr ""
 
 #: src/commands/SetTrackInfoCommand.cpp
 msgid "Set Track"
@@ -5816,6 +6391,10 @@ msgid "Allo&w clipping"
 msgstr "cho phé&p ghim đỉnh"
 
 #: src/effects/AutoDuck.cpp
+msgid "Auto Duck"
+msgstr ""
+
+#: src/effects/AutoDuck.cpp
 msgid "Reduces (ducks) the volume of one or more tracks whenever the volume of a specified \"control\" track reaches a particular level"
 msgstr "giảm (nhỏ) âm lượng của (các) đoạn âm mỗi khi âm lượng đạt đến một mức độ nhất định"
 
@@ -5833,12 +6412,18 @@ msgstr "Bạn đã chọn một dải âm toàn khoảng lặng. Hiệu ứng T�
 msgid "Auto Duck needs a control track which must be placed below the selected track(s)."
 msgstr "Auto Duck yêu cầu có một dải điều khiển nằm dưới dải được chọn."
 
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+msgid "db"
+msgstr ""
+
 #: src/effects/AutoDuck.cpp
 msgid "Duck &amount:"
 msgstr "hệ số &điểu khiển:"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "giây"
 
@@ -5862,7 +6447,8 @@ msgstr "trường độ bên trong &giảm dân"
 msgid "Inner &fade up length:"
 msgstr "trường độ bên trong &mờ dân"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "&Ngưỡng:"
 
@@ -5881,6 +6467,29 @@ msgstr "Hiệu ứng điều chỉnh giai điệu đơn giản"
 #: src/effects/BassTreble.cpp
 msgid "Tone controls"
 msgstr "điều chỉnh giai điệu."
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Bass (dB):"
+msgstr "Khuếch đại Bass - âm Trầm"
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "Ba&ss (dB):"
+msgstr "Mức độ âm thanh (dB):"
+
+#: src/effects/BassTreble.cpp
+msgid "Bass"
+msgstr ""
+
+#: src/effects/BassTreble.cpp
+#, fuzzy
+msgid "&Treble (dB):"
+msgstr "Mức độ âm thanh (dB):"
+
+#: src/effects/BassTreble.cpp
+msgid "Treble"
+msgstr ""
 
 #: src/effects/BassTreble.cpp
 msgid "&Volume (dB):"
@@ -5980,17 +6589,39 @@ msgstr "Đến (Hz) "
 msgid "t&o"
 msgstr "đế&n"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "Phần trăm t&hay đổi"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "Phần trăm thay đổi"
 
 #: src/effects/ChangePitch.cpp src/effects/ChangeTempo.cpp
 msgid "&Use high quality stretching (slow)"
 msgstr "&dùng chế độ kéo âm chất lượng cao (thấp)"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr ""
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr ""
+
+#. i18n-hint: n/a is an English abbreviation meaning "not applicable".
+#. i18n-hint: Can mean "not available," "not applicable," "no answer"
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
+msgid "n/a"
+msgstr ""
 
 #: src/effects/ChangeSpeed.cpp
 msgid "Change Speed"
@@ -6008,8 +6639,15 @@ msgstr "Thay đổi tốc độ là thay đổi cả nhịp điệu và độ ca
 msgid "&Speed Multiplier:"
 msgstr "&bộ nhân tốc độ"
 
+#. i18n-hint: "rpm" is an English abbreviation meaning "revolutions per minute".
+#. "vinyl" refers to old-fashioned phonograph records
+#: src/effects/ChangeSpeed.cpp
+msgid "Standard Vinyl rpm:"
+msgstr ""
+
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "Từ rpm"
@@ -6022,6 +6660,7 @@ msgstr "&Từ"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "Đến rpm"
@@ -6131,6 +6770,47 @@ msgstr "Click xóa"
 msgid "Click Removal is designed to remove clicks on audio tracks"
 msgstr "nút \"click xóa\" được dùng để xóa các tiếng lách cách trên đoạn âm audio"
 
+#: src/effects/ClickRemoval.cpp
+msgid "Algorithm not effective on this audio. Nothing changed."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+#, c-format
+msgid "Selection must be larger than %d samples."
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "&Threshold (lower is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp src/effects/Compressor.cpp
+#, fuzzy
+msgid "Threshold"
+msgstr "Ngưỡng:"
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max &Spike Width (higher is more sensitive):"
+msgstr ""
+
+#: src/effects/ClickRemoval.cpp
+msgid "Max Spike Width"
+msgstr ""
+
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Compressor"
+msgstr "Trình biên dịch:"
+
+#: src/effects/Compressor.cpp
+msgid "Compresses the dynamic range of audio"
+msgstr ""
+
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr ""
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6141,9 +6821,28 @@ msgstr "%.2f secs - giây"
 msgid "%.1f secs"
 msgstr "%.1f secs - giây"
 
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr ""
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr ""
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
+msgstr "Tỉ lệ%.0f - 1 "
+
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Ratio %.1f to 1"
 msgstr "Tỉ lệ%.0f - 1 "
 
 #: src/effects/Compressor.cpp
@@ -6162,6 +6861,50 @@ msgstr "&Tỉ lệ"
 msgid "Ratio"
 msgstr "Tỉ lệ"
 
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "&Attack Time:"
+msgstr "Thời gian bắt đầu:"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' where the
+#. * sound dies away.  So this means 'onset duration'.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Attack Time"
+msgstr "Thời gian bắt đầu"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "R&elease Time:"
+msgstr "Chọn thơi gian"
+
+#. i18n-hint: Particularly in percussion, sounds can be regarded as having
+#. * an 'attack' phase where the sound builds up and a 'decay' or 'release' where the
+#. * sound dies away.
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "Release Time"
+msgstr "Chọn thơi gian"
+
+#. i18n-hint: Make-up, i.e. correct for any reduction, rather than fabricate it.
+#: src/effects/Compressor.cpp
+msgid "Ma&ke-up gain for 0 dB after compressing"
+msgstr ""
+
+#. i18n-hint: "Compress" here means reduce variations of sound volume,
+#. NOT related to file-size compression; Peaks means extremes in volume
+#: src/effects/Compressor.cpp
+#, fuzzy
+msgid "C&ompress based on Peaks"
+msgstr "So sánh cùng khoảng xác định trên 2 đoạn âm."
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Threshold %d dB"
@@ -6172,12 +6915,45 @@ msgstr "Ngưỡng: %d dB"
 msgid "Noise Floor %d dB"
 msgstr "Nhiễu nhỏ nhất - Noise Floor %d dB"
 
+#: src/effects/Compressor.cpp
+#, fuzzy, c-format
+msgid "Attack Time %.2f secs"
+msgstr "%.2f secs - giây"
+
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "Release Time %.1f secs"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "You can only measure one track at a time."
+msgstr ""
+
 #: src/effects/Contrast.cpp
 msgid "Please select an audio track."
 msgstr "Hãy chọn một đoạn âm audio."
 
+#: src/effects/Contrast.cpp
+msgid ""
+"Invalid audio selection.\n"
+"Please ensure that audio is selected."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid ""
+"Nothing to measure.\n"
+"Please select a section of a track."
+msgstr "Hãy chọn trong một đoạn âm mono."
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Contrast Analyzer, for measuring RMS volume differences between two selections of audio."
+msgstr ""
+
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "Kết thúc"
 
@@ -6185,18 +6961,332 @@ msgstr "Kết thúc"
 msgid "Volume    "
 msgstr "Âm lượng"
 
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Foreground:"
+msgstr "nền:"
+
+#: src/effects/Contrast.cpp
+msgid "Foreground start time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground end time"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Measure selection"
+msgstr "Xoá phần đã chọn"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Background:"
+msgstr "nền:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background start time"
+msgstr "nền:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background end time"
+msgstr "nền:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Mea&sure selection"
+msgstr "Xoá phần đã chọn"
+
+#: src/effects/Contrast.cpp
+msgid "Result"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Co&ntrast Result:"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "R&eset"
+msgstr "Thiết lập lại"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "&Difference:"
+msgstr "Tuỳ chọn:"
+
 #: src/effects/Contrast.cpp src/menus/HelpMenus.cpp src/prefs/GUIPrefs.cpp
 msgid "&Help"
 msgstr "Trợ &giúp"
+
+#. i18n-hint: RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "RMS = %s."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr ""
 
 #: src/effects/Contrast.cpp
 msgid "zero"
 msgstr "điểm không"
 
 #: src/effects/Contrast.cpp
+#, fuzzy
+msgid "indeterminate"
+msgstr "Không quyết định được"
+
+#. i18n-hint: dB abbreviates decibels
+#. * RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB RMS"
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+msgid "Infinite dB difference"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Difference is indeterminate."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Difference = %.2f RMS dB."
+msgstr ""
+
+#. i18n-hint: dB abbreviates decibels
+#. RMS abbreviates root mean square, a certain averaging method
+#: src/effects/Contrast.cpp
+msgid "Difference = infinite RMS dB."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background level too high"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background higher than foreground"
+msgstr ""
+
+#. i18n-hint: WCAG2 is the 'Web Content Accessibility Guidelines (WCAG) 2.0', see http://www.w3.org/TR/WCAG20/
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Pass"
+msgstr ""
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG2 Fail"
+msgstr ""
+
+#. i18n-hint: i.e. difference in loudness at the moment.
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Current difference"
+msgstr "Dự án hiện hành"
+
+#: src/effects/Contrast.cpp
+msgid "Measured foreground level"
+msgstr ""
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, fuzzy, c-format
+msgid "%.2f dB"
+msgstr "%.2f secs - giây"
+
+#: src/effects/Contrast.cpp
+msgid "No foreground measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Foreground not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Measured background level"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "No background measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Background not yet measured"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Export Contrast Result As:"
+msgstr "Xuất nhãn thành:"
+
+#. i18n-hint: WCAG abbreviates Web Content Accessibility Guidelines
+#: src/effects/Contrast.cpp
+msgid "WCAG 2.0 Success Criteria 1.4.7 Contrast Results"
+msgstr ""
+
+#: src/effects/Contrast.cpp
 #, c-format
 msgid "Filename = %s."
 msgstr "Filename - Tên Tập Tin = %s."
+
+#: src/effects/Contrast.cpp
+msgid "Foreground"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time started = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "Time ended = %2d hour(s), %2d minute(s), %.2f seconds."
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Background"
+msgstr "nền:"
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Results"
+msgstr "Mặc định"
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Pass"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Success Criteria 1.4.7 of WCAG 2.0: Fail"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Data gathered"
+msgstr ""
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+msgid "Contrast Analysis (WCAG 2 compliance)"
+msgstr ""
+
+#: src/effects/Contrast.cpp
+#, fuzzy
+msgid "Contrast..."
+msgstr "Tương phản cao"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Hard Clipping"
+msgstr "Tìm điểm ghim"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Soft Clipping"
+msgstr "Đang Ghim"
+
+#: src/effects/Distortion.cpp
+msgid "Soft Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Medium Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Cubic Curve (odd harmonics)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Even Harmonics"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Expand and Compress"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Leveller"
+msgstr "Mức"
+
+#: src/effects/Distortion.cpp
+msgid "Rectifier Distortion"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Hard Limiter 1413"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Hard clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, no-c-format
+msgid "Soft clip -12dB, 80% make-up gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Fuzz Box"
+msgstr ""
+
+#: src/effects/Distortion.cpp src/effects/Equalization.cpp
+msgid "Walkie-talkie"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Blues drive sustain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Light Crunch Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Heavy Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "3rd Harmonic (Perfect Fifth)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Valve Overdrive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "2nd Harmonic (Octave)"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Gated Expansion Distortion"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "Leveller, Light, -70dB noise floor"
@@ -6219,20 +7309,133 @@ msgid "Leveller, Heaviest, -70dB noise floor"
 msgstr "Leveller, Heaviest (Nặng Nhất), -70dB noise floor  (Nhiễu nhỏ nhất)"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Half-wave Rectifier"
+msgstr "Full-wave Rectifier - Bộ chỉnh lưu toàn sóng (DC bị chặn)"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Full-wave Rectifier"
+msgstr "Full-wave Rectifier - Bộ chỉnh lưu toàn sóng (DC bị chặn)"
+
+#: src/effects/Distortion.cpp
 msgid "Full-wave Rectifier (DC blocked)"
 msgstr "Full-wave Rectifier - Bộ chỉnh lưu toàn sóng (DC bị chặn)"
+
+#: src/effects/Distortion.cpp
+msgid "Percussion Limiter"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Upper Threshold"
+msgstr "Ngưỡng:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 1"
+msgstr "Các tham số"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter 2"
+msgstr "Các tham số"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Number of repeats"
+msgstr "Số lượng lần chỉnh sửa:"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Distortion"
+msgstr "Độ dài"
+
+#: src/effects/Distortion.cpp
+msgid "Waveshaping distortion effect"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Distortion type:"
+msgstr ""
 
 #: src/effects/Distortion.cpp
 msgid "DC blocking filter"
 msgstr "Bộ lọc chặn DC"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Threshold controls"
+msgstr "điều chỉnh giai điệu."
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Parameter controls"
+msgstr "Các tham số"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Clipping level"
+msgstr "Đang Ghim"
+
+#: src/effects/Distortion.cpp
+msgid "Drive"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Make-up Gain"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Clipping threshold"
+msgstr "Đang Ghim"
+
+#: src/effects/Distortion.cpp
+msgid "Hardness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Distortion amount"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "Output level"
 msgstr "Tín hiệu đầu ra"
 
 #: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Repeat processing"
+msgstr "Lặp lại %s"
+
+#: src/effects/Distortion.cpp
+msgid "Harmonic brightness"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Levelling fine adjustment"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "Degree of Levelling"
+msgstr ""
+
+#: src/effects/Distortion.cpp
 msgid "dB Limit"
 msgstr "Giới hạn dB"
+
+#: src/effects/Distortion.cpp
+#, fuzzy
+msgid "Wet level"
+msgstr "Tín hiệu đầu ra"
+
+#: src/effects/Distortion.cpp
+msgid "Residual level"
+msgstr ""
+
+#: src/effects/Distortion.cpp
+msgid "(Not Used):"
+msgstr ""
 
 #. i18n-hint: Control range.
 #: src/effects/Distortion.cpp
@@ -6258,35 +7461,104 @@ msgstr "(0 đến 5):"
 msgid "DTMF Tones"
 msgstr "Tones DTMF "
 
+#: src/effects/DtmfGen.cpp
+msgid "Generates dual-tone multi-frequency (DTMF) tones like those produced by the keypad on telephones"
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+msgid ""
+"DTMF sequence empty.\n"
+"Check ALL settings for this effect."
+msgstr ""
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "DTMF &sequence:"
+msgstr "Tần số (Hz)"
+
 #: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/ToneGen.cpp
 msgid "&Amplitude (0-1):"
 msgstr "Biên độ (0-1):"
+
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "&Duration:"
+msgstr "Độ dài:"
+
+#: src/effects/DtmfGen.cpp
+#, fuzzy
+msgid "&Tone/silence ratio:"
+msgstr "Độ dài khoảng lặng:"
 
 #: src/effects/DtmfGen.cpp
 msgid "Duty cycle:"
 msgstr "Tuần hoàn:"
 
 #: src/effects/DtmfGen.cpp
+#, fuzzy, c-format
+msgid "%.1f %%"
+msgstr "%.1f secs - giây"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "Độ dài tone:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr ""
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "Độ dài khoảng lặng:"
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr ""
 
 #: src/effects/Echo.cpp
 msgid "Echo"
 msgstr "Tiếng vọng"
 
 #: src/effects/Echo.cpp
+#, fuzzy
+msgid "Repeats the selected audio again and again"
+msgstr "Đang xuất âm thanh đã chọn ra %s"
+
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
+msgid "Requested value exceeds memory capacity."
+msgstr ""
+
+#: src/effects/Echo.cpp
 msgid "&Delay time (seconds):"
 msgstr "&Thời gian Trễ (giây):"
+
+#: src/effects/Echo.cpp
+#, fuzzy
+msgid "D&ecay factor:"
+msgstr "Hệ số suy hao:"
+
+#: src/effects/Effect.cpp
+msgid "Built-in"
+msgstr ""
 
 #: src/effects/Effect.cpp
 msgid "Presets"
 msgstr "Presets - Thiết lập sẵn"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp
+#, fuzzy
+msgid "Export Effect Parameters"
+msgstr "nhập thống số hiệu ứng"
+
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "Không thể mở tập tin: \"%s\""
@@ -6310,6 +7582,12 @@ msgstr "nhập thống số hiệu ứng"
 msgid "%s: is not a valid presets file.\n"
 msgstr "%s: không phải là một tập tin thiết lập sẵn hợp lệ.\n"
 
+#. i18n-hint %s will be replaced by a file name
+#: src/effects/Effect.cpp
+#, c-format
+msgid "%s: is for a different Effect, Generator or Analyzer.\n"
+msgstr ""
+
 #: src/effects/Effect.cpp
 msgid "Preparing preview"
 msgstr "Đang chuẩn bị phát thử"
@@ -6317,6 +7595,15 @@ msgstr "Đang chuẩn bị phát thử"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "Đang phát thử"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+#, fuzzy
+msgid "Nyquist"
+msgstr "Lỗi Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -6352,6 +7639,41 @@ msgstr "Cài đặt hiện tại"
 msgid "Factory Defaults"
 msgstr "Thiết lập sẵn mặc định"
 
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following effect failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Effect failed to initialize"
+msgstr "Chọn (các) tập tin để cài đặt"
+
+#: src/effects/EffectManager.cpp
+#, c-format
+msgid ""
+"Attempting to initialize the following command failed:\n"
+"\n"
+"%s\n"
+"\n"
+"More information may be available in 'Help > Diagnostics > Show Log'"
+msgstr ""
+
+#: src/effects/EffectManager.cpp
+#, fuzzy
+msgid "Command failed to initialize"
+msgstr "Không thể khởi tạo phần bổ sung Vamp"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Effects Rack"
+msgstr "Hiển thị Effects Rack (thanh công cụ hiệu ứng)"
+
 #: src/effects/EffectUI.cpp
 msgid "&Apply"
 msgstr "&Áp dụng"
@@ -6361,20 +7683,55 @@ msgid "Latency: 0"
 msgstr "Độ trễ: 0"
 
 #: src/effects/EffectUI.cpp
+msgid "&Bypass"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Active State"
+msgstr "Xếp Điểm Đầu"
+
+#: src/effects/EffectUI.cpp
+msgid "Set effect active state"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
 msgid "Show/Hide Editor"
 msgstr "Hiển thị/ Ẩn trình soạn thảo "
+
+#: src/effects/EffectUI.cpp
+msgid "Open/close effect editor"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Move Up"
 msgstr "Chuyển Lên"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect up in the rack"
+msgstr "Di chuyển đoạn lên/xuống giữa các dải"
+
+#: src/effects/EffectUI.cpp
 msgid "Move Down"
 msgstr "Chuyển xuống"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Move effect down in the rack"
+msgstr "Di chuyển đoạn lên/xuống giữa các dải"
+
+#: src/effects/EffectUI.cpp
 msgid "Favorite"
 msgstr "Yêu thích"
+
+#: src/effects/EffectUI.cpp
+msgid "Mark effect as a favorite"
+msgstr ""
+
+#: src/effects/EffectUI.cpp
+msgid "Remove effect from the rack"
+msgstr ""
 
 #: src/effects/EffectUI.cpp
 msgid "Name of the effect"
@@ -6386,12 +7743,22 @@ msgid "Latency: %4d"
 msgstr "Độ trễ: %4d"
 
 #: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Some Command"
+msgstr "Chọn lệnh"
+
+#: src/effects/EffectUI.cpp
 msgid "Manage presets and options"
 msgstr "Quản lý thiết lập sẵn và tùy chọn"
 
 #: src/effects/EffectUI.cpp
 msgid "&Manage"
 msgstr "&Quản lý"
+
+#: src/effects/EffectUI.cpp
+#, fuzzy
+msgid "Start and stop playback"
+msgstr "Bắt &Phát Lại"
 
 #. i18n-hint: The access key "&P" should be the same in
 #. "Stop &Playback" and "Start &Playback"
@@ -6517,6 +7884,15 @@ msgstr "Tắt phát lại"
 msgid "Play"
 msgstr "Phát"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Cosine"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cubic"
 msgstr "Khối"
@@ -6534,12 +7910,106 @@ msgid "Graphic EQ"
 msgstr "EQ đồ hoạ"
 
 #: src/effects/Equalization.cpp
+msgid "Adjusts the volume levels of particular frequencies"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "100Hz Rumble"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AM Radio"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Bass Boost"
 msgstr "Khuếch đại Bass - âm Trầm"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Bass Cut"
+msgstr "Khuếch đại Bass - âm Trầm"
+
+#: src/effects/Equalization.cpp
+msgid "Low rolloff for speech"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Telephone"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Treble Boost"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Treble Cut"
+msgstr "Dán nhãn tại điểm cắt"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"To use this filter curve in a macro, please choose a new name for it.\n"
+"Choose the 'Save/Manage Curves...' button and rename the 'unnamed' curve, then use that one."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Filter Curve EQ needs a different name"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "To apply Equalization, all selected tracks must have the same sample rate."
+msgstr "Để vẽ phổ, tất cả các đoạn âm được chọn phải có cùng tốc độ lấy mẫu"
+
+#: src/effects/Equalization.cpp
+msgid "Track sample rate is too low for this effect."
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Effect Unavailable"
 msgstr "Hiệu ứng không có sẵn"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Max dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "Min dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -6554,6 +8024,33 @@ msgid "&Draw"
 msgstr "&Vẽ"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Graphic"
+msgstr "EQ đồ hoạ"
+
+#: src/effects/Equalization.cpp
+msgid "Interpolation type"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Linear Frequency Scale"
+msgstr "Tần số tuyến tính"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Li&near Frequency Scale"
+msgstr "Tần số tuyến tính"
+
+#: src/effects/Equalization.cpp
+msgid "Length of &Filter:"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Length of Filter"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "&Select Curve:"
 msgstr "&Chọn cung"
 
@@ -6564,6 +8061,10 @@ msgstr "Chọn cung"
 #: src/effects/Equalization.cpp
 msgid "S&ave/Manage Curves..."
 msgstr "Lưu / Quản Lý Cung"
+
+#: src/effects/Equalization.cpp
+msgid "Fla&tten"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&Invert"
@@ -6584,6 +8085,27 @@ msgstr " Đang &Xử lý:"
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "Mặc đị&nh"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "SSE &Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "AV&X Threaded"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Bench"
+msgstr "Đối chuẩn"
 
 #. i18n-hint: name of the 'unnamed' custom curve
 #: src/effects/Equalization.cpp
@@ -6613,8 +8135,22 @@ msgid "Error Saving Equalization Curves"
 msgstr "Lỗi khi lưu EQ Curves"
 
 #: src/effects/Equalization.cpp
+msgid "Requested curve not found, using 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "Curve not found"
 msgstr "Không tìm cong được"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves List"
+msgstr "Lưu / Quản Lý Cung"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Manage Curves"
+msgstr "Lưu / Quản Lý Cung"
 
 #: src/effects/Equalization.cpp
 msgid "&Curves"
@@ -6629,8 +8165,27 @@ msgid "D&elete..."
 msgstr "&Xoá"
 
 #: src/effects/Equalization.cpp
+#, fuzzy
+msgid "&Get More..."
+msgstr "Đọc Thông Tin..."
+
+#: src/effects/Equalization.cpp
 msgid "De&faults"
 msgstr "Mă&c định"
+
+#: src/effects/Equalization.cpp
+msgid ""
+"Rename 'unnamed' to save a new entry.\n"
+"'OK' saves all changes, 'Cancel' doesn't."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' always stays at the bottom of the list"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "'unnamed' is special"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 #, c-format
@@ -6647,6 +8202,33 @@ msgid "Rename '%s'"
 msgstr "Đặt lại tên '%s'"
 
 #: src/effects/Equalization.cpp
+msgid "Name is the same as the original one"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Same name"
+msgstr "Tên phông"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "Overwrite existing curve '%s'?"
+msgstr "Ghi đè lên tập tin có sẵn"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curve exists"
+msgstr "Tên Cong"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+msgid "Can't delete 'unnamed'"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 #, c-format
 msgid "Delete '%s'?"
 msgstr "Xoá  '%s'?"
@@ -6659,6 +8241,47 @@ msgstr "Xác nhận việc xoá bỏ"
 #, c-format
 msgid "Delete %d items?"
 msgstr " Xoá bỏ %d thứ?"
+
+#: src/effects/Equalization.cpp
+msgid "You cannot delete the 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Choose an EQ curve file"
+msgstr "Chọn nơi để lưu lại các tập tin"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Export EQ curves as..."
+msgstr "Xuất &nhãn..."
+
+#: src/effects/Equalization.cpp
+msgid "You cannot export 'unnamed' curve, it is special."
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Cannot Export 'unnamed'"
+msgstr "Không thể xuất âm thanh ra %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy, c-format
+msgid "%d curves exported to %s"
+msgstr ""
+"%s\n"
+"\n"
+"Tập tin thu âm đã xuất: %s"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "Curves exported"
+msgstr "Không tìm cong được"
+
+#: src/effects/Equalization.cpp
+#, fuzzy
+msgid "No curves exported"
+msgstr "Không có thiết lập sẵn để xuất"
 
 #: src/effects/Equalization48x.cpp
 #, c-format
@@ -6685,21 +8308,70 @@ msgstr "Âm lượng tăng dần"
 msgid "Fade Out"
 msgstr "Âm lượng giảm dần"
 
+#: src/effects/Fade.cpp
+#, fuzzy
+msgid "Applies a linear fade-in to the selected audio"
+msgstr "Nhấn và rê chuột để chọn âm thanh"
+
+#: src/effects/Fade.cpp
+msgid "Applies a linear fade-out to the selected audio"
+msgstr ""
+
 #: src/effects/FindClipping.cpp
 msgid "Find Clipping"
 msgstr "Tìm điểm ghim"
 
 #: src/effects/FindClipping.cpp
+msgid "Creates labels where clipping is detected"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
 msgid "Clipping"
 msgstr "Đang Ghim"
+
+#: src/effects/FindClipping.cpp
+msgid "&Start threshold (samples):"
+msgstr ""
+
+#: src/effects/FindClipping.cpp
+msgid "St&op threshold (samples):"
+msgstr ""
+
+#: src/effects/Generator.cpp
+#, fuzzy
+msgid "There is not enough room available to generate the audio"
+msgstr "Không đủ chỗ để dán vùng chọn"
 
 #: src/effects/Invert.cpp
 msgid "Invert"
 msgstr "Đảo"
 
+#: src/effects/Invert.cpp
+msgid "Flips the audio samples upside-down, reversing their polarity"
+msgstr ""
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Builtin Effects"
+msgstr "Tất cả hiệu ứng"
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
+msgstr "cung cấp lệnh nội trang cho Audacity"
+
+#: src/effects/LoadEffects.cpp
+#, fuzzy
+msgid "Unknown built-in effect name"
+msgstr "lệnh nội trang không xác định"
+
 #: src/effects/Loudness.cpp
 msgid "perceived loudness"
 msgstr "Cường độ âm thanh được cảm nhận "
+
+#: src/effects/Loudness.cpp src/widgets/Meter.cpp
+msgid "RMS"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Loudness Normalization"
@@ -6733,8 +8405,20 @@ msgid "Loudness LUFS"
 msgstr "Cách tối ưu cường độ âm thanh LUFS"
 
 #: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
+
+#: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
 msgstr "Chuẩn hoá kênh &stereo riêng biệt"
+
+#: src/effects/Loudness.cpp
+msgid "&Treat mono as dual-mono (recommended)"
+msgstr ""
 
 #: src/effects/Loudness.cpp src/effects/Normalize.cpp
 msgid "(Maximum 0dB)"
@@ -6746,21 +8430,81 @@ msgctxt "noise"
 msgid "White"
 msgstr "Màu trắng"
 
+#. i18n-hint: not a color, but "pink noise" having a spectrum with more power
+#. in low frequencies
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Pink"
+msgstr ""
+
+#. i18n-hint: a kind of noise spectrum also known as "red" or "brown"
+#: src/effects/Noise.cpp
+msgctxt "noise"
+msgid "Brownian"
+msgstr ""
+
 #: src/effects/Noise.cpp
 msgid "Noise"
 msgstr "Nhiễu"
+
+#: src/effects/Noise.cpp
+msgid "Generates one of three different types of noise"
+msgstr ""
 
 #: src/effects/Noise.cpp
 msgid "&Noise type:"
 msgstr "Loại &Nhiễu"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Median"
+msgstr "Trung bình"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Second greatest"
+msgstr "Đoạn âm thứ hai"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Old"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "none, Hann (2.0.6 behavior)"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "Hann, Hann (mặc định)"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (mặc định)"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, none"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
 msgstr "Giảm Nhiễu"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Removes background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "Steps per block are too few for the window types."
@@ -6771,6 +8515,31 @@ msgid "Steps per block cannot exceed the window size."
 msgstr "Các bước trên mỗi khối quá nhiểu với kích thước cừa số. "
 
 #: src/effects/NoiseReduction.cpp
+msgid "Median method is not implemented for more than four steps per window."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "You must specify the same window size for steps 1 and 2."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Warning: window types are not the same as for profiling."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "All noise profile data must have the same sample rate."
+msgstr "Để vẽ phổ, tất cả các đoạn âm được chọn phải có cùng tốc độ lấy mẫu"
+
+#: src/effects/NoiseReduction.cpp
+msgid "The sample rate of the noise profile must match that of the sound to be processed."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "Selected noise profile is too short."
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
 msgid "&Noise reduction (dB):"
 msgstr "Giảm &Nhiễu (dB):"
 
@@ -6778,8 +8547,51 @@ msgstr "Giảm &Nhiễu (dB):"
 msgid "Noise reduction"
 msgstr "Giảm Nhiễu"
 
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Sensitivity:"
+msgstr "Độ nhạy"
+
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Sensitivity"
+msgstr "Độ nhạy"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Attac&k time (secs):"
+msgstr "Thời gian trễ (giây):"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Attack time"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "R&elease time (secs):"
+msgstr "&Thời gian Trễ (giây):"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Release time"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Frequency smoothing (bands):"
+msgstr "&Tần số (Hz):"
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Frequency smoothing"
+msgstr "Bộ phân tích tần số"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Sensiti&vity (dB):"
+msgstr "Độ nhạy"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Old Sensitivity"
 msgstr "Độ nhạy"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
@@ -6787,24 +8599,139 @@ msgid "Step 1"
 msgstr "Bước 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "Chọn vùng có nhiễu để phân tích,\n"
 "Bấm nút 'Phân tích nhiễu' sau khi chọn:"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "&Get Noise Profile"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Step 2"
 msgstr "Bước 2"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid ""
+"Select all of the audio you want filtered, choose how much noise you want\n"
+"filtered out, and then click 'OK' to reduce noise.\n"
+msgstr ""
+"Chọn tất cả các vùng bạn cần xoá nhiễu, chọn hệ số lọc nhiễu, sau đó\n"
+"nhấn 'OK' để bắt đầu xoá nhiễu.\n"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
 msgid "Noise:"
 msgstr "Nhiễu:"
 
+#. i18n-hint: Translate differently from "Residue" !
+#: src/effects/NoiseReduction.cpp
+msgid "Re&duce"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+msgid "&Isolate"
+msgstr ""
+
+#. i18n-hint: Means the difference between effect and original sound.  Translate differently from "Reduce" !
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Resid&ue"
+msgstr "Chỉnh kích thước lại"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Advanced Settings"
+msgstr "Zoom theo chiều dọc và nâng cao "
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "&Window types:"
+msgstr "&Loại cửa sổ:"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Window si&ze:"
+msgstr "&Kích thước cửa sổ:"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "2048 (default)"
+msgstr "1024 - mặc định"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "S&teps per window:"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "4 (default)"
+msgstr "1024 - mặc định"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Discrimination &method:"
+msgstr ""
+
 #: src/effects/NoiseRemoval.cpp
 msgid "Noise Removal"
 msgstr "Xoá nhiễu"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Removes constant background noise such as fans, tape noise, or hums"
+msgstr ""
 
 #: src/effects/NoiseRemoval.cpp
 msgid ""
@@ -6818,12 +8745,46 @@ msgstr ""
 msgid "Noise re&duction (dB):"
 msgstr "Giảm biên &độ nhiễu (dB):"
 
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "&Sensitivity (dB):"
+msgstr "Độ nhạy"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Fr&equency smoothing (Hz):"
+msgstr "&Tần số (Hz):"
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Attac&k/decay time (secs):"
+msgstr "&Thời gian Trễ (giây):"
+
+#: src/effects/NoiseRemoval.cpp
+msgid "Attack/decay time"
+msgstr ""
+
+#: src/effects/NoiseRemoval.cpp
+#, fuzzy
+msgid "Re&move"
+msgstr "Xoá bỏ"
+
 #: src/effects/Normalize.cpp
 msgid "Normalize"
 msgstr "Chuẩn hoá"
 
 #: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Sets the peak amplitude of one or more tracks"
+msgstr "Thiết lập cường độ âm thanh cho đoạn âm"
+
+#: src/effects/Normalize.cpp
 msgid "Removing DC offset and Normalizing...\n"
+msgstr "Loại bỏ độ di DC và chuẩn hóa ...\n"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Removing DC offset...\n"
 msgstr "Loại bỏ độ di DC và chuẩn hóa ...\n"
 
 #: src/effects/Normalize.cpp
@@ -6831,12 +8792,111 @@ msgid "Normalizing without removing DC offset...\n"
 msgstr "Chuẩn hoá mà không cần loại bỏ độ di DC \n"
 
 #: src/effects/Normalize.cpp
+msgid "Not doing anything...\n"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Analyzing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, fuzzy, c-format
+msgid "Processing stereo channels independently: %s"
+msgstr "Chuẩn hoá kênh &stereo riêng biệt"
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing first track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+#, c-format
+msgid "Processing second track of stereo pair: %s"
+msgstr ""
+
+#: src/effects/Normalize.cpp
+msgid "&Remove DC offset (center on 0.0 vertically)"
+msgstr ""
+
+#: src/effects/Normalize.cpp
 msgid "&Normalize peak amplitude to   "
 msgstr "Chuẩn hoá biên độ đỉnh "
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "Peak amplitude dB"
+msgstr "&đỉnh khuếch đại mới (dB):"
+
+#: src/effects/Normalize.cpp
+#, fuzzy
+msgid "N&ormalize stereo channels independently"
+msgstr "Chuẩn hoá kênh &stereo riêng biệt"
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr ""
+
+#: src/effects/Paulstretch.cpp
+msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
+msgstr ""
+
+#. i18n-hint: This is how many times longer the sound will be, e.g. applying
+#. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
+#. * will give an (approximately) 10 second sound
+#.
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "&Stretch Factor:"
+msgstr "Hệ số suy hao:"
+
+#: src/effects/Paulstretch.cpp
+#, fuzzy
+msgid "&Time Resolution (seconds):"
+msgstr "&Thời gian Trễ (giây):"
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Audio selection too short to preview.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"Unable to Preview.\n"
+"\n"
+"For the current audio selection, the maximum\n"
+"'Time Resolution' is %.1f seconds."
+msgstr ""
+
+#. i18n-hint: 'Time Resolution' is the name of a control in the Paulstretch effect.
+#: src/effects/Paulstretch.cpp
+#, c-format
+msgid ""
+"The 'Time Resolution' is too long for the selection.\n"
+"\n"
+"Try increasing the audio selection to at least %.1f seconds,\n"
+"or reducing the 'Time Resolution' to less than %.1f seconds."
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "Phaser"
 msgstr "Dịch pha"
+
+#: src/effects/Phaser.cpp
+msgid "Combines phase-shifted signals with the original signal"
+msgstr ""
 
 #: src/effects/Phaser.cpp
 msgid "&Stages:"
@@ -6846,9 +8906,46 @@ msgstr "dàn dựng"
 msgid "Stages"
 msgstr "vùng nội dung"
 
+#: src/effects/Phaser.cpp
+msgid "&Dry/Wet:"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dry Wet"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+#, fuzzy
+msgid "LFO Freq&uency (Hz):"
+msgstr "&Tần số (Hz):"
+
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "LFO frequency in hertz"
 msgstr "LFO Bộ dao động tần thấp (Hz)"
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO Sta&rt Phase (deg.):"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "LFO start phase in degrees"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Dept&h:"
+msgstr ""
+
+#: src/effects/Phaser.cpp src/effects/Wahwah.cpp
+msgid "Depth in percent"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Feedbac&k (%):"
+msgstr ""
+
+#: src/effects/Phaser.cpp
+msgid "Feedback in percent"
+msgstr ""
 
 #: src/effects/Phaser.cpp src/effects/Wahwah.cpp
 msgid "&Output gain (dB):"
@@ -6863,6 +8960,11 @@ msgid "Repair"
 msgstr "Sửa"
 
 #: src/effects/Repair.cpp
+#, fuzzy
+msgid "Sets the peak amplitude of a one or more tracks"
+msgstr "Thiết lập cường độ âm thanh cho đoạn âm"
+
+#: src/effects/Repair.cpp
 msgid ""
 "The Repair effect is intended to be used on very short sections of damaged audio (up to 128 samples).\n"
 "\n"
@@ -6872,13 +8974,416 @@ msgstr ""
 "\n"
 "Phóng to và chọn khung thời gian cần sửa chữa."
 
+#: src/effects/Repair.cpp
+msgid ""
+"Repair works by using audio data outside the selection region.\n"
+"\n"
+"Please select a region that has audio touching at least one side of it.\n"
+"\n"
+"The more surrounding audio, the better it performs."
+msgstr ""
+
 #: src/effects/Repeat.cpp
 msgid "Repeat"
 msgstr "Lặp lại"
 
+#: src/effects/Repeat.cpp
+msgid "Repeats the selection the specified number of times"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+#, fuzzy
+msgid "&Number of repeats to add:"
+msgstr "Số lượng lần chỉnh sửa:"
+
+#: src/effects/Repeat.cpp
+msgid "Current selection length: dd:hh:mm:ss"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+msgid "New selection length: dd:hh:mm:ss"
+msgstr ""
+
+#: src/effects/Repeat.cpp
+#, fuzzy, c-format
+msgid "Current selection length: %s"
+msgstr "Độ dài vùng chọn"
+
+#: src/effects/Repeat.cpp
+#, fuzzy, c-format
+msgid "New selection length: %s"
+msgstr "Độ dài vùng chọn"
+
+#: src/effects/Repeat.cpp
+msgid "Warning: No repeats."
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Vocal I"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Vocal II"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Bathroom"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Bright"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Small Room Dark"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Medium Room"
+msgstr "Trung bình"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Large Room"
+msgstr "Các biểu tượng &Lớn"
+
+#: src/effects/Reverb.cpp
+msgid "Church Hall"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Cathedral"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Reverb"
+msgstr "Đảo ngược"
+
+#: src/effects/Reverb.cpp
+msgid "Adds ambience or a \"hall effect\""
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "&Room Size (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "&Pre-delay (ms):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Rever&berance (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Da&mping (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Tone &Low (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Tone &High (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Wet &Gain (dB):"
+msgstr "&Đầu ra Gain (dB):"
+
+#: src/effects/Reverb.cpp
+#, fuzzy
+msgid "Dr&y Gain (dB):"
+msgstr "&Đầu ra Gain (dB):"
+
+#: src/effects/Reverb.cpp
+msgid "Stereo Wid&th (%):"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+msgid "Wet O&nly"
+msgstr ""
+
+#: src/effects/Reverb.cpp
+#, fuzzy, c-format
+msgid "Reverb: %s"
+msgstr "Đảo ngược"
+
 #: src/effects/Reverse.cpp
 msgid "Reverse"
 msgstr "Đảo ngược"
+
+#: src/effects/Reverse.cpp
+#, fuzzy
+msgid "Reverses the selected audio"
+msgstr "Đang xuất âm thanh đã chọn ra %s"
+
+#: src/effects/SBSMSEffect.h
+msgid "SBSMS Time / Pitch Stretch"
+msgstr ""
+
+#. i18n-hint: Butterworth is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Butterworth"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type I"
+msgstr ""
+
+#. i18n-hint: Chebyshev is the name of the person after whom the filter type is named.
+#: src/effects/ScienFilter.cpp
+msgid "Chebyshev Type II"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Lowpass"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Highpass"
+msgstr "cao:"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Classic Filters"
+msgstr "Cổ điển"
+
+#. i18n-hint: "infinite impulse response"
+#: src/effects/ScienFilter.cpp
+msgid "Performs IIR filtering that emulates analog filters"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "To apply a filter, all selected tracks must have the same sample rate."
+msgstr "Để vẽ phổ, tất cả các đoạn âm được chọn phải có cùng tốc độ lấy mẫu"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Filter Type:"
+msgstr "Loại Bộ đo"
+
+#. i18n-hint: 'Order' means the complexity of the filter, and is a number between 1 and 10.
+#: src/effects/ScienFilter.cpp
+msgid "O&rder:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "&Passband Ripple:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Passband Ripple (dB)"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "&Subtype:"
+msgstr "Dựng kiểu:"
+
+#: src/effects/ScienFilter.cpp
+#, fuzzy
+msgid "Cutoff (Hz)"
+msgstr "Đến (Hz) "
+
+#: src/effects/ScienFilter.cpp
+msgid "C&utoff:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation:"
+msgstr ""
+
+#: src/effects/ScienFilter.cpp
+msgid "Minimum S&topband Attenuation (dB)"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Align MIDI to Audio"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Frame Period:"
+msgstr "Khung hình:"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Frame Period"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size:"
+msgstr "&Kích thước cửa sổ:"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Window Size"
+msgstr "&Kích thước cửa sổ:"
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Force Final Alignment"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+msgid "Ignore Silence at Beginnings and Endings"
+msgstr ""
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Silence Threshold:"
+msgstr "Ngưỡng:"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Silence Threshold"
+msgstr "Ngưỡng:"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time:"
+msgstr "Tên thiết lập sẵn:"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Presmooth Time"
+msgstr "Tên thiết lập sẵn:"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time:"
+msgstr "Thời gian kết thúc:"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Line Time"
+msgstr "Thời gian kết thúc"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time:"
+msgstr "Thời gian bắt đầu:"
+
+#. i18n-hint: The English would be clearer if it had 'Duration' rather than 'Time'
+#. This is a NEW experimental effect, and until we have it documented in the user
+#. manual we don't have a clear description of what this parameter does.
+#. It is OK to leave it in English.
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Smooth Time"
+msgstr "Làm mượt mẫu"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Use Defaults"
+msgstr "Mặc định"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, fuzzy
+msgid "Restore Defaults"
+msgstr "Thiết lập sẵn mặc định"
+
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
+#. i18n-hint: noun
+#: src/effects/Silence.cpp
+#, fuzzy
+msgctxt "generator"
+msgid "Silence"
+msgstr "Phát hiện khoảng im lặng"
+
+#: src/effects/Silence.cpp
+msgid "Creates audio of zero amplitude"
+msgstr ""
+
+#: src/effects/StereoToMono.cpp
+#, fuzzy
+msgid "Stereo To Mono"
+msgstr "Chia 1 dải âm Stereo thành 2 dải âm MO&NO "
+
+#: src/effects/StereoToMono.cpp
+msgid "Converts stereo tracks to mono"
+msgstr ""
+
+#: src/effects/StereoToMono.cpp
+#, fuzzy
+msgid "Resampling left channel"
+msgstr "lấy mẫu thất bại."
+
+#: src/effects/StereoToMono.cpp
+#, fuzzy
+msgid "Resampling right channel"
+msgstr "Kênh phải"
+
+#: src/effects/StereoToMono.cpp
+msgid "Mixing down to mono"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Sliding Stretch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+msgid "Allows continuous changes to the tempo and/or pitch"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Tempo Change (%)"
+msgstr "Thay đổi nhịp điệu  HQ Chất Lượng Cao"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Tempo Change (%)"
+msgstr "Thay đổi nhịp điệu  HQ Chất Lượng Cao"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Initial Pitch Shift"
+msgstr "Thay đổi độ cao của âm LQ Chất Lượng Thấp"
+
+#: src/effects/TimeScale.cpp
+msgid "(&semitones) [-12 to 12]:"
+msgstr ""
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "(%) [-50 to 100]:"
+msgstr "(0 đến 100):"
+
+#: src/effects/TimeScale.cpp
+#, fuzzy
+msgid "Final Pitch Shift"
+msgstr "Thay đổi độ cao của âm LQ Chất Lượng Thấp"
+
+#: src/effects/TimeScale.cpp
+msgid "(s&emitones) [-12 to 12]:"
+msgstr ""
 
 #: src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp
 msgid "Logarithmic"
@@ -6901,44 +9406,189 @@ msgid "Square, no alias"
 msgstr "Vuông, không có biệt danh"
 
 #: src/effects/ToneGen.cpp
+msgid "Chirp"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Tone"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates an ascending or descending tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+msgid "Generates a constant frequency tone of one of four types"
+msgstr ""
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "&Waveform:"
+msgstr "Dạng sóng"
+
+#: src/effects/ToneGen.cpp
 msgid "&Frequency (Hz):"
 msgstr "&Tần số (Hz):"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Frequency Hertz Start"
+msgstr "Kết Thúc Tần Số (Hz)"
 
 #: src/effects/ToneGen.cpp
 msgid "Frequency Hertz End"
 msgstr "Kết Thúc Tần Số (Hz)"
 
 #: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "Amplitude Start"
+msgstr "Kết Thúc Biên Độ"
+
+#: src/effects/ToneGen.cpp
 msgid "Amplitude End"
 msgstr "Kết Thúc Biên Độ"
+
+#: src/effects/ToneGen.cpp
+#, fuzzy
+msgid "I&nterpolation:"
+msgstr "&Vị trí"
 
 #: src/effects/TruncSilence.cpp
 msgid "Truncate Detected Silence"
 msgstr "Cắt rút bỏ khoảng lặng đã phát hiện"
 
 #: src/effects/TruncSilence.cpp
+msgid "Compress Excess Silence"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
 msgid "Truncate Silence"
 msgstr "Cắt bỏ khoảng lặng"
+
+#: src/effects/TruncSilence.cpp
+msgid "Automatically reduces the length of passages where the volume is below a specified level"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "When truncating independently, there may only be one selected audio track in each Sync-Locked Track Group."
+msgstr ""
 
 #: src/effects/TruncSilence.cpp
 msgid "Detect Silence"
 msgstr "Phát hiện khoảng im lặng"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Tr&uncate to:"
+msgstr "Cắt bỏ khoảng lặng"
+
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+msgid "C&ompress to:"
+msgstr ""
+
+#: src/effects/TruncSilence.cpp
+#, fuzzy
+msgid "Trunc&ate tracks independently"
+msgstr "Chuẩn hoá kênh &stereo riêng biệt"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effects"
+msgstr "Hiệu ứng LV2 Effects"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Adds the ability to use VST effects in Tenacity."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Scanning Shell VST"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Registering %d of %d: %-64.64s"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "Không thể tải thư viện"
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "VST Effect Options"
+msgstr "Thiết lập hiệu ứng"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "Buffer Size"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "&Buffer Size (8 to 1048576 samples):"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Latency Compensation"
+msgstr "Tùy biến DarkAudacity"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Enable &compensation"
+msgstr "Bật Lưu Tự động?"
+
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "Graphical Mode"
+msgstr "EQ đồ hoạ"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Most VST effects have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &graphical interface"
 msgstr "Bật &giao diện đồ họa"
 
 #: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "Audio In: %d, Audio Out: %d"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Save VST Preset As:"
 msgstr "Lưu thiết lập sẵn VST tên:"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+msgid "Standard VST bank file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Standard VST program file"
+msgstr ""
+
+#: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Tập tin thiết lập sẵn Audacity VST"
+
+#: src/effects/VST/VSTEffect.cpp
+msgid "Unrecognized file extension."
+msgstr ""
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "Error Saving VST Presets"
@@ -6960,13 +9610,52 @@ msgstr "Lỗi khi tải thiết lập sẵn VST"
 msgid "Unable to load presets file."
 msgstr "Không thể tải tập tin thiết lập sẵn."
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "Thiết lập hiệu ứng"
 
 #: src/effects/VST/VSTEffect.cpp
+#, fuzzy
+msgid "Unable to allocate memory when loading presets file."
+msgstr "Không thể tải tập tin thiết lập sẵn."
+
+#: src/effects/VST/VSTEffect.cpp
 msgid "Unable to read presets file."
 msgstr "Không thể đọc tập tin thiết lập sẵn"
+
+#: src/effects/VST/VSTEffect.cpp
+#, c-format
+msgid "This parameter file was saved from %s. Continue?"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Wahwah"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Rapid tone quality variations, like that guitar sound so popular in the 1970's"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+msgid "Dept&h (%):"
+msgstr ""
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Reso&nance:"
+msgstr "Resonant Noise -Nhiễu Cộng hưởng"
+
+#: src/effects/Wahwah.cpp
+#, fuzzy
+msgid "Resonance"
+msgstr "Resonant Noise -Nhiễu Cộng hưởng"
 
 #: src/effects/Wahwah.cpp
 msgid "Wah Frequency Offse&t (%):"
@@ -6975,6 +9664,59 @@ msgstr "Độ di &tần của Wah (%):"
 #: src/effects/Wahwah.cpp
 msgid "Wah frequency offset in percent"
 msgstr "Độ di tần của Wah (%):"
+
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Audio Unit Effects"
+msgstr "Nhập thiết lập sẵn Audio"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Provides Audio Unit Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Could not find component"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Could not initialize component"
+msgstr "Không thể khởi tạo thư viện mã hóa MP3!"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Audio Unit Effect Options"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "User Interface"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Select &interface"
+msgstr "Chọn dải âm"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp src/prefs/KeyConfigPrefs.cpp
+msgid "Full"
+msgstr ""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Generic"
+msgstr "Máy Tạo"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+msgid "Basic"
+msgstr ""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Import Audio Unit Presets"
@@ -6987,6 +9729,16 @@ msgstr "Thiết lập sẵn (có thể chọn nhiều)"
 #: src/effects/audiounits/AudioUnitEffect.cpp src/export/ExportMP3.cpp
 msgid "Preset"
 msgstr "Preset - Thiết lập sẵn"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Location"
+msgstr "&Vị trí"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy, c-format
+msgid "Couldn't open \"%s\""
+msgstr "Không thể mở tập tin: \"%s\""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
@@ -7019,6 +9771,11 @@ msgid "Export Audio Unit Preset As %s:"
 msgstr "Xuất thiết lập sẵn audio vời tên %s:"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Standard Audio Unit preset file"
+msgstr "Nhập thiết lập sẵn Audio"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid ""
 "Could not export \"%s\" preset\n"
@@ -7043,30 +9800,188 @@ msgid "Failed to set preset name"
 msgstr "Lỗi khi đặt tên thiết lập sẫn"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to retrieve preset content"
+msgstr "Lỗi khi đặt tên thiết lập sẫn"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert property list to XML data"
+msgstr "Lỗi khi mở cơ sở dữ liệu của dự án"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "XML data is empty after conversion"
+msgstr "Chuyển đổi tốc độ lấy mẫu"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to write XML preset to \"%s\""
 msgstr "Không thể lưu thiết lập sẵn XML vào \"%s\""
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to convert preset to internal format"
+msgstr "Lỗi khi đặt tên thiết lập sẫn"
+
+#: src/effects/audiounits/AudioUnitEffect.cpp
+#, fuzzy
+msgid "Failed to create property list for preset"
+msgstr "Không thể đặt thông tin class  cho thiết lập sẵn \"%s\""
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 #, c-format
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "Không thể đặt thông tin class  cho thiết lập sẵn \"%s\""
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Audio Unit"
+msgstr "Tập tin Audio"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "LADSPA Effects"
+msgstr "Tất cả hiệu ứng"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Provides LADSPA Effects"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "Tenacity no longer uses vst-bridge"
+msgstr ""
+
+#: src/effects/ladspa/LadspaEffect.cpp
+#, fuzzy
+msgid "LADSPA Effect Options"
+msgstr "Thiết lập hiệu ứng"
+
+#: src/effects/ladspa/LadspaEffect.cpp
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr ""
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy, c-format
+msgid "%s:"
+msgstr "%s :"
+
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "Đầu ra hiệu ứng"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, fuzzy
+msgid "LV2 Effect Settings"
+msgstr "Thiết lập hiệu ứng"
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "&Buffer Size (8 to %d) samples:"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+msgid "Couldn't instantiate effect"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported feature %s\n"
+msgstr ""
+
+#: src/effects/lv2/LV2Effect.cpp
+#, c-format
+msgid "%s requires unsupported option %s\n"
+msgstr ""
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "Generator"
 msgstr "Máy Tạo"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "Hiệu ứng LV2 Effects"
 
+#: src/effects/lv2/LoadLV2.cpp
+msgid "Provides LV2 Effects support to Tenacity"
+msgstr ""
+
+#: src/effects/nyquist/LoadNyquist.cpp
+#, fuzzy
+msgid "Nyquist Effects"
+msgstr "Các Tập lệnh Nyquist"
+
+#: src/effects/nyquist/LoadNyquist.cpp
+msgid "Provides Nyquist Effects support to Tenacity"
+msgstr ""
+
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Applying Nyquist Effect..."
 msgstr "Đang áp dụng hiệu ứng Nyquist..."
+
+#. i18n-hint: It is acceptable to translate this the same as for "Nyquist Prompt"
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist Worker"
+msgstr "&Nyquist Workbench (bàn làm việc)"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Ill-formed Nyquist plug-in header"
+msgstr "%s, Plug-ins - Điện toán Nyquist"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Enable track spectrogram view before\n"
+"applying 'Spectral' effects."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"To use 'Spectral effects', enable 'Spectral Selection'\n"
+"in the track Spectrogram settings and select the\n"
+"frequency range for the effect to act on."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid "error: File \"%s\" specified in header but not found in plug-in path.\n"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Audio selection required."
+msgstr "Chưa chọn Audio"
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist Error"
@@ -7077,8 +9992,31 @@ msgid "Sorry, cannot apply effect on stereo tracks where the tracks don't match.
 msgstr "Không thể áp dụng hiệu ứng lên dải âm stereo có các kênh khác nhau."
 
 #: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Selection too long for Nyquist code.\n"
+"Maximum allowed selection is %ld samples\n"
+"(about %.1f hours at 44100 Hz sample rate)."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Debug Output: "
 msgstr "Sửa lỗi đầu ra:"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Processing complete."
+msgstr " Đang &Xử lý:"
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return audio from Nyquist.\n"
+msgstr ""
+
+#. i18n-hint: Don't translate ';type tool'.
+#: src/effects/nyquist/Nyquist.cpp
+msgid "';type tool' effects cannot return labels from Nyquist.\n"
+msgstr ""
 
 #. i18n-hint: "%s" is replaced by name of plug-in.
 #: src/effects/nyquist/Nyquist.cpp
@@ -7091,8 +10029,42 @@ msgid "plug-in"
 msgstr "Plug-in \"điện toán\""
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned a list."
+msgstr "Nyquist trả về quá nhiều kênh âm thanh.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "Nyquist returned the value: %f"
+msgstr "Nyquist trả về quá nhiều kênh âm thanh.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "Nyquist returned the value: %d"
+msgstr "Nyquist trả về quá nhiều kênh âm thanh.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Nyquist returned too many audio channels.\n"
 msgstr "Nyquist trả về quá nhiều kênh âm thanh.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned one audio channel as an array.\n"
+msgstr "Nyquist trả về quá nhiều kênh âm thanh.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned an empty array.\n"
+msgstr "Nyquist trả về quá nhiều kênh âm thanh.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Nyquist returned nil audio.\n"
+msgstr "Nyquist trả về quá nhiều kênh âm thanh.\n"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "[Warning: Nyquist returned invalid UTF-8 string, converted here as Latin-1]"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 #, c-format
@@ -7100,12 +10072,50 @@ msgid "This version of Audacity does not support Nyquist plug-in version %ld"
 msgstr "Phiên bản Audacity này không hỗ trợ phiên bản plug-in Nyquist %ld"
 
 #: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Could not open file"
+msgstr "Không mở được tập tin: %s"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Your code looks like SAL syntax, but there is no 'return' statement.\n"
+"For SAL, use a return statement such as:\n"
+"\treturn *track* * 0.1\n"
+"or for LISP, begin with an open parenthesis such as:\n"
+"\t(mult *track* 0.1)\n"
+" ."
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
 msgid "Error in Nyquist code"
 msgstr "Lỗi trong mã Nyquist"
+
+#. i18n-hint: refers to programming "languages"
+#: src/effects/nyquist/Nyquist.cpp
+msgid "Could not determine language"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid "\"%s\" is not a valid file path."
+msgstr "%s: không phải là một tập tin thiết lập sẵn hợp lệ.\n"
+
+#. i18n-hint: Warning that there is one quotation mark rather than a pair.
+#: src/effects/nyquist/Nyquist.cpp
+#, c-format
+msgid ""
+"Mismatched quotes in\n"
+"%s"
+msgstr ""
 
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Enter Nyquist Command: "
 msgstr "Nhập lệnh Nyquist:"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "&Load"
+msgstr "&Nạp..."
 
 #. i18n-hint: Nyquist is the name of a programming language
 #: src/effects/nyquist/Nyquist.cpp
@@ -7116,6 +10126,57 @@ msgstr "Các Tập lệnh Nyquist"
 #: src/effects/nyquist/Nyquist.cpp
 msgid "Lisp scripts"
 msgstr "Tập lệnh Lisp"
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid ""
+"Current program has been modified.\n"
+"Discard changes?"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be loaded"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+msgid "File could not be saved"
+msgstr ""
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy, c-format
+msgid ""
+"Value range:\n"
+"%s to %s"
+msgstr "%s Lưu các thay đổi %s không?"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Value Error"
+msgstr "Lỗi tập tin"
+
+#: src/effects/nyquist/Nyquist.cpp plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Select a file"
+msgstr "Chọn tập tin"
+
+#: src/effects/nyquist/Nyquist.cpp
+#, fuzzy
+msgid "Save file as"
+msgstr "Lưu tập tin"
+
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "untitled"
+msgstr "Chưa có tên"
+
+#: src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "Vamp Effects"
+msgstr "Hiệu ứng LV2 Effects"
+
+#: src/effects/vamp/LoadVamp.cpp
+msgid "Provides Vamp Effects support to Tenacity"
+msgstr ""
 
 #: src/effects/vamp/VampEffect.cpp
 msgid "Sorry, Vamp Plug-ins cannot be run on stereo tracks where the individual channels of the track do not match."
@@ -7137,6 +10198,21 @@ msgstr "Thiết lập phần bổ sung"
 msgid "Program"
 msgstr "Chương trình"
 
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "No format specific options"
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Export Audio"
+msgstr "Xuất dự án thành tập tin âm thanh"
+
 #: src/export/Export.cpp src/export/ExportMultiple.cpp src/menus/EditMenus.cpp
 msgid "Edit Metadata Tags"
 msgstr "sửa các thẻ meta"
@@ -7146,26 +10222,122 @@ msgid "Exported Tags"
 msgstr "Thẻ đã xuất"
 
 #: src/export/Export.cpp
+msgid "All selected audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp src/export/ExportMultiple.cpp
+msgid "All audio is muted."
+msgstr ""
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "Are you sure you want to export the file as \"%s\"?\n"
+msgstr "Bạn chắc mình muốn xoá \"%s\" chứ?"
+
+#: src/export/Export.cpp
+#, c-format
+msgid ""
+"You are about to export a %s file with the name \"%s\".\n"
+"\n"
+"Normally these files end in \".%s\", and some programs will not open files with nonstandard extensions.\n"
+"\n"
+"Are you sure you want to export the file under this name?"
+msgstr ""
+
+#: src/export/Export.cpp
 msgid "Sorry, pathnames longer than 256 characters not supported."
 msgstr "Không cấp nhận đường dẫn dài hơn 256 chữ."
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid "A file named \"%s\" already exists. Replace?"
+msgstr ""
+"Có Thiết lập sẵn rồi\n"
+"\n"
+"Bạn có muốn thay thế không? "
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one mono file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down and exported as one stereo file."
+msgstr ""
+
+#: src/export/Export.cpp
+msgid "Your tracks will be mixed down to one exported file according to the encoder settings."
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "Advanced Mixing Options"
 msgstr "Tuỳ chọn nâng cao cho bộ Trộn"
 
 #: src/export/Export.cpp
+#, fuzzy
+msgid "Format Options"
+msgstr "Tùy chọn"
+
+#: src/export/Export.cpp
 #, c-format
 msgid "Channel: %2d"
 msgstr "Kênh: %2d"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr ""
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr ""
 
 #: src/export/Export.cpp
 #, c-format
 msgid "Output Channels: %2d"
 msgstr "Kênh đầu ra: %2d"
 
+#: src/export/Export.cpp
+#, fuzzy
+msgid "Mixer Panel"
+msgstr "Bảng đoạn âm thanh"
+
+#: src/export/Export.cpp
+#, fuzzy, c-format
+msgid ""
+"Unable to export.\n"
+"Error %s"
+msgstr ""
+"Không thể tải  môđun \"%s\" .\n"
+"\n"
+"Lỗi: %s"
+
 #: src/export/ExportCL.cpp
 msgid "Show output"
 msgstr "Hiển thị đầu ra"
+
+#. i18n-hint: Some programmer-oriented terminology here:
+#. "Data" refers to the sound to be exported, "piped" means sent,
+#. and "standard in" means the default input stream that the external program,
+#. named by %f, will read.  And yes, it's %f, not %s -- this isn't actually used
+#. in the program as a format string.  Keep %f unchanged.
+#: src/export/ExportCL.cpp
+#, c-format
+msgid "Data will be piped to standard in. \"%f\" uses the file name in the export window."
+msgstr ""
+
+#. i18n-hint files that can be run as programs
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Executables"
+msgstr "Tập lệnh Scriptables"
+
+#: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Find path to command"
+msgstr "lệnh chuyển"
 
 #: src/export/ExportCL.cpp
 msgid "(external program)"
@@ -7185,8 +10357,44 @@ msgid "Exporting the selected audio using command-line encoder"
 msgstr "Xuất âm thanh đã chọn dùng bộ mã hoá bằng dòng lệnh"
 
 #: src/export/ExportCL.cpp
+#, fuzzy
+msgid "Exporting the audio using command-line encoder"
+msgstr "Xuất âm thanh đã chọn dùng bộ mã hoá bằng dòng lệnh"
+
+#: src/export/ExportCL.cpp
 msgid "Command Output"
 msgstr "Đầu ra của lệnh"
+
+#: src/export/ExportCL.cpp
+msgid "&OK"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "You've specified a file name without an extension. Are you sure?"
+msgstr ""
+
+#: src/export/ExportCL.cpp
+msgid "Program name appears to be missing."
+msgstr ""
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "\"%s\" couldn't be found."
+msgstr "Không thể  tim được tập tin \"%s\"."
+
+#: src/export/ExportCL.cpp
+#, fuzzy, c-format
+msgid "Unable to locate \"%s\" in your path."
+msgstr ""
+"Không thể tải  môđun \"%s\" .\n"
+"\n"
+"Lỗi: %s"
+
+#: src/export/ExportFFmpeg.cpp
+msgid ""
+"Properly configured FFmpeg is required to proceed.\n"
+"You can configure it at Preferences > Libraries."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 #, c-format
@@ -7216,24 +10424,96 @@ msgstr "Lỗi FFmpeg - Không thể mở tập tin đầu ra \"%s\"  Mã lỗi l
 msgid "FFmpeg : ERROR - Can't write headers to output file \"%s\". Error code is %d."
 msgstr "FFmpeg : LỖI - Không thể viết tiêu đề lên tệp đầu ra \"%s\". Lỗi code là %d."
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"FFmpeg cannot find audio codec 0x%x.\n"
+"Support for this codec is probably not compiled in."
+msgstr ""
+
 #: src/export/ExportFFmpeg.cpp
 msgid "The codec reported a generic error (EPERM)"
 msgstr "Codec  có lỗi  (EPERM)"
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "The codec reported an invalid parameter (EINVAL)"
+msgstr "Codec  có lỗi  (EPERM)"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpeg.cpp
+#, c-format
+msgid ""
+"Can't open audio codec \"%s\" (0x%x)\n"
+"\n"
+"%s"
+msgstr ""
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg : ERROR - Can't allocate buffer to read into from audio FIFO."
+msgstr "FFmpeg: LỖI - không thể xác định phạm vi định dạng đầu ra."
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg : ERROR - Could not get sample buffer size"
+msgstr "FFmpeg : LỖI - Không thể ghi đoạn âm cuối cùng vào tệp đầu ra."
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg : ERROR - Could not allocate bytes for samples buffer"
+msgstr "FFmpeg: LỖI - không thể xác định phạm vi định dạng đầu ra."
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg : ERROR - Could not setup audio frame"
+msgstr "FFmpeg : LỖI - Không thể ghi đoạn âm cuối cùng vào tệp đầu ra."
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg : ERROR - encoding frame failed"
+msgstr "FFmpeg : LỖI - Không thể ghi đoạn âm cuối cùng vào tệp đầu ra."
+
+#: src/export/ExportFFmpeg.cpp
+msgid "FFmpeg : ERROR - Too much remaining data."
+msgstr ""
 
 #: src/export/ExportFFmpeg.cpp
 msgid "FFmpeg : ERROR - Couldn't write last audio frame to output file."
 msgstr "FFmpeg : LỖI - Không thể ghi đoạn âm cuối cùng vào tệp đầu ra."
 
 #: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg : ERROR - nAudioFrameSizeOut too large."
+msgstr "FFmpeg : LỖI  - Không thể thêm chuỗi âm thanh vào tệp tin đầu ra\"%s\"."
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy
+msgid "FFmpeg : ERROR - Can't encode audio frame."
+msgstr "FFmpeg : LỖI  - Không thể thêm chuỗi âm thanh vào tệp tin đầu ra\"%s\"."
+
+#: src/export/ExportFFmpeg.cpp
 #, c-format
 msgid "Attempted to export %d channels, but maximum number of channels for selected output format is %d"
 msgstr "Đã thử xuất %dkênh, nhưng số lượng kênh lớn nhất để chọn định dạng đầu ra chỉ là %d"
+
+#: src/export/ExportFFmpeg.cpp
+#, fuzzy, c-format
+msgid "Exporting selected audio as %s"
+msgstr "Đang xuất âm thanh đã chọn ra %s"
+
+#: src/export/ExportFFmpeg.cpp src/export/ExportPCM.cpp
+#, fuzzy, c-format
+msgid "Exporting the audio as %s"
+msgstr "Đang xuất âm thanh với tốc độ %d Kbps"
 
 #: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
 msgid "Invalid sample rate"
 msgstr "Tốc độ lấy mẫu không hợp lệ"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "Đổi tốc độ lấy mẫu"
 
@@ -7263,6 +10543,14 @@ msgstr "Bạn có thể đổi tốc độ lấy mẫu sang các giá trị dư�
 msgid "Sample Rates"
 msgstr "Tốc độ lấy mẫu"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "Tốc độ bit:"
@@ -7271,9 +10559,256 @@ msgstr "Tốc độ bit:"
 msgid "Quality (kbps):"
 msgstr "Chất lượng (kbps):"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f secs - giây"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "On"
+msgstr "&Mở"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Constrained"
+msgstr "Không đổi"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Audio"
+msgstr "Âm t&hanh..."
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Low Delay"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Narrowband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mediumband"
+msgstr "Trung bình"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Super Wideband"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Fullband"
+msgstr "Toàn bộ cửa sổ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression"
+msgstr "So sánh Audio"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Frame Duration:"
+msgstr "Độ dài:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Vbr Mode:"
+msgstr "Chế độ"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Application:"
+msgstr "Áp dụng quy trình"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Cutoff:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Open custom FFmpeg format options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Current Format:"
+msgstr "Dự án hiện hành"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Current Codec:"
+msgstr "Dự án hiện hành"
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Error Saving FFmpeg Presets"
 msgstr "Lỗi khi lưu thiết lập sẵn FFmpeg"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Overwrite preset '%s'?"
+msgstr "Bạn có muốn xóa thiết lập sẵn '%s' không?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Confirm Overwrite"
+msgstr "Xác nhận việc tất"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select format before saving a profile"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Please select codec before saving a profile"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Preset '%s' does not exist."
+msgstr "Chưa có thư mục %s. Có tạo nó không?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "Replace preset '%s'?"
+msgstr "Bạn có muốn xóa thiết lập sẵn '%s' không?"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Main"
+msgstr "Bộ trộn chính"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LTP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "M4A (AAC) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AC3 Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "AMR (narrow band) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Opus (OggOpus) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "WMA (version 2) Files (FFmpeg)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Custom FFmpeg Export"
+msgstr "Nhập/ Xuất FFmpeg"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Estimate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "2-level"
+msgstr "Mức"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "4-level"
+msgstr "Mức"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8-level"
+msgstr "Mức"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Full search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Log search"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Configure custom FFmpeg options"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Preset:"
@@ -7291,6 +10826,15 @@ msgstr "Nhập Thiết lập sẵn"
 msgid "Export Presets"
 msgstr "Xuất thiết lập sẵn"
 
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Codec:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Not all formats and codecs are compatible. Nor are all option combinations compatible with all codecs."
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Show All Formats"
 msgstr "Hiển thị tất cả định dạng"
@@ -7300,16 +10844,94 @@ msgid "Show All Codecs"
 msgstr "Hiển thị tất cả Codecs"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "General Options"
+msgstr "Lựa chọn Thời gian biểu"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"ISO 639 3-letter language code\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Language:"
 msgstr "Ngôn ngữ:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Bit Reservoir"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Codec tag (FOURCC)\n"
+"Optional\n"
+"empty - automatic"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Tag:"
 msgstr "Tag-Thẻ:"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Bit Rate (bits/second) - influences the resulting file size and quality\n"
+"Some codecs may only accept specific values (128k, 192k, 256k etc)\n"
+"0 - automatic\n"
+"Recommended - 192000"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Overall quality, used differently by different codecs\n"
+"Required for vorbis\n"
+"0 - automatic\n"
+"-1 - off (use bitrate instead)"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportOGG.cpp
 msgid "Quality:"
 msgstr "Chất lượng:"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Sample rate (Hz)\n"
+"0 - don't change sample rate"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Sample Rate:"
+msgstr "Tốc độ lấy mẫu"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Audio cutoff bandwidth (Hz)\n"
+"Optional\n"
+"0 - automatic"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"AAC Profile\n"
+"Low Complexity - default\n"
+"Most players won't play anything other than LC"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Profile:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "FLAC options"
+msgstr "Tập tìn FLAC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -7324,6 +10946,11 @@ msgstr ""
 "-1 - tự động\n"
 "Thấp nhất - 0 (mã hoá nhanh, tệp đầu ra lớn)\n"
 "Cao nhất - 10 (mã hoá chậm, tệp đầu ra nhỏ)"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Compression:"
+msgstr "So sánh Audio"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -7358,16 +10985,81 @@ msgstr ""
 "tối đa - 15"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "LPC"
+msgstr "Dụng LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Prediction Order Method\n"
+"Estimate - fastest, lower compression\n"
+"Log search - slowest, best compression\n"
+"Full search - default"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "PdO Method:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Minimal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Min. PdO"
 msgstr "Tối thiểu PdO"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximal prediction order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 32 (with LPC) or 4 (without LPC)"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Max. PdO"
 msgstr "Tối đa PdO"
 
 #: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid ""
+"Minimal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+"độ chính xác LPC \n"
+"Không bắt buộc\n"
+"0 - mặc định\n"
+"tối thiểu- 1\n"
+"tối đa - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Min. PtO"
 msgstr "Tối thiểu PtO"
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid ""
+"Maximal partition order\n"
+"Optional\n"
+"-1 - default\n"
+"min - 0\n"
+"max - 8"
+msgstr ""
+"Kích thước khung\n"
+"không bắt buộc\n"
+"0 - mặc định\n"
+"tối thiểu - 16\n"
+"tối đa - 65535"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Max. PtO"
@@ -7378,6 +11070,51 @@ msgstr "Tối đa PtO"
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Use LPC"
 msgstr "Dụng LPC"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "MPEG container options"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid ""
+"Maximum bit rate of the multiplexed stream\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+
+#. i18n-hint: 'mux' is short for multiplexor, a device that selects between several inputs
+#. 'Mux Rate' is a parameter that has some bearing on compression ratio for MPEG
+#. it has a hard to predict effect on the degree of compression
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Mux Rate:"
+msgstr "Tốc độ:"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid ""
+"Packet size\n"
+"Optional\n"
+"0 - default"
+msgstr ""
+"Kích thước khung\n"
+"không bắt buộc\n"
+"0 - mặc định\n"
+"tối thiểu - 16\n"
+"tối đa - 65535"
+
+#. i18n-hint: 'Packet Size' is a parameter that has some bearing on compression ratio for MPEG
+#. compression.  It measures how big a chunk of audio is compressed in one piece.
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Packet Size:"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "You can't delete a preset without name"
+msgstr "Bạn không thể lưu một thiết lập sẵn mà không có tên"
 
 #: src/export/ExportFFmpegDialogs.cpp
 #, c-format
@@ -7402,8 +11139,32 @@ msgstr "Xuất thiết lập sẵn vào tập tin XML nào? "
 
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "Format %s is not compatible with codec %s."
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "Incompatible format and codec"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "Failed to guess format"
+msgstr "Lỗi phục hồi kết nối"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Failed to find the codec"
 msgstr "Không tìm thấy codec"
+
+#: src/export/ExportFLAC.cpp
+msgid "16 bit"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
+msgid "24 bit"
+msgstr ""
 
 #: src/export/ExportFLAC.cpp
 msgid "0 (fastest)"
@@ -7431,7 +11192,19 @@ msgid "FLAC export couldn't open %s"
 msgstr "Xuất FLAC không thể mở %s"
 
 #: src/export/ExportFLAC.cpp
+#, c-format
+msgid ""
+"FLAC encoder failed to initialize\n"
+"Status: %d"
+msgstr ""
+
+#: src/export/ExportFLAC.cpp
 msgid "Exporting the selected audio as FLAC"
+msgstr "Xuất âm thanh đã chọn thành FLAC"
+
+#: src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "Exporting the audio as FLAC"
 msgstr "Xuất âm thanh đã chọn thành FLAC"
 
 #: src/export/ExportMP2.cpp
@@ -7459,6 +11232,42 @@ msgstr "Đang xuất âm thanh với tốc độ %ld Kbps"
 #: src/export/ExportMP3.cpp
 msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (Chất Lượng Cao Nhất)"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "Hết sức, 220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "Mặc định, 170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "Trung bình, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "Trung bình, 145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
@@ -7490,7 +11299,8 @@ msgstr "Trên cả tuyệt"
 msgid "Extreme"
 msgstr "Cực kỳ"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "Chuẩn"
 
@@ -7515,6 +11325,11 @@ msgid "Joint Stereo"
 msgstr "Stereo chung"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Stereo"
+msgstr "Chuyển thành Stereo"
+
+#: src/export/ExportMP3.cpp
 msgid "Bit Rate Mode:"
 msgstr "Chế độ bit:"
 
@@ -7528,8 +11343,17 @@ msgid "Channel Mode:"
 msgstr "Chế độ kênh:"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+msgid "Force export to mono"
+msgstr ""
+
+#. i18n-hint: LAME is the name of an MP3 converter and should not be translated
+#: src/export/ExportMP3.cpp
+msgid "Locate LAME"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Audacity yêu cầu tập tin %s để tạo MP3."
 
 #: src/export/ExportMP3.cpp
@@ -7543,6 +11367,12 @@ msgstr "Vị trí của %s:"
 msgid "To find %s, click here -->"
 msgstr "Để tìm %s, nhấn vào đây -->"
 
+#. i18n-hint: There is a  button to the right of the arrow.
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "To get a free copy of LAME, click here -->"
+msgstr "Để nhận một bản sao chép FFmpeg miễn phí, hãy nhấp chuột vào ->>"
+
 #. i18n-hint: It's asking for the location of a file, for
 #. * example, "Where is lame_enc.dll?" - you could translate
 #. * "Where would I find the file %s" instead if you want.
@@ -7550,6 +11380,13 @@ msgstr "Để tìm %s, nhấn vào đây -->"
 #, c-format
 msgid "Where is %s?"
 msgstr "%s ở đâu thế?"
+
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid ""
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
+msgstr ""
 
 #: src/export/ExportMP3.cpp
 msgid "Only lame_enc.dll"
@@ -7566,6 +11403,11 @@ msgstr "Chỉ  libmp3lame.dylib"
 #: src/export/ExportMP3.cpp
 msgid "Only libmp3lame.so.0"
 msgstr "Chỉ libmp3lame.so.0"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "Primary shared object files"
+msgstr "Tập tin dự án AUP3"
 
 #: src/export/ExportMP3.cpp
 msgid "Extended libraries"
@@ -7648,9 +11490,29 @@ msgstr ""
 msgid "MP3 export library not found"
 msgstr "Không thể tìm thấy thư viện xuất MP3"
 
+#: src/export/ExportMP3.cpp
+msgid "(Built-in)"
+msgstr ""
+
 #: src/export/ExportMultiple.cpp
 msgid "Export Multiple"
 msgstr "Xuất ra nhiều tập tin"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Cannot Export Multiple"
+msgstr "Xuất ra nhiều tập tin"
+
+#: src/export/ExportMultiple.cpp
+msgid ""
+"You have no unmuted Audio Tracks and no applicable \n"
+"labels, so you cannot export to separate audio files."
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Export files to:"
+msgstr "Xuất nhãn thành:"
 
 #: src/export/ExportMultiple.cpp
 msgid "Folder:"
@@ -7659,6 +11521,11 @@ msgstr "Thủ mục:"
 #: src/export/ExportMultiple.cpp
 msgid "Create"
 msgstr "Tạo"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Options:"
+msgstr "Tùy chọn"
 
 #: src/export/ExportMultiple.cpp
 msgid "Split files based on:"
@@ -7685,7 +11552,22 @@ msgid "Using Label/Track Name"
 msgstr "Dùng Nhãn/Tên dải âm"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering before Label/Track Name"
+msgstr "Dùng Nhãn/Tên dải âm"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "Numbering after File name prefix"
+msgstr "Tiền tố của tên tập tin:"
+
+#: src/export/ExportMultiple.cpp
 msgid "File name prefix:"
+msgstr "Tiền tố của tên tập tin:"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy
+msgid "File name prefix"
 msgstr "Tiền tố của tên tập tin:"
 
 #: src/export/ExportMultiple.cpp
@@ -7702,8 +11584,28 @@ msgid "Choose a location to save the exported files"
 msgstr "Chọn một nơi để lưu các tập tin xuất đã xuất"
 
 #: src/export/ExportMultiple.cpp
+#, fuzzy, c-format
+msgid "Successfully exported the following %lld file(s)."
+msgstr "Không  thể xuất (các) tập tin:  %lld"
+
+#: src/export/ExportMultiple.cpp
 #, c-format
 msgid "Something went wrong after exporting the following %lld file(s)."
+msgstr "Không  thể xuất (các) tập tin:  %lld"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy, c-format
+msgid "Export canceled after exporting the following %lld file(s)."
+msgstr "Không  thể xuất (các) tập tin:  %lld"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy, c-format
+msgid "Export stopped after exporting the following %lld file(s)."
+msgstr "Không  thể xuất (các) tập tin:  %lld"
+
+#: src/export/ExportMultiple.cpp
+#, fuzzy, c-format
+msgid "Something went really wrong after exporting the following %lld file(s)."
 msgstr "Không  thể xuất (các) tập tin:  %lld"
 
 #: src/export/ExportMultiple.cpp
@@ -7718,6 +11620,31 @@ msgstr ""
 "Bạn có muốn tạo nó không?"
 
 #: src/export/ExportMultiple.cpp
+msgid "Continue to export remaining files?"
+msgstr ""
+
+#. i18n-hint: The second %s gives some letters that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name.\n"
+"You cannot use any of these characters:\n"
+"\n"
+"%s\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#. i18n-hint: The second %s gives a letter that can't be used.
+#: src/export/ExportMultiple.cpp
+#, c-format
+msgid ""
+"Label or track \"%s\" is not a legal file name. You cannot use \"%s\".\n"
+"\n"
+"Suggested replacement:"
+msgstr ""
+
+#: src/export/ExportMultiple.cpp
 msgid "Save As..."
 msgstr "Lưu mới..."
 
@@ -7730,8 +11657,46 @@ msgid "Unable to export - rate or quality problem"
 msgstr "Không thể xuất  vì vấn đề tốc độ hoặc chất lượng "
 
 #: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with metadata"
+msgstr "Không thể xuất  vì vấn đề tốc độ hoặc chất lượng "
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem initialising"
+msgstr "Không thể xuất  vì vấn đề tốc độ hoặc chất lượng "
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem creating stream"
+msgstr "Không thể xuất  vì vấn đề tốc độ hoặc chất lượng "
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with packets"
+msgstr "Không thể xuất  vì vấn đề tốc độ hoặc chất lượng "
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Unable to export - problem with file"
+msgstr "Không thể xuất  vì vấn đề tốc độ hoặc chất lượng "
+
+#: src/export/ExportOGG.cpp
 msgid "Exporting the selected audio as Ogg Vorbis"
 msgstr "Đang xuất âm thanh đã chọn ra tập tin dạng Ogg Vorbis"
+
+#: src/export/ExportOGG.cpp
+#, fuzzy
+msgid "Exporting the audio as Ogg Vorbis"
+msgstr "Đang xuất âm thanh đã chọn ra tập tin dạng Ogg Vorbis"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Header:"
@@ -7742,8 +11707,33 @@ msgid "Encoding:"
 msgstr "Mã hoá:"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
+msgid "Other uncompressed files"
+msgstr "WAV, AIFF, và các định dạng không nén khác"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
+"Tenacity cannot do this, the Export was abandoned."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
 msgid "Error Exporting"
 msgstr "Lỗi khi xuất"
+
+#: src/export/ExportPCM.cpp
+msgid ""
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
+"files bigger than 4GB."
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "GSM 6.10 requires mono"
+msgstr ""
+
+#: src/export/ExportPCM.cpp
+msgid "WAVEX and GSM 6.10 formats are not compatible"
+msgstr ""
 
 #: src/export/ExportPCM.cpp
 msgid "Cannot export audio in this format."
@@ -7767,12 +11757,29 @@ msgstr ""
 "Libsndfile nói \"%s\""
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy
+msgid "All supported files"
+msgstr "Loại tập tin không được hỗ trợ"
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
+msgstr ""
+"\"%s\"\n"
+"đây là một tập tin MIDI, không phải tập tin âm thanh.\n"
+"Audacity không thể chạy định dạng tập tin này, nhưng bạn vẫn có thể chạy nó. \n"
+"chỉnh sửa tệp này bằng cách click vào Tệp>Nhập>MIDI."
+
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" \n"
+"is a not an audio file. \n"
+"Tenacity cannot open this type of file."
 msgstr ""
 "\"%s\"\n"
 "đây là một tập tin MIDI, không phải tập tin âm thanh.\n"
@@ -7784,18 +11791,18 @@ msgid "Select stream(s) to import"
 msgstr "chọn (các) luồng để nhập vào."
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "Phiên bản Audacity này không hỗ trợ %s khi biên dịch."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\" là một bài hát trong CD âm thanh.\n"
 "Audacity không thể trực tiếp mở nó.\n"
@@ -7804,10 +11811,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\" là một danh sách bài hát.\n"
@@ -7816,10 +11823,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" là một tập tin Windows Media Audio.\n"
@@ -7828,10 +11835,36 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is an Advanced Audio Coding file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
+"Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" là một tập tin Wavpack.\n"
+"Audacity không thể mở loại tập tin này.\n"
+"Bạn phải tự mình chuyển nó về 1 định dạng Audacity hỗ trợ, như WAV hay AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is an encrypted audio file. \n"
+"These typically are from an online music store. \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
+"extract the CD track to a supported audio format such as WAV or AIFF."
+msgstr ""
+"\"%s\" là một tập tin Windows Media Audio.\n"
+"Audacity không thể mở định dạng này vì lỗi vi phạm bản quyền.\n"
+"Bạn phải tự mình chuyển nó về 1 định dạng Audacity hỗ trợ, như WAV hay AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" là một tập tin RealPlayer.\n"
@@ -7840,12 +11873,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\" là một tập tin giữ liệu gốc, không phải tập tin âm thanh.\n"
 "Audacity không thể mở loại tập tin này.\n"
@@ -7854,10 +11887,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -7870,10 +11903,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" là một tập tin Wavpack.\n"
@@ -7882,10 +11915,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" là một tập tin Dolby Digital.\n"
@@ -7894,11 +11927,23 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
+msgstr ""
+"\"%s\" là một tập tin Ogg Speex.\n"
+"Audacity không thể mở loại tập tin này.\n"
+"Bạn phải tự mình chuyển nó về 1 định dạng Audacity hỗ trợ, như WAV hay AIFF."
+
+#. i18n-hint: %s will be the filename
+#: src/import/Import.cpp
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is a video file. \n"
+"Tenacity cannot currently open this type of file. \n"
+"You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" là một tập tin Ogg Speex.\n"
 "Audacity không thể mở loại tập tin này.\n"
@@ -7911,9 +11956,9 @@ msgstr "Không thể  tim được tập tin \"%s\"."
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -7921,11 +11966,22 @@ msgstr ""
 "\n"
 "%s để tìm các tập tin chưa nén, hãy thử chọn Tệp>Nhập>dữ liệu thô."
 
+#: src/import/Import.cpp
+msgid ""
+"Try installing FFmpeg.\n"
+"\n"
+msgstr ""
+
+#: src/import/Import.cpp src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s, %s"
+msgstr "%s, kiểm tra thử phần mềm"
+
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -7953,6 +12009,19 @@ msgstr ""
 #: src/import/ImportAUP.cpp
 msgid "Import Project"
 msgstr "Nhập Dự Án"
+
+#: src/import/ImportAUP.cpp
+msgid ""
+"This project was saved by Audacity version 1.0 or earlier. The format has\n"
+"changed and this version of Audacity is unable to import the project.\n"
+"\n"
+"Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
+"you may import it with this version of Tenacity."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Internal error in importer...tag not recognized"
+msgstr ""
 
 #: src/import/ImportAUP.cpp
 #, c-format
@@ -7993,7 +12062,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "Không tìm thấy thư mục dữ liệu của dự án: \"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "Đã tìm thấy đoạn âm MIDI trong các tệp dự án này, tuy nhiên phiên bản Audacity này không hỗ trợ MIDI."
 
 #: src/import/ImportAUP.cpp
@@ -8004,26 +12074,93 @@ msgstr "Nhập dự án"
 msgid "The active project already has a time track and one was encountered in the project being imported, bypassing imported time track."
 msgstr "Dự án đang hoạt động hiện có một chuỗi âm và một trong số chúng đã gây ra sung đột với dự án đang được chèn vào, bỏ qua chuỗi âm thanh được chèn."
 
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'maxsamples' attribute."
+msgstr "Thuộc tính 'vpos' của dự án không hợp lệ."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "Thuộc tính 'selLow' của dự án không hợp lệ."
+
+#: src/import/ImportAUP.cpp
+#, fuzzy
+msgid "Invalid sequence 'numsamples' attribute."
+msgstr "Thuộc tính 'vpos' của dự án không hợp lệ."
+
+#: src/import/ImportAUP.cpp
+msgid "Unable to parse the waveblock 'start' attribute"
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing project file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid simpleblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid silentblockfile 'len' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Missing alias file %s\n"
+"\n"
+"Inserting silence instead."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliasstart' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+msgid "Missing or invalid pcmaliasblockfile 'aliaslen' attribute."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, c-format
+msgid ""
+"Error while processing %s\n"
+"\n"
+"Inserting silence."
+msgstr ""
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Failed to open %s"
+msgstr "Không gỡ bỏ được %s"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Failed to seek to position %lld in %s"
+msgstr "Lỗi khi đặt tên thiết lập sẫn"
+
+#: src/import/ImportAUP.cpp
+#, fuzzy, c-format
+msgid "Unable to read %lld samples from %s"
+msgstr "Không thể đọc thiết lập sẵn từ \"%s\""
+
+#: src/import/ImportFFmpeg.cpp
+msgid "FFmpeg-compatible files"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportFFmpeg.cpp
+#, c-format
+msgid "Index[%02x] Codec[%s], Language[%s], Bitrate[%s], Channels[%d], Duration[%d]"
+msgstr ""
+
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "Tập tin FLAC"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "Trình nhập GStreamer"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "Không thể dừng 'stream state'."
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "Không thể chèn tệp, lỗi thay đổi trạng thái."
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "Lỗi GStreamer: %s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -8062,13 +12199,41 @@ msgstr "Đã nhập MIDI từ '%s'"
 msgid "Import MIDI"
 msgstr "Nhập MIDI"
 
+#: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s: Filename too short."
+msgstr "Không mở được tập tin: %s"
+
+#: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s: Incorrect filetype."
+msgstr "Không mở được tập tin: %s"
+
+#: src/import/ImportMIDI.cpp
+#, fuzzy, c-format
+msgid "Could not open file %s."
+msgstr "Không mở được tập tin: %s"
+
 #: src/import/ImportMP3.cpp
 msgid "MP3 files"
 msgstr "Tập tin MP3"
 
+#: src/import/ImportMP3.cpp
+msgid ""
+"Import failed\n"
+"\n"
+"This is likely caused by a malformed MP3.\n"
+"\n"
+msgstr ""
+
 #: src/import/ImportOGG.cpp
 msgid "Ogg Vorbis files"
 msgstr "Tập tin Ogg Vorbis"
+
+#: src/import/ImportOGG.cpp
+#, c-format
+msgid "Index[%02x] Version[%d], Channels[%d], Rate[%ld]"
+msgstr ""
 
 #: src/import/ImportOGG.cpp
 msgid "Media read error"
@@ -8094,6 +12259,183 @@ msgstr "Lỗi Logic bên trong"
 msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV, AIFF, và các định dạng không nén khác"
 
+#: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr ""
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "OGG (OGG Container format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 16 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 24 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Signed 32 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Unsigned 8 bit PCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "64 bit float"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "12 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
+
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
 msgid "Importing %s"
@@ -8102,6 +12444,11 @@ msgstr "Đang nhập %s"
 #: src/import/ImportQT.cpp
 msgid "QuickTime files"
 msgstr "Tập tin QuickTime"
+
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to start QuickTime extraction"
+msgstr "Không thể thiết lập chất lượng kết xuất cho QuickTime "
 
 #: src/import/ImportQT.cpp
 msgid "Unable to set QuickTime render quality"
@@ -8119,6 +12466,11 @@ msgstr "Không thể đọc thuộc tính  kích cỡ mẫu cho QuickTime"
 msgid "Unable to retrieve stream description"
 msgstr "Không nhận được miêu tả của kênh truyền (stream)"
 
+#: src/import/ImportQT.cpp
+#, fuzzy
+msgid "Unable to get fill buffer"
+msgstr "Không thể lưu tập tin thể loại."
+
 #. i18n-hint: 'Raw' means 'unprocessed' here and should usually be translated.
 #: src/import/ImportRaw.cpp
 msgid "Import Raw"
@@ -8133,6 +12485,18 @@ msgstr "Nhập dữ liệu thô"
 #: src/import/ImportRaw.cpp
 msgid "No endianness"
 msgstr "Không có endianness"
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Little-endian"
+msgstr ""
+
+#. i18n-hint: Refers to byte-order.  Don't translate this if you don't
+#. know the correct technical word.
+#: src/import/ImportRaw.cpp
+msgid "Big-endian"
+msgstr ""
 
 #. i18n-hint: Refers to byte-order.  Don't translate "endianness" if you don't
 #. know the correct technical word.
@@ -8153,10 +12517,25 @@ msgstr "Lập thể (Stereo)"
 msgid "%d Channels"
 msgstr "%d kênh"
 
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Byte order:"
+msgstr "Trật tự nhập."
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "Channels:"
+msgstr "Kênh"
+
 #. i18n-hint: (noun)
 #: src/import/ImportRaw.cpp
 msgid "Start offset:"
 msgstr "Offset bắt đầu:"
+
+#: src/import/ImportRaw.cpp
+#, fuzzy
+msgid "bytes"
+msgstr "%sbytes"
 
 #: src/import/ImportRaw.cpp
 msgid "Amount to import:"
@@ -8171,17 +12550,150 @@ msgstr "Tốc độ lấy mẫu:"
 msgid "&Import"
 msgstr "&Nhập"
 
+#: src/import/RawAudioGuess.cpp
+msgid "Bad data size. Could not import audio"
+msgstr ""
+
+#. i18n-hint: given the name of a track, specify its left channel
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s left"
+msgstr ""
+
+#. i18n-hint: given the name of a track, specify its right channel
+#: src/menus/ClipMenus.cpp
+#, fuzzy, c-format
+msgid "%s right"
+msgstr "Nhẹ"
+
+#. i18n-hint:
+#. First %s is replaced with the noun "start" or "end"
+#. identifying one end of a clip,
+#. first number gives the position of that clip in a sequence
+#. of clips,
+#. last number counts all clips,
+#. and the last string is the name of the track containing the
+#. clips.
+#.
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s %d of %d clip %s"
+msgid_plural "%s %d of %d clips %s"
+msgstr[0] ""
+
 #: src/menus/ClipMenus.cpp
 msgid "start"
 msgstr "bắt đầu"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "end"
+msgstr "Kết thúc"
+
+#. i18n-hint:
+#. First two %s are each replaced with the noun "start"
+#. or with "end", identifying and end of a clip,
+#. first and second numbers give the position of those clips in
+#. a sequence of clips,
+#. last number counts all clips,
+#. and the last string is the name of the track containing the
+#. clips.
+#.
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s %d and %s %d of %d clip %s"
+msgid_plural "%s %d and %s %d of %d clips %s"
+msgstr[0] ""
+
+#. i18n-hint:
+#. first number identifies one of a sequence of clips,
+#. last number counts the clips,
+#. string names a track
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%d of %d clip %s"
+msgid_plural "%d of %d clips %s"
+msgstr[0] ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the right"
+msgstr "Đã dịch dải/đoạn sang qua bên phải %.02f giây"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time shifted clips to the left"
+msgstr "Đã dịch dải/đoạn sang qua bên trái %.02f giây"
+
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "Di chuyển mốc thời gian"
 
 #: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "clip not moved"
+msgstr "Tập lệnh chưa lưu."
+
+#: src/menus/ClipMenus.cpp src/menus/EditMenus.cpp
+msgid "Clip B&oundaries"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary to Cursor"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Ne&xt Clip Boundary"
+msgstr "Di chuyên con trò đến bắt đầu vùng chọn:"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Previo&us Clip"
+msgstr "Kế trước"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Select Previous Clip"
+msgstr "Chọn clip tiếp theo"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "N&ext Clip"
+msgstr "Đặt clip"
+
+#: src/menus/ClipMenus.cpp
 msgid "Select Next Clip"
 msgstr "Chọn clip tiếp theo"
+
+#: src/menus/ClipMenus.cpp
+msgid "Pre&vious Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Prev Clip Boundary"
+msgstr "Di chuyên con trò đến kết thúc dự án"
+
+#: src/menus/ClipMenus.cpp
+msgid "Ne&xt Clip Boundary"
+msgstr ""
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Cursor to Next Clip Boundary"
+msgstr "Di chuyên con trò đến bắt đầu vùng chọn:"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time Shift &Left"
+msgstr "Công cụ di chuyển"
+
+#: src/menus/ClipMenus.cpp
+#, fuzzy
+msgid "Time Shift &Right"
+msgstr "Công cụ di chuyển"
 
 #: src/menus/EditMenus.cpp
 msgid "Pasted text from the clipboard"
@@ -8246,7 +12758,25 @@ msgstr "Chia và xoá"
 msgid "Silenced selected tracks for %.2f seconds at %.2f"
 msgstr "Đã tạo khoảng lặng đoạn %.2f giây tại %.2f vào đoạn hiện hành"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#. i18n-hint: verb
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgctxt "command"
+msgid "Silence"
+msgstr "Phát hiện khoảng im lặng"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Trim selected audio tracks from %.2f seconds to %.2f seconds"
+msgstr "Đã tạo khoảng lặng đoạn %.2f giây tại %.2f vào đoạn hiện hành"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Trim Audio"
+msgstr "Đang ghi âm"
+
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "Chia"
 
@@ -8266,6 +12796,15 @@ msgstr "Đã ghép nối %.2f giây tại t=%.2f"
 #: src/menus/EditMenus.cpp
 msgid "Join"
 msgstr "Ghép nối"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy, c-format
+msgid "Detached %.2f seconds at t=%.2f"
+msgstr "Đã xoá %.2f giây tại t=%.2f"
+
+#: src/menus/EditMenus.cpp
+msgid "Detach"
+msgstr ""
 
 #: src/menus/EditMenus.cpp
 msgid "Metadata Tags"
@@ -8299,6 +12838,10 @@ msgstr "&Dán"
 msgid "Duplic&ate"
 msgstr "N&hân đôi"
 
+#: src/menus/EditMenus.cpp
+msgid "R&emove Special"
+msgstr ""
+
 #. i18n-hint: (verb) Do a special kind of cut
 #: src/menus/EditMenus.cpp
 msgid "Spl&it Cut"
@@ -8308,6 +12851,18 @@ msgstr "Ch&ia và Cắt"
 #: src/menus/EditMenus.cpp
 msgid "Split D&elete"
 msgstr "Chia &và Xoá"
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Silence Audi&o"
+msgstr "chọn Audio."
+
+#. i18n-hint: (verb)
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Tri&m Audio"
+msgstr "Đang ghi âm"
 
 #. i18n-hint: (verb) It's an item on a menu.
 #: src/menus/EditMenus.cpp
@@ -8328,8 +12883,32 @@ msgid "Detac&h at Silences"
 msgstr "Tách ra k&hi Im lặng"
 
 #: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "&Metadata..."
+msgstr "&Dữ liệu thô..."
+
+#: src/menus/EditMenus.cpp
 msgid "Pre&ferences..."
 msgstr " &Tuỳ thích..."
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "&Delete Key"
+msgstr "&Xoá"
+
+#: src/menus/EditMenus.cpp
+#, fuzzy
+msgid "Delete Key&2"
+msgstr "Xoá"
+
+#: src/menus/ExtraMenus.cpp
+msgid "Ext&ra"
+msgstr ""
+
+#: src/menus/ExtraMenus.cpp
+#, fuzzy
+msgid "De&vice"
+msgstr "&Thiết bị:"
 
 #: src/menus/ExtraMenus.cpp
 msgid "Change &Recording Device..."
@@ -8338,6 +12917,20 @@ msgstr "Thay đổi thiết bị &Ghi âm..."
 #: src/menus/ExtraMenus.cpp
 msgid "Change &Playback Device..."
 msgstr "Thay đổi thiết bị &Phát âm thanh..."
+
+#: src/menus/ExtraMenus.cpp
+#, fuzzy
+msgid "Change Audio &Host..."
+msgstr "So sánh Audio..."
+
+#: src/menus/ExtraMenus.cpp
+#, fuzzy
+msgid "Change Recording Cha&nnels..."
+msgstr "Các kênh ghi âm"
+
+#: src/menus/ExtraMenus.cpp
+msgid "&Full Screen (on/off)"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 #, c-format
@@ -8349,8 +12942,24 @@ msgstr ""
 "Tập tin đã tồn tại. Hãy chọn một tên khác"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export Selected Audio"
+msgstr "Đang xuất âm thanh đã chọn ra %s"
+
+#. i18n-hint: filename containing exported text from label tracks
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "labels.txt"
+msgstr "Dòng chữ trong nhãn"
+
+#: src/menus/FileMenus.cpp
 msgid "There are no label tracks to export."
 msgstr "Không có nhãn đoạn âm nào để xuất"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Please select only one Note Track at a time."
+msgstr "Hãy chọn một đoạn âm ghi chú - Note Track"
 
 #: src/menus/FileMenus.cpp
 msgid "Please select a Note Track."
@@ -8359,6 +12968,22 @@ msgstr "Hãy chọn một đoạn âm ghi chú - Note Track"
 #: src/menus/FileMenus.cpp
 msgid "Export MIDI As:"
 msgstr "Xuất  MIDI  tên tập tin: "
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI file"
+msgstr "Tập tin XML"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Allegro file"
+msgstr "Tất cả tập tin"
+
+#: src/menus/FileMenus.cpp
+msgid ""
+"You have selected a filename with an unrecognized file extension.\n"
+"Do you want to continue?"
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "Export MIDI"
@@ -8374,13 +12999,39 @@ msgid "Import Labels"
 msgstr "Nhập nhãn"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Select a MIDI file"
+msgstr "Chọn tập tin"
+
+#: src/menus/FileMenus.cpp
 msgid "MIDI and Allegro files"
 msgstr "Tập tin MIDI  và Allegro"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "MIDI files"
+msgstr "Tập tin XML"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Allegro files"
+msgstr "Tất cả tập tin"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Dangerous Reset..."
+msgstr "Lưu thiết lập sẵn..."
 
 #. i18n-hint: This is the name of the menu item on Mac OS X only
 #: src/menus/FileMenus.cpp
 msgid "Open Recent"
 msgstr "Mở gần đây"
+
+#. i18n-hint: This is the name of the menu item on Windows and Linux
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Recent &Files"
+msgstr "Lưu tập tin"
 
 #: src/menus/FileMenus.cpp
 msgid "&Save Project"
@@ -8391,6 +13042,41 @@ msgid "Save Project &As..."
 msgstr "Lưu &như dự án mới..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Backup Project..."
+msgstr "Mở Dụ Ấn..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Export"
+msgstr "Xuất"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export as MP&3"
+msgstr "Xuất tập tin định dạng FLAC"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export as &WAV"
+msgstr "Xuất tập tin định dạng FLAC"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export as &OGG"
+msgstr "Xuất tập tin định dạng FLAC"
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&Export Audio..."
+msgstr "&Xuất tập tin..."
+
+#: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Expo&rt Selected Audio..."
+msgstr "chọn Audio."
+
+#: src/menus/FileMenus.cpp
 msgid "Export &Labels..."
 msgstr "Xuất &nhãn..."
 
@@ -8399,12 +13085,21 @@ msgid "Export &Multiple..."
 msgstr "Xuất ra &nhiều tập tin"
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "Export MI&DI..."
+msgstr "Xuất  MIDI"
+
+#: src/menus/FileMenus.cpp
 msgid "&Audio..."
 msgstr "Âm t&hanh..."
 
 #: src/menus/FileMenus.cpp
 msgid "&Labels..."
 msgstr "&Nhãn..."
+
+#: src/menus/FileMenus.cpp
+msgid "&MIDI..."
+msgstr ""
 
 #: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
@@ -8425,12 +13120,64 @@ msgid "E&xit"
 msgstr "Th&oát"
 
 #: src/menus/FileMenus.cpp
+msgid "Hidden File Menu"
+msgstr ""
+
+#: src/menus/FileMenus.cpp
 msgid "Export as FLAC"
 msgstr "Xuất tập tin định dạng FLAC"
 
 #: src/menus/HelpMenus.cpp
+#, fuzzy, c-format
+msgid "Save %s"
+msgstr "Đã lưu %s"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy, c-format
+msgid "Unable to save %s"
+msgstr "Không thể lưu tập tin thể loại."
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Do you have these problems?"
+msgstr "Bạn có muốn lưu các thay đổi không?"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Fix"
+msgstr "Trộn"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Quick Fixes"
+msgstr "Tập tin QuickTime"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Nothing to do"
+msgstr "Không thể huỷ bước"
+
+#: src/menus/HelpMenus.cpp
+msgid "No quick, easily fixed problems were found"
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Clocks on the Tracks"
+msgstr "Chọn đoạn âm"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "Can't select precisely"
+msgstr "Không mở được tập tin dự án"
+
+#: src/menus/HelpMenus.cpp
 msgid "Recording stops and starts"
 msgstr "Bắt đầu và dừng ghi âm:"
+
+#: src/menus/HelpMenus.cpp
+msgid "Fixed"
+msgstr ""
 
 #: src/menus/HelpMenus.cpp
 msgid "Audio Device Info"
@@ -8441,8 +13188,30 @@ msgid "MIDI Device Info"
 msgstr "Thông tin thiết bị MIDI"
 
 #: src/menus/HelpMenus.cpp
+msgid "&Quick Fix..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
 msgid "&Getting Started"
 msgstr "&Bắt Đầu"
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Manual"
+msgstr "&Quản lý"
+
+#: src/menus/HelpMenus.cpp
+msgid "&Quick Help..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+msgid "&Manual..."
+msgstr ""
+
+#: src/menus/HelpMenus.cpp
+#, fuzzy
+msgid "&Diagnostics"
+msgstr "chạy tác vụ tự chẩn đoán"
 
 #: src/menus/HelpMenus.cpp
 msgid "Au&dio Device Info..."
@@ -8456,11 +13225,8 @@ msgstr "Thông tin thiết bị &MIDI"
 msgid "Show &Log..."
 msgstr "Hiển thị &Nhật ký máy "
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "&Thông tin về Audacity..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "Đã thêm nhãn"
 
@@ -8512,9 +13278,27 @@ msgstr "Chia vùng audio được dán nhãn đã bị xoá "
 msgid "Split Delete Labeled Audio"
 msgstr "Chia và xóa audio được dán nhãn "
 
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silenced labeled audio regions"
+msgstr "Vùng Audio được dán nhãn đã bị xoá "
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence Labeled Audio"
+msgstr "Xoá audio được dán nhãn"
+
 #: src/menus/LabelMenus.cpp
 msgid "Copied labeled audio regions to clipboard"
 msgstr "Đã sao chép Audio có nhãn vào bộ nhớ sao chép Clipboard"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Copy Labeled Audio"
+msgstr "Cắt audio được dán nhãn "
 
 #. i18n-hint: (verb) past tense.  Audacity has just split the labeled
 #. audio (a point or a region)
@@ -8527,6 +13311,33 @@ msgstr "Chia audio được dán nhãn (điểm hoặc khu vực)"
 msgid "Split Labeled Audio"
 msgstr "Chia audio được dán nhãn"
 
+#. i18n-hint: (verb) Audacity has just joined the labeled audio (points or
+#. regions)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Joined labeled audio (points or regions)"
+msgstr "Chia audio được dán nhãn (điểm hoặc khu vực)"
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Join Labeled Audio"
+msgstr "Chia audio được dán nhãn"
+
+#. i18n-hint: (verb) Audacity has just detached the labeled audio regions.
+#. This message appears in history and tells you about something
+#. Audacity has done.
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detached labeled audio regions"
+msgstr "Vùng Audio được dán nhãn đã bị xoá "
+
+#. i18n-hint: (verb)
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Detach Labeled Audio"
+msgstr "Xoá audio được dán nhãn"
+
 #: src/menus/LabelMenus.cpp
 msgid "&Labels"
 msgstr "Các &Nhãn"
@@ -8536,8 +13347,27 @@ msgid "&Edit Labels..."
 msgstr "&Chỉnh Sửa các Nhãn"
 
 #: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Add Label at &Selection"
+msgstr "Phát đến vùng chọn"
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Add Label at &Playback Position"
+msgstr "Bên &trái vị trí phát lại"
+
+#: src/menus/LabelMenus.cpp
 msgid "Paste Te&xt to New Label"
 msgstr "Dán &Văn bản vào nhãn mới"
+
+#: src/menus/LabelMenus.cpp
+msgid "&Type to Create a Label (on/off)"
+msgstr ""
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "La&beled Audio"
+msgstr "Cắt audio được dán nhãn "
 
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
@@ -8569,6 +13399,16 @@ msgstr "Chia &và Xoá"
 msgid "Label Split Delete"
 msgstr "Dán nhãn tại điểm Chia và Xoa"
 
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Silence &Audio"
+msgstr "chọn Audio."
+
+#: src/menus/LabelMenus.cpp
+#, fuzzy
+msgid "Label Silence"
+msgstr "Nhãn Xoa"
+
 #. i18n-hint: (verb)
 #: src/menus/LabelMenus.cpp
 msgid "Co&py"
@@ -8591,6 +13431,78 @@ msgstr "Dán  nhãn tại điếm Chia"
 msgid "Label Join"
 msgstr "Ghép nối nhãn"
 
+#: src/menus/NavigationMenus.cpp
+msgid "Move Backward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Forward Through Active Windows"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Foc&us"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move &Backward from Toolbars to Tracks"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move F&orward from Toolbars to Tracks"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to &Previous Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+#, fuzzy
+msgid "Move Focus to &Next Track"
+msgstr "Ghi Đoạn Âm &Mới"
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to &First Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to &Last Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to P&revious and Select"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Move Focus to N&ext and Select"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "&Toggle Focused Track"
+msgstr ""
+
+#: src/menus/NavigationMenus.cpp
+msgid "Toggle Focuse&d Track"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+msgid "Uncategorized"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "..."
+msgstr "Mới..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Unknown"
+msgstr "Lỗi chưa xác định"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy, c-format
+msgid "&Repeat %s"
+msgstr "Lặp lại %s"
+
 #: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Plug-in %d to %d"
@@ -8605,16 +13517,70 @@ msgid "Add / Remove Plug-ins..."
 msgstr "Thêm/Xoá Plug-ins (điện toán) "
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Generator"
+msgstr "Máy Tạo"
+
+#: src/menus/PluginMenus.cpp
 msgid "Effe&ct"
 msgstr "&Hiệu ứng"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Effect"
+msgstr "Chọn mục tiêu EQ Effect (Hiệu ứng)"
 
 #: src/menus/PluginMenus.cpp
 msgid "&Analyze"
 msgstr "&Phân tích"
 
 #: src/menus/PluginMenus.cpp
+msgid "Repeat Last Analyzer"
+msgstr ""
+
+#: src/menus/PluginMenus.cpp src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "T&ools"
+msgstr "Công cụ"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Repeat Last Tool"
+msgstr "Lặp lại %s"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Macros..."
+msgstr "Lệnh Macro"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Apply Macro"
+msgstr "Thực hiện lệnh tự động Macro"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Palette..."
+msgstr "&Xoá"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Reset &Configuration"
+msgstr "Lỗi cấu trúc Audacity"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "&Screenshot..."
+msgstr "Screenshot - Chụp ảnh màn hình..."
+
+#: src/menus/PluginMenus.cpp
 msgid "&Run Benchmark..."
 msgstr "&Đối chuẩn thử..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Simulate Recording Errors"
+msgstr "Lưu Bộ ghi Thời gian thành"
 
 #: src/menus/PluginMenus.cpp
 msgid "Detect Upstream Dropouts"
@@ -8624,6 +13590,16 @@ msgstr "Phát hiện các khoảng hụt tiếng ngược dòng 'upstream dropou
 #: src/menus/PluginMenus.cpp
 msgid "Script&ables I"
 msgstr "T&ập lệnh Scriptables I"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Select Time..."
+msgstr "Chọn thơi gian"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Select Frequencies..."
+msgstr "Chọn tần số"
 
 #: src/menus/PluginMenus.cpp
 msgid "Select Tracks..."
@@ -8638,8 +13614,38 @@ msgid "Set Track Audio..."
 msgstr "Đặt đoạn âm audio..."
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Track Visuals..."
+msgstr "đặt tầm nhìn đoạn âm "
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Get Preference..."
+msgstr "Đọc Tuỳ Chọn:"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Preference..."
+msgstr "đặt tùy chỉnh"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Clip..."
+msgstr "Đặt clip"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Envelope..."
+msgstr "đặt đường biên độ"
+
+#: src/menus/PluginMenus.cpp
 msgid "Set Label..."
 msgstr "Đặt nhãn..."
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Set Project..."
+msgstr "Lưu Dụ Ấn..."
 
 #. i18n-hint: Scriptables are commands normally used from Python, Perl etc.
 #: src/menus/PluginMenus.cpp
@@ -8655,6 +13661,16 @@ msgid "Get Info..."
 msgstr "Đọc Thông Tin..."
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Message..."
+msgstr "Tin nhắn"
+
+#: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Help..."
+msgstr "Trợ giúp"
+
+#: src/menus/PluginMenus.cpp
 msgid "Open Project..."
 msgstr "Mở Dụ Ấn..."
 
@@ -8663,8 +13679,33 @@ msgid "Save Project..."
 msgstr "Lưu Dụ Ấn..."
 
 #: src/menus/PluginMenus.cpp
+#, fuzzy
+msgid "Move Mouse..."
+msgstr "Chọn..."
+
+#: src/menus/PluginMenus.cpp
 msgid "Compare Audio..."
 msgstr "So sánh Audio..."
+
+#. i18n-hint: Screenshot in the help menu has a much bigger dialog.
+#: src/menus/PluginMenus.cpp
+msgid "Screenshot (short format)..."
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Left Selection Boundary"
+msgstr "Đặt điểm chọn"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Position"
+msgstr "Vị trí âm thanh"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Right Selection Boundary"
+msgstr "Đặt điểm chọn"
 
 #. i18n-hint: (verb) It's an item on a menu.
 #: src/menus/SelectMenus.cpp
@@ -8674,6 +13715,11 @@ msgstr "&Chọn"
 #: src/menus/SelectMenus.cpp
 msgid "&None"
 msgstr "&Không gì hết"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select None"
+msgstr "Vùng chọn"
 
 #: src/menus/SelectMenus.cpp src/menus/TrackMenus.cpp
 msgid "&Tracks"
@@ -8688,11 +13734,31 @@ msgid "In All &Sync-Locked Tracks"
 msgstr "Trong tất cả các &Đoạn âm Sync-Locked Tracks "
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Sync-Locked"
+msgstr "Sync đã bị khóa"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "R&egion"
+msgstr "Chơi phần"
+
+#: src/menus/SelectMenus.cpp
 msgid "&Left at Playback Position"
 msgstr "Bên &trái vị trí phát lại"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Selection Left at Play Position"
+msgstr "Bên &trái vị trí phát lại"
+
+#: src/menus/SelectMenus.cpp
 msgid "&Right at Playback Position"
+msgstr "Bên &phải vị trí phát lại"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Set Selection Right at Play Position"
 msgstr "Bên &phải vị trí phát lại"
 
 #: src/menus/SelectMenus.cpp
@@ -8720,6 +13786,36 @@ msgid "Select Track Start to End"
 msgstr "Chọn Từ Đầu Đoạn Ấm Đến Kết Thúc"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "S&tore Selection"
+msgstr "Lựa chọn quang phổ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Retrieve Selectio&n"
+msgstr "Lựa chọn quang phổ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "S&pectral"
+msgstr "Phổ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "To&ggle Spectral Selection"
+msgstr "Lựa chọn quang phổ"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Next &Higher Peak Frequency"
+msgstr "Tần số cao"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Next &Lower Peak Frequency"
+msgstr "Tần số thấp"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor to Stored &Cursor Position"
 msgstr "Di chuyển con trò đến vị trí đã lưu"
 
@@ -8732,8 +13828,41 @@ msgid "Store Cursor Pos&ition"
 msgstr "Lưu v&ị trí con trò"
 
 #: src/menus/SelectMenus.cpp
+msgid "At &Zero Crossings"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Select Zero Crossing"
+msgstr "Chọn clip tiếp theo"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "&Selection"
+msgstr "Vùng chọn"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Snap-To &Off"
+msgstr "Dính tới"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Snap-To &Nearest"
+msgstr "Gần nhất"
+
+#: src/menus/SelectMenus.cpp
+msgid "Snap-To &Prior"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
 msgid "Selection to &Start"
 msgstr "Chọn về &Đầu"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection to En&d"
+msgstr "Kết thúc vùng chọn"
 
 #: src/menus/SelectMenus.cpp
 msgid "Selection Extend &Left"
@@ -8752,12 +13881,32 @@ msgid "Set (or Extend) Rig&ht Selection"
 msgstr "Đặt (hoặc Nới) Vùng chọn sang &Phải"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Contract L&eft"
+msgstr "Vùng chọn nới sang &trái"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Contract R&ight"
+msgstr "Vùng chọn nới sang &phải"
+
+#: src/menus/SelectMenus.cpp
 msgid "&Cursor to"
 msgstr "Di chuyến &con trò đến"
 
 #: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Selection Star&t"
+msgstr "Bắt đầu vùng chọn"
+
+#: src/menus/SelectMenus.cpp
 msgid "Cursor to Selection Start"
 msgstr "Di chuyên con trò đến bắt đầu vùng chọn:"
+
+#: src/menus/SelectMenus.cpp src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Selection En&d"
+msgstr "Kết thúc vùng chọn"
 
 #: src/menus/SelectMenus.cpp
 msgid "Cursor to Selection End"
@@ -8799,16 +13948,64 @@ msgstr "Di chuyên con trò đến kết thúc dự án"
 msgid "&Cursor"
 msgstr "&Con trò"
 
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Left"
+msgstr "Di chuyến &con trò đến"
+
+#: src/menus/SelectMenus.cpp
+#, fuzzy
+msgid "Cursor &Right"
+msgstr "Di chuyến &con trò đến"
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Sh&ort Jump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Shor&t Jump Right"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long J&ump Left"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Cursor Long Ju&mp Right"
+msgstr ""
+
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "&Tìm thấy"
 
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Left During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Short Seek &Right During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Le&ft During Playback"
+msgstr ""
+
+#: src/menus/SelectMenus.cpp
+msgid "Long Seek Rig&ht During Playback"
+msgstr ""
+
 #: src/menus/ToolbarMenus.cpp
 msgid "&Toolbars"
 msgstr "&Thanh công cụ"
+
+#. i18n-hint: (verb)
+#: src/menus/ToolbarMenus.cpp
+msgid "Edit &Mode (on/off)"
+msgstr ""
 
 #: src/menus/ToolbarMenus.cpp
 msgid "Reset Toolb&ars"
@@ -8835,21 +14032,91 @@ msgstr "Đã trộn và kết xuất %d dải thành một dải stereo mới"
 msgid "Mixed and rendered %d tracks into one new mono track"
 msgstr "Đã trộn và kết xuất %d dải thành một dải mono mới"
 
+#. i18n-hint: One or more audio tracks have been panned
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Panned audio track(s)"
+msgstr "Đã thay đổi tốc độ lấy mẫu cho dải âm"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan Track"
+msgstr "Track - Đoạn âm"
+
 #: src/menus/TrackMenus.cpp
 msgid "Start to &Zero"
 msgstr "Từ Đầu đến &Điểm Không"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Start to &Cursor/Selection Start"
+msgstr "Di chuyên con trò đến bắt đầu vùng chọn:"
 
 #: src/menus/TrackMenus.cpp
 msgid "Start to Selection &End"
 msgstr "Từ Đầu đến Phần được chọn"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "End to Cu&rsor/Selection Start"
+msgstr "Di chuyên con trò đến bắt đầu vùng chọn:"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "End to Selection En&d"
+msgstr "Di chuyên đến kết thúc vùng chọn:"
+
+#. i18n-hint: In this and similar messages describing editing actions,
+#. the starting or ending points of tracks are re-"aligned" to other
+#. times, and the time selection may be "moved" too.  The first
+#. noun -- "start" in this example -- is the object of a verb (not of
+#. an implied preposition "from").
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to zero"
+msgstr "Xếp tại thời điểm không"
+
+#: src/menus/TrackMenus.cpp
 msgid "Aligned start to zero"
 msgstr "Xếp tại thời điểm không"
+
+#. i18n-hint: This and similar messages give shorter descriptions of
+#. the aligning and moving editing actions
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move Start"
+msgstr "Xếp Điểm Đầu"
 
 #: src/menus/TrackMenus.cpp
 msgid "Align Start"
 msgstr "Xếp Điểm Đầu"
+
+#: src/menus/TrackMenus.cpp
+msgid "Aligned/Moved start to cursor/selection start"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to cursor/selection start"
+msgstr "Xếp tại thời điểm không"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved start to selection end"
+msgstr "Xếp tại thời điểm không"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned start to selection end"
+msgstr "Xếp tại thời điểm không"
+
+#: src/menus/TrackMenus.cpp
+msgid "Aligned/Moved end to cursor/selection start"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Aligned end to cursor/selection start"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Align/Move End"
@@ -8858,6 +14125,63 @@ msgstr "Xếp / Di chuyển Kết thúc"
 #: src/menus/TrackMenus.cpp
 msgid "Align End"
 msgstr "Xếp kết thúc"
+
+#: src/menus/TrackMenus.cpp
+msgid "Aligned/Moved end to selection end"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to selection end"
+msgstr "Di chuyên đến kết thúc vùng chọn:"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved end to end"
+msgstr "Xếp / Di chuyển Kết thúc"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned end to end"
+msgstr "Xếp tại thời điểm không"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move End to End"
+msgstr "Xếp / Di chuyển Kết thúc"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align End to End"
+msgstr "Xếp kết thúc"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned/Moved together"
+msgstr "Xếp / Di chuyển Kết thúc"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Aligned together"
+msgstr "Xếp tại thời điểm không"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align/Move Together"
+msgstr "Xếp / Di chuyển Kết thúc"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align Together"
+msgstr "Xếp Điểm Đầu"
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronize MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Synchronizing MIDI and Audio Tracks"
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Adjusted gain"
@@ -8884,14 +14208,20 @@ msgid "Created new label track"
 msgstr "Tạo nhãn mới cho đoạn âm"
 
 #: src/menus/TrackMenus.cpp
+msgid "This version of Tenacity only allows one time track for each project window."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "Đã tạo đoạn thời gian mới"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "Tốc độ lấy mẫu mới (Hz):"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "Giá trị bạn nhập không hợp lệ"
 
@@ -8913,17 +14243,40 @@ msgid "Please select at least one audio track and one MIDI track."
 msgstr "Hãy  chọn  ít nhất một đoạn âm audio và một đoạn âm MIDI"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy, c-format
+msgid "Alignment completed: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
+msgstr "Lỗi hiệu chỉnh: đầu vào quá ngắn: MIDI từ %.2fđến %.2f giây, audio từ %.2f đến %.2f giây."
+
+#: src/menus/TrackMenus.cpp
+msgid "Sync MIDI with Audio"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 #, c-format
 msgid "Alignment error: input too short: MIDI from %.2f to %.2f secs, Audio from %.2f to %.2f secs."
 msgstr "Lỗi hiệu chỉnh: đầu vào quá ngắn: MIDI từ %.2fđến %.2f giây, audio từ %.2f đến %.2f giây."
+
+#: src/menus/TrackMenus.cpp
+msgid "Internal error reported by alignment process."
+msgstr ""
 
 #: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by time"
 msgstr "Sắp xếp dải âm theo thời gian"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Time"
+msgstr "Thời gian bắt đầu"
+
+#: src/menus/TrackMenus.cpp
 msgid "Tracks sorted by name"
 msgstr "Sắp xếp dải âm theo tên"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sort by Name"
+msgstr "Tên nghệ sĩ"
 
 #: src/menus/TrackMenus.cpp
 msgid "Can't delete track with active audio"
@@ -8954,6 +14307,11 @@ msgid "Mi&x"
 msgstr "&Trọn"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mix Stereo Down to &Mono"
+msgstr "Chia 1 dải âm Stereo thành 2 dải âm MO&NO "
+
+#: src/menus/TrackMenus.cpp
 msgid "Mi&x and Render"
 msgstr "Trộn và &Kết xuất"
 
@@ -8970,12 +14328,167 @@ msgid "Remo&ve Tracks"
 msgstr "&Xoá Dải âm"
 
 #: src/menus/TrackMenus.cpp
+msgid "M&ute/Unmute"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
 msgid "&Mute All Tracks"
 msgstr "&Tắt tiếng mọi dải âm"
 
 #: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Unmute All Tracks"
+msgstr "&Tắt tiếng mọi dải âm"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Mut&e Tracks"
+msgstr "&Tắt tiếng mọi dải âm"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "U&nmute Tracks"
+msgstr "&Tắt tiếng mọi dải âm"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Pan"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Left"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Pan Left"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Right"
+msgstr "Nhẹ"
+
+#: src/menus/TrackMenus.cpp
+msgid "Pan Right"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Center"
+msgstr "Giữa"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Pan Center"
+msgstr "Giữa"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align Tracks"
+msgstr "Tất cả đoạn âm"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Align End to End"
+msgstr "Xếp kết thúc"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Align &Together"
+msgstr "Xếp Điểm Đầu"
+
+#: src/menus/TrackMenus.cpp
+msgid "&Move Selection with Tracks (on/off)"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Move Sele&ction and Tracks"
+msgstr "Chọn đoạn âm"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "S&ort Tracks"
+msgstr "Đoạn âm thấp"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "By &Start Time"
+msgstr "Thời gian bắt đầu"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "By &Name"
+msgstr "&Tên"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Sync-&Lock Tracks (on/off)"
+msgstr "Trong tất cả các &Đoạn âm Sync-Locked Tracks "
+
+#: src/menus/TrackMenus.cpp
 msgid "&Track"
 msgstr "&Đoạn âm"
+
+#: src/menus/TrackMenus.cpp
+msgid "Change P&an on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Pan &Left on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Pan &Right on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Change Gai&n on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Increase Gain on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Decrease Gain on Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "Op&en Menu on Focused Track..."
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "M&ute/Unmute Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+msgid "&Solo/Unsolo Focused Track"
+msgstr ""
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "&Close Focused Track"
+msgstr "&Gộp các đoạn âm lại"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Move Focused Track U&p"
+msgstr "Chuyển đoạn âm lên"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Move Focused Track Do&wn"
+msgstr "Chuyển đoạn âm xuống"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Move Focused Track to T&op"
+msgstr "chuyển đoạn âm lên trên"
+
+#: src/menus/TrackMenus.cpp
+#, fuzzy
+msgid "Move Focused Track to &Bottom"
+msgstr "Chuyển đoạn âm xuống dưới"
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
@@ -8987,9 +14500,44 @@ msgstr "Đang phát"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "Đang ghi âm"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no label track"
+msgstr "Nhãn đoạn âm"
+
+#: src/menus/TransportMenus.cpp
+msgid "no label track at or below focused track"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, c-format
+msgid "%s %d of %d"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "no labels in label track"
+msgstr "Tạo nhãn mới cho đoạn âm"
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used with more than one open project.\n"
+"\n"
+"Please close any additional projects and try again."
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+msgid ""
+"Timer Recording cannot be used while you have unsaved changes.\n"
+"\n"
+"Please save or close this project and try again."
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a mono track."
@@ -8998,6 +14546,23 @@ msgstr "Hãy chọn trong một đoạn âm mono."
 #: src/menus/TransportMenus.cpp
 msgid "Please select in a stereo track or two mono tracks."
 msgstr "Hãy chọn trong một đoạn âm stereo hoặc hai đoạn âm mono. "
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy, c-format
+msgid "Please select at least %d channels."
+msgstr "Hãy  chọn  ít nhất một đoạn âm audio và một đoạn âm MIDI"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Please select a time within a clip."
+msgstr "Hãy chọn một đoạn âm ghi chú - Note Track"
+
+#. i18n-hint: 'Transport' is the name given to the set of controls that
+#. play, record, pause etc.
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Tra&nsport"
+msgstr "Chuyển đổi"
 
 #: src/menus/TransportMenus.cpp
 msgid "Pl&aying"
@@ -9009,8 +14574,22 @@ msgid "Pl&ay/Stop"
 msgstr "&Chơi /Dừng"
 
 #: src/menus/TransportMenus.cpp
+msgid "Play/Stop and &Set Cursor"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play"
+msgstr "Phát  lặp lại"
+
+#: src/menus/TransportMenus.cpp
 msgid "&Pause"
 msgstr "&Dừng"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Recording"
+msgstr "Đang ghi âm"
 
 #. i18n-hint: (verb)
 #: src/menus/TransportMenus.cpp
@@ -9018,8 +14597,22 @@ msgid "&Record"
 msgstr "&Ghi âm"
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Append Record"
+msgstr "&Ghi âm"
+
+#: src/menus/TransportMenus.cpp
 msgid "Record &New Track"
 msgstr "Ghi Đoạn Âm &Mới"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Timer Record..."
+msgstr "Bộ ghi Thời gian"
+
+#: src/menus/TransportMenus.cpp
+msgid "Punch and Rol&l Record"
+msgstr ""
 
 #: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
@@ -9036,6 +14629,40 @@ msgstr "&Mở khoá"
 #: src/menus/TransportMenus.cpp
 msgid "R&escan Audio Devices"
 msgstr "&Quét lại thiêt bị audio "
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Transport &Options"
+msgstr "Chuyển đổi"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Sound Activation Le&vel..."
+msgstr "Thu âm đã bật"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Sound A&ctivated Recording (on/off)"
+msgstr "Thu âm đã bật"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Pinned Play/Record &Head (on/off)"
+msgstr "Ghim đầu đánh dấu"
+
+#: src/menus/TransportMenus.cpp
+msgid "&Overdub (on/off)"
+msgstr ""
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "So&ftware Playthrough (on/off)"
+msgstr "&chương trình đang chạy thông qua đầu vào."
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "T&ransport"
+msgstr "Chuyển đổi"
 
 #. i18n-hint: (verb) Start playing audio
 #: src/menus/TransportMenus.cpp
@@ -9055,10 +14682,60 @@ msgstr "Phát đúng 1 giây"
 msgid "Play to &Selection"
 msgstr "Phát đến vùng chọn"
 
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play &Before Selection Start"
+msgstr "Bắt đầu vùng chọn"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play Af&ter Selection Start"
+msgstr "Bắt đầu vùng chọn"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play Be&fore Selection End"
+msgstr "Phát đến vùng chọn"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play Aft&er Selection End"
+msgstr "Phát đến vùng chọn"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play Before a&nd After Selection Start"
+msgstr "Di chuyên con trò đến bắt đầu vùng chọn:"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play Before an&d After Selection End"
+msgstr "Phát đến vùng chọn"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview"
+msgstr "Nghe thử cắt"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Play-at-Speed"
+msgstr "Tốc độ phát"
+
 #. i18n-hint: 'Normal Play-at-Speed' doesn't loop or cut preview.
 #: src/menus/TransportMenus.cpp
 msgid "Normal Pl&ay-at-Speed"
 msgstr "Tốc độ phát &Bình thường"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "&Loop Play-at-Speed"
+msgstr "Tốc độ phát"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Play C&ut Preview-at-Speed"
+msgstr "Tốc độ phát"
 
 #: src/menus/TransportMenus.cpp
 msgid "Ad&just Playback Speed..."
@@ -9072,9 +14749,26 @@ msgstr "&Tăng tốc độ phát lại"
 msgid "&Decrease Playback Speed"
 msgstr "&Giảm tốc độ phát lại"
 
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Move to Pre&vious Label"
+msgstr "Đi tới S-expr ở dưới"
+
+#: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Move to Ne&xt Label"
+msgstr "Rê chuột để Seek (tua rê)"
+
 #: src/menus/ViewMenus.cpp
 msgid "&View"
 msgstr "&Xem"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) full sized
+#: src/menus/ViewMenus.cpp src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Zoom"
+msgstr "Thu phóng"
 
 #: src/menus/ViewMenus.cpp
 msgid "Zoom &In"
@@ -9101,12 +14795,54 @@ msgid "Advanced &Vertical Zooming"
 msgstr "Zoom theo chiều dọc và nâng cao "
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "T&rack Size"
+msgstr "Tên bài hát"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "&Fit to Width"
+msgstr "Vừa dự án vào trong cửa sổ"
+
+#: src/menus/ViewMenus.cpp
+msgid "Fit to &Height"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
 msgid "&Collapse All Tracks"
 msgstr "&Gộp các đoạn âm lại"
 
 #: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "E&xpand Collapsed Tracks"
+msgstr "&Gộp các đoạn âm lại"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Sk&ip to"
+msgstr "Chuyển về cuối"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Selection Sta&rt"
+msgstr "Bắt đầu vùng chọn"
+
+#: src/menus/ViewMenus.cpp
+#, fuzzy
+msgid "Skip to Selection Start"
+msgstr "Di chuyên đến kết thúc vùng chọn:"
+
+#: src/menus/ViewMenus.cpp
 msgid "Skip to Selection End"
 msgstr "Di chuyên đến kết thúc vùng chọn:"
+
+#: src/menus/ViewMenus.cpp
+msgid "&Extra Menus (on/off)"
+msgstr ""
+
+#: src/menus/ViewMenus.cpp
+msgid "Track &Name (on/off)"
+msgstr ""
 
 #: src/menus/ViewMenus.cpp
 msgid "&Show Clipping (on/off)"
@@ -9116,9 +14852,42 @@ msgstr "Hiển thị Clipping (những âm thanh quá giới hạn) (bật/tắt
 msgid "Show Effects Rack"
 msgstr "Hiển thị Effects Rack (thanh công cụ hiệu ứng)"
 
+#: src/menus/WindowMenus.cpp
+#, fuzzy
+msgid "&Window"
+msgstr "Cửa sổ"
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make (the current
+#. * window) shrink to an icon on the dock
+#: src/menus/WindowMenus.cpp
+msgid "&Minimize"
+msgstr ""
+
+#. i18n-hint: Standard Macintosh Window menu item:  Make all project
+#. * windows un-hidden
+#: src/menus/WindowMenus.cpp
+msgid "&Bring All to Front"
+msgstr ""
+
+#. i18n-hint: Shrink all project windows to icons on the Macintosh
+#. tooldock
+#: src/menus/WindowMenus.cpp
+msgid "Minimize All Projects"
+msgstr ""
+
 #: src/ondemand/ODComputeSummaryTask.h
 msgid "Import complete. Calculating waveform"
 msgstr "nhập hoàn tất. Đang tính toán waveform."
+
+#: src/ondemand/ODDecodeTask.h
+#, fuzzy
+msgid "Decoding Waveform"
+msgstr "Bản ghi âm đã lưu:"
+
+#: src/ondemand/ODWaveTrackTaskQueue.cpp
+#, c-format
+msgid "%s %2.0f%% complete. Click to change task focal point."
+msgstr ""
 
 #: src/prefs/ApplicationPrefs.cpp
 msgid "Preferences for Application"
@@ -9126,12 +14895,21 @@ msgstr "Tuỳ chọn Chất Lượng"
 
 #: src/prefs/ApplicationPrefs.cpp
 #, fuzzy
-msgid "Update Audacity"
+msgid "Update Tenacity"
 msgstr "Thoát Audacity"
+
+#: src/prefs/ApplicationPrefs.cpp
+msgid "&Check for Updates"
+msgstr ""
 
 #: src/prefs/BatchPrefs.cpp src/prefs/BatchPrefs.h
 msgid "Batch"
 msgstr "Lệnh Gộp"
+
+#: src/prefs/BatchPrefs.cpp
+#, fuzzy
+msgid "Preferences for Batch"
+msgstr "Tuỳ chọn Chất Lượng"
 
 #: src/prefs/BatchPrefs.cpp src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Behaviors"
@@ -9149,11 +14927,23 @@ msgstr "Thiết bị"
 msgid "Preferences for Device"
 msgstr "Tuỳ chọn cho thiết bị"
 
+#. i18n-hint Software interface to audio devices
+#: src/prefs/DevicePrefs.cpp
+msgctxt "device"
+msgid "Interface"
+msgstr ""
+
+#. i18n-hint: (noun)
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+msgid "&Host:"
+msgstr ""
+
 #: src/prefs/DevicePrefs.cpp
 msgid "Using:"
 msgstr "Dùng:"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "Phát lại"
 
@@ -9166,21 +14956,111 @@ msgid "De&vice:"
 msgstr "&Thiết bị:"
 
 #: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "Cha&nnels:"
+msgstr "Kênh"
+
+#: src/prefs/DevicePrefs.cpp
 msgid "Latency"
 msgstr "Độ trễ"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "mili giây"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "&Buffer length:"
+msgstr "&trường độ mới"
+
+#: src/prefs/DevicePrefs.cpp
+msgid "&Latency compensation:"
+msgstr ""
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "No audio interfaces"
+msgstr "Đã xoá bỏ (các) đoạn âm audio"
 
 #: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
 msgid "No devices found"
 msgstr "Không tìm thấy thiết bị"
 
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "1 (Mono)"
+msgstr "Đơn thể (Mono)"
+
+#: src/prefs/DevicePrefs.cpp
+#, fuzzy
+msgid "2 (Stereo)"
+msgstr "Lập thể (Stereo)"
+
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "Thư mục"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Preferences for Directories"
+msgstr "Tuỳ chọn cho thiết bị"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Default directories"
+msgstr "Thư mục"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid ""
+"Leave a field empty to go to the last directory used for that operation.\n"
+"Fill in a field to always go to that directory for that operation."
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "O&pen:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Browse..."
+msgstr "Duyệt..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "S&ave:"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "B&rowse..."
+msgstr "Duyệt..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Import:"
+msgstr "&Nhập"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Br&owse..."
+msgstr "Duyệt..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Export:"
+msgstr "Xuất"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Bro&wse..."
+msgstr "Duyệt..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Macro output:"
+msgstr "Hiển thị đầu ra"
 
 #: src/prefs/DirectoriesPrefs.cpp
 msgid "Temporary files directory"
@@ -9191,8 +15071,32 @@ msgid "&Location:"
 msgstr "&Vị trí"
 
 #: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temporary files directory cannot be on a FAT drive."
+msgstr "Thư mục tạm thời"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Brow&se..."
+msgstr "Duyệt..."
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "&Free Space:"
+msgstr "Vũng đĩa đã dùng"
+
+#: src/prefs/DirectoriesPrefs.cpp
 msgid "Choose a location to place the temporary directory"
 msgstr "Chọn vị trí đặt thư mục tạm thời"
+
+#: src/prefs/DirectoriesPrefs.cpp
+msgid "unavailable - above location doesn't exist"
+msgstr ""
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Choose a location"
+msgstr "Chọn nơi để lưu lại các tập tin"
 
 #: src/prefs/DirectoriesPrefs.cpp
 #, c-format
@@ -9214,20 +15118,109 @@ msgid "Directory %s is not writable"
 msgstr "Không thể ghi vào thư mục %s"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "Việc chuyển đổi thư mục tạm thời sẽ có hiệu lực từ lần chạy sau của Audacity"
+
+#: src/prefs/DirectoriesPrefs.cpp
+#, fuzzy
+msgid "Temp Directory Update"
+msgstr "Thư mục tạm thời mới"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Preferences for Effects"
+msgstr "Tuỳ thích ảnh phổ"
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Sorted by Effect Name"
+msgstr "nhập thống số hiệu ứng"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Publisher and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Sorted by Type and Effect Name"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Publisher"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Grouped by Type"
+msgstr ""
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Lỗi Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "Bật các hiệu ứng"
 
 #: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Effect Options"
+msgstr "Thiết lập hiệu ứng"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "S&ort or Group:"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
 msgid "&Maximum effects per group (0 to disable):"
 msgstr "Các hiệu ứng tối đa trong mỗi nhóm (0 để tắt bỏ):"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Plugin Options"
+msgstr "Thiết lập phần bổ sung"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Check for updated plugins when Tenacity starts"
+msgstr ""
+
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "Quét lại các plugin \"điện toán\" vào lần tiếp theo Audacity được khởi động"
+
+#: src/prefs/EffectsPrefs.cpp
+msgid "Instruction Set"
+msgstr ""
 
 #: src/prefs/EffectsPrefs.cpp
 msgid "&Use SSE/SSE2/.../AVX"
@@ -9244,20 +15237,86 @@ msgid "Preferences for ExtImport"
 msgstr "Tùy chọn cho ExtImport."
 
 #: src/prefs/ExtImportPrefs.cpp
+msgid "A&ttempt to use filter in OpenFile dialog first"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
 msgid "Rules to choose import filters"
 msgstr "Hướng dẫn chèn bộ lọc."
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "File extensions"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "Mime-types"
+msgstr ""
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Importer order"
 msgstr "Trật tự nhập."
 
 #: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &up"
+msgstr "Chuyển lên &trên"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move rule &down"
+msgstr "Chuyển &xuống dưới"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move f&ilter up"
+msgstr "Chuyển lên &trên"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Move &filter down"
+msgstr "Chuyển &xuống dưới"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "&Add new rule"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "De&lete selected rule"
+msgstr "Xoá audio được dán nhãn"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Unused filters:"
+msgstr "Loại tập tin không được hỗ trợ"
+
+#: src/prefs/ExtImportPrefs.cpp
+msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
+msgstr ""
+
+#: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
 msgstr "Phát hiện khoảng trống"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Do you really want to delete selected rule?"
+msgstr "Bạn chắc mình muốn xoá %s chứ?"
+
+#: src/prefs/ExtImportPrefs.cpp
+#, fuzzy
+msgid "Rule deletion confirmation"
+msgstr "Thông tin biên dịch"
 
 #: src/prefs/ExtImportPrefs.h
 msgid "Ext Import"
 msgstr "nhập ngoài."
+
+#. i18n-hint: refers to Audacity's user interface settings
+#: src/prefs/GUIPrefs.cpp
+msgctxt "GUI"
+msgid "Interface"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Preferences for GUI"
@@ -9276,6 +15335,16 @@ msgid "-60 dB (PCM range of 10 bit samples)"
 msgstr "-60 dB (PCM dùng 10 bit lấy mẫu)"
 
 #: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-72 dB (PCM range of 12 bit samples)"
+msgstr "-60 dB (PCM dùng 10 bit lấy mẫu)"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "-84 dB (PCM range of 14 bit samples)"
+msgstr "-145 dB (PCM dùng 24 bit lấy mẫu)"
+
+#: src/prefs/GUIPrefs.cpp
 msgid "-96 dB (PCM range of 16 bit samples)"
 msgstr "-96 dB (PCM dùng 16 bit lấy mẫu)"
 
@@ -9288,6 +15357,10 @@ msgid "-145 dB (PCM range of 24 bit samples)"
 msgstr "-145 dB (PCM dùng 24 bit lấy mẫu)"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Local"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "From Internet"
 msgstr "Từ Internet"
 
@@ -9298,6 +15371,19 @@ msgstr "Hiển thị"
 #: src/prefs/GUIPrefs.cpp
 msgid "&Language:"
 msgstr "&Ngôn Ngữ:"
+
+#: src/prefs/GUIPrefs.cpp
+#, fuzzy
+msgid "Location of &Manual:"
+msgstr "Vị trí của %s:"
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Th&eme:"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Meter dB &range:"
+msgstr ""
 
 #: src/prefs/GUIPrefs.cpp
 msgid "Show 'How to Get &Help' at launch"
@@ -9316,8 +15402,34 @@ msgid "&Beep on completion of longer activities"
 msgstr "&Bíp khi hoàn thành các tác vụ kéo dài"
 
 #: src/prefs/GUIPrefs.cpp
+msgid "Re&tain labels if selection snaps to a label"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "B&lend system and Tenacity theme"
+msgstr ""
+
+#. i18n-hint: RTL stands for 'Right to Left'
+#: src/prefs/GUIPrefs.cpp
+msgid "Use mostly Left-to-Right layouts in RTL languages"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+msgid "Never use comma as decimal point"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
 msgid "Show Timeline Tooltips"
 msgstr "Hiển thị hộp thoại trợ giúp cho dòng thời gian "
+
+#: src/prefs/GUIPrefs.cpp src/toolbars/ScrubbingToolBar.cpp
+msgid "Show Scrub Ruler"
+msgstr ""
+
+#: src/prefs/GUIPrefs.cpp
+#, c-format
+msgid "Language \"%s\" is unknown"
+msgstr ""
 
 #: src/prefs/GUIPrefs.h
 msgid "GUI"
@@ -9332,12 +15444,55 @@ msgid "Preferences for ImportExport"
 msgstr "Tất cả tuỳ thích Nhập / Xuất"
 
 #: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Mix down to Stereo or Mono"
+msgstr "Chia 1 dải âm Stereo thành 2 dải âm MO&NO "
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Use Advanced Mixing Options"
+msgstr "Tuỳ chọn nâng cao cho bộ Trộn"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "S&tandard"
+msgstr "Chuẩn"
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "E&xtended (with frequency ranges)"
+msgstr "chọn vùng tần số."
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "&Seconds"
+msgstr "Giây"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Beats"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
 msgid "When exporting tracks to an audio file"
 msgstr "Khi xuất các dải âm thành tập tin âm thanh"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "S&how Metadata Tags editor before export"
 msgstr "c&hạy trình biên soạn các thẻ meta trước khi xuất bản"
+
+#. i18n-hint 'blank space' is space on the tracks with no audio in it
+#: src/prefs/ImportExportPrefs.cpp
+msgid "&Ignore blank space at the beginning"
+msgstr ""
+
+#: src/prefs/ImportExportPrefs.cpp
+#, fuzzy
+msgid "Exported Label Style:"
+msgstr "Xuất nhãn thành:"
+
+#: src/prefs/ImportExportPrefs.cpp
+msgid "Exported Allegro (.gro) files save time as:"
+msgstr ""
 
 #: src/prefs/ImportExportPrefs.h
 msgid "IMPORT EXPORT"
@@ -9349,6 +15504,23 @@ msgid "Keyboard"
 msgstr "Bàn phím"
 
 #: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Preferences for KeyConfig"
+msgstr "Tuỳ chọn ghi âm"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Keyboard preferences currently unavailable."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "Open a new project to modify keyboard shortcuts."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "&Hotkey:"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Key Bindings"
 msgstr "Gán phím tắt"
 
@@ -9357,12 +15529,45 @@ msgid "View by:"
 msgstr "&Xem:"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Tree"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "&Name"
 msgstr "&Tên"
 
 #: src/prefs/KeyConfigPrefs.cpp
+msgid "&Key"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by tree"
+msgstr "&Xem:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by name"
+msgstr "&Xem:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "View by key"
+msgstr "&Xem:"
+
+#: src/prefs/KeyConfigPrefs.cpp
 msgid "Searc&h:"
 msgstr "&Tìm:"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Bindings"
+msgstr "Gán phím tắt"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Short cut"
+msgstr "Đoạn âm thấp"
 
 #. i18n-hint: (verb)
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9382,7 +15587,15 @@ msgid "&Defaults"
 msgstr "Mặc đị&nh"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, c-format
+msgid ""
+"\n"
+"   *   \"%s\"  (because the shortcut '%s' is used by \"%s\")\n"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "Chọn một tập tin XML chứa các phím tắt cho Audacity..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -9423,6 +15636,43 @@ msgstr "Xuất phím tắt ra tập tin tên:"
 msgid "Error Exporting Keyboard Shortcuts"
 msgstr "Lỗi khi xuất phím tắt vào tập tin"
 
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You may not assign a key to this entry"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid "You must select a binding before assigning a shortcut"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"\n"
+"\t and\n"
+"\n"
+"\t"
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
+msgid ""
+"The keyboard shortcut '%s' is already assigned to:\n"
+"\n"
+"\t%s\n"
+"\n"
+"\n"
+"Click OK to assign the shortcut to\n"
+"\n"
+"\t%s\n"
+"\n"
+"instead. Otherwise, click Cancel."
+msgstr ""
+
+#: src/prefs/KeyConfigPrefs.h
+#, fuzzy
+msgid "Key Config"
+msgstr "Gán phím tắt"
+
 #: src/prefs/LibraryPrefs.cpp
 msgid "Preferences for Library"
 msgstr "Tuỳ chọn thư viện"
@@ -9444,6 +15694,11 @@ msgid "No compatible FFmpeg library was found"
 msgstr "Không tìm thấy thư viện FFmpeg tương thích"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
+msgid "FFmpeg support is not compiled in"
+msgstr "Hỗ trợ FFmpeg đã không được tích hợp"
+
+#: src/prefs/LibraryPrefs.cpp
 msgid "FFmpeg Library Version:"
 msgstr "Phiên bản thư viện FFmpeg"
 
@@ -9459,6 +15714,16 @@ msgstr "&Tìm Vị Trí"
 msgid "Dow&nload"
 msgstr "Tải xuố&ng"
 
+#: src/prefs/LibraryPrefs.cpp
+msgid ""
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
+"Do you still want to locate them manually?"
+msgstr ""
+
+#: src/prefs/LibraryPrefs.cpp
+msgid "Success"
+msgstr ""
+
 #: src/prefs/LibraryPrefs.h
 msgid "Library"
 msgstr "Thư viện"
@@ -9469,22 +15734,106 @@ msgid "MIDI Devices"
 msgstr "Thiết bị MIDI"
 
 #: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "Preferences for MidiIO"
+msgstr "Tuỳ chọn cho GUI (Giao diện đồ họa người dùng)"
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "No MIDI interfaces"
+msgstr "Thiết bị MIDI"
+
+#. i18n-hint Software interface to MIDI
+#: src/prefs/MidiIOPrefs.cpp
+msgctxt "MIDI"
+msgid "Interface"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
 msgid "Using: PortMidi"
 msgstr "Đang dụng: PortMidi"
+
+#: src/prefs/MidiIOPrefs.cpp
+msgid "MIDI Synth L&atency (ms):"
+msgstr ""
+
+#: src/prefs/MidiIOPrefs.cpp
+#, fuzzy
+msgid "The MIDI Synthesizer Latency must be an integer"
+msgstr "Tần số nhỏ nhất phải là số nguyên"
 
 #: src/prefs/MidiIOPrefs.h
 msgid "Midi IO"
 msgstr "Midi  IO (đầu ra/đầu vào)"
 
+#. i18n-hint: Modules are optional extensions to Audacity that add NEW features.
 #: src/prefs/ModulePrefs.cpp
+msgid "Modules"
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Preferences for Module"
+msgstr "Tuỳ chọn Chất Lượng"
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr "Đây là các mô-đun thử nghiemj. Bật lên nếu bạn đã tham khảo Hướng dẫn sử dụng Audacity và bạn biết mình đang làm gì."
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
+msgstr ""
+
+#. i18n-hint preserve the leading spaces
+#: src/prefs/ModulePrefs.cpp
+msgid "  'New' means no choice has been made yet."
+msgstr ""
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
+msgstr "Việc chuyển đổi thư mục tạm thời sẽ có hiệu lực từ lần chạy sau của Audacity"
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Ask"
+msgstr "&Hỏi"
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "Failed"
+msgstr "Không thành công!"
+
+#: src/prefs/ModulePrefs.cpp
+#, fuzzy
+msgid "No modules were found"
+msgstr "Không tìm thấy"
+
+#: src/prefs/ModulePrefs.h
+msgid "Module"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
 msgstr "Chuột"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Preferences for Mouse"
+msgstr "Tuỳ chọn cho GUI (Giao diện đồ họa người dùng)"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Mouse Bindings (default values, not configurable)"
@@ -9518,7 +15867,10 @@ msgstr "Kéo thả chuột trái"
 msgid "Set Selection Range"
 msgstr "Đặt giới hạn vùng chọn"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift+Click chuột trái"
 
@@ -9537,6 +15889,11 @@ msgstr "Chọn đoạn hoặc toàn bộ dải"
 #: src/prefs/MousePrefs.cpp
 msgid "Wheel-Rotate"
 msgstr "Lăn chuột"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Change scrub speed"
+msgstr "Thay đổi tốc độ"
 
 #: src/prefs/MousePrefs.cpp
 msgid "Zoom in on Point"
@@ -9583,8 +15940,17 @@ msgid "Zoom default"
 msgstr "Zoom mặc định"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Move clip left/right or between tracks"
+msgstr "Di chuyển đoạn lên/xuống giữa các dải"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Shift-Left-Drag"
 msgstr "Giữ Shift rồi kéo thả chuột trái"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move all clips in track left/right"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp
 msgid "-Left-Drag"
@@ -9593,6 +15959,15 @@ msgstr "-Kéo thả chuột trái"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "Di chuyển đoạn lên/xuống giữa các dải"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-Kéo thả chuột trái"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -9640,12 +16015,35 @@ msgid "Any"
 msgstr "Bất kỳ"
 
 #: src/prefs/MousePrefs.cpp
+msgid "Scroll tracks up or down"
+msgstr ""
+
+#: src/prefs/MousePrefs.cpp
 msgid "Shift-Wheel-Rotate"
 msgstr "Shift+Lăn chuột"
 
 #: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Scroll waveform"
+msgstr "Dạng sóng"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "-Wheel-Rotate"
+msgstr "Lăn chuột"
+
+#: src/prefs/MousePrefs.cpp
 msgid "Zoom waveform in or out"
 msgstr "Phóng to hoặc thu nhỏ dạng sóng"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "-Shift-Wheel-Rotate"
+msgstr "Shift+Lăn chuột"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Vertical Scale Waveform (dB) range"
+msgstr ""
 
 #: src/prefs/PlaybackPrefs.cpp
 msgid "Preferences for Playback"
@@ -9676,9 +16074,34 @@ msgstr "Nghe thử sau khi cắt vùng:"
 msgid "Seek Time when playing"
 msgstr "Tìm thời gian khi phát"
 
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Short period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Lo&ng period:"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Vari-Speed Play"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "&Micro-fades"
+msgstr ""
+
+#: src/prefs/PlaybackPrefs.cpp
+msgid "Always scrub un&pinned"
+msgstr ""
+
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Tuỳ thích của Audacity"
+
+#: src/prefs/PrefsDialog.cpp
+msgid "Category"
+msgstr ""
 
 #: src/prefs/PrefsDialog.cpp src/prefs/PrefsDialog.h
 msgid "Preferences:"
@@ -9687,6 +16110,11 @@ msgstr "Tuỳ chọn:"
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "Tuỳ chọn Chất Lượng"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -9705,8 +16133,18 @@ msgid "Default Sample &Format:"
 msgstr "Định dạng mẫu mặc định:"
 
 #: src/prefs/QualityPrefs.cpp
+#, fuzzy
+msgid "Real-time Conversion"
+msgstr "Chuyển đổi tốc độ lấy mẫu"
+
+#: src/prefs/QualityPrefs.cpp
 msgid "Sample Rate Con&verter:"
 msgstr "Bộ &chuyển đổi tốc độ lấy mẫu:"
+
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "&Dither:"
+msgstr ""
 
 #: src/prefs/QualityPrefs.cpp
 msgid "High-quality Conversion"
@@ -9716,9 +16154,30 @@ msgstr "Chuyển đổi HQ chất lượng cao"
 msgid "Sample Rate Conver&ter:"
 msgstr "Bộ &chuyển đổi tốc độ lấy mẫu:"
 
+#. i18n-hint: technical term for randomization to reduce undesirable resampling artifacts
+#: src/prefs/QualityPrefs.cpp
+msgid "Dit&her:"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "16-bit"
+msgstr ""
+
+#: src/prefs/QualitySettings.cpp
+msgid "24-bit"
+msgstr ""
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Preferences for Recording"
 msgstr "Tuỳ chọn ghi âm"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Play &other tracks while recording (overdub)"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Use &hardware to play other tracks"
+msgstr ""
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "&Software playthrough of input"
@@ -9734,6 +16193,11 @@ msgid "Detect dropouts"
 msgstr "Phát hiện các khoảng hụt tiếng 'dropout'"
 
 #: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Sound Activated Recording"
+msgstr "Thu âm đã bật"
+
+#: src/prefs/RecordingPrefs.cpp
 msgid "Le&vel (dB):"
 msgstr "Mức độ âm thanh (dB):"
 
@@ -9742,9 +16206,25 @@ msgstr "Mức độ âm thanh (dB):"
 msgid "Name newly recorded tracks"
 msgstr "Đặt tên cho các dải âm mới ghi"
 
+#. i18n-hint: end of two-part phrase, "Name newly recorded tracks with:"
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "With:"
+msgstr "Trong:"
+
 #: src/prefs/RecordingPrefs.cpp
 msgid "Custom Track &Name"
 msgstr "Tên dải"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Custom name text"
+msgstr "Cắ&t dòng chữ trong nhãn"
+
+#: src/prefs/RecordingPrefs.cpp
+#, fuzzy
+msgid "Recorded_Audio"
+msgstr "Đã thu âm"
 
 #: src/prefs/RecordingPrefs.cpp
 msgid "&Track Number"
@@ -9759,16 +16239,73 @@ msgid "System T&ime"
 msgstr "Thời g&ian hệ thống"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "Bật Điều chỉnh Cấp độ Thu âm Tự động."
+#, fuzzy
+msgid "Punch and Roll Recording"
+msgstr "Tuỳ chọn ghi âm"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "Trong:"
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Cross&fade:"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr ""
+
+#. i18n-hint: Time units, that is Period = 1 / Frequency
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Period"
+msgstr ""
+
+#. i18n-hint: New color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (default)"
+msgstr "Zoom mặc định"
+
+#. i18n-hint: Classic color scheme(from theme) for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Color (classic)"
+msgstr "Cổ điển"
+
+#. i18n-hint: Grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgctxt "spectrum prefs"
+msgid "Grayscale"
+msgstr "gam xám"
+
+#. i18n-hint: Inverse grayscale color scheme for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgctxt "spectrum prefs"
+msgid "Inverse grayscale"
+msgstr ""
 
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Frequencies"
 msgstr "Tần số (Hz)"
+
+#. i18n-hint: the Reassignment algorithm for spectrograms
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Reassignment"
+msgstr ""
 
 #. i18n-hint: EAC abbreviates "Enhanced Autocorrelation"
 #: src/prefs/SpectrogramSettings.cpp
@@ -9782,6 +16319,24 @@ msgstr "Tần số lớn nhất phải lớn hơn 100 Hz"
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Minimum frequency must be at least 0 Hz"
 msgstr "Tần số nhỏ nhất phải lớn hơn 0 Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "Minimum frequency must be less than maximum frequency"
+msgstr "Tần số nhỏ nhất phải lớn hơn 0 Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+#, fuzzy
+msgid "The range must be at least 1 dB"
+msgstr "Tần số nhỏ nhất phải lớn hơn 0 Hz"
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain cannot be negative"
+msgstr ""
+
+#: src/prefs/SpectrogramSettings.cpp
+msgid "The frequency gain must be no more than 60 dB/dec"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Spectrogram Settings"
@@ -9800,6 +16355,11 @@ msgstr "Tuỳ thích ảnh phổ"
 msgid "&Use Preferences"
 msgstr "Dụng Tuỳ thích"
 
+#: src/prefs/SpectrumPrefs.cpp src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "S&cale:"
+msgstr "gam:"
+
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Mi&n Frequency (Hz):"
 msgstr "Tần số nhỏ nhất (Hz):"
@@ -9807,6 +16367,25 @@ msgstr "Tần số nhỏ nhất (Hz):"
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Ma&x Frequency (Hz):"
 msgstr "Tần số lớn nhất (Hz):"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Colors"
+msgstr "Màu:"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Gain (dB):"
+msgstr "&Đầu ra Gain (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "&Range (dB):"
+msgstr "Mức độ âm thanh (dB):"
+
+#: src/prefs/SpectrumPrefs.cpp
+msgid "High &boost (dB/dec):"
+msgstr ""
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Algorithm"
@@ -9829,6 +16408,10 @@ msgid "1024 - default"
 msgstr "1024 - mặc định"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - hầu hết băng hẹp"
 
@@ -9837,8 +16420,23 @@ msgid "Window &type:"
 msgstr "&Loại cửa sổ:"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "&Zero padding factor:"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Ena&ble Spectral Selection"
+msgstr "Lựa chọn quang phổ"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "Show a grid along the &Y-axis"
 msgstr "Hiển thị đường kẻ lưới bằng trục &Y"
+
+#. i18n-hint: FFT stands for Fast Fourier Transform and probably shouldn't be translated
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "FFT Find Notes"
+msgstr "&Tìm nốt nhạc"
 
 #: src/prefs/SpectrumPrefs.cpp
 msgid "Minimum Amplitude (dB):"
@@ -9857,6 +16455,16 @@ msgid "&Quantize Notes"
 msgstr "&Lượng tử hoá nốt"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Global settings"
+msgstr "Thiết lập phần bổ sung"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "Ena&ble spectral selection"
+msgstr "Bật lựa chọn kéo thả"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "The maximum frequency must be an integer"
 msgstr "Tần số lớn nhất phải là số nguyên"
 
@@ -9865,8 +16473,33 @@ msgid "The minimum frequency must be an integer"
 msgstr "Tần số nhỏ nhất phải là số nguyên"
 
 #: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The gain must be an integer"
+msgstr "Tần số lớn nhất phải là số nguyên"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The range must be a positive integer"
+msgstr "Tần số lớn nhất phải là số nguyên"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The frequency gain must be an integer"
+msgstr "Tần số lớn nhất phải là số nguyên"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "The minimum amplitude (dB) must be an integer"
 msgstr "Biên độ nhỏ nhất (dB) phải là số nguyên"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be an integer"
+msgstr "Tần số lớn nhất phải là số nguyên"
+
+#: src/prefs/SpectrumPrefs.cpp
+#, fuzzy
+msgid "The maximum number of notes must be in the range 1..128"
+msgstr "Tần số lớn nhất phải là số nguyên"
 
 #. i18n-hint: A theme is a consistent visual style across an application's
 #. graphical user interface, including choices of colors, and similarity of images
@@ -9877,8 +16510,32 @@ msgid "Theme"
 msgstr "Sắc thái giao diện"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
+msgid "Preferences for Theme"
+msgstr "Tuỳ chọn cho thiết bị"
+
+#: src/prefs/ThemePrefs.cpp
 msgid "Info"
 msgstr "Thông tin"
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Themability is an experimental feature.\n"
+"\n"
+"To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
+"ImageCacheVxx.png using an image editor such as the Gimp.\n"
+"\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
+"\n"
+"(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
+"though the image file shows other icons too.)"
+msgstr ""
+
+#: src/prefs/ThemePrefs.cpp
+msgid ""
+"Saving and loading individual theme files uses a separate file for each image, but is\n"
+"otherwise the same idea."
+msgstr ""
 
 #. i18n-hint: && in here is an escape character to get a single & on screen,
 #. * so keep it as is
@@ -9906,13 +16563,55 @@ msgstr "Lưu tập tin"
 msgid "Load Files"
 msgstr "Nạp tập tin"
 
+#. i18n-hint: i.e. the behaviors of tracks
+#: src/prefs/TracksBehaviorsPrefs.cpp src/prefs/TracksBehaviorsPrefs.h
+#, fuzzy
+msgid "Tracks Behaviors"
+msgstr "Hành vi"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Preferences for TracksBehaviors"
+msgstr "Tuỳ chọn cho thiết bị"
+
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Simple"
 msgstr "Đơn giản"
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Multi-track"
+msgstr "Nhiều"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Select all audio, if selection required"
+msgstr ""
+
+#. i18n-hint: Cut-lines are lines that can expand to show the cut audio.
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Enable cut &lines"
+msgstr "Bật plug-ins (điện toán) mới "
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Enable &dragging selection edges"
 msgstr "Bật chọn kéo thả bằng cạnh"
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Editing a clip can &move other clips"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "\"Move track focus\" c&ycles repeatedly through tracks"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "&Type to create a label"
+msgstr ""
+
+#: src/prefs/TracksBehaviorsPrefs.cpp
+msgid "Use dialog for the &name of a new label"
+msgstr ""
 
 #: src/prefs/TracksBehaviorsPrefs.cpp
 msgid "Enable scrolling left of &zero"
@@ -9922,9 +16621,37 @@ msgstr "Bật cuộn sang bên trái số không"
 msgid "Advanced &vertical zooming"
 msgstr "Zoom theo chiều dọc và nâng cao "
 
+#: src/prefs/TracksBehaviorsPrefs.cpp
+#, fuzzy
+msgid "Solo &Button:"
+msgstr "Nút"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Logarithmic (dB)"
+msgstr "Logarith"
+
 #: src/prefs/TracksPrefs.cpp src/prefs/WaveformPrefs.h
 msgid "Waveform"
 msgstr "Dạng sóng"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Spectrogram"
+msgstr "Ảnh phổ"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Connect dots"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Stem plot"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Fit to Width"
+msgstr "Vừa dự án vào trong cửa sổ"
 
 #: src/prefs/TracksPrefs.cpp src/toolbars/EditToolBar.cpp
 msgid "Zoom to Selection"
@@ -9970,9 +16697,69 @@ msgstr "1/500 Giây"
 msgid "MilliSeconds"
 msgstr "Mili Giây"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Samples"
+msgstr "mẫu"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "4 Pixels per Sample"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "Zoom tối đa "
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Preferences for Tracks"
+msgstr "Tuỳ chọn phát lại"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Auto-&fit track height"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Sho&w track name as overlay"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Use &half-wave display when collapsed"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "&Pinned Recording/Playback head"
+msgstr "Thu âm/tua chạy từ đàu đánh dấu"
+
+#: src/prefs/TracksPrefs.cpp
+msgid "A&uto-scroll if head unpinned"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+msgid "Pinned &head position"
+msgstr ""
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Default &view mode:"
+msgstr "Tốc độ lấy mẫu mặc định:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Default Waveform scale:"
+msgstr "Định dạng mẫu mặc định:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Display &samples:"
+msgstr "Hiển thị:"
+
+#: src/prefs/TracksPrefs.cpp
+#, fuzzy
+msgid "Default audio track &name:"
+msgstr "Tạo dải âm mới"
 
 #. i18n-hint: The default name for an audio track.
 #: src/prefs/TracksPrefs.cpp
@@ -9991,6 +16778,16 @@ msgstr "Thiết lập sẵn 1:"
 msgid "Preset 2:"
 msgstr "Thiết lập sẵn 2:"
 
+#: src/prefs/WarningsPrefs.cpp src/prefs/WarningsPrefs.h
+#, fuzzy
+msgid "Warnings"
+msgstr "Cảnh báo"
+
+#: src/prefs/WarningsPrefs.cpp
+#, fuzzy
+msgid "Preferences for Warnings"
+msgstr "Tuỳ chọn ghi âm"
+
 #: src/prefs/WarningsPrefs.cpp
 msgid "Show Warnings/Prompts for"
 msgstr "Hiển thị Cảnh báo/ Hộp thoại cho"
@@ -10003,16 +16800,43 @@ msgstr "Đang lưu các dự án"
 msgid "Saving &empty project"
 msgstr "Đang lưu dự ấn &trống"
 
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down to &mono during export"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down to &stereo during export"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Mixing down on export (&Custom FFmpeg or external program)"
+msgstr ""
+
+#: src/prefs/WarningsPrefs.cpp
+msgid "Missing file &name extension during export"
+msgstr ""
+
+#. i18n-hint: A waveform is a visual representation of vibration
+#: src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "Waveforms"
+msgstr "Dạng sóng"
+
+#: src/prefs/WaveformPrefs.cpp
+#, fuzzy
+msgid "Preferences for Waveforms"
+msgstr "Tuỳ thích ảnh phổ"
+
+#: src/prefs/WaveformPrefs.cpp
+msgid "Waveform dB &range:"
+msgstr ""
+
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
 #: src/toolbars/ControlToolBar.cpp
 msgid "Stopped"
 msgstr "Đã tắt"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "Tạm dừng"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
@@ -10023,6 +16847,18 @@ msgid "Skip to End"
 msgstr "Chuyển về cuối"
 
 #: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "Tạm dừng"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "Chọn đến  Đầu"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "Chọn từ đây đến kết thúc"
+
+#: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
 msgstr "Phát  lặp lại"
 
@@ -10031,12 +16867,9 @@ msgid "Record New Track"
 msgstr "Ghi dải âm mới"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "Chọn từ đây đến kết thúc"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "Chọn đến  Đầu"
+#, fuzzy
+msgid "Append Record"
+msgstr "Thu"
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
@@ -10044,6 +16877,18 @@ msgstr "Chọn đến  Đầu"
 #, c-format
 msgid "%s Paused."
 msgstr "%s Đã tạm dừng."
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr ""
+
+#. i18n-hint: Clicking this menu item shows the toolbar
+#. with the big buttons on it (play record etc)
+#: src/toolbars/ControlToolBar.cpp
+#, fuzzy
+msgid "&Transport Toolbar"
+msgstr "Chuyển đổi"
 
 #. i18n-hint: (noun) It's the device used for playback.
 #: src/toolbars/DeviceToolBar.cpp
@@ -10054,6 +16899,11 @@ msgstr "Thiết bị phát âm thanh"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Device"
 msgstr "Thiết bị ghi âm."
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Audio Host"
+msgstr "Vị trí âm thanh"
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Recording Channels"
@@ -10074,6 +16924,11 @@ msgstr "Chọn thiết bị ghi âm"
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Select Playback Device"
 msgstr "Chọn thiết bị phát âm thanh"
+
+#: src/toolbars/DeviceToolBar.cpp
+#, fuzzy
+msgid "Select Audio Host"
+msgstr "chọn Audio."
 
 #: src/toolbars/DeviceToolBar.cpp
 msgid "Select Recording Channels"
@@ -10097,22 +16952,57 @@ msgstr "Cắt vùng chọn"
 msgid "Copy selection"
 msgstr "Sao Chép vùng chọn"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+msgid "Trim audio outside selection"
+msgstr ""
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Silence audio selection"
+msgstr "Xoá phần đã chọn"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Sync-Lock Tracks"
+msgstr "Trong tất cả các &Đoạn âm Sync-Locked Tracks "
+
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "Phóng to"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "Thu nhỏ"
+
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Fit selection to width"
+msgstr "Vừa dự án vào trong cửa sổ"
 
 #: src/toolbars/EditToolBar.cpp
 msgid "Fit project to width"
 msgstr "Vừa dự án vào trong cửa sổ"
 
+#: src/toolbars/EditToolBar.cpp
+#, fuzzy
+msgid "Open Effects Rack"
+msgstr "Hiển thị Effects Rack (thanh công cụ hiệu ứng)"
+
 #. i18n-hint: Clicking this menu item shows the toolbar for editing
 #: src/toolbars/EditToolBar.cpp
 msgid "&Edit Toolbar"
 msgstr "Thanh công cụ &Chỉnh sửa "
+
+#: src/toolbars/MeterToolBar.cpp
+#, fuzzy
+msgid "Combined Meter"
+msgstr "Bộ đo ghi âm"
 
 #: src/toolbars/MeterToolBar.cpp
 msgid "Recording Meter"
@@ -10156,33 +17046,74 @@ msgstr "Thanh công cụ đo độ cao &Ghi âm "
 msgid "&Playback Meter Toolbar"
 msgstr "Thanh công cụ đo độ cao &Phát âm thanh "
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "Âm lượng ghi âm"
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Seek"
+msgstr ""
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "Âm lượng phát lại"
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scrub Ruler"
+msgstr "Hủy bỏ "
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "Âm lượng phát lại: %.2f (emulated)"
+#: src/toolbars/ScrubbingToolBar.cpp src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrubbing"
+msgstr "Hủy bỏ "
 
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "Âm lượng phát lại: %.2f"
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Stop Scrubbing"
+msgstr "Dừng Tập lệnh"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Start Scrubbing"
+msgstr "Bắt đầu Tập lệnh"
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Stop Seeking"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips
+#.
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Start Seeking"
+msgstr "Bắt đầu đo"
+
+#: src/toolbars/ScrubbingToolBar.cpp
+msgid "Hide Scrub Ruler"
+msgstr ""
 
 #. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "Thanh công cụ của &Bộ trộn âm thanh"
+#. that enables Scrub or Seek playback and Scrub Ruler
+#: src/toolbars/ScrubbingToolBar.cpp
+#, fuzzy
+msgid "Scru&b Toolbar"
+msgstr "&Thanh công cụ"
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Project Rate (Hz)"
 msgstr "Tần số của dự án (Hz):"
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Snap-To"
+msgstr "Dính tới"
 
 #: src/toolbars/SelectionBar.cpp src/toolbars/TimeToolBar.cpp
 msgid "Audio Position"
@@ -10190,6 +17121,21 @@ msgstr "Vị trí âm thanh"
 
 #: src/toolbars/SelectionBar.cpp
 msgid "Start and End of Selection"
+msgstr "Phần được chọn"
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Start and Length of Selection"
+msgstr "Phần được chọn"
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Length and End of Selection"
+msgstr "Phần được chọn"
+
+#: src/toolbars/SelectionBar.cpp
+#, fuzzy
+msgid "Length and Center of Selection"
 msgstr "Phần được chọn"
 
 #: src/toolbars/SelectionBar.cpp src/toolbars/SpectralSelectionBar.cpp
@@ -10204,9 +17150,24 @@ msgstr "Dính tới"
 msgid "Length"
 msgstr "Độ dài"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "Giữa"
+
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "Snap Clicks/Selections to %s"
+msgstr ""
+
+#. i18n-hint: %s is replaced e.g by one of 'Length', 'Center',
+#. 'Start', or 'End' (translated), to indicate that it will be
+#. calculated from other parameters.
+#: src/toolbars/SelectionBar.cpp
+#, c-format
+msgid "%s - driven"
+msgstr ""
 
 #. i18n-hint: each string is replaced by one of 'Length', 'Center',
 #. 'Start', or 'End' (translated)
@@ -10223,11 +17184,35 @@ msgstr ""
 msgid "&Selection Toolbar"
 msgstr "Thanh công cụ &Vùng chọn"
 
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Center frequency and Width"
+msgstr "Tần số tuyến tính"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Low and High Frequencies"
+msgstr "Tần số cao"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+#, fuzzy
+msgid "Center Frequency"
+msgstr "Tần số tuyến tính"
+
+#: src/toolbars/SpectralSelectionBar.cpp
+msgid "Bandwidth"
+msgstr ""
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for selecting a frequency range of audio
 #: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spe&ctral Selection Toolbar"
 msgstr "Thanh công cụ &chọn phổ thính âm"
+
+#: src/toolbars/TimeToolBar.cpp
+#, fuzzy
+msgid "Time"
+msgstr "Bấm giờ"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for viewing actual time of the cursor
@@ -10237,8 +17222,8 @@ msgstr "Thanh công cụ &Thời gian"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Thanh công cụ %s của Audacity"
 
 #: src/toolbars/ToolBar.cpp
@@ -10265,9 +17250,15 @@ msgstr "Công cụ di chuyển"
 msgid "Zoom Tool"
 msgstr "Công cụ thu phóng"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "Công cụ vẽ"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "Multi-Tool"
+msgstr "Nhiều"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "Slide Tool"
@@ -10284,12 +17275,32 @@ msgid "&Selection Tool"
 msgstr "Công cụ &Vùng chọn"
 
 #: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Envelope Tool"
+msgstr "Công cụ biên độ"
+
+#: src/toolbars/ToolsToolBar.cpp
 msgid "&Draw Tool"
 msgstr "Công cụ &vẽ"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "&Zoom Tool"
 msgstr "Công cụ &Thu phóng"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Time Shift Tool"
+msgstr "Công cụ di chuyển"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Multi Tool"
+msgstr "Công cụ &Vùng chọn"
+
+#: src/toolbars/ToolsToolBar.cpp
+#, fuzzy
+msgid "&Previous Tool"
+msgstr "Kế trước"
 
 #: src/toolbars/ToolsToolBar.cpp
 msgid "&Next Tool"
@@ -10303,17 +17314,32 @@ msgstr "Phát ở tốc độ đã chọn"
 msgid "Playback Speed"
 msgstr "Tốc độ phát lại"
 
+#: src/toolbars/TranscriptionToolBar.cpp
+#, fuzzy
+msgid "Looped-Play-at-Speed"
+msgstr "Tốc độ phát"
+
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. for transcription (currently just vary play speed)
 #: src/toolbars/TranscriptionToolBar.cpp
 msgid "Pla&y-at-Speed Toolbar"
 msgstr "Thanh công cụ tốc độ phát âm thanh"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag one or more label boundaries."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+msgid "Drag label boundary."
+msgstr ""
+
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "Đã sửa lại nhãn"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "Chỉnh sửa nhãn"
 
@@ -10368,13 +17394,77 @@ msgstr "Đã sửa nhãn"
 msgid "New label"
 msgstr "Nhãn mới"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#, fuzzy
+msgid "Up &Octave"
+msgstr "đến quãng tám"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#, fuzzy
+msgid "Down Octa&ve"
+msgstr "đến quãng tám"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "Nhấn chuột để phóng to theo chiều dọc. Nhấn chuột + Shift để thu nhỏ. Rê chuột để chọn vùng zoom "
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#, fuzzy
+msgid "Right-click for menu."
+msgstr "Nhắp chuột phải"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "Zoom mặc định "
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Shift-Right-Click"
+msgstr "Shift+Click chuột trái"
+
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Left-Click/Left-Drag"
+msgstr "Giữ Shift rồi kéo thả chuột trái"
+
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+#, fuzzy
+msgid "Click and drag to stretch selected region."
+msgstr "Nhấn và rê chuột để chọn âm thanh"
+
+#. i18n-hint: (noun) The track that is used for MIDI notes which can be
+#. dragged to change their duration.
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+#, fuzzy
+msgid "Stretch Note Track"
+msgstr "Đặt ghi chú cho dải âm"
+
+#. i18n-hint: In the history list, indicates a MIDI note has
+#. been dragged to change its duration (stretch it). Using either past
+#. or present tense is fine here.  If unsure, go for whichever is
+#. shorter.
+#: src/tracks/playabletrack/notetrack/ui/StretchHandle.cpp
+msgid "Stretch"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to expand, Right-Click to remove"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+msgid "Left-Click to merge clips"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Merged Clips"
@@ -10388,7 +17478,8 @@ msgstr "Kết hợp lại"
 msgid "Expanded Cut Line"
 msgstr "Mở rộng đường cắt"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "Mở rộng"
 
@@ -10405,16 +17496,67 @@ msgid "To use Draw, zoom in further until you can see the individual samples."
 msgstr "Để dùng công cụ Vẽ, bạn phải phóng to đủ để thấy từng mẫu riêng biệt."
 
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#, fuzzy
+msgid "Moved Samples"
+msgstr "Đã di chuyển thanh trượt cân bằng trái/phải"
+
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "Chỉnh sửa mẫu"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
 msgstr "Zoom để phù hợp với màn hình "
 
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy
+msgid "&Spectrogram"
+msgstr "Ảnh phổ"
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid ""
+"To change Spectrogram Settings, stop any\n"
+" playing or recording first."
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+msgid "Stop the Audio First"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, fuzzy
+msgid "S&pectrogram Settings..."
+msgstr "Cái đặt Ảnh phổ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Format"
+msgstr "Định dạng:"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Changing sample format"
+msgstr "Tốc độ lấy mẫu không hợp lệ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   0%%"
+msgstr " Đang Xử lý: %s"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Processing...   %i%%"
+msgstr " Đang Xử lý: %s"
+
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "Thay '%s' thành %s"
@@ -10422,6 +17564,63 @@ msgstr "Thay '%s' thành %s"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Format Change"
 msgstr "Thay đổi định dạng"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Rat&e"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "16000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "&Other..."
+msgstr "Khác..."
 
 #. i18n-hint: The string names a track
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
@@ -10438,8 +17637,33 @@ msgid "Set Rate"
 msgstr "Đặt tốc độ lấy mẫu"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#, fuzzy
+msgid "&Multi-view"
+msgstr "Nhiều"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Ma&ke Stereo Track"
+msgstr "Đoạn âm &Stereo"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Swap Stereo &Channels"
+msgstr "2 (Stereo) kênh ghi âm"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Spl&it Stereo Track"
+msgstr "Đoạn âm &Stereo"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split Stereo to Mo&no"
 msgstr "Chia 1 dải âm Stereo thành 2 dải âm MO&NO "
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "Mono"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Left Channel"
@@ -10466,6 +17690,17 @@ msgstr "Chuyển thành Stereo"
 #. i18n-hint: The string names a track
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
+msgid "Swapped Channels in '%s'"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy
+msgid "Swap Channels"
+msgstr "%d kênh"
+
+#. i18n-hint: The string names a track
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, c-format
 msgid "Split stereo track '%s'"
 msgstr "Chia dải âm stereo '%s'"
 
@@ -10480,6 +17715,16 @@ msgid "Split to Mono"
 msgstr "Chuyển thành Mono"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Stereo, %dHz"
+msgstr "Trái, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#, fuzzy, c-format
+msgid "Mono, %dHz"
+msgstr "Trái, %dHz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 #, c-format
 msgid "Left, %dHz"
 msgstr "Trái, %dHz"
@@ -10489,14 +17734,23 @@ msgstr "Trái, %dHz"
 msgid "Right, %dHz"
 msgstr "Phải, %dHz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr ""
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% Trái"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% Phải"
@@ -10504,6 +17758,54 @@ msgstr "%.0f%% Phải"
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
 msgid "Click and drag to adjust sizes of sub-views, double-click to split evenly"
 msgstr "Click và rê chuột để điều chỉnh kích cỡ tương đối"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+#, fuzzy
+msgid "Click and drag to rearrange sub-views"
+msgstr "Nhấn và rê để di chuyển dải âm theo thời gian"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Rearrange sub-views"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackView.cpp
+msgid "Close sub-view"
+msgstr ""
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x1/2"
+msgstr "Phóng to"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Zoom x2"
+msgstr "Thu phóng"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#, fuzzy
+msgid "Half Wave"
+msgstr "nửa bức sóng"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "Wa&veform"
+msgstr "Dạng sóng"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "&Wave Color"
+msgstr "Dạng sóng"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy, c-format
+msgid "Instrument %i"
+msgstr "Nhạc cụ"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#, fuzzy
+msgid "WaveColor Change"
+msgstr "Thay đổi tốc độ lấy mẫu"
 
 #: src/tracks/timetrack/ui/TimeTrackControls.cpp
 msgid "Change lower speed limit (%) to:"
@@ -10531,11 +17833,84 @@ msgstr "Đặt giới hạn thành '%ld' - '%ld'"
 msgid "Set Range"
 msgstr "Đặt giới hạn"
 
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "Set Display"
+msgstr "Hiển thị"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track display to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to linear"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set Interpolation"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Set time track interpolation to logarithmic"
+msgstr ""
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "&Linear scale"
+msgstr "Tuyến tính"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "L&ogarithmic scale"
+msgstr "Logarith"
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+#, fuzzy
+msgid "&Range..."
+msgstr "&Đặt lại tên..."
+
+#: src/tracks/timetrack/ui/TimeTrackControls.cpp
+msgid "Logarithmic &Interpolation"
+msgstr ""
+
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
+
+#: src/tracks/ui/CommonTrackControls.cpp
 #, fuzzy
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "Nhấn và rê để di chuyển dải âm theo thời gian"
+msgid "&Name..."
+msgstr "&Đặt lại tên..."
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track &Up"
+msgstr "Chuyển đoạn âm lên"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track &Down"
+msgstr "Chuyển đoạn âm xuống"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track to &Top"
+msgstr "chuyển đoạn âm lên trên"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Move Track to &Bottom"
+msgstr "Chuyển đoạn âm xuống dưới"
+
+#: src/tracks/ui/CommonTrackControls.cpp
+#, fuzzy
+msgid "Set Track Name"
+msgstr "Đặt đoạn âm"
 
 #: src/tracks/ui/CommonTrackControls.cpp
 #, c-format
@@ -10559,6 +17934,57 @@ msgstr "Nhấn và rê chuột để hiệu chỉnh đường bao biên độ"
 msgid "Adjusted envelope."
 msgstr "Đã sửa lại đường bao biên độ."
 
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "&Scrub"
+msgstr "Hủy bỏ "
+
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Seeking"
+msgstr ""
+
+#. i18n-hint: These commands assist the user in finding a sound by ear. ...
+#. "Scrubbing" is variable-speed playback, ...
+#. "Seeking" is normal speed playback but with skips, ...
+#.
+#: src/tracks/ui/Scrubbing.cpp
+msgid "Scrub &Ruler"
+msgstr ""
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Playing at Speed"
+msgstr "Tốc độ phát"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Move mouse pointer to Seek"
+msgstr "Rê chuột để Seek (tua rê)"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Move mouse pointer to Scrub"
+msgstr "Rê chuột để Scrub (tua ngắt quãng)"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scru&bbing"
+msgstr "Hủy bỏ "
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub Bac&kwards"
+msgstr "Chuyển &Lùi Lại"
+
+#: src/tracks/ui/Scrubbing.cpp
+#, fuzzy
+msgid "Scrub For&wards"
+msgstr "Chuyến về phía &Trước"
+
 #: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to move left selection boundary."
 msgstr "Nhấn và rê chuột để di chuyển giới hạn trái của vùng chọn."
@@ -10568,12 +17994,69 @@ msgid "Click and drag to move right selection boundary."
 msgstr "Nhấn và rê chuột để di chuyển giới hạn phải của vùng chọn."
 
 #: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move bottom selection frequency."
+msgstr "Nhấn và rê chuột để di chuyển giới hạn trái của vùng chọn."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move top selection frequency."
+msgstr "Nhấn và rê chuột để di chuyển giới hạn trái của vùng chọn."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move center selection frequency to a spectral peak."
+msgstr "Nhấn và rê chuột để di chuyển giới hạn trái của vùng chọn."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to move center selection frequency."
+msgstr "Nhấn và rê chuột để di chuyển giới hạn trái của vùng chọn."
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to adjust frequency bandwidth."
+msgstr "Nhấn và rê chuột để chọn âm thanh"
+
+#. i18n-hint: These are the names of a menu and a command in that menu
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Edit, Preferences..."
+msgstr "&Tuỳ thích..."
+
+#. i18n-hint: %s is usually replaced by "Ctrl+P" for Windows/Linux, "Command+," for Mac
+#: src/tracks/ui/SelectHandle.cpp
+#, c-format
+msgid "Multi-Tool Mode: %s for Mouse and Keyboard Preferences."
+msgstr ""
+
+#: src/tracks/ui/SelectHandle.cpp
+#, fuzzy
+msgid "Click and drag to set frequency bandwidth."
+msgstr "Nhấn và rê chuột để chọn âm thanh"
+
+#: src/tracks/ui/SelectHandle.cpp
 msgid "Click and drag to select audio"
 msgstr "Nhấn và rê chuột để chọn âm thanh"
+
+#. i18n-hint: "Snapping" means automatic alignment of selection edges to any nearby label or clip boundaries
+#: src/tracks/ui/SelectHandle.cpp
+msgid "(snapping)"
+msgstr ""
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Click and drag to move a track in time"
 msgstr "Nhấn và rê để di chuyển dải âm theo thời gian"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Could not shift between tracks"
+msgstr "Di chuyển đoạn lên/xuống giữa các dải"
+
+#: src/tracks/ui/TimeShiftHandle.cpp
+#, fuzzy
+msgid "Moved clips to another track"
+msgstr "Di chuyển đoạn lên/xuống giữa các dải"
 
 #: src/tracks/ui/TimeShiftHandle.cpp
 #, c-format
@@ -10584,6 +18067,10 @@ msgstr "Đã dịch dải/đoạn sang qua bên phải %.02f giây"
 #, c-format
 msgid "Time shifted tracks/clips left %.02f seconds"
 msgstr "Đã dịch dải/đoạn sang qua bên trái %.02f giây"
+
+#: src/tracks/ui/TrackButtonHandles.cpp
+msgid "Collapse"
+msgstr ""
 
 #: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Command+Click to deselect"
@@ -10601,11 +18088,40 @@ msgstr "Ctrl+Click để bỏ chọn"
 msgid "Open menu..."
 msgstr "&Mở  menu..."
 
+#. i18n-hint: Command names a modifier key on Macintosh keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Command+Click"
+msgstr "Lệnh"
+
+#. i18n-hint: Ctrl names a modifier key on Windows or Linux keyboards
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy
+msgid "Ctrl+Click"
+msgstr "Ctrl+Click để bỏ chọn"
+
+#. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "%s to select or deselect track. Drag up or down to change track order."
+msgstr "%s để chọn hoặc bỏ chọn dải âm "
+
 #. i18n-hint: %s is replaced by (translation of) 'Ctrl+Click' on windows, 'Command+Click' on Mac
 #: src/tracks/ui/TrackSelectHandle.cpp
 #, c-format
 msgid "%s to select or deselect track."
 msgstr "%s để chọn hoặc bỏ chọn dải âm "
+
+#. i18n-hint: will substitute name of track for %s
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' up"
+msgstr "Đã chuyển '%s' lên"
+
+#: src/tracks/ui/TrackSelectHandle.cpp
+#, fuzzy, c-format
+msgid "Moved '%s' down"
+msgstr "Đã chuyển '%s xuống"
 
 #: src/tracks/ui/TrackSelectHandle.cpp
 msgid "Move Track"
@@ -10635,6 +18151,38 @@ msgstr "Nhấn"
 msgid "Button"
 msgstr "Nút"
 
+#. i18n-hint: One-letter abbreviation for Left, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Left, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "L"
+msgstr ""
+
+#. i18n-hint: One-letter abbreviation for Right, in the Pan slider
+#. i18n-hint: One-letter abbreviation for Right, in VU Meter
+#: src/widgets/ASlider.cpp src/widgets/Meter.cpp
+msgid "R"
+msgstr ""
+
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr ""
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Lệnh Macro%s đã tồn tại. bạn có muốn thay thế nó không?"
+
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+msgid "Please choose an existing file."
+msgstr ""
+
+#: src/widgets/FileDialog/mac/FileDialogPrivate.mm
+#, fuzzy
+msgid "File type:"
+msgstr "Dựng kiểu:"
+
 #: src/widgets/FileHistory.cpp
 msgid "&Clear"
 msgstr "&Xoá"
@@ -10652,8 +18200,32 @@ msgid "Empty"
 msgstr "Trống"
 
 #: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Backwards"
+msgstr "Chuyển &Lùi Lại"
+
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
+#, fuzzy
+msgid "Forwards"
+msgstr "Chuyến về phía &Trước"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
+
+#: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
 msgstr "Trợ giúp từ Internet"
+
+#: src/widgets/KeyView.cpp
+msgid "Menu"
+msgstr ""
 
 #: src/widgets/Meter.cpp
 msgid "Click to Start Monitoring"
@@ -10666,6 +18238,11 @@ msgstr "Click để đo"
 #: src/widgets/Meter.cpp
 msgid "Click to Start"
 msgstr "Click để Bắt đầu"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Click"
+msgstr "Click chuột trái"
 
 #: src/widgets/Meter.cpp
 msgid "Stop Monitoring"
@@ -10688,6 +18265,13 @@ msgid "Refresh Rate"
 msgstr "Đặt tốc độ lấy mẫu"
 
 #: src/widgets/Meter.cpp
+msgid ""
+"Higher refresh rates make the meter show more frequent\n"
+"changes. A rate of 30 per second or less should prevent\n"
+"the meter affecting audio quality on slower machines."
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter refresh rate per second [1-100]"
 msgstr "Tần số quét bộ đo [1-100]:"
 
@@ -10700,16 +18284,63 @@ msgid "Meter Style"
 msgstr "Kiểu Bộ đo"
 
 #: src/widgets/Meter.cpp
+msgid "Gradient"
+msgstr ""
+
+#: src/widgets/Meter.cpp
 msgid "Meter Type"
 msgstr "Loại Bộ đo"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Orientation"
+msgstr "Độ dài"
+
+#: src/widgets/Meter.cpp plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Automatic"
+msgstr "Lưu Tự động"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Horizontal"
+msgstr "Đúng &Cỡ"
+
+#: src/widgets/Meter.cpp
+#, fuzzy
+msgid "Vertical"
+msgstr "Chia theo chiều &Thẳng đứng "
 
 #: src/widgets/Meter.cpp
 msgid " Monitoring "
 msgstr " Đang đo "
 
+#: src/widgets/Meter.cpp
+msgid " Active "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %2.f dB"
+msgstr ""
+
+#: src/widgets/Meter.cpp
+#, c-format
+msgid " Peak %.2f "
+msgstr ""
+
+#: src/widgets/Meter.cpp
+msgid " Clipped "
+msgstr ""
+
 #: src/widgets/MultiDialog.cpp
 msgid "Show Log for Details"
 msgstr "Hiển thị chi tiết nhật ký máy "
+
+#: src/widgets/MultiDialog.cpp
+#, fuzzy
+msgid "Please select an action"
+msgstr "Hãy chọn một đoạn âm audio."
 
 #. i18n-hint: Format string for displaying time in seconds. Change the comma
 #. * in the middle to the 1000s separator for your locale, and the 'seconds'
@@ -10717,6 +18348,29 @@ msgstr "Hiển thị chi tiết nhật ký máy "
 #: src/widgets/NumericTextCtrl.cpp
 msgid "01000,01000 seconds"
 msgstr "01000,01000 giây"
+
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss"
+msgstr "hh:mm:ss + mẫu"
+
+#. i18n-hint: Format string for displaying time in hours, minutes and
+#. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
+#. * change the numbers unless there aren't 60 seconds in a minute in your
+#. * locale
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s"
+msgstr "0100 ngày 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr ""
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -10728,10 +18382,41 @@ msgid "0100 days 024 h 060 m 060 s"
 msgstr "0100 ngày 024 h 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
+#. * minutes, seconds and hundredths of a second (1/100 second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "hh:mm:ss + hundredths"
+msgstr "hh:mm:ss + mẫu"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and hundredths of a second. Change the 'h' to the abbreviation for hours,
+#. * 'm' to the abbreviation for minutes and 's' to the abbreviation for seconds
+#. * (the hundredths are shown as decimal seconds). Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>0100 s"
+msgstr "0100 ngày 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and milliseconds (1/1000 second)
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + milliseconds"
 msgstr "hh:mm:ss + milli giây"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and milliseconds. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes and 's' to the abbreviation for seconds (the
+#. * milliseconds are shown as decimal seconds) . Don't change the numbers
+#. * unless there aren't 60 minutes in an hour in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060>01000 s"
+msgstr "0100 ngày 024 h 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in hours,
 #. * minutes, seconds and samples (at the current project sample rate)
@@ -10739,9 +18424,22 @@ msgstr "hh:mm:ss + milli giây"
 msgid "hh:mm:ss + samples"
 msgstr "hh:mm:ss + mẫu"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and samples. Change the 'h' to the abbreviation for hours, 'm' to the
+#. * abbreviation for minutes, 's' to the abbreviation for seconds and
+#. * translate samples . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+># samples"
+msgstr "0100 ngày 024 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "mẫu"
@@ -10759,6 +18457,18 @@ msgstr "01000,01000,01000 mẫu|#"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + film frames (24 fps)"
 msgstr "hh:mm:ss + film frame (24 fps)"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames at 24 frames per second. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames' . Don't change the numbers
+#. * unless there aren't 60 seconds in a minute in your locale.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>24 frames"
+msgstr "0100 ngày 024 h 060 m 060 s"
 
 #. i18n-hint: Name of time display format that shows time in frames (lots of
 #. * frames) at 24 frames per second (commonly used for films)
@@ -10781,12 +18491,35 @@ msgstr "01000,01000 frame|24"
 msgid "hh:mm:ss + NTSC drop frames"
 msgstr "hh:mm:ss + NTSC drop frame"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the |N alone, it's important!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>30 frames|N"
+msgstr "01000,01000 frame|24"
+
 #. i18n-hint: Name of time display format that shows time in hours, minutes,
 #. * seconds and frames at NTSC TV non-drop-frame rate (used for American /
 #. * Japanese TV, and doesn't quite match wall time
 #: src/widgets/NumericTextCtrl.cpp
 msgid "hh:mm:ss + NTSC non-drop frames"
 msgstr "hh:mm:ss + NTSC non-drop frame"
+
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with NTSC drop frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Leave the | .999000999 alone,
+#. * the whole things really is slightly off-speed!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>030 frames| .999000999"
+msgstr "01000,01000 frame|29.97002997"
 
 #. i18n-hint: Name of time display format that shows time in frames at NTSC
 #. * TV frame rate (used for American / Japanese TV
@@ -10809,6 +18542,17 @@ msgstr "01000,01000 frame|29.97002997"
 msgid "hh:mm:ss + PAL frames (25 fps)"
 msgstr "hh:mm:ss + PAL frame (25 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with PAL TV frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'. Nice simple time code!
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>25 frames"
+msgstr "0100 ngày 024 h 060 m 060 s"
+
 #. i18n-hint: Name of time display format that shows time in frames at PAL
 #. * TV frame rate (used for European TV)
 #: src/widgets/NumericTextCtrl.cpp
@@ -10829,6 +18573,24 @@ msgstr "01000,01000 frame|25"
 msgid "hh:mm:ss + CDDA frames (75 fps)"
 msgstr "hh:mm:ss + CDDA frame (75 fps)"
 
+#. i18n-hint: Format string for displaying time in hours, minutes, seconds
+#. * and frames with CD Audio frames. Change the 'h' to the abbreviation
+#. * for hours, 'm' to the abbreviation for minutes, 's' to the abbreviation
+#. * for seconds and translate 'frames'.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "0100 h 060 m 060 s+>75 frames"
+msgstr "0100 ngày 024 h 060 m 060 s"
+
+#. i18n-hint: Name of time display format that shows time in frames at CD
+#. * Audio frame rate (75 frames per second)
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "CDDA frames (75 fps)"
+msgstr "PAL frame (25 fps)"
+
 #. i18n-hint: Format string for displaying time in frames with CD Audio
 #. * frames. Change the comma
 #. * in the middle to the 1000s separator for your locale,
@@ -10837,15 +18599,124 @@ msgstr "hh:mm:ss + CDDA frame (75 fps)"
 msgid "01000,01000 frames|75"
 msgstr "01000,01000 frame|75"
 
+#. i18n-hint: Format string for displaying frequency in hertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "010,01000>0100 Hz"
+msgstr "01000,01000,01000 mẫu|#"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr ""
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr ""
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
 msgid "octaves"
 msgstr "octaves  \"bát độ\""
 
+#. i18n-hint: Format string for displaying log of frequency in octaves.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+#, fuzzy
+msgid "100>01000 octaves|1.442695041"
+msgstr "01000,01000 frame|24"
+
+#. i18n-hint: an octave is a doubling of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of octaves"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in semitones and cents
+#: src/widgets/NumericTextCtrl.cpp
+msgid "semitones + cents"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in semitones
+#. * and cents.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "1000 semitones >0100 cents|17.312340491"
+msgstr ""
+
+#. i18n-hint: a cent is a hundredth of a semitone (which is 1/12 octave)
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hundredths of cents"
+msgstr ""
+
+#. i18n-hint: Name of display format that shows log of frequency
+#. * in decades
+#: src/widgets/NumericTextCtrl.cpp
+msgid "decades"
+msgstr ""
+
+#. i18n-hint: Format string for displaying log of frequency in decades.
+#. * Change the decimal points for your locale. Don't change the numbers.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "10>01000 decades|0.434294482"
+msgstr ""
+
+#. i18n-hint: a decade is a tenfold increase of frequency
+#: src/widgets/NumericTextCtrl.cpp
+msgid "thousandths of decades"
+msgstr ""
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "(Use context menu to change format.)"
+msgstr ""
+
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "1/100 giây - centiseconds"
+
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Elapsed Time:"
+msgstr "Thời gian kết thúc:"
+
+#: src/widgets/ProgressDialog.cpp
+msgid "Remaining Time:"
+msgstr ""
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Cancel"
+msgstr "&Hủy bỏ"
+
+#: src/widgets/ProgressDialog.cpp
+#, fuzzy
+msgid "Are you sure you wish to cancel?"
+msgstr "Bạn chắc mình muốn đóng không?"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Confirm Cancel"
@@ -10873,6 +18744,11 @@ msgstr "Xác nhận đóng"
 msgid "Unable to write files to directory: %s."
 msgstr "Không thể đọc thiết lập sẵn từ \"%s\""
 
+#. i18n-hint: This message describes the error in the Error dialog.
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+msgid "Please check that the directory exists, has the necessary permissions, and the drive isn't full."
+msgstr ""
+
 #. i18n-hint: %s is replaced with 'Preferences > Directories'.
 #: src/widgets/UnwritableLocationErrorDialog.cpp
 #, c-format
@@ -10891,6 +18767,10 @@ msgid "Don't show this warning again"
 msgstr "Không hiện cảnh báo này nữa"
 
 #: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr ""
+
+#: src/widgets/numformatter.cpp
 msgid "Infinity"
 msgstr "Vô cùng"
 
@@ -10899,12 +18779,62 @@ msgid "-Infinity"
 msgstr "-Vô cùng"
 
 #: src/widgets/valnum.cpp
+msgid "Validation error"
+msgstr ""
+
+#: src/widgets/valnum.cpp
 msgid "Empty value"
 msgstr "Trống"
+
+#: src/widgets/valnum.cpp
+msgid "Malformed number"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Not in range %d to %d"
+msgstr "Không thể huỷ bước"
+
+#: src/widgets/valnum.cpp
+msgid "Value overflow"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+msgid "Too many decimal digits"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, c-format
+msgid "Value not in range: %s to %s"
+msgstr ""
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Value must not be less than %s"
+msgstr "Không được để trống phần tên"
+
+#: src/widgets/valnum.cpp
+#, fuzzy, c-format
+msgid "Value must not be greater than %s"
+msgstr "Không được để trống phần tên"
+
+#: src/widgets/wxPanelWrapper.h
+msgid "Dialog"
+msgstr ""
 
 #: src/widgets/wxPanelWrapper.h
 msgid "Select a directory"
 msgstr "Chọn một thư mục"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "Directory Dialog"
+msgstr "Thư mục"
+
+#: src/widgets/wxPanelWrapper.h
+#, fuzzy
+msgid "File Dialog"
+msgstr "Tìm hộp thoại"
 
 #: src/xml/XMLFileReader.cpp
 #, c-format
@@ -10916,19 +18846,150 @@ msgstr "Lỗi: %s ở line %lu"
 msgid "Could not load file: \"%s\""
 msgstr "Không thể nạp tập tin: \"%s\""
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: src/xml/XMLFileReader.cpp
+#, fuzzy
+msgid "Could not parse XML"
+msgstr "không thể ghi vào %s\n"
+
+#: plug-ins/SpectralEditMulti.ny
+#, fuzzy
+msgid "Spectral edit multi tool"
+msgstr "Lựa chọn quang phổ"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Filtering..."
+msgstr "Đang chuẩn bị...\n"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+msgid "Released under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~aHãy chọn một tần số (Hz)"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                       frequencies are both ~a Hz).~%~\n"
+"                       Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "Lỗi.~%"
 
+#: plug-ins/SpectralEditParametricEQ.ny
+msgid "Spectral edit parametric EQ"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Gain (dB)"
+msgstr "Đầu ra Gain (dB)"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aLow frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid "~aHigh frequency is undefined."
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, fuzzy, lisp-format
+msgid "~aCenter frequency must be above 0 Hz."
+msgstr "Tần số nhỏ nhất phải lớn hơn 0 Hz"
+
+#: plug-ins/SpectralEditParametricEQ.ny
+#, lisp-format
+msgid ""
+"~aFrequency selection is too high for track sample rate.~%~\n"
+"                        For the current track, the high frequency setting cannot~%~\n"
+"                        be greater than ~a Hz"
+msgstr ""
+
+#: plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#, lisp-format
+msgid ""
+"~aBandwidth is zero (the upper and lower~%~\n"
+"                         frequencies are both ~a Hz).~%~\n"
+"                         Please select a frequency range."
+msgstr ""
+
+#: plug-ins/SpectralEditShelves.ny
+#, fuzzy
+msgid "Spectral edit shelves"
+msgstr "Chọn quang phổ"
+
 #: plug-ins/StudioFadeOut.ny
 msgid "Studio Fade Out"
 msgstr "Âm lượng giảm dần - Studio  Fade Out"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Applying Fade..."
+msgstr "Đang áp dụng..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "Đặt mặc đị&nh"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+msgid "GNU General Public License v2.0 or later"
+msgstr ""
+
+#: plug-ins/StudioFadeOut.ny
+#, lisp-format
+msgid "Selection too short.~%It must be more than 2 samples."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Adjustable Fade"
+msgstr "Đã điều chỉnh cân bằng trái/phải"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Fade Type"
+msgstr "Âm lượng tăng dần"
 
 #: plug-ins/adjustable-fade.ny
 msgid "Fade Up"
@@ -10939,6 +19000,43 @@ msgid "Fade Down"
 msgstr "Âm lượng giảm dần"
 
 #: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "S-Curve Up"
+msgstr "Tên Cong"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "S-Curve Down"
+msgstr "Chuyển xuống"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Mid-fade Adjust (%)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Start/End as"
+msgstr "Ngày bắt đầu"
+
+#: plug-ins/adjustable-fade.ny
+msgid "% of Original"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "dB Gain"
+msgstr "Độ khuếch đại"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Start (or end)"
+msgstr "Từ Đầu đến &Điểm Không"
+
+#: plug-ins/adjustable-fade.ny
+msgid "End (or start)"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 msgid "Handy Presets (override controls)"
 msgstr "Thiết lập sẵn hữu ích (Handy Presets)"
 
@@ -10947,9 +19045,81 @@ msgid "None Selected"
 msgstr "Chưa được chọn"
 
 #: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Linear In"
+msgstr "Tuyến tính"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Linear Out"
+msgstr "Tuyến tính"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Exponential Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Logarithmic In"
+msgstr "Logarith"
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Logarithmic Out"
+msgstr "Logarith"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Rounded In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "Rounded Out"
+msgstr "Âm lượng giảm dần"
+
+#: plug-ins/adjustable-fade.ny
+msgid "Cosine In"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+msgid "Cosine Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, fuzzy
+msgid "S-Curve In"
+msgstr "Tên Cong"
+
+#: plug-ins/adjustable-fade.ny
+msgid "S-Curve Out"
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
 #, lisp-format
 msgid "Error~%~%"
 msgstr "Lỗi~%~%"
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be negative."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid "~aPercentage values cannot be more than 1000 %."
+msgstr ""
+
+#: plug-ins/adjustable-fade.ny
+#, lisp-format
+msgid ""
+"~adB values cannot be more than +100 dB.~%~%~\n"
+"                                 Hint: 6 dB doubles the amplitude~%~\n"
+"                                 -6 dB halves the amplitude."
+msgstr ""
 
 #: plug-ins/beat.ny
 msgid "Beat Finder"
@@ -10959,17 +19129,209 @@ msgstr "Tìm điểm ghim"
 msgid "Finding beats..."
 msgstr "Đang tìm điểm ghim..."
 
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Audacity"
+msgstr "Tập nhật ký của Audacity"
+
+#: plug-ins/beat.ny
+#, fuzzy
+msgid "Threshold Percentage"
+msgstr "Ngưỡng:"
+
+#: plug-ins/clipfix.ny
+#, fuzzy
+msgid "Clip Fix"
+msgstr "Đang Ghim"
+
+#: plug-ins/clipfix.ny
+msgid "Reconstructing clips..."
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Benjamin Schwartz and Steve Daulton"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Licensing confirmed under terms of the GNU General Public License version 2"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Threshold of Clipping (%)"
+msgstr ""
+
+#: plug-ins/clipfix.ny
+msgid "Reduce amplitude to allow for restored peaks (dB)"
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+msgid "Crossfade Clips"
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+msgid "Crossfading..."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%More than 2 audio clips selected."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Invalid selection.~%Empty space at start/ end of the selection."
+msgstr ""
+
+#: plug-ins/crossfadeclips.ny
+#, lisp-format
+msgid "Error.~%Crossfade Clips may only be applied to one track."
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Crossfade Tracks"
+msgstr "Đặt ghi chú cho dải âm"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Fade type"
+msgstr "Âm lượng tăng dần"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Constant Gain"
+msgstr "Không đổi"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Constant Power 1"
+msgstr "Không đổi"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Constant Power 2"
+msgstr "Không đổi"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Custom Curve"
+msgstr "Tùy chỉnh"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Custom curve"
+msgstr "Tùy chỉnh"
+
+#: plug-ins/crossfadetracks.ny
+#, fuzzy
+msgid "Fade direction"
+msgstr "Giảm Nhiễu"
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating Out / In"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+msgid "Alternating In / Out"
+msgstr ""
+
+#: plug-ins/crossfadetracks.ny
+#, lisp-format
+msgid "Error.~%Select 2 (or more) tracks to crossfade."
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Delay"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Applying Delay Effect..."
+msgstr "Đang áp dụng hiệu ứng Nyquist..."
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay type"
+msgstr "Loại Nhãn"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Regular"
+msgstr "Chữ nhật"
+
+#: plug-ins/delay.ny
+msgid "Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Reverse Bouncing Ball"
+msgstr ""
+
+#: plug-ins/delay.ny
+msgid "Delay level per echo (dB)"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Delay time (seconds)"
+msgstr "Thời gian trễ (giây):"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Pitch change effect"
+msgstr "Xem hiệu ứng trước"
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Pitch/Tempo"
+msgstr "Độ cao của âm"
+
 #: plug-ins/delay.ny
 msgid "Low-quality Pitch Shift"
 msgstr "Thay đổi độ cao của âm LQ Chất Lượng Thấp"
+
+#: plug-ins/delay.ny
+msgid "Pitch change per echo (semitones)"
+msgstr ""
+
+#: plug-ins/delay.ny
+#, fuzzy
+msgid "Number of echoes"
+msgstr "Số lượng nhãn"
+
+#: plug-ins/delay.ny
+msgid "Allow duration to change"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "EQ XML to TXT Converter"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Select target EQ effect"
 msgstr "Chọn mục tiêu EQ Effect (Hiệu ứng)"
 
 #: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "Equalization XML file"
+msgstr "Cân bằng tần số"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+#, fuzzy
+msgid "XML file"
+msgstr "Tập tin XML"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "If output text file exists"
 msgstr "Liệu tập tin văn bản đầu ra có tồn tại"
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Append number"
+msgstr ""
+
+#: plug-ins/eq-xml-to-txt-converter.ny
+msgid "Overwrite"
+msgstr ""
 
 #: plug-ins/eq-xml-to-txt-converter.ny
 #, lisp-format
@@ -10988,17 +19350,59 @@ msgid "Error.~%File cannot be written:~%\"~a.txt\""
 msgstr "Lỗi.~%File tập tin không được lưu:~%\"~a.txt\""
 
 #: plug-ins/equalabel.ny
+msgid "Regular Interval Labels"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Adding equally-spaced labels to the label track..."
+msgstr ""
+
+#. i18n-hint: Refers to the controls 'Number of labels' and 'Label interval'.
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Create labels based on"
+msgstr "Chia tập tin dựa trên:"
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Number & Interval"
+msgstr "Số kênh"
+
+#: plug-ins/equalabel.ny
 msgid "Number of Labels"
 msgstr "Số lượng nhãn"
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Label Interval"
+msgstr "Chỉ Mục Nhãn"
 
 #: plug-ins/equalabel.ny
 msgid "Number of labels"
 msgstr "Số lượng nhãn"
 
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Label interval (seconds)"
+msgstr "Độ dài (giây)"
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Length of label region (seconds)"
+msgstr "Độ dài (giây)"
+
+#: plug-ins/equalabel.ny
+msgid "Adjust label interval to fit length"
+msgstr ""
+
 #. i18n-hint: Do not translate '##1'
 #: plug-ins/equalabel.ny plug-ins/label-sounds.ny
 msgid "Label text"
 msgstr "Dòng chữ trong nhãn"
+
+#: plug-ins/equalabel.ny
+msgid "Minimum number of digits in label"
+msgstr ""
 
 #: plug-ins/equalabel.ny
 msgid "None - Text Only"
@@ -11029,16 +19433,237 @@ msgid "3 (After Label)"
 msgstr "3 (Sau nhãn)"
 
 #: plug-ins/equalabel.ny
+msgid "Begin numbering from"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+msgid "Message on completion"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Details"
+msgstr "&Chi tiết"
+
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "Warnings only"
+msgstr "Cảnh báo"
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "Warning: Overlapping region labels.~%"
+msgstr ""
+
+#. i18n-hint:  Type of label
+#: plug-ins/equalabel.ny
+#, fuzzy
+msgid "region labels"
+msgstr "nhãn điểm"
+
+#: plug-ins/equalabel.ny
 msgid "point labels"
 msgstr "nhãn điểm"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#. i18n-hint:  Number of labels produced at specified intervals.
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~a~a ~a at intervals of ~a seconds.~%"
+msgstr ""
+
+#: plug-ins/equalabel.ny
+#, lisp-format
+msgid "~aRegion length = ~a seconds."
+msgstr ""
+
+#: plug-ins/highpass.ny
+msgid "High-Pass Filter"
+msgstr ""
+
+#: plug-ins/highpass.ny
+#, fuzzy
+msgid "Performing High-Pass Filter..."
+msgstr "Đang thực hiện %d chỉnh sửa...\n"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "Tần số (Hz)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "Roll-off (dB per octave)"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#, fuzzy
+msgid "Frequency must be at least 0.1 Hz."
+msgstr "Tần số nhỏ nhất phải lớn hơn 0 Hz"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                   Track sample rate is ~a Hz~%~\n"
+"                   Frequency must be less than ~a Hz."
+msgstr ""
+
+#. i18n-hint: Name of effect that labels sounds
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Label Sounds"
+msgstr "Ghép nối nhãn"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Threshold level (dB)"
+msgstr "Ngưỡng: %d dB"
+
+#: plug-ins/label-sounds.ny
+msgid "Threshold measurement"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Peak level"
+msgstr "Độ cao phát lại"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Average level"
+msgstr "Trung bình"
+
+#: plug-ins/label-sounds.ny
+msgid "RMS level"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Minimum silence duration"
+msgstr "Độ dài khoảng lặng:"
+
+#: plug-ins/label-sounds.ny
+msgid "Minimum label interval"
+msgstr ""
 
 #: plug-ins/label-sounds.ny
 msgid "Label type"
 msgstr "Loại Nhãn"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Point before sound"
+msgstr "Stereo chung"
+
+#: plug-ins/label-sounds.ny
+#, fuzzy
+msgid "Point after sound"
+msgstr "Stereo chung"
+
+#: plug-ins/label-sounds.ny
+msgid "Region around sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Region between sounds"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum leading silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Maximum trailing silence"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+msgid "Sound ##1"
+msgstr ""
+
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Too many silences detected.~%Only the first 10000 labels added."
+msgstr ""
+
+#. i18n-hint: '~a' will be replaced by a time duration
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Error.~%Selection must be less than ~a."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
+msgstr ""
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Limiter"
+msgstr "Giới hạn dB"
+
+#: plug-ins/limiter.ny
+msgid "Limiting..."
+msgstr ""
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Type"
+msgstr "Loại:"
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Soft Limit"
+msgstr "Giới hạn dB"
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Hard Limit"
+msgstr "Giới hạn dB"
+
+#. i18n-hint: clipping of wave peaks and troughs, not division of a track into clips
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Soft Clip"
+msgstr "Đặt clip"
+
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Hard Clip"
+msgstr "Kết hợp các đoạn"
 
 #: plug-ins/limiter.ny
 msgid ""
@@ -11056,18 +19681,211 @@ msgstr ""
 "Núm Gain điều chỉnh đầu vào (dB) \n"
 "Right channel / Kênh bên phải"
 
+#: plug-ins/limiter.ny
+#, fuzzy
+msgid "Limit to (dB)"
+msgstr "Trái (dB)"
+
+#: plug-ins/limiter.ny plug-ins/noisegate.ny
+msgid "Hold (ms)"
+msgstr ""
+
+#: plug-ins/limiter.ny
+msgid "Apply Make-up Gain"
+msgstr ""
+
+#: plug-ins/lowpass.ny
+#, fuzzy
+msgid "Low-Pass Filter"
+msgstr "Nạp tập tin"
+
+#: plug-ins/lowpass.ny
+#, fuzzy
+msgid "Performing Low-Pass Filter..."
+msgstr "Đang thực hiện %d chỉnh sửa...\n"
+
 #: plug-ins/noisegate.ny
 msgid "Noise Gate"
 msgstr "Noise Gate - Bộ lọc Nhiễu"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Select Function"
+msgstr "Vùng chọn"
+
+#: plug-ins/noisegate.ny
+msgid "Gate"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Analyze Noise Level"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Stereo Linking"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Link Stereo Tracks"
+msgstr "Đoạn âm &Stereo"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Don't Link Stereo"
+msgstr "Stereo chung"
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Gate threshold (dB)"
+msgstr "Ngưỡng: %d dB"
+
+#: plug-ins/noisegate.ny
+msgid "Gate frequencies above (kHz)"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, fuzzy
+msgid "Level reduction (dB)"
+msgstr "Giảm &Nhiễu (dB):"
+
+#: plug-ins/noisegate.ny
+msgid "Attack (ms)"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+msgid "Decay (ms)"
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Selection too long.\n"
+"Maximum length is ~a."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
+"Insufficient audio selected.\n"
+"Make the selection longer than ~a ms."
+msgstr ""
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Notch Filter"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, fuzzy
+msgid "Applying Notch Filter..."
+msgstr "Đang áp dụng hiệu ứng Nyquist..."
+
+#: plug-ins/notch.ny
+msgid "Steve Daulton and Bill Wharrie"
+msgstr ""
+
+#: plug-ins/notch.ny
+msgid "Q (higher value reduces width)"
+msgstr ""
+
+#: plug-ins/notch.ny
+#, lisp-format
+msgid ""
+"Error:~%~%Frequency (~a Hz) is too high for track sample rate.~%~%~\n"
+"                 Track sample rate is ~a Hz.~%~\n"
+"                 Frequency must be less than ~a Hz."
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Nyquist Plug-in Installer"
+msgstr "%s, Plug-ins - Điện toán Nyquist"
 
 #. i18n-hint: "Browse..." is text on a button that launches a file browser.
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Select file(s) to install"
 msgstr "Chọn (các) tập tin để cài đặt"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Plug-in"
+msgstr "Plug-in \"điện toán\""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Lisp file"
+msgstr "Tập tin %s "
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "HTML file"
+msgstr "Tập tin XML"
+
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "Tập tin văn bản"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "All supported"
+msgstr "Hỗ trợ trình bổ sung"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Allow overwriting"
+msgstr "cho phé&p ghim đỉnh"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy
+msgid "Disallow"
+msgstr "Không cho phép"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+msgid "Allow"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Success.~%Files written to:~%~s~%"
+msgstr ""
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, fuzzy, lisp-format
+msgid "Warning.~%Failed to copy some files:~%"
+msgstr ""
+"Lỗi khi mở cơ sở tập tin dữ liệu :\n"
+"\n"
+"%s"
+
+#: plug-ins/nyquist-plug-in-installer.ny
+#, lisp-format
+msgid "Plug-ins installed.~%(Use the Plug-in Manager to enable effects):"
+msgstr ""
 
 #: plug-ins/nyquist-plug-in-installer.ny
 msgid "Plug-ins updated:"
@@ -11098,9 +19916,204 @@ msgstr "Không thể lưu vào thư mục Plug-ins (điện toán) "
 msgid "Error.~%No file selected."
 msgstr "Lỗi.~% Chưa  chọn tập tin."
 
+#: plug-ins/pluck.ny
+msgid "Pluck"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Generating pluck sound..."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Pluck MIDI pitch"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Fade-out type"
+msgstr "Loại Nhãn"
+
+#: plug-ins/pluck.ny
+msgid "Abrupt"
+msgstr ""
+
+#: plug-ins/pluck.ny
+msgid "Gradual"
+msgstr ""
+
+#: plug-ins/pluck.ny
+#, fuzzy
+msgid "Duration (60s max)"
+msgstr "Độ dài"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Rhythm Track"
+msgstr "Đoạn âm thấp"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Generating Rhythm..."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Tempo (bpm)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "30 - 300 beats/minute"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Beats per bar"
+msgstr "nhịp điệu mỗi phút"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 20 beats/measure"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Swing amount"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Number of bars"
+msgstr "Số lượng nhãn"
+
+#: plug-ins/rhythmtrack.ny
+msgid "1 - 1000 bars"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Rhythm track duration"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Used if 'Number of bars' = 0"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Start time offset"
+msgstr "Offset bắt đầu:"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Silence before first beat"
+msgstr "Tính cả âm thanh trước nhãn đầu tiên"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Beat sound"
+msgstr "Tìm điểm ghim"
+
+#: plug-ins/rhythmtrack.ny
+msgid "Metronome Tick"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Ping (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Cowbell"
+msgstr ""
+
 #: plug-ins/rhythmtrack.ny
 msgid "Resonant Noise"
 msgstr "Resonant Noise -Nhiễu Cộng hưởng"
+
+#: plug-ins/rhythmtrack.ny
+#, fuzzy
+msgid "Noise Click"
+msgstr "Nhiễu nhỏ nhất - Noise Floor "
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (short)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "Drip (long)"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of strong beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "18 - 116"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid "MIDI pitch of weak beat"
+msgstr ""
+
+#: plug-ins/rhythmtrack.ny
+msgid ""
+"Set either 'Number of bars' or\n"
+"'Rhythm track duration' to greater than zero."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Risset Drum"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Generating Risset Drum..."
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Decay (seconds)"
+msgstr "Thời gian trễ (giây):"
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Center frequency of noise (Hz)"
+msgstr "Tần số nhỏ nhất (Hz):"
+
+#: plug-ins/rissetdrum.ny
+msgid "Width of noise band (Hz)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+msgid "Amount of noise in mix (percent)"
+msgstr ""
+
+#: plug-ins/rissetdrum.ny
+#, fuzzy
+msgid "Amplitude (0 - 1)"
+msgstr "Biên độ (0-1):"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample Data Export"
+msgstr "Chèn mẫu dữ liệu."
 
 #: plug-ins/sample-data-export.ny
 msgid "Analyzing..."
@@ -11111,6 +20124,76 @@ msgid "Limit output to first"
 msgstr "Giới hạn đầu ra cơ bản."
 
 #: plug-ins/sample-data-export.ny
+msgid "Measurement scale"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Export data to"
+msgstr "Xuất lệnh Macro"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "CSV files"
+msgstr "Tập tin FLAC"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "HTML files"
+msgstr "Tập tin XML"
+
+#: plug-ins/sample-data-export.ny
+msgid "Index (text files only)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample Count"
+msgstr "Chỉnh sửa mẫu"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Time Indexed"
+msgstr "Chỉ Mục Nhãn"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Include header information"
+msgstr "Không thể phân tích thông tin dự án."
+
+#: plug-ins/sample-data-export.ny
+msgid "Minimal"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "All"
+msgstr "&Tất"
+
+#: plug-ins/sample-data-export.ny
+msgid "Optional header text"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Channel layout for stereo"
+msgstr ""
+
+#. i18n-hint: Left and Right
+#: plug-ins/sample-data-export.ny
+msgid "L-R on Same Line"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Alternate Lines"
+msgstr ""
+
+#. i18n-hint: L for Left
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "L Channel First"
+msgstr "%d kênh"
+
+#: plug-ins/sample-data-export.ny
 msgid "Show messages"
 msgstr "Hiển thị tin nhắn"
 
@@ -11118,10 +20201,140 @@ msgstr "Hiển thị tin nhắn"
 msgid "Errors Only"
 msgstr "Chỉ Lỗi"
 
+#. i18n-hint abbreviates negative infinity
+#: plug-ins/sample-data-export.ny
+msgid "[-inf]"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "Left Channel.~%~%"
+msgstr "Kênh trái"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~%~%Right Channel.~%~%"
+msgstr "Kênh phải"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~aData written to:~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Sample Rate: ~a Hz.  Sample values on ~a scale.~%~a~%~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a   ~a~%~aSample Rate: ~a Hz.~%Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a   ~a~%~aSample Rate: ~a Hz. Sample values on ~a scale.~%~\n"
+"                     Length processed: ~a samples ~a seconds.~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"~a~%Sample Rate: ~a Hz. Sample values on ~a scale. ~a.~%~aLength processed: ~a ~\n"
+"                  samples, ~a seconds.~%Peak amplitude: ~a (linear) ~a dB.  Unweighted RMS: ~a dB.~%~\n"
+"                  DC offset: ~a~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a lin, ~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy, lisp-format
+msgid "~a samples."
+msgstr "mẫu"
+
 #: plug-ins/sample-data-export.ny
 #, lisp-format
 msgid "~a seconds."
 msgstr "~a giây."
+
+#: plug-ins/sample-data-export.ny
+msgid "Audio data analysis:"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Sample Rate:</b> &nbsp;&nbsp;~a Hz."
+msgstr ""
+
+#. i18n-hint: abbreviates "decibels"
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>Peak Amplitude:</b> &nbsp;&nbsp;~a (linear) &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: RMS abbreviates root-mean-square, a method of averaging a signal; there also "weighted" versions of it but this isn't that
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>RMS</b> (unweighted): &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#. i18n-hint: DC derives from "direct current" in electronics, really means the zero frequency component of a signal
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "<b>DC Offset:</b> &nbsp;&nbsp;~a"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left: ~a lin, ~a dB | Right: ~a linear, &nbsp;&nbsp;~a dB."
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "sample data"
+msgstr "Chỉnh sửa mẫu"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Sample #"
+msgstr "Chỉnh sửa mẫu"
+
+#: plug-ins/sample-data-export.ny
+msgid "Value (linear)"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Value (dB)"
+msgstr "&Âm lượng (dB):"
+
+#: plug-ins/sample-data-export.ny
+msgid "audio sample value analysis"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Left (linear)"
+msgstr "Trái (dB)"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "Right (linear)"
+msgstr "Phải (dB)"
 
 #: plug-ins/sample-data-export.ny
 msgid "Left (dB)"
@@ -11130,6 +20343,58 @@ msgstr "Trái (dB)"
 #: plug-ins/sample-data-export.ny
 msgid "Right (dB)"
 msgstr "Phải (dB)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid ""
+"Produced with <span>Sample Data Export</span> for\n"
+"<a href=\"~a\">Audacity</a> by Steve\n"
+"Daulton"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "linear"
+msgstr "Tuyến tính"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "2 channels (stereo)"
+msgstr "Lập thể (Stereo)"
+
+#: plug-ins/sample-data-export.ny
+#, fuzzy
+msgid "1 channel (mono)"
+msgstr "Đơn thể (Mono)"
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One column per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "One row per channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel then Right channel on same line.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left and right channels on alternate lines.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+#, lisp-format
+msgid "Left channel first then right channel.~%"
+msgstr ""
+
+#: plug-ins/sample-data-export.ny
+msgid "Unspecified channel order"
+msgstr ""
 
 #: plug-ins/sample-data-export.ny
 #, lisp-format
@@ -11149,17 +20414,264 @@ msgid "Select file"
 msgstr "Chọn tập tin"
 
 #: plug-ins/sample-data-import.ny
+msgid "Invalid data handling"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, fuzzy
+msgid "Throw Error"
+msgstr "Lỗi"
+
+#: plug-ins/sample-data-import.ny
+msgid "Read as Zero"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"                        '~a' could not be opened.~%~\n"
+"                        Check that file exists."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error:~%~\n"
+"              The file must contain only plain ASCII text.~%~\n"
+"              (Invalid byte '~a' at byte number: ~a)"
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
+#, lisp-format
+msgid ""
+"Error~%~\n"
+"              Data must be numbers in plain ASCII text.~%~\n"
+"              '~a' is not a numeric value."
+msgstr ""
+
+#: plug-ins/sample-data-import.ny
 #, lisp-format
 msgid "Error.~%Unable to open file"
 msgstr "Lỗi.~% Không thể mở tập tin"
+
+#: plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "Spectral Delete"
+msgstr "Chọn quang phổ"
+
+#: plug-ins/spectral-delete.ny
+#, lisp-format
+msgid "Error.~%Track sample rate below 100 Hz is not supported."
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Tremolo"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+#, fuzzy
+msgid "Applying Tremolo..."
+msgstr "Đang áp dụng..."
+
+#: plug-ins/tremolo.ny
+#, fuzzy
+msgid "Waveform type"
+msgstr "Dạng sóng"
+
+#: plug-ins/tremolo.ny
+#, fuzzy
+msgid "Inverse Sawtooth"
+msgstr "Răng cưa"
+
+#: plug-ins/tremolo.ny
+msgid "Starting phase (degrees)"
+msgstr ""
+
+#: plug-ins/tremolo.ny
+msgid "Wet level (percent)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Vocal Reduction and Isolation"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Applying Action..."
+msgstr "Đang áp dụng..."
+
+#: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Remove Vocals: to mono"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Remove Vocals"
+msgstr "&Xoá Dải âm"
+
+#: plug-ins/vocalrediso.ny
+msgid "Isolate Vocals"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Isolate Vocals and Invert"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "Remove Center: to mono"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Remove Center"
+msgstr "Xoá đường cắt"
+
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Isolate Center"
+msgstr "Giữa"
+
+#: plug-ins/vocalrediso.ny
+msgid "Isolate Center and Invert"
+msgstr ""
 
 #: plug-ins/vocalrediso.ny
 msgid "Analyze"
 msgstr "Phân tích"
 
+#: plug-ins/vocalrediso.ny
+#, fuzzy
+msgid "Strength"
+msgstr "Độ dài"
+
+#: plug-ins/vocalrediso.ny
+msgid "Low Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "High Cut for Vocals (Hz)"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
+msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid " - A fairly good value, at least stereo in average and not too wide spread."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are almost not related.\n"
+"                Either you have only noise or the piece is mastered in a unbalanced manner.\n"
+"                The center extraction can still be good though."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - Although the Track is stereo, the field is obviously extra wide.\n"
+"                This can cause strange effects.\n"
+"                Especially when played by only one speaker."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are nearly identical.\n"
+"                  Obviously, a pseudo stereo effect has been used\n"
+"                  to spread the signal over the physical distance between the speakers.\n"
+"                  Don't expect good results from a center removal."
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
+msgid "This plug-in works only with stereo tracks."
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Vocoder"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Processing Vocoder..."
+msgstr " Đang &Xử lý:"
+
+#: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Distance: (1 to 120, default = 20)"
+msgstr ""
+
 #: plug-ins/vocoder.ny
 msgid "Output choice"
 msgstr "Lựa chọn đầu ra"
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Both Channels"
+msgstr "%d kênh"
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Right Only"
+msgstr "Kênh phải"
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Number of vocoder bands"
+msgstr "Số kênh"
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of original audio (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+msgid "Amplitude of white noise (percent)"
+msgstr ""
+
+#: plug-ins/vocoder.ny
+#, fuzzy
+msgid "Amplitude of Radar Needles (percent)"
+msgstr "Tần số Radar Needles (Hz)"
 
 #: plug-ins/vocoder.ny
 msgid "Frequency of Radar Needles (Hz)"
@@ -11170,11 +20682,119 @@ msgstr "Tần số Radar Needles (Hz)"
 msgid "Error.~%Stereo track required."
 msgstr "Lỗi. Bạn phải có dải âm ~%Stereo"
 
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "&bỏ qua"
+
+#, fuzzy
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "Đang ghi âm"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Nhập Id:"
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "Thư viện hệ thống GUI (Giao diện người dùng đồ họa)"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã dừng hoạt động. Không thể tối ưu hóa thêm. Cấp độ còn quá cao."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã giảm âm lượng xuống %f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã dừng hoạt động. Không thể tối ưu hóa thêm nữa. Cấp độ còn quá thấp."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã tăng âm lượng lên %.2f."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã đừng. Tổng số phân tích đã vượt quá mức và mức âm lượng phù hợp vẫn chưa được tìm thấy. Vẫn còn quá cao."
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã đừng. Tổng số phân tích đã vượt quá mức và mức âm lượng phù hợp vẫn chưa được tìm thấy. Vẫn còn quá thấp."
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "Điều chỉnh Cấp độ Thu âm Tự động đã dừng. %.2f được xem là mức âm lượng vừa phải."
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "Nhận %d khi mở thiết bị \n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "Không mở được bộ phối cổng (Portmixer)\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "Các bộ phối mixer hợp lệ:\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "Các nguồn thu âm hợp lệ:\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "Các âm lượng phát tiếng hợp lệ:\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "Âm lượng thu âm được giả lập\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "Âm lượng thu âm gốc\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "Âm lượng phát tiếng được giả lập\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "Âm lượng phát tiếng gốc\n"
+
+#, fuzzy
+#~ msgid "Unknown date and time"
+#~ msgstr "Ngày giờ kết thúc"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "Trình nhập GStreamer"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "Không thể dừng 'stream state'."
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "Không thể chèn tệp, lỗi thay đổi trạng thái."
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "Lỗi GStreamer: %s"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "&Thông tin về Audacity..."
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "Bật Điều chỉnh Cấp độ Thu âm Tự động."
+
+#~ msgid "Recording Volume"
+#~ msgstr "Âm lượng ghi âm"
+
+#~ msgid "Playback Volume"
+#~ msgstr "Âm lượng phát lại"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "Âm lượng phát lại: %.2f (emulated)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "Âm lượng phát lại: %.2f"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "Thanh công cụ của &Bộ trộn âm thanh"
+
+#, fuzzy
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "Nhấn và rê để di chuyển dải âm theo thời gian"
+
 #~ msgid "Program build date:"
 #~ msgstr "Ngày tạo phần mềm:"
-
-#~ msgid "Unknown error"
-#~ msgstr "Lỗi chưa xác định"
 
 #~ msgid "%s is a free program written by a worldwide team of %s. %s is %s for Windows, Mac, and GNU/Linux (and other Unix-like systems)."
 #~ msgstr "%s là phần mềm miễn phí được viết bởi nhóm trên toàn thế giới.  %s. %s là %s cho  Windows, Mac và GNU / Linux (và các hệ thống giống Unix khác)."
@@ -11213,6 +20833,3 @@ msgstr "Lỗi. Bạn phải có dải âm ~%Stereo"
 
 #~ msgid "Check Online"
 #~ msgstr "Kiểm tra Online"
-
-#~ msgid "Gray Scale"
-#~ msgstr "gam xám"

--- a/locale/zh.po
+++ b/locale/zh.po
@@ -17,82 +17,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-09-05 05:56+0000\n"
 "Last-Translator: Liu Wenyuan <15816141883@163.com>\n"
-"Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
-"tenacity/tenacity/zh_Hans/>\n"
+"Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/tenacity/tenacity/zh_Hans/>\n"
 "Language: zh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "更新 Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "跳过(&S)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "安装更新(&I)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "更新日志"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "在 GitHub 上阅读更多信息"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "检查更新时出错"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "无法连接到 Tenacity 更新服务器。"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "更新数据已损坏。"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "下载更新时出错。"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "无法打开 Tenacity 下载链接。"
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "Tenacity %s 可用！"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "录音"
 
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
@@ -102,6 +36,24 @@ msgstr "不能决定"
 #, c-format
 msgid "%s bytes"
 msgstr "%s 字节"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -228,7 +180,8 @@ msgid "Script"
 msgstr "脚本"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "输出"
 
@@ -244,7 +197,12 @@ msgstr "Nyquist 脚本 (*.ny)|*.ny|Lisp 脚本 (*.lsp)|*.lsp|所有文件|*"
 msgid "Script was not saved."
 msgstr "脚本未被保存。"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "警告"
 
@@ -265,7 +223,16 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango 图标库 （工具栏图标）"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr "(C) 2009 Leland Lucius 作品"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "外部 Tenacity 模块，提供一个用于编写效果的简单 IDE 。"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -288,7 +255,8 @@ msgstr "无标题"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist 效果工作台 - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "新建"
 
@@ -328,7 +296,8 @@ msgstr "复制"
 msgid "Copy to clipboard"
 msgstr "复制到剪贴板"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "剪切"
 
@@ -336,7 +305,8 @@ msgstr "剪切"
 msgid "Cut to clipboard"
 msgstr "剪切到剪贴板"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "粘贴"
 
@@ -361,7 +331,8 @@ msgstr "全选"
 msgid "Select all text"
 msgstr "选择所有文本"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "撤销"
 
@@ -369,7 +340,8 @@ msgstr "撤销"
 msgid "Undo last change"
 msgstr "撤消上次更改"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "重做"
 
@@ -426,7 +398,8 @@ msgid "Go to next S-expr"
 msgstr "转到下一个 S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "开始"
 
@@ -434,7 +407,8 @@ msgstr "开始"
 msgid "Start script"
 msgstr "启动脚本"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "停止"
 
@@ -449,7 +423,8 @@ msgid "About %s"
 msgstr "关于 %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "确定"
 
@@ -457,11 +432,13 @@ msgstr "确定"
 msgid "Build Information"
 msgstr "构建信息"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "已启用"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "未启用"
 
@@ -471,8 +448,9 @@ msgid "The Build"
 msgstr "构建"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "Github 提交 ID："
+#, fuzzy
+msgid "Version:"
+msgstr "版本"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -482,22 +460,28 @@ msgstr "构建类型："
 msgid "Compiler:"
 msgstr "编译器："
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "安装目录前缀："
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "设置文件夹:"
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "设置文件夹:"
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "文件格式支持"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "跨平台 GUI 库"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -511,7 +495,6 @@ msgstr "采样率转换"
 msgid "MP3 Importing"
 msgstr "MP3 导入"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis 导入／导出"
@@ -520,7 +503,6 @@ msgstr "Ogg Vorbis 导入／导出"
 msgid "ID3 tag support"
 msgstr "ID3 标签支持"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC 导入／导出"
@@ -538,14 +520,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg 导入／导出"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "通过 GStreamer 导入"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "特性"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "插件支持"
 
@@ -560,6 +534,10 @@ msgstr "音高和速度改变支持"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "极限音高和速度改变支持"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "特性"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -678,6 +656,10 @@ msgstr "%s, Audacity 图形"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s (包含入 %s, %s, %s, %s 和 %s)"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
@@ -686,6 +668,10 @@ msgstr "免费、开源、跨平台的声音录制和编辑软件。"
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "制作组"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "请注意名称是按字母顺序而不是按重要性排序的。"
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -734,6 +720,7 @@ msgstr "Audacity 网站和图形"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr "中文（简体）翻译：<br><a href=\"zm1990s@gmail.com\">ZhangMin</a> 张敏<br><a href=\"mailto:liouxiao@hotmail.com\">Liu Xiao Xi</a> 刘晓曦<br><a href=\"mailto:ruanbeihong@gmail.com\">James Ruan</a> 阮贝鸿<br><a href=\"mailto:isaac.yc@gmail.com\">Chao YU</a> 余超<br><a href=\"mailto:snowwolf1001@gmail.com\">mkpoli</a><br><a href=\"mailto:fungdaat31@outlook.com\">WhiredPlanck</a>"
@@ -758,6 +745,16 @@ msgstr "%s 网站: "
 msgid "%s %s 1999-%s %s contributors"
 msgstr "%s %s 1999-%s %s 贡献者"
 
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "Audacity%s 商标在本软件中仅用于说明和信息目的。"
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity 并非由 MuseCY SM 有限公司或 Dominic Mazzoni 所制造或背书。"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "录制时时间线操作已禁用"
@@ -779,6 +776,7 @@ msgstr "时间线"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "单击并拖动以定位播放"
@@ -786,6 +784,7 @@ msgstr "单击并拖动以定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "点击并拖动以跟随播放"
@@ -793,6 +792,7 @@ msgstr "点击并拖动以跟随播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "点击并移动以跟随播放。点击并拖动以定位播放。"
@@ -800,6 +800,7 @@ msgstr "点击并移动以跟随播放。点击并拖动以定位播放。"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "移动以定位播放"
@@ -807,6 +808,7 @@ msgstr "移动以定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "移动以跟随播放"
@@ -863,7 +865,17 @@ msgstr ""
 "不能锁定超出工程\n"
 "终点的区域。"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "错误"
 
@@ -887,7 +899,8 @@ msgstr ""
 "此问题只会在软件安装结束后出现一次，当且仅当你选择了重置偏好设置。"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "重置 Tenacity 偏好设置"
 
 #: src/AudacityApp.cpp
@@ -902,7 +915,8 @@ msgstr ""
 "它已经从最近使用文件列表中移除了。"
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "SQLite 库初始化失败。  Tenacity 无法继续。"
 
 #: src/AudacityApp.cpp
@@ -927,7 +941,7 @@ msgstr "打开(&O)..."
 msgid "Open &Recent..."
 msgstr "打开最近使用的(&R)..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "&关于 Tenacity..."
 
@@ -940,9 +954,10 @@ msgid "&File"
 msgstr "文件(&F)"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity 找不到安全的可以存储临时文件的地方。\n"
@@ -950,20 +965,23 @@ msgstr ""
 "请在偏好设置里输入一个适当的路径。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity 找不到可以存储临时文件的地方。\n"
 "请在偏好设置对话框里输入一个适当的路径。"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "即将退出 Tenacity。请重启 Tenacity 以使用新的临时目录。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -972,15 +990,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity 不能锁住临时文件目录。\n"
 "这个目录可能正被另一个 Tenacity 进程使用。\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "仍想启动 Tenacity 吗？"
 
 #: src/AudacityApp.cpp
@@ -988,19 +1008,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "锁定临时目录出错"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "系统发现另一个 Tenacity 正在运行。\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "在当前运行的 Tenacity 中使用新建或打开命令\n"
 "来同时打开多个工程。\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity 已经在运行了"
 
 #: src/AudacityApp.cpp
@@ -1016,7 +1039,8 @@ msgstr ""
 "也许需要重启一次。"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Tenacity 启动失败"
 
 #: src/AudacityApp.cpp
@@ -1056,8 +1080,9 @@ msgstr ""
 "也许需要重启一次。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1089,7 +1114,8 @@ msgstr "运行自检"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "显示 Tenacity 版本"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1099,9 +1125,10 @@ msgid "audio or project file name"
 msgstr "音频或者工程的文件名"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1114,16 +1141,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Tenacity 工程文件"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "消息"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Tenacity 配置错误"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1133,7 +1162,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "T无法访问下列配置文件:\n"
 "\n"
@@ -1145,12 +1174,15 @@ msgstr ""
 "\n"
 "如果您选择“退出 Tenacity”，您的工程可能会处于未保存状态，下次打开时将恢复。"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "帮助"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "退出 Tenacity (&Q)"
 
 #: src/AudacityFileConfig.cpp
@@ -1158,7 +1190,8 @@ msgid "&Retry"
 msgstr "重试(&R)"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacity 日志"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1170,7 +1203,8 @@ msgstr "保存(&S)..."
 msgid "Cl&ear"
 msgstr "清除(&E)"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "关闭(&C)"
 
@@ -1225,7 +1259,8 @@ msgid "Error Initializing Midi"
 msgstr "MIDI初始化错误"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity 音频"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1240,37 +1275,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "内存空间不足！"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "录制音量自动调整已停止。无法进一步优化。音量依然过高。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "录制音量自动调整器已将音量降低到 %f。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "录制音量自动调整已停止。无法进一步优化。音量依然过低。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "录制音量自动调整器已将音量提高到 %.2f。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "录制音量自动调整已停止。分析数值已经超过上限，但仍未找到合适的音量值。音量依然过高。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "录制音量自动调整已停止。分析数值已经超过上限，但仍未找到合适的音量值。音量依然过低。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "录制音量自动调整已停止。 %.2f 似乎是合适的音量。"
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1369,43 +1373,6 @@ msgstr "未找到“%s”的播放设备。\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "不能在没有两个设备时检查互采样率。\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "打开设备时收到%d\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "不能打开 Portmixer\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "有效的混合器：\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "可用录制源：\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "可用播放音量：\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "模拟录制音量\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "本地录制音量\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "模拟播放音量\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "本地播放音量\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1448,8 +1415,9 @@ msgid "Automatic Crash Recovery"
 msgstr "崩溃自动恢复"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1462,12 +1430,14 @@ msgid "Recoverable &projects"
 msgstr "可恢复的工程(&P)"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "选择"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "名称"
 
@@ -1553,6 +1523,11 @@ msgstr "效果"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "菜单命令（带参数）"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1698,7 +1673,8 @@ msgstr "恢复(&S)"
 msgid "I&mport..."
 msgstr "导入(&M)..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "导出(&X)..."
 
@@ -1739,7 +1715,8 @@ msgstr "上移(&U)"
 msgid "Move &Down"
 msgstr "下移(&D)"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "保存(&S)"
 
@@ -1822,7 +1799,8 @@ msgid "Run"
 msgstr "运行"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "关闭"
 
@@ -1968,10 +1946,6 @@ msgid "No revision identifier was provided"
 msgstr "没有提供修订标识符"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "日期和时间不详"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "调试版本 (调试级别 %d)"
@@ -2054,6 +2028,11 @@ msgid ""
 msgstr ""
 "必须先选择一些音频才能使用它\n"
 "（选择其他类型的轨道不行）"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2216,6 +2195,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "复制名称到剪贴板(&C)"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "丢失"
 
@@ -2224,10 +2208,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "如果继续，工程将不会保存到磁盘上，要这样做吗？"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2241,7 +2226,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "依赖性检查"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "无"
 
@@ -2249,7 +2237,7 @@ msgstr "无"
 msgid "Rectangle"
 msgstr "矩形"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "三角形"
 
@@ -2261,14 +2249,60 @@ msgstr "给定形"
 msgid "Rectangular"
 msgstr "矩形"
 
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr "高斯函数（a=2.5）"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr "高斯函数（a=3.5）"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr "高斯函数（a=4.5）"
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "FFmpeg 支持没有被编译进"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2290,8 +2324,8 @@ msgid "Locate FFmpeg"
 msgstr "定位 FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity 需要文件 %s 来通过 FFmpeg 导出／导入音频。"
 
 #: src/FFmpeg.cpp
@@ -2304,7 +2338,8 @@ msgstr "“%s”的位置："
 msgid "To find '%s', click here -->"
 msgstr "要寻找“%s”，请点击这里→"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "浏览..."
 
@@ -2330,8 +2365,9 @@ msgid "FFmpeg not found"
 msgstr "FFmpeg没有找到"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2361,24 +2397,24 @@ msgid "Only libavformat.so"
 msgstr "仅 libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity 无法打开文件： %s。"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr "Tenacity 无法读取文件： %s。"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Tenacity 成功写入了文件 %s 但是改名为 %s 时失败。"
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2416,7 +2452,9 @@ msgstr "不要复制任何音频(&N)"
 msgid "As&k"
 msgstr "询问(&K)"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "所有文件"
 
@@ -2441,6 +2479,10 @@ msgstr "文本文件"
 #: src/FileNames.cpp
 msgid "XML files"
 msgstr "XML 文件"
+
+#: src/FileNames.cpp
+msgid ", "
+msgstr ", "
 
 #. i18n-hint a type or types such as "txt" or "txt, xml" will be
 #. substituted for %s
@@ -2507,7 +2549,12 @@ msgstr "对数频率"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "分贝"
 
@@ -2518,6 +2565,15 @@ msgstr "滚动"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "缩放"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
@@ -2582,6 +2638,18 @@ msgid "s"
 msgstr "秒"
 
 #. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %d dB"
+msgstr "%d Hz (%s) = %d dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
+#: src/FreqWindow.cpp
+#, c-format
+msgid "%d Hz (%s) = %.1f dB"
+msgstr "%d Hz (%s) = %.1f dB"
+
+#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
 #. * the %.4f are numbers, and 'sec' should be an abbreviation for seconds
 #: src/FreqWindow.cpp
 #, c-format
@@ -2603,7 +2671,8 @@ msgstr "频谱图.txt"
 msgid "Export Spectral Data As:"
 msgstr "将频谱数据导出为："
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "无法写入文件：%s"
@@ -2692,9 +2761,7 @@ msgstr "我们强烈建议使用我们最新的稳定版本，它具有完整的
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"你可以通过加入我们的 [[https://tenacityaudio.org|Tenacity 社区]]来帮助我们让 Tenacity "
-"变得更好。<hr><br><br>"
+msgstr "你可以通过加入我们的 [[https://tenacityaudio.org|Tenacity 社区]]来帮助我们让 Tenacity 变得更好。<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2724,9 +2791,7 @@ msgstr "更多：请访问我们的 [[https://wiki.audacityteam.org/index.php|Wi
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"如果你的计算机上另行安装了 FFmpeg 库，则 Tenacity 可以导入诸多其它未受保护格式（例如 M4A/WMA、便携式录音机的压缩 "
-"WAV、视频文件中音频等）。"
+msgstr "如果你的计算机上另行安装了 FFmpeg 库，则 Tenacity 可以导入诸多其它未受保护格式（例如 M4A/WMA、便携式录音机的压缩 WAV、视频文件中音频等）。"
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
@@ -2734,16 +2799,11 @@ msgstr "你也可以通过阅读帮助，来了解如何导入[[https://manual.a
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"使用手册好像没有被安装。请[[*URL*|在线浏览使用手册]]。<br><br>如果希望总是在线浏览使用手册，请将界面偏好设置中“使用手册的位置”更改为“"
-"从互联网”。"
+msgstr "使用手册好像没有被安装。请[[*URL*|在线浏览使用手册]]。<br><br>如果希望总是在线浏览使用手册，请将界面偏好设置中“使用手册的位置”更改为“从互联网”。"
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"使用手册好像没有被安装。请[[*URL*|在线浏览使用手册]]或[[https://manual.audacityteam.org/man/"
-"unzipping_the_manual."
-"html|下载使用手册]].。<br><br>如果希望总是在线浏览使用手册，请将界面偏好设置中“使用手册的位置”更改为“从互联网”。"
+msgstr "使用手册好像没有被安装。请[[*URL*|在线浏览使用手册]]或[[https://manual.audacityteam.org/man/unzipping_the_manual.html|下载使用手册]].。<br><br>如果希望总是在线浏览使用手册，请将界面偏好设置中“使用手册的位置”更改为“从互联网”。"
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2802,19 +2862,19 @@ msgid "&History..."
 msgstr "历史记录(&H)..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "内部错误在 %s 于 %s 行 %d。\n"
 "请通过 https://forum.audacityteam.org/ 来通知 Tenacity 团队。"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s 内部错误，位于第 %s 行 %d\n"
 "请通过 https://tenacityaudio.org/ 告知 Tenacity 团队。"
@@ -2833,7 +2893,9 @@ msgid "Track"
 msgstr "音轨"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "标签"
 
@@ -2893,7 +2955,8 @@ msgstr "输入标签轨名"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "标签轨"
 
@@ -2904,11 +2967,13 @@ msgstr "一个或更多的标签无法读取。"
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Tenacity 第一次运行"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "选择Tenacity使用的语言："
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2918,7 +2983,8 @@ msgstr "选择Tenacity使用的语言："
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "你选择的语言 - %s (%s) - 和系统语言 %s (%s) 不同。"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "确认"
 
@@ -2936,12 +3002,13 @@ msgstr ""
 "原文件已被存为“%s”"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "打开 Tenacity 工程"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Tenacity 卡拉OK%s"
 
 #: src/LyricsWindow.cpp
@@ -2992,19 +3059,23 @@ msgid "Mixing and rendering tracks"
 msgstr "混音并渲染轨道"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tenacity混音板%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "音量增强"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "速度"
 
@@ -3013,17 +3084,23 @@ msgid "Musical Instrument"
 msgstr "乐器"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "左右声道平衡"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "静音"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "独奏"
 
@@ -3031,15 +3108,18 @@ msgstr "独奏"
 msgid "Signal Level Meter"
 msgstr "信号电平指示"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "已移动音量增强滑杆"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "已移动速度滑杆"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "已移动左右声道平衡滑杆"
 
@@ -3074,9 +3154,9 @@ msgstr ""
 "它将不会被加载。"
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3110,16 +3190,19 @@ msgstr ""
 "\n"
 "仅使用信任源的模块"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "是"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "否"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity 模块加载器"
 
 #: src/ModuleManager.cpp
@@ -3142,6 +3225,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "音符轨"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "C"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "C♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "D"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "D♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "E"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "F"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "F♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "G"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "G♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "A"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "A♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "B"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "D♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "E♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "G♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "A♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "B♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "C♯/D♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "D♯/E♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "F♯/G♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "G♯/A♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "A♯/B♭"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3250,7 +3443,8 @@ msgstr "选择所有(&S)"
 msgid "C&lear All"
 msgstr "清除所有(&L)"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "启用(&E)"
 
@@ -3330,9 +3524,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "不匹配的采样率"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "选择的音轨太少，无法以该采样率进行录制。\n"
@@ -3361,10 +3556,11 @@ msgid "Dropouts"
 msgstr "丢失"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3404,11 +3600,11 @@ msgid "Inspecting project file data"
 msgstr "正在检查工程文件数据"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3451,11 +3647,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "警告 - 缺失替身文件"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "文件夹“%s”的工程检查\n"
@@ -3480,12 +3676,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "警告 - 缺失替身概要文件"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3543,7 +3739,8 @@ msgstr "警告 - 孤立的块文件"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "进度"
 
@@ -3564,6 +3761,15 @@ msgstr ""
 #: src/ProjectFSCK.cpp
 msgid "Warning: Problems in Automatic Recovery"
 msgstr "警告：自动恢复时发生问题"
+
+#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
+msgid "<untitled>"
+msgstr "<无标题工程>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[工程 %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3633,12 +3839,14 @@ msgstr ""
 "（无法创建所需的临时文件）"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "这不是一个 Tenacity 工程文件"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3772,9 +3980,9 @@ msgid "Error Writing to File"
 msgstr "写入文件出错"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3790,9 +3998,16 @@ msgstr "正在压实工程"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[工程 %02i] Tenacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3801,10 +4016,10 @@ msgstr "(已恢复的)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "此文件是用 Tenacity %s 保存的。\n"
 "现在所使用的是 Tenacity %s。需要升级至新的版本才能打开这个文件。"
@@ -3876,8 +4091,9 @@ msgid "Backing up project"
 msgstr "备份工程"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3886,8 +4102,9 @@ msgstr ""
 "它已恢复到最后一个快照状态。"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3966,8 +4183,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%s将工程 \"%s\" 另存为..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "“保存工程”指的是保存 Tenacity 工程文件，而不是音频文件。\n"
@@ -4044,11 +4262,12 @@ msgid "Error Opening Project"
 msgstr "打开工程出错"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "你正打开一个自动创建的备份文件。\n"
 "这样做会可能导致严重的数据丢失。\n"
@@ -4159,8 +4378,8 @@ msgid "Automatic database backup failed."
 msgstr "自动备份数据库失败。"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "欢迎使用 Tenacity 版本 %s"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4373,7 +4592,8 @@ msgstr "全部偏好设置"
 msgid "SelectionBar"
 msgstr "选择栏"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "频谱选区"
 
@@ -4381,46 +4601,55 @@ msgstr "频谱选区"
 msgid "Timer"
 msgstr "计时器"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "工具"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "播录"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "混音器"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "指示表"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "播放指示"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "录制指示"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "编辑"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "设备"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "以指定速度播放"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "跟随播放"
 
@@ -4435,7 +4664,10 @@ msgstr "标尺"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "轨道"
 
@@ -4545,7 +4777,8 @@ msgid "Activation level (dB):"
 msgstr "激活电平(dB)："
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "欢迎来到Tenacity!"
 
 #: src/SplashDialog.cpp
@@ -4692,9 +4925,9 @@ msgstr ""
 "有关合适驱动器的提示，请单击“帮助”按钮。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity 无法写文件：\n"
@@ -4714,9 +4947,9 @@ msgstr ""
 " %s。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4725,9 +4958,9 @@ msgstr ""
 "。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity 无法写文件到文件：\n"
@@ -4744,9 +4977,9 @@ msgstr ""
 " %s。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4756,9 +4989,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4767,8 +5000,9 @@ msgstr ""
 "也许png格式错误？"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity 无法读默认主题.\n"
@@ -4806,9 +5040,9 @@ msgstr ""
 "已经存在了。覆盖吗？"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity 无法保存文件：\n"
@@ -4847,7 +5081,11 @@ msgstr "自定义"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "持续时间"
 
@@ -4858,7 +5096,8 @@ msgid "Time Track"
 msgstr "时间轨"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Tenacity 定时录音"
 
 #: src/TimerRecordDialog.cpp
@@ -4932,7 +5171,8 @@ msgstr "当前工程"
 msgid "Recording start:"
 msgstr "开始录制："
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "持续时间："
 
@@ -4953,7 +5193,8 @@ msgid "Action after Timer Recording:"
 msgstr "定时录音完成后动作："
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Tenacity计时录制进度"
 
 #: src/TimerRecordDialog.cpp
@@ -5049,6 +5290,7 @@ msgstr "099 天 024 时 060 分 060 秒"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "开始日期和时间"
@@ -5093,7 +5335,8 @@ msgstr "开启自动导出(&E)？"
 msgid "Export Project As:"
 msgstr "导出工程为："
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "选项"
 
@@ -5106,7 +5349,8 @@ msgid "Do nothing"
 msgstr "什么都不做"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "退出 Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5130,7 +5374,8 @@ msgid "Scheduled to stop at:"
 msgstr "计划停止于："
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Tenacity定时录音 － 等待开始"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5156,7 +5401,8 @@ msgid "Recording Exported:"
 msgstr "录音已导出："
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Tenacity 定时录音 － 等待开始"
 
 #: src/TrackInfo.cpp
@@ -5353,7 +5599,11 @@ msgid "Applying %s..."
 msgstr "应用 %s 中..."
 
 #. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%s: %s"
 msgstr "%s：%s"
@@ -5376,13 +5626,15 @@ msgstr "%s 不是被 %s 所接受的参数"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "参数“%s”的值无效：应为 %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "命令"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "重复 %s"
@@ -5415,6 +5667,10 @@ msgstr "阈值："
 #: src/commands/CompareAudioCommand.h
 msgid "Compares a range on two tracks."
 msgstr "比较两个轨道上的范围。"
+
+#: src/commands/Demo.cpp
+msgid "Demo"
+msgstr "演示"
 
 #: src/commands/Demo.cpp
 msgid "Delay time (seconds):"
@@ -5505,13 +5761,24 @@ msgstr "片段"
 msgid "Envelopes"
 msgstr "包络"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "标签"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "盒子"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr "JSON"
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr "LISP"
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5521,7 +5788,8 @@ msgstr "简约"
 msgid "Type:"
 msgstr "类型："
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "格式："
 
@@ -5548,6 +5816,10 @@ msgstr "注释"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "命令："
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr "_"
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5585,12 +5857,17 @@ msgstr "导出至文件。"
 msgid "Builtin Commands"
 msgstr "内置命令"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tenacity 团队"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "提供 Tenacity 内置的命令"
 
 #: src/commands/LoadCommands.cpp
@@ -5653,7 +5930,10 @@ msgstr "清除日志内容。"
 msgid "Get Preference"
 msgstr "获取偏好设置"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "名称："
 
@@ -5701,7 +5981,8 @@ msgstr "全屏幕"
 msgid "Toolbars"
 msgstr "工具栏"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "效果"
 
@@ -5841,7 +6122,8 @@ msgstr "设置"
 msgid "Add"
 msgstr "添加"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "移除"
 
@@ -5926,7 +6208,8 @@ msgid "Edited Envelope"
 msgstr "已编辑的包络线"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "包络线"
 
@@ -6026,7 +6309,10 @@ msgstr "声道平衡："
 msgid "Set Track Visuals"
 msgstr "设置轨道视觉效果"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "线性"
 
@@ -6139,7 +6425,9 @@ msgid "Duck &amount:"
 msgstr "回避量(&A):"
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "秒"
 
@@ -6163,7 +6451,8 @@ msgstr "向内渐弱长度(&O):"
 msgid "Inner &fade up length:"
 msgstr "向内渐强长度(&F):"
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "阈值(&T):"
 
@@ -6302,11 +6591,13 @@ msgstr "到 (Hz)"
 msgid "t&o"
 msgstr "到(&O)"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "改变百分比(&H):"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "改变百分比"
 
@@ -6314,9 +6605,23 @@ msgstr "改变百分比"
 msgid "&Use high quality stretching (slow)"
 msgstr "使用高品质的拉伸 (慢) (&U)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr "33⅓"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr "45"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr "78"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "不可用"
 
@@ -6344,6 +6649,7 @@ msgstr "标准黑胶唱片转速（RPM）："
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "从（RPM）"
@@ -6356,6 +6662,7 @@ msgstr "从(&F)"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "到（RPM）"
@@ -6498,6 +6805,12 @@ msgstr "压缩器"
 msgid "Compresses the dynamic range of audio"
 msgstr "压缩音频的动态范围"
 
+#. i18n-hint: usually leave this as is as dB doesn't get translated
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%3d dB"
+msgstr "%3d dB"
+
 #: src/effects/Compressor.cpp src/effects/ScoreAlignDialog.cpp
 #, c-format
 msgid "%.2f secs"
@@ -6637,7 +6950,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "对照分析器，用于测量两个音频选区间的方均根音量差别。"
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "结束"
 
@@ -6702,6 +7016,12 @@ msgstr "帮助(&H)"
 #, c-format
 msgid "RMS = %s."
 msgstr "方均根 = %s."
+
+#. i18n-hint: dB abbreviates decibels
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%s dB"
+msgstr "%s dB"
 
 #: src/effects/Contrast.cpp
 msgid "zero"
@@ -6770,6 +7090,12 @@ msgstr "当前差别"
 #: src/effects/Contrast.cpp
 msgid "Measured foreground level"
 msgstr "已测量的前景电平"
+
+#. i18n-hint: short form of 'decibels'
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%.2f dB"
+msgstr "%.2f dB"
 
 #: src/effects/Contrast.cpp
 msgid "No foreground measured"
@@ -7079,6 +7405,26 @@ msgstr "剩余等级"
 msgid "(Not Used):"
 msgstr "(未使用):"
 
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-100 to 0 dB):"
+msgstr "（-100 至 0 dB）："
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(-80 to -20 dB):"
+msgstr "（-80 至 -20 dB）："
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 100):"
+msgstr "（0 至 100）："
+
+#. i18n-hint: Control range.
+#: src/effects/Distortion.cpp
+msgid "(0 to 5):"
+msgstr "（0 至 5）："
+
 #: src/effects/DtmfGen.cpp
 msgid "DTMF Tones"
 msgstr "DTMF 音"
@@ -7103,7 +7449,9 @@ msgstr "DTMF 序列(&S):"
 msgid "&Amplitude (0-1):"
 msgstr "振幅 (0 至 1)(&A):"
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "长度(&D)："
 
@@ -7116,12 +7464,29 @@ msgid "Duty cycle:"
 msgstr "占空比："
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr "%.1f %%"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "音的持续时间："
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "空白持续时间："
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr "%0.f ms"
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7131,7 +7496,8 @@ msgstr "回声"
 msgid "Repeats the selected audio again and again"
 msgstr "一遍遍地重复选中音频"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "请求值超过内存容量。"
 
@@ -7155,7 +7521,8 @@ msgstr "预设"
 msgid "Export Effect Parameters"
 msgstr "导出效果参数"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "无法打开文件： \"%s\""
@@ -7192,6 +7559,14 @@ msgstr "准备预览中"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "预览中"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7525,6 +7900,10 @@ msgid "Low rolloff for speech"
 msgstr "语音低滚降"
 
 #: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr "RIAA"
+
+#: src/effects/Equalization.cpp
 msgid "Telephone"
 msgstr "电话"
 
@@ -7561,12 +7940,41 @@ msgid "Effect Unavailable"
 msgstr "效果不可用"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "+ dB"
+msgstr "+ dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Max dB"
 msgstr "最大分贝"
 
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+#, c-format
+msgid "%d dB"
+msgstr "%d dB"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "Min dB"
 msgstr "最小分贝"
+
+#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
+msgid "- dB"
+msgstr "- dB"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr "%g kHz"
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr "%gk"
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7639,6 +8047,10 @@ msgstr "处理中(&P): "
 #: src/effects/Equalization.cpp
 msgid "D&efault"
 msgstr "默认(&E)"
+
+#: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr "&SSE"
 
 #: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
@@ -7892,7 +8304,8 @@ msgid "Builtin Effects"
 msgstr "内建效果器"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "提供 Tenacity 内建的效果器"
 
 #: src/effects/LoadEffects.cpp
@@ -7937,6 +8350,10 @@ msgstr "标准化(&N)"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "LUFS 响度"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr "LUFS"
 
 #: src/effects/Loudness.cpp
 msgid "RMS dB"
@@ -8010,8 +8427,20 @@ msgid "Hann, Hann (default)"
 msgstr "Hann, Hann (默认)"
 
 #: src/effects/NoiseReduction.cpp
+msgid "Blackman, Hann"
+msgstr "Blackman, Hann"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hamming, none"
 msgstr "Hamming, 无"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Hann"
+msgstr "Hamming, Hann"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr "Hamming, Reciprocal Hamming"
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -8106,8 +8535,9 @@ msgid "Step 1"
 msgstr "步骤 1"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "选择几秒只有噪声的音频让 Tenacity 知道过滤什么，\n"
@@ -8159,13 +8589,62 @@ msgstr "窗口类型(&W):"
 msgid "Window si&ze:"
 msgstr "窗口大小(&Z):"
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+msgid "8"
+msgstr "8"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr "16"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr "32"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr "64"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr "128"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr "256"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr "512"
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr "1024"
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2048（默认）"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr "4096"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr "8192"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr "16384"
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "每个窗口的音级(&T):"
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr "2"
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8281,12 +8760,17 @@ msgid "N&ormalize stereo channels independently"
 msgstr "分别标准化立体声的两个声道(&N)"
 
 #: src/effects/Paulstretch.cpp
+msgid "Paulstretch"
+msgstr "Paul 拉伸"
+
+#: src/effects/Paulstretch.cpp
 msgid "Paulstretch is only for an extreme time-stretch or \"stasis\" effect"
 msgstr "仅当需要极端的时间伸缩或者需要实现“停滞”效果时使用 Paulstrech"
 
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "延长系数(&S):"
@@ -8729,6 +9213,11 @@ msgstr "使用默认设置"
 msgid "Restore Defaults"
 msgstr "恢复默认设置"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr "%.3f"
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8887,6 +9376,10 @@ msgstr "检测静音"
 msgid "Tr&uncate to:"
 msgstr "截断到 (&U):"
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr "%"
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "压缩到(&O):"
@@ -8900,7 +9393,8 @@ msgid "VST Effects"
 msgstr "VST效果器"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "让 Tenacity 可以使用 VST 效果器。"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8912,7 +9406,8 @@ msgstr "扫描 Shell VST 中"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "注册 %d / %d: %-64.64s 中"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "无法载入此库"
 
@@ -8932,17 +9427,17 @@ msgstr "缓冲区大小会控制在每次迭代中发送给效果的样本数量
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "缓冲大小（8 到 1048576 个采样）(&B)："
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "延迟补偿"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
-msgstr ""
-"作为其处理过程的一部分，某些 VST 效果必须延迟将音频返回 Tenacity 的时间。 当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。 "
-"启用此选项将提供该补偿，但可能不适用于所有 VST 效果。"
+msgstr "作为其处理过程的一部分，某些 VST 效果必须延迟将音频返回 Tenacity 的时间。 当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。 启用此选项将提供该补偿，但可能不适用于所有 VST 效果。"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "启用补偿(&C)"
 
@@ -8976,7 +9471,8 @@ msgid "Standard VST program file"
 msgstr "标准 VST 程序文件"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Tenacity VST 预设文件"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9003,7 +9499,8 @@ msgstr "加载 VST 预设错误"
 msgid "Unable to load presets file."
 msgstr "无法加载预设文件。"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "效果设定"
 
@@ -9019,6 +9516,12 @@ msgstr "无法读取预设文件。"
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "此参数文件由%s保存。继续吗？"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr "VST"
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -9054,7 +9557,8 @@ msgid "Audio Unit Effects"
 msgstr "Audio Unit 效果"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "为 Tenacity 提供 Audio Unit 效果器支持"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9070,10 +9574,9 @@ msgid "Audio Unit Effect Options"
 msgstr "Audio Unit 效果器选项"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
-msgstr ""
-"作为其处理的一部分过程，某些 Audio Unit 效果必须延迟将音频返回 Tenacity 的时间。 "
-"当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。 启用此选项将提供该补偿，但可能不适用于所有 Audio Unit 效果。"
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr "作为其处理的一部分过程，某些 Audio Unit 效果必须延迟将音频返回 Tenacity 的时间。 当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。 启用此选项将提供该补偿，但可能不适用于所有 Audio Unit 效果。"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9208,8 +9711,15 @@ msgstr "无法为预设创建属性列表"
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "无法为 \"%s\" 预设设定类信息"
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+msgid "Audio Unit"
+msgstr "Audio Unit"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA 效果器"
@@ -9219,7 +9729,8 @@ msgid "Provides LADSPA Effects"
 msgstr "提供 LADSPA 效果"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity 不再使用 VST 桥"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9227,14 +9738,29 @@ msgid "LADSPA Effect Options"
 msgstr "LADSPA 效果器选项"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
-msgstr ""
-"作为其处理的一部分过程，某些 LADSPA 效果必须延迟将音频返回 Tenacity 的时间。 当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。"
-" 启用此选项将提供该补偿，但可能不适用于所有 LADSPA 效果。"
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr "作为其处理的一部分过程，某些 LADSPA 效果必须延迟将音频返回 Tenacity 的时间。 当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。 启用此选项将提供该补偿，但可能不适用于所有 LADSPA 效果。"
+
+#. i18n-hint: An item name introducing a value, which is not part of the string but
+#. appears in a following text box window; translate with appropriate punctuation
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#, c-format
+msgid "%s:"
+msgstr "%s："
 
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "效果器输出"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+msgid "LADSPA"
+msgstr "LADSPA"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9246,10 +9772,9 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "缓冲大小 (8 到 %d 个采样) (&B):"
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
-msgstr ""
-"作为其处理中的一部分过程，某些 LV2 效果必须延迟将音频返回 Tenacity 的时间。 当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。 "
-"启用此选项将提供该补偿，但可能不适用于所有 LV2 效果。"
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr "作为其处理中的一部分过程，某些 LV2 效果必须延迟将音频返回 Tenacity 的时间。 当不补偿此延迟时，你会注意到音频中已经插入了小的静音片段。 启用此选项将提供该补偿，但可能不适用于所有 LV2 效果。"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -9273,12 +9798,19 @@ msgstr "%s 需要不受支持的选项 %s\n"
 msgid "Generator"
 msgstr "生成器"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr "LV2"
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 效果"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "为 Tenacity 提供 LV2 效果器支持"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9286,7 +9818,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist 效果器"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "为 Tenacity 提供 Nyquist 效果器支持"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9514,7 +10047,8 @@ msgstr "选择一个文件"
 msgid "Save file as"
 msgstr "保存文件为"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "未命名"
 
@@ -9523,7 +10057,8 @@ msgid "Vamp Effects"
 msgstr "Vamp 效果器"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "为 Tenacity 提供 Vamp 效果器支持"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9545,6 +10080,12 @@ msgstr "插件设定"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "程序"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr "Vamp"
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9623,6 +10164,18 @@ msgstr "格式选项"
 #, c-format
 msgid "Channel: %2d"
 msgstr "通道： %2d"
+
+#. i18n-hint: track name and L abbreviating Left channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - L"
+msgstr "%s - 左"
+
+#. i18n-hint: track name and R abbreviating Right channel
+#: src/export/Export.cpp
+#, c-format
+msgid "%s - R"
+msgstr "%s - 右"
 
 #: src/export/Export.cpp
 #, c-format
@@ -9833,7 +10386,8 @@ msgstr "正以 %s 导出音频"
 msgid "Invalid sample rate"
 msgstr "无效的采样率"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "重采样"
 
@@ -9863,6 +10417,14 @@ msgstr "你可以重采样到下述任一采样率。"
 msgid "Sample Rates"
 msgstr "采样率"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr "%d kbps"
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "比特率："
@@ -9870,6 +10432,48 @@ msgstr "比特率："
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "质量（kbps）："
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, c-format
+msgid "%.2f kbps"
+msgstr "%.2f kbps"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr "0"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr "1"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr "3"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "4"
+msgstr "4"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "5"
+msgstr "5"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr "6"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "7"
+msgstr "7"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr "9"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr "10"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9880,12 +10484,40 @@ msgid "Constrained"
 msgstr "受约束"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr "VOIP"
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "音频"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "低延迟"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr "2.5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr "5 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr "10 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr "20 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr "40 ms"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr "60 ms"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -10090,6 +10722,10 @@ msgstr "语言："
 msgid "Bit Reservoir"
 msgstr "储位器"
 
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "VBL"
+msgstr "VBL"
+
 #. i18n-hint: "codec" is short for a "coder-decoder" algorithm
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10222,6 +10858,10 @@ msgstr ""
 "0 - 默认\n"
 "最小 - 1\n"
 "最大 - 15"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "LPC"
+msgstr "LPC"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid ""
@@ -10478,6 +11118,38 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (最佳质量)"
 
 #: src/export/ExportMP3.cpp
+msgid "200-250 kbps"
+msgstr "200-250 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "170-210 kbps"
+msgstr "170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "155-195 kbps"
+msgstr "155-195 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "145-185 kbps"
+msgstr "145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr "110-150 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr "95-135 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr "80-120 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr "65-105 kbps"
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (更小的文件)"
 
@@ -10507,7 +11179,8 @@ msgstr "发狂"
 msgid "Extreme"
 msgstr "极端"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "标准"
 
@@ -10558,8 +11231,8 @@ msgid "Locate LAME"
 msgstr "定位 LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity 需要 %s 才能创建 MP3。"
 
 #: src/export/ExportMP3.cpp
@@ -10587,10 +11260,10 @@ msgid "Where is %s?"
 msgstr "%s 在哪里？"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "试图连接到 lame_enc.dll v%d.%d。此版本与 Tenacity %d.%d.%d 不兼容。\n"
 "请下载最新版本的“LAME for Tenacity”。"
@@ -10895,6 +11568,14 @@ msgstr "将选定的音频导出为 Ogg Vorbis 文件"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "将选定的音频导出为 Ogg Vorbis 格式"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr "AIFF（苹果/SGI）"
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr "WAV（微软）"
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "数据头格式："
@@ -10908,9 +11589,10 @@ msgid "Other uncompressed files"
 msgstr "其它无压缩音频文件"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "你尝试导出一个大于 4 GB 的 WAV 或 AIFF 文件。\n"
 "Tenacity 无法做到，导出将被放弃。"
@@ -10920,8 +11602,9 @@ msgid "Error Exporting"
 msgstr "导出时出错"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "你导出的 WAV 文件已被截断，因 Tenacity 无法导出大于\n"
@@ -10961,11 +11644,11 @@ msgid "All supported files"
 msgstr "所有支持的文件"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -10974,11 +11657,11 @@ msgstr ""
 "点击文件->导入->MIDI 来编辑它。"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "“%s”\n"
 "不是音频文件。\n"
@@ -10989,18 +11672,18 @@ msgid "Select stream(s) to import"
 msgstr "选择要导入的流"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "此版本的 Tenacity 在编译时没有附带针对 %s 的支持。"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "\"%s\"是音频 CD 轨道。\n"
 "Tenacity 不能直接打开音频 CD。\n"
@@ -11009,10 +11692,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "\"%s\"是播放列表文件。\n"
@@ -11021,10 +11704,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"是 Windows Media Audio 文件。\n"
@@ -11033,10 +11716,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"是一个高级音频编码文件。\n"
@@ -11045,12 +11728,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "\"%s\"是加密的音频文件。\n"
@@ -11061,10 +11744,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\"是RealPlayer media文件。\n"
@@ -11073,12 +11756,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "\"%s\"是基于音符的文件，不是音频文件。\n"
 "Tenacity不能打开这类文件。\n"
@@ -11087,10 +11770,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11103,10 +11786,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" 是Wavpack文件。\n"
@@ -11115,10 +11798,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Dolby Digital audio文件。\n"
@@ -11127,10 +11810,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" Ogg Speex audio文件。\n"
@@ -11139,10 +11822,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "\"%s\" 视频文件。\n"
@@ -11156,9 +11839,9 @@ msgstr "未找到文件“%s”。"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11182,9 +11865,9 @@ msgstr "%s，%s"
 # 这里我保留前人翻译的“读取”对译“understood”因为用“理解”可能会有点奇怪？ - mkpoli 2017-11-25
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11214,12 +11897,13 @@ msgid "Import Project"
 msgstr "导入工程"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "该工程是由 Tenacity v1.0 或更早版本保存的。格式有所\n"
 "更改，所以此版本的 Tenacity 无法导入工程。\n"
@@ -11270,7 +11954,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "找不到工程数据目录：\"%s\""
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "工程文件中含有 MIDI 轨道，但是此 Tenacity 版本不包含 MIDI 支持，将绕过这些轨道。"
 
 #: src/import/ImportAUP.cpp
@@ -11375,40 +12060,6 @@ msgstr "索引[%02x] 编解码器[%s], 语言[%s], 比特率[%s], 声道数[%d],
 msgid "FLAC files"
 msgstr "FLAC 文件"
 
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer 兼容文件"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "无法在加载解码器到管线"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer 导入器"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "不能设置流状态为暂停。"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "索引[%02d], 类型[%s], 声道[%d], 比率[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "文件不包含任何音频流。"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "不能导入文件，状态更改失败。"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer 错误：%s"
-
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
 msgstr "基本文本格式的文件列表"
@@ -11511,8 +12162,97 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV、AIFF 及其它未压缩类型"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr "AU (Sun/NeXT)"
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr "AVR（Audio Visual Research）"
+
+#: src/import/ImportPCM.cpp
+msgid "CAF (Apple Core Audio File)"
+msgstr "CAF（苹果 Core Audio 文件）"
+
+#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
+#: src/import/ImportPCM.cpp
+msgid "FLAC (FLAC Lossless Audio Codec)"
+msgstr "FLAC（FLAC 无损编解码器）"
+
+#: src/import/ImportPCM.cpp
+msgid "HTK (HMM Tool Kit)"
+msgstr "HTK（HMM 工具集）"
+
+#: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr "IFF（Amiga IFF/SVX8/SV16）"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr "MAT4（GNU Octave 2.0 / Matlab 4.2）"
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr "MAT5（GNU Octave 2.1 / Matlab 5.0）"
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr "MPC（雅家 MPC 2k）"
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG 容器格式)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr "PAF（Ensoniq PARIS）"
+
+#: src/import/ImportPCM.cpp
+msgid "PVF (Portable Voice Format)"
+msgstr "PVF（便携式语音格式）"
+
+#: src/import/ImportPCM.cpp
+msgid "RAW (header-less)"
+msgstr "RAW（无文件头）"
+
+#: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr "RF64 (RIFF 64)"
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr "SD2（Sound Designer II）"
+
+#: src/import/ImportPCM.cpp
+msgid "SDS (Midi Sample Dump Standard)"
+msgstr "SDS（Midi 采样转储标准）"
+
+#: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr "SF（Berkeley/IRCAM/CARL）"
+
+#: src/import/ImportPCM.cpp
+msgid "VOC (Creative Labs)"
+msgstr "VOC（创新科技）"
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr "W64（SoundFoundry WAVE 64）"
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr "WAV（NIST Sphere）"
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr "WAVEX（微软）"
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr "WVE（Psion Series 3）"
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr "XI（FastTracker 2）"
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11543,8 +12283,60 @@ msgid "64 bit float"
 msgstr "64 位浮点"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr "U-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr "A-Law"
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr "IMA ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr "微软 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr "GSM 6.10"
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr "32kbs G721 ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr "24kbs G723 ADPCM"
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12 位 DWVW"
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DWVW"
+msgstr "16 位 DWVW"
+
+#: src/import/ImportPCM.cpp
+msgid "24 bit DWVW"
+msgstr "24 位 DWVW"
+
+#: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr "VOX ADPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "16 bit DPCM"
+msgstr "16 位 DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "8 bit DPCM"
+msgstr "8 位 DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr "Vorbis"
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11671,6 +12463,21 @@ msgstr "%s 左"
 msgid "%s right"
 msgstr "%s 右"
 
+#. i18n-hint:
+#. First %s is replaced with the noun "start" or "end"
+#. identifying one end of a clip,
+#. first number gives the position of that clip in a sequence
+#. of clips,
+#. last number counts all clips,
+#. and the last string is the name of the track containing the
+#. clips.
+#.
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s %d of %d clip %s"
+msgid_plural "%s %d of %d clips %s"
+msgstr[0] "%s 第 %d 共 %d 片段在 %s"
+
 #: src/menus/ClipMenus.cpp
 msgid "start"
 msgstr "起点"
@@ -11678,6 +12485,31 @@ msgstr "起点"
 #: src/menus/ClipMenus.cpp
 msgid "end"
 msgstr "终点"
+
+#. i18n-hint:
+#. First two %s are each replaced with the noun "start"
+#. or with "end", identifying and end of a clip,
+#. first and second numbers give the position of those clips in
+#. a sequence of clips,
+#. last number counts all clips,
+#. and the last string is the name of the track containing the
+#. clips.
+#.
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%s %d and %s %d of %d clip %s"
+msgid_plural "%s %d and %s %d of %d clips %s"
+msgstr[0] "%s 第 %d 和 %s 第 %d 共 %d 片段在 %s"
+
+#. i18n-hint:
+#. first number identifies one of a sequence of clips,
+#. last number counts the clips,
+#. string names a track
+#: src/menus/ClipMenus.cpp
+#, c-format
+msgid "%d of %d clip %s"
+msgid_plural "%d of %d clips %s"
+msgstr[0] "第 %d 共 %d 片段在 %s"
 
 #: src/menus/ClipMenus.cpp
 msgid "Time shifted clips to the right"
@@ -11687,7 +12519,8 @@ msgstr "时间移动片段到右侧"
 msgid "Time shifted clips to the left"
 msgstr "时间移动片段到左侧"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "时间-移动(Time-Shift)"
 
@@ -11825,7 +12658,8 @@ msgstr "修剪选择的音频音轨从 %.2f 秒到 %.2f 秒"
 msgid "Trim Audio"
 msgstr "修剪音频"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "分离"
 
@@ -11948,34 +12782,6 @@ msgstr "删除键 &2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "额外(&R)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "混音器工具栏(&X)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "调整播放音量(&J)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "增加播放音量(&I)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "减少播放音量(&D)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "调整录制音量(&U)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "增加录制音量(&N)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "减小录制音量(&E)"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12243,8 +13049,9 @@ msgid "&Getting Started"
 msgstr "入门(&G)"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Tenacity 手册(&M)"
+#, fuzzy
+msgid "&Manual"
+msgstr "使用手册(&M)..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12270,11 +13077,8 @@ msgstr "MIDI 设备信息(&D)..."
 msgid "Show &Log..."
 msgstr "显示日志(&L)..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "关于Tenacity(&A)..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "已添加标签"
 
@@ -12522,6 +13326,10 @@ msgstr "选择/取消 轨道(&D)"
 #: src/menus/PluginMenus.cpp
 msgid "Uncategorized"
 msgstr "未分类"
+
+#: src/menus/PluginMenus.cpp
+msgid "..."
+msgstr "..."
 
 #: src/menus/PluginMenus.cpp
 msgid "Unknown"
@@ -12960,6 +13768,7 @@ msgstr "光标大右跳(&M)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "定位播放(&K)"
@@ -13171,18 +13980,21 @@ msgid "Created new label track"
 msgstr "新建标签轨"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "此版本的 Tenacity 仅允许每个工程窗口拥有一条时间轨。"
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "新建时间轨"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "新采样率(Hz)："
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "输入的值无效"
 
@@ -13439,7 +14251,9 @@ msgstr "正在播放"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "录音"
 
@@ -13588,10 +14402,6 @@ msgstr "原带配音（开/关）(&O)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "软件同步监听（开/关）(&F)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "录制电平自动调节（开/关） (&U)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13806,7 +14616,8 @@ msgid "Preferences for Application"
 msgstr "质量偏好设置"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "更新 Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13852,7 +14663,8 @@ msgstr "音频主机(&H)："
 msgid "Using:"
 msgstr "使用："
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "播放"
 
@@ -13872,7 +14684,8 @@ msgstr "声道数(&N)："
 msgid "Latency"
 msgstr "延迟"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "毫秒"
 
@@ -13901,7 +14714,8 @@ msgid "2 (Stereo)"
 msgstr "2 (立体声)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "目录"
 
@@ -14009,7 +14823,8 @@ msgid "Directory %s is not writable"
 msgstr "目录%s不可写"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "在重新启动 Tenacity 之前，对临时目录的更改将不会生效"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14040,6 +14855,39 @@ msgstr "将同发布者划为一组"
 msgid "Grouped by Type"
 msgstr "将同类型划为一组"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr "&LADSPA"
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr "LV&2"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+msgid "N&yquist"
+msgstr "N&yquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr "&Vamp"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr "V&ST"
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "启用效果"
@@ -14061,11 +14909,13 @@ msgid "Plugin Options"
 msgstr "插件选项"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "当 Tenacity 启动时检测插件更新"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "下次启动 Tenacity 时重新扫描插件"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14136,9 +14986,7 @@ msgstr "未用到的过滤器："
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"在项中发现空隔字符(空格、制表符[tab]或换行符)，可能无法进行模式匹配。建议删除(trim)首尾的空隔字符，除非你知道确实要保留它们。是否需要Tena"
-"city为你删除到这些空隔字符？"
+msgstr "在项中发现空隔字符(空格、制表符[tab]或换行符)，可能无法进行模式匹配。建议删除(trim)首尾的空隔字符，除非你知道确实要保留它们。是否需要Tenacity为你删除到这些空隔字符？"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -14247,7 +15095,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "如果选区自动吸附到标签边缘，则保持标签(&R)"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "混合系统和 Tenacity 主题(&B)"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14271,6 +15120,10 @@ msgstr "显示跟随播放标尺"
 #, c-format
 msgid "Language \"%s\" is unknown"
 msgstr "语言“%s”未知"
+
+#: src/prefs/GUIPrefs.h
+msgid "GUI"
+msgstr "用户界面"
 
 #: src/prefs/ImportExportPrefs.cpp
 msgid "Import / Export"
@@ -14421,7 +15274,8 @@ msgstr ""
 "   *   \"%s\"  (因为快捷键 '%s' 已被 \"%s\" 使用)\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "选择包含Tenacity键盘快捷键定义的XML文件..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14554,8 +15408,9 @@ msgid "Dow&nload"
 msgstr "下载(&N)"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity 已自动检测到有效的 FFmpeg 库。\n"
@@ -14614,8 +15469,9 @@ msgid "Preferences for Module"
 msgstr "模块偏好设置"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "这些测试模块。请在阅读完 Tenacity 使用手册后\n"
@@ -14623,12 +15479,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  “询问” 表示 Tenacity 每次启动时都会询问是否要加载此模块。"
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  “失败” 表示 Tenacity 发现模块已损坏，不会运行。"
 
 #. i18n-hint preserve the leading spaces
@@ -14637,7 +15495,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  “新建” 表示尚未作出任何选择。"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "这些设置只会在 Tenacity 启动时生效。"
 
 #: src/prefs/ModulePrefs.cpp
@@ -14655,6 +15514,10 @@ msgstr "未找到模块"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "模块"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr "Ctrl"
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14696,7 +15559,10 @@ msgstr "按住左键-拖拽"
 msgid "Set Selection Range"
 msgstr "设置选区范围"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift 键-左键双击"
 
@@ -14783,6 +15649,15 @@ msgstr "-左键拖动"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "在轨道间上下移动剪辑"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "-左键拖动"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -14907,7 +15782,8 @@ msgid "Always scrub un&pinned"
 msgstr "总是不固定跟随播放(&P)"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Tenacity 偏好设置"
 
 #: src/prefs/PrefsDialog.cpp
@@ -14921,6 +15797,11 @@ msgstr "偏好设置："
 #: src/prefs/QualityPrefs.cpp
 msgid "Preferences for Quality"
 msgstr "质量偏好设置"
+
+#: src/prefs/QualityPrefs.cpp
+#, c-format
+msgid "%i Hz"
+msgstr "%i Hz"
 
 #: src/prefs/QualityPrefs.cpp
 msgid "Other..."
@@ -15040,39 +15921,6 @@ msgid "System T&ime"
 msgstr "系统时间(&T)"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "自动录制电平调节"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "启用自动录制电平调节。"
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "目标峰值："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "在..内："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "分析时间："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "毫秒(一次分析的时间)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "连续分析次数："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 表示无限"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "插卷录制"
 
@@ -15088,6 +15936,16 @@ msgstr "交叉渐变(&F)："
 #: src/prefs/SpectrogramSettings.cpp
 msgid "Mel"
 msgstr "梅尔刻度"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr "Bark"
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
+#: src/prefs/SpectrogramSettings.cpp
+msgid "ERB"
+msgstr "ERB"
 
 #. i18n-hint: Time units, that is Period = 1 / Frequency
 #: src/prefs/SpectrogramSettings.cpp
@@ -15222,6 +16080,10 @@ msgid "1024 - default"
 msgstr "1024 - 默认"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr "2048"
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - 最窄频带"
 
@@ -15319,13 +16181,14 @@ msgid "Info"
 msgstr "信息"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15508,7 +16371,8 @@ msgstr "采样"
 msgid "4 Pixels per Sample"
 msgstr "每个采样 4 像素"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "最大缩放"
 
@@ -15630,16 +16494,24 @@ msgid "Stopped"
 msgstr "已停止"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "暂停"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "跳至开始位置"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "跳至结束位置"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "暂停"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "选择至起点"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "选择至终点"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15653,20 +16525,17 @@ msgstr "录制新轨道"
 msgid "Append Record"
 msgstr "追加录音"
 
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "选择至终点"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "选择至起点"
-
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
 #: src/toolbars/ControlToolBar.cpp src/tracks/ui/Scrubbing.cpp
 #, c-format
 msgid "%s Paused."
 msgstr "%s 已暂停。"
+
+#: src/toolbars/ControlToolBar.cpp
+#, c-format
+msgid "%s."
+msgstr "%s。"
 
 #. i18n-hint: Clicking this menu item shows the toolbar
 #. with the big buttons on it (play record etc)
@@ -15746,11 +16615,17 @@ msgstr "静音音频选区"
 msgid "Sync-Lock Tracks"
 msgstr "同步锁定轨道"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "放大"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "缩小"
 
@@ -15817,43 +16692,6 @@ msgstr "录音仪表栏(&R)"
 msgid "&Playback Meter Toolbar"
 msgstr "播放仪表栏(&P)"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "录制音量"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "播放音量"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "录制音量：%.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "录制音量 (不可用；使用系统混音器。)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "播放音量：%.2f（模拟）"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "播放音量：%.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "播放音量 (不可用；使用系统混音器。)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "混音器工具栏(&X)"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "定位"
@@ -15869,6 +16707,7 @@ msgstr "跟随播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "停止跟随播放"
@@ -15876,6 +16715,7 @@ msgstr "停止跟随播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "启动跟随播放"
@@ -15883,6 +16723,7 @@ msgstr "启动跟随播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "停止定位播放"
@@ -15890,6 +16731,7 @@ msgstr "停止定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "开始定位播放"
@@ -15944,7 +16786,9 @@ msgstr "吸附到"
 msgid "Length"
 msgstr "长度"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "中央"
 
@@ -16008,8 +16852,8 @@ msgstr "时间工具栏(&T)"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Tenacity %s工具栏"
 
 #: src/toolbars/ToolBar.cpp
@@ -16036,7 +16880,8 @@ msgstr "时间移动工具"
 msgid "Zoom Tool"
 msgstr "缩放工具"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "绘制工具"
 
@@ -16112,11 +16957,13 @@ msgstr "拖动一个或多个标签边界。"
 msgid "Drag label boundary."
 msgstr "拖动标签边界。"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "已修改的标签"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "标签编辑"
 
@@ -16171,31 +17018,42 @@ msgstr "编辑标签"
 msgid "New label"
 msgstr "新标签"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "提高八倍音阶(&O)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "降低八倍音阶(&V)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "单击在垂直方向放大。按住Shift键单击缩小。拖拽指定一个缩放区域。"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "右击以打开菜单。"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "缩放重置"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift 键-右键单击"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "左键单击/左键拖拽"
 
@@ -16237,7 +17095,8 @@ msgstr "合并"
 msgid "Expanded Cut Line"
 msgstr "已展开的剪切线"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "扩展"
 
@@ -16260,6 +17119,11 @@ msgstr "已移动采样点"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "采样编辑"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr "k"
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16305,7 +17169,8 @@ msgstr "处理中... %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "已将“%s”改变为 %s"
@@ -16319,8 +17184,52 @@ msgid "Rat&e"
 msgstr "采样率(&E)"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "8000 Hz"
+msgstr "8000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "11025 Hz"
+msgstr "11025 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "16000 Hz"
 msgstr "16000Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "22050 Hz"
+msgstr "22050 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "44100 Hz"
+msgstr "44100 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "48000 Hz"
+msgstr "48000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "88200 Hz"
+msgstr "88200 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "96000 Hz"
+msgstr "96000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "176400 Hz"
+msgstr "176400 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "192000 Hz"
+msgstr "192000 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "352800 Hz"
+msgstr "352800 Hz"
+
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+msgid "384000 Hz"
+msgstr "384000 Hz"
 
 #: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "&Other..."
@@ -16340,7 +17249,8 @@ msgstr "改变采样率"
 msgid "Set Rate"
 msgstr "设定采样率"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "多视图(&M)"
 
@@ -16432,14 +17342,23 @@ msgstr "左，%d Hz"
 msgid "Right, %dHz"
 msgstr "右，%d Hz"
 
+#. i18n-hint dB abbreviates decibels
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%+.1f dB"
+msgstr "%+.1f dB"
+
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "%.0f%% 左"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "%.0f%% 右"
@@ -16557,8 +17476,8 @@ msgstr "对数插值(&I)"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "单击并拖动可调整，双击可重置"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16609,6 +17528,7 @@ msgstr "已调整的包络。"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "跟随播放(&S)"
@@ -16620,6 +17540,7 @@ msgstr "定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "跟随播放标尺(&R)"
@@ -16816,6 +17737,12 @@ msgstr "左"
 msgid "R"
 msgstr "右"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, c-format
+msgid "%.2fx"
+msgstr "%.2fx"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -16849,9 +17776,19 @@ msgstr "空"
 msgid "Backwards"
 msgstr "后退"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr "<"
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "前进"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ">"
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -16980,6 +17917,12 @@ msgstr "请选择一个动作"
 msgid "01000,01000 seconds"
 msgstr "01000,01000 秒"
 
+#. i18n-hint: Name of time display format that shows time in hours, minutes
+#. * and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hh:mm:ss"
+msgstr "时:分:秒"
+
 #. i18n-hint: Format string for displaying time in hours, minutes and
 #. * seconds. Change the 'h' to the abbreviation for hours, 'm' to the
 #. * abbreviation for minutes and 's' to the abbreviation for seconds. Don't
@@ -16988,6 +17931,12 @@ msgstr "01000,01000 秒"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "0100 h 060 m 060 s"
 msgstr "0100 时 060 分 060 秒"
+
+#. i18n-hint: Name of time display format that shows time in days, hours,
+#. * minutes and seconds
+#: src/widgets/NumericTextCtrl.cpp
+msgid "dd:hh:mm:ss"
+msgstr "日:时:分:秒"
 
 #. i18n-hint: Format string for displaying time in days, hours, minutes and
 #. * seconds. Change the 'days' to the word for days, 'h' to the abbreviation
@@ -17052,6 +18001,7 @@ msgstr "0100 时 060 分 060 秒+># 采样"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "采样"
@@ -17217,6 +18167,11 @@ msgstr "0100000>0100 Hz"
 msgid "centihertz"
 msgstr "百分之一赫兹"
 
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr "kHz"
+
 #. i18n-hint: Format string for displaying frequency in kilohertz. Change
 #. * the decimal point for your locale. Don't change the numbers.
 #. * The decimal separator is specified using '<' if your language uses a ',' or
@@ -17293,6 +18248,11 @@ msgstr "（使用上下文菜单改变格式。）"
 msgid "centiseconds"
 msgstr "百分之一秒"
 
+#: src/widgets/PopupMenuTable.h
+#, c-format
+msgid "%s (%s)"
+msgstr "%s（%s）"
+
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
 msgstr "已用时间："
@@ -17354,6 +18314,10 @@ msgstr "文件夹偏好设置"
 #: src/widgets/Warning.cpp
 msgid "Don't show this warning again"
 msgstr "下次不再显示此警告"
+
+#: src/widgets/numformatter.cpp
+msgid "NaN"
+msgstr "NaN"
 
 #: src/widgets/numformatter.cpp
 msgid "Infinity"
@@ -17437,15 +18401,27 @@ msgstr "无法解析 XML"
 msgid "Spectral edit multi tool"
 msgstr "频谱多功能编辑工具"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "滤波中......"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr "Paul Licameli"
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "基于 GNU 通用公共许可证版本 2 的条款下发布"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~a请选择频率。"
@@ -17472,7 +18448,8 @@ msgstr ""
 "                      尝试增加低频率限制~%~\n"
 "                      或缩短滤波器“宽度”。"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "错误。~%"
@@ -17533,6 +18510,24 @@ msgstr "录音室淡出"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "正在应用淡出..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+msgid "Steve Daulton"
+msgstr "Steve Daulton"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "根据 GNU 通用公共许可证第 2 版或更高版本的条款发布。"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17676,6 +18671,10 @@ msgstr "节拍寻找"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "正在寻找节拍..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18000,13 +18999,38 @@ msgstr "高通滤波器"
 msgid "Performing High-Pass Filter..."
 msgstr "正在执行高通滤波器......"
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr "Dominic Mazzoni"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "频率 (Hz)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "卷开 (分贝每八度)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr "6 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr "12 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr "24 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr "36 dB"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr "48 dB"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -18027,10 +19051,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "标签声音"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "根据 GNU 通用公共许可证第 2 版或更高版本的条款发布。"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18276,6 +19296,12 @@ msgstr ""
 "基于头 ~a 秒的峰值在 ~a dB~%\n"
 "建议的阈值设置为 ~a dB。"
 
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr "~a 时~a 分"
+
 #: plug-ins/notch.ny
 msgid "Notch Filter"
 msgstr "陷波滤波器"
@@ -18324,7 +19350,8 @@ msgstr "Lisp 文件"
 msgid "HTML file"
 msgstr "HTML 文件"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "文本文件"
 
@@ -18401,6 +19428,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "C 音符的 MIDI 值：36，48，60 （中央 C），72，84，96。"
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr "David R.Sky"
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "拨弦 MIDI 音高"
 
@@ -18447,6 +19478,10 @@ msgstr "每小节 1 ~ 20 拍"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "摇摆量"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr "+/- 1"
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18539,6 +19574,10 @@ msgstr "Risset 鼓点"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "生成 Risset 鼓点..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr "Steven Jones"
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -18946,6 +19985,10 @@ msgid "Applying Action..."
 msgstr "正在应用动作..."
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr "Robert Haenggi"
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "移除人声：至单声道"
 
@@ -19094,6 +20137,10 @@ msgid "Processing Vocoder..."
 msgstr "正在处理声码器..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr "Edgar-RFT"
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "距离（1 至 120，默认 20）"
 
@@ -19133,6 +20180,229 @@ msgstr "脉冲列频率（Hz）"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "错误。~%需要立体声轨。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "更新 Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "跳过(&S)"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "安装更新(&I)"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "更新日志"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "在 GitHub 上阅读更多信息"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "检查更新时出错"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "无法连接到 Tenacity 更新服务器。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "更新数据已损坏。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "下载更新时出错。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "无法打开 Tenacity 下载链接。"
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "Tenacity %s 可用！"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "录音"
+
+#~ msgid "Commit Id:"
+#~ msgstr "Github 提交 ID："
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "跨平台 GUI 库"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "通过 GStreamer 导入"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "录制音量自动调整已停止。无法进一步优化。音量依然过高。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "录制音量自动调整器已将音量降低到 %f。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "录制音量自动调整已停止。无法进一步优化。音量依然过低。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "录制音量自动调整器已将音量提高到 %.2f。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "录制音量自动调整已停止。分析数值已经超过上限，但仍未找到合适的音量值。音量依然过高。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "录制音量自动调整已停止。分析数值已经超过上限，但仍未找到合适的音量值。音量依然过低。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "录制音量自动调整已停止。 %.2f 似乎是合适的音量。"
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "打开设备时收到%d\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "不能打开 Portmixer\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "有效的混合器：\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "可用录制源：\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "可用播放音量：\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "模拟录制音量\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "本地录制音量\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "模拟播放音量\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "本地播放音量\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "日期和时间不详"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer 兼容文件"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "无法在加载解码器到管线"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer 导入器"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "不能设置流状态为暂停。"
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "索引[%02d], 类型[%s], 声道[%d], 比率[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "文件不包含任何音频流。"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "不能导入文件，状态更改失败。"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer 错误：%s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "混音器工具栏(&X)"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "调整播放音量(&J)..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "增加播放音量(&I)"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "减少播放音量(&D)"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "调整录制音量(&U)..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "增加录制音量(&N)"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "减小录制音量(&E)"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Tenacity 手册(&M)"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "关于Tenacity(&A)..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "录制电平自动调节（开/关） (&U)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "自动录制电平调节"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "启用自动录制电平调节。"
+
+#~ msgid "Target Peak:"
+#~ msgstr "目标峰值："
+
+#~ msgid "Within:"
+#~ msgstr "在..内："
+
+#~ msgid "Analysis Time:"
+#~ msgstr "分析时间："
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "毫秒(一次分析的时间)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "连续分析次数："
+
+#~ msgid "0 means endless"
+#~ msgstr "0 表示无限"
+
+#~ msgid "Recording Volume"
+#~ msgstr "录制音量"
+
+#~ msgid "Playback Volume"
+#~ msgstr "播放音量"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "录制音量：%.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "录制音量 (不可用；使用系统混音器。)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "播放音量：%.2f（模拟）"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "播放音量：%.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "播放音量 (不可用；使用系统混音器。)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "混音器工具栏(&X)"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "单击并拖动可调整，双击可重置"
 
 #~ msgid "Program build date:"
 #~ msgstr "程序构建日期:"
@@ -20876,9 +22146,6 @@ msgstr "错误。~%需要立体声轨。"
 #~ msgid "Offset"
 #~ msgstr "偏移"
 
-#~ msgid "Version"
-#~ msgstr "版本"
-
 #~ msgid "Heavy"
 #~ msgstr "强"
 
@@ -21275,1040 +22542,6 @@ msgstr "错误。~%需要立体声轨。"
 #~ msgid "[Project %02i] Audacity "
 #~ msgstr "[工程 %02i] Tenacity "
 
-#: src/prefs/MousePrefs.cpp
-msgid "Ctrl"
-msgstr "Ctrl"
-
-#: src/prefs/GUIPrefs.h
-msgid "GUI"
-msgstr "用户界面"
-
-#: src/commands/Demo.cpp
-msgid "Demo"
-msgstr "演示"
-
-#: src/ProjectFileIO.cpp
 #, c-format
-msgid "[Project %02i] "
-msgstr "[工程 %02i] "
-
-#: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
-msgid "<untitled>"
-msgstr "<无标题工程>"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %.1f dB"
-msgstr "%d Hz (%s) = %.1f dB"
-
-#. i18n-hint: The %d's are replaced by numbers, the %s by musical notes, e.g. A#
-#: src/FreqWindow.cpp
-#, c-format
-msgid "%d Hz (%s) = %d dB"
-msgstr "%d Hz (%s) = %d dB"
-
-#: src/FileNames.cpp
-msgid ", "
-msgstr ", "
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
-#, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr "Audacity%s 商标在本软件中仅用于说明和信息目的。"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s KB"
-msgstr "%s kB"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr "请注意名称是按字母顺序而不是按重要性排序的。"
-
-#: plug-ins/rhythmtrack.ny
-msgid "+/- 1"
-msgstr "+/- 1"
-
-#: src/import/ImportPCM.cpp
-msgid "IFF (Amiga IFF/SVX8/SV16)"
-msgstr "IFF（Amiga IFF/SVX8/SV16）"
-
-#: src/import/ImportPCM.cpp
-msgid "HTK (HMM Tool Kit)"
-msgstr "HTK（HMM 工具集）"
-
-#. i18n-hint: "codec" is short for a "coder-decoder" algorithm
-#: src/import/ImportPCM.cpp
-msgid "FLAC (FLAC Lossless Audio Codec)"
-msgstr "FLAC（FLAC 无损编解码器）"
-
-#: src/import/ImportPCM.cpp
-msgid "CAF (Apple Core Audio File)"
-msgstr "CAF（苹果 Core Audio 文件）"
-
-#: src/import/ImportPCM.cpp
-msgid "AVR (Audio Visual Research)"
-msgstr "AVR（Audio Visual Research）"
-
-#: src/import/ImportPCM.cpp
-msgid "AU (Sun/NeXT)"
-msgstr "AU (Sun/NeXT)"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "WAV (Microsoft)"
-msgstr "WAV（微软）"
-
-#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
-msgid "AIFF (Apple/SGI)"
-msgstr "AIFF（苹果/SGI）"
-
-#: src/export/ExportMP3.cpp
-msgid "65-105 kbps"
-msgstr "65-105 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "80-120 kbps"
-msgstr "80-120 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "95-135 kbps"
-msgstr "95-135 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "110-150 kbps"
-msgstr "110-150 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "145-185 kbps"
-msgstr "145-185 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "155-195 kbps"
-msgstr "155-195 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "170-210 kbps"
-msgstr "170-210 kbps"
-
-#: src/export/ExportMP3.cpp
-msgid "200-250 kbps"
-msgstr "200-250 kbps"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "LPC"
-msgstr "LPC"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VBL"
-msgstr "VBL"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "60 ms"
-msgstr "60 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "40 ms"
-msgstr "40 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "20 ms"
-msgstr "20 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10 ms"
-msgstr "10 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "5 ms"
-msgstr "5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "2.5 ms"
-msgstr "2.5 ms"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "VOIP"
-msgstr "VOIP"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "10"
-msgstr "10"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "9"
-msgstr "9"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "7"
-msgstr "7"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "6"
-msgstr "6"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "5"
-msgstr "5"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "4"
-msgstr "4"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "3"
-msgstr "3"
-
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "1"
-msgstr "1"
-
-#: src/export/ExportFFmpegDialogs.cpp
-msgid "0"
-msgstr "0"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#: src/export/ExportFFmpegDialogs.cpp
-#, c-format
-msgid "%.2f kbps"
-msgstr "%.2f kbps"
-
-#. i18n-hint kbps abbreviates "thousands of bits per second"
-#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
-#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp src/export/ExportMP3.cpp
-#, c-format
-msgid "%d kbps"
-msgstr "%d kbps"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/effects/vamp/VampEffect.h
-msgid "Vamp"
-msgstr "Vamp"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/effects/lv2/LV2Effect.h
-msgid "LV2"
-msgstr "LV2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/effects/ladspa/LadspaEffect.h
-msgid "LADSPA"
-msgstr "LADSPA"
-
-#. i18n-hint: An item name introducing a value, which is not part of the string but
-#. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
-#, c-format
-msgid "%s:"
-msgstr "%s："
-
-#: src/effects/Equalization.cpp
-msgid "&SSE"
-msgstr "&SSE"
-
-#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%gk"
-msgstr "%gk"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%g kHz"
-msgstr "%g kHz"
-
-#: src/effects/Equalization.cpp
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "- dB"
-msgstr "- dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-#, c-format
-msgid "%d dB"
-msgstr "%d dB"
-
-#: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
-msgid "+ dB"
-msgstr "+ dB"
-
-#: src/effects/Equalization.cpp
-msgid "RIAA"
-msgstr "RIAA"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%0.f ms"
-msgstr "%0.f ms"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.0f ms"
-msgstr "%.0f ms"
-
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.1f %%"
-msgstr "%.1f %%"
-
-#. i18n-hint: Control range.
-#: src/effects/Distortion.cpp
-msgid "(0 to 5):"
-msgstr "（0 至 5）："
-
-#. i18n-hint: Control range.
-#: src/effects/Distortion.cpp
-msgid "(0 to 100):"
-msgstr "（0 至 100）："
-
-#. i18n-hint: Control range.
-#: src/effects/Distortion.cpp
-msgid "(-80 to -20 dB):"
-msgstr "（-80 至 -20 dB）："
-
-#. i18n-hint: Control range.
-#: src/effects/Distortion.cpp
-msgid "(-100 to 0 dB):"
-msgstr "（-100 至 0 dB）："
-
-#. i18n-hint: short form of 'decibels'
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%.2f dB"
-msgstr "%.2f dB"
-
-#. i18n-hint: dB abbreviates decibels
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%s dB"
-msgstr "%s dB"
-
-#. i18n-hint: usually leave this as is as dB doesn't get translated
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%3d dB"
-msgstr "%3d dB"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "78"
-msgstr "78"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "45"
-msgstr "45"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "33⅓"
-msgstr "33⅓"
-
-#: src/commands/HelpCommand.cpp
-msgid "_"
-msgstr "_"
-
-#. i18n-hint name of a computer programming language
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "LISP"
-msgstr "LISP"
-
-#. i18n-hint JavaScript Object Notation
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "JSON"
-msgstr "JSON"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "A♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "G♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "B"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "A♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "A"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "D"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "C♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "C"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=4.5)"
-msgstr "高斯函数（a=4.5）"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=3.5)"
-msgstr "高斯函数（a=3.5）"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=2.5)"
-msgstr "高斯函数（a=2.5）"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr "Tenacity 并非由 MuseCY SM 有限公司或 Dominic Mazzoni 所制造或背书。"
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "(C) 2009 by Leland Lucius"
-msgstr "(C) 2009 Leland Lucius 作品"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#. i18n-hint: the name of an Apple audio software protocol
-#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
-#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
-msgid "Audio Unit"
-msgstr "Audio Unit"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/effects/VST/VSTEffect.h
-msgid "VST"
-msgstr "VST"
-
-#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
-msgid "%"
-msgstr "%"
-
-#: src/effects/ScoreAlignDialog.cpp
-#, c-format
-msgid "%.3f"
-msgstr "%.3f"
-
-#: src/effects/Paulstretch.cpp
-msgid "Paulstretch"
-msgstr "Paul 拉伸"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
-msgid "2"
-msgstr "2"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16384"
-msgstr "16384"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "8192"
-msgstr "8192"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "4096"
-msgstr "4096"
-
-#: src/effects/NoiseReduction.cpp
-msgid "1024"
-msgstr "1024"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "512"
-msgstr "512"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "256"
-msgstr "256"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "128"
-msgstr "128"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "64"
-msgstr "64"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "32"
-msgstr "32"
-
-#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
-msgid "16"
-msgstr "16"
-
-#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
-msgid "8"
-msgstr "8"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Hamming, Reciprocal Hamming"
-msgstr "Hamming, Reciprocal Hamming"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Hamming, Hann"
-msgstr "Hamming, Hann"
-
-#: src/effects/NoiseReduction.cpp
-msgid "Blackman, Hann"
-msgstr "Blackman, Hann"
-
-#: src/effects/Loudness.cpp
-msgid "LUFS"
-msgstr "LUFS"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "A♯/B♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "G♯/A♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "F♯/G♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "D♯/E♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "C♯/D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "B♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "G♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "G"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "F♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "F"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "E"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "D♯"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "36 dB"
-msgstr "36 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "24 dB"
-msgstr "24 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "12 dB"
-msgstr "12 dB"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "6 dB"
-msgstr "6 dB"
-
-#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny
-msgid "Steve Daulton"
-msgstr "Steve Daulton"
-
-#. i18n-hint: Name of display format that shows frequency in kilohertz
-#: src/widgets/NumericTextCtrl.cpp
-msgid "kHz"
-msgstr "kHz"
-
-#. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
-#, c-format
-msgid "%+.1f dB"
-msgstr "%+.1f dB"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "384000 Hz"
-msgstr "384000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "352800 Hz"
-msgstr "352800 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "192000 Hz"
-msgstr "192000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "176400 Hz"
-msgstr "176400 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "96000 Hz"
-msgstr "96000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "88200 Hz"
-msgstr "88200 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "48000 Hz"
-msgstr "48000 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "44100 Hz"
-msgstr "44100 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "22050 Hz"
-msgstr "22050 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "11025 Hz"
-msgstr "11025 Hz"
-
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
-msgid "8000 Hz"
-msgstr "8000 Hz"
-
-#. i18n-hint k abbreviating kilo meaning thousands
-#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
-msgid "k"
-msgstr "k"
-
-#: src/prefs/SpectrumPrefs.cpp
-msgid "2048"
-msgstr "2048"
-
-#: src/prefs/QualityPrefs.cpp
-#, c-format
-msgid "%i Hz"
-msgstr "%i Hz"
-
-#: src/import/ImportPCM.cpp
-msgid "Vorbis"
-msgstr "Vorbis"
-
-#: src/import/ImportPCM.cpp
-msgid "U-Law"
-msgstr "U-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "RF64 (RIFF 64)"
-msgstr "RF64 (RIFF 64)"
-
-#: src/import/ImportPCM.cpp
-msgid "PAF (Ensoniq PARIS)"
-msgstr "PAF（Ensoniq PARIS）"
-
-#: src/import/ImportPCM.cpp
-msgid "MPC (Akai MPC 2k)"
-msgstr "MPC（雅家 MPC 2k）"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
-msgstr "MAT5（GNU Octave 2.1 / Matlab 5.0）"
-
-#: src/import/ImportPCM.cpp
-msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
-msgstr "MAT4（GNU Octave 2.0 / Matlab 4.2）"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny
-msgid "48 dB"
-msgstr "48 dB"
-
-#. i18n-hint:
-#. first number identifies one of a sequence of clips,
-#. last number counts the clips,
-#. string names a track
-#: src/menus/ClipMenus.cpp
-#, c-format
-msgid "%d of %d clip %s"
-msgid_plural "%d of %d clips %s"
-msgstr[0] "第 %d 共 %d 片段在 %s"
-
-#. i18n-hint:
-#. First two %s are each replaced with the noun "start"
-#. or with "end", identifying and end of a clip,
-#. first and second numbers give the position of those clips in
-#. a sequence of clips,
-#. last number counts all clips,
-#. and the last string is the name of the track containing the
-#. clips.
-#: src/menus/ClipMenus.cpp
-#, c-format
-msgid "%s %d and %s %d of %d clip %s"
-msgid_plural "%s %d and %s %d of %d clips %s"
-msgstr[0] "%s 第 %d 和 %s 第 %d 共 %d 片段在 %s"
-
-#. i18n-hint:
-#. First %s is replaced with the noun "start" or "end"
-#. identifying one end of a clip,
-#. first number gives the position of that clip in a sequence
-#. of clips,
-#. last number counts all clips,
-#. and the last string is the name of the track containing the
-#. clips.
-#: src/menus/ClipMenus.cpp
-#, c-format
-msgid "%s %d of %d clip %s"
-msgid_plural "%s %d of %d clips %s"
-msgstr[0] "%s 第 %d 共 %d 片段在 %s"
-
-#: plug-ins/vocoder.ny
-msgid "Edgar-RFT"
-msgstr "Edgar-RFT"
-
-#: plug-ins/vocalrediso.ny
-msgid "Robert Haenggi"
-msgstr "Robert Haenggi"
-
-#: plug-ins/rissetdrum.ny
-msgid "Steven Jones"
-msgstr "Steven Jones"
-
-#: plug-ins/pluck.ny
-msgid "David R.Sky"
-msgstr "David R.Sky"
-
-#. i18n-hint: hours and minutes. Do not translate "~a".
-#: plug-ins/noisegate.ny
-#, lisp-format
-msgid "~ah ~am"
-msgstr "~a 时~a 分"
-
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
-msgid "Dominic Mazzoni"
-msgstr "Dominic Mazzoni"
-
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
-msgid "Paul Licameli"
-msgstr "Paul Licameli"
-
-#: src/widgets/numformatter.cpp
-msgid "NaN"
-msgstr "NaN"
-
-#: src/widgets/PopupMenuTable.h
-#, c-format
-msgid "%s (%s)"
-msgstr "%s（%s）"
-
-#. i18n-hint: Name of time display format that shows time in days, hours,
-#. * minutes and seconds
-#: src/widgets/NumericTextCtrl.cpp
-msgid "dd:hh:mm:ss"
-msgstr "日:时:分:秒"
-
-#. i18n-hint: Name of time display format that shows time in hours, minutes
-#. * and seconds
-#: src/widgets/NumericTextCtrl.cpp
-msgid "hh:mm:ss"
-msgstr "时:分:秒"
-
-#. i18n-hint arrowhead meaning forward movement
-#: src/widgets/HelpSystem.cpp
-msgid ">"
-msgstr ">"
-
-#. i18n-hint arrowhead meaning backward movement
-#: src/widgets/HelpSystem.cpp
-msgid "<"
-msgstr "<"
-
-#. i18n-hint: "x" suggests a multiplicative factor
-#: src/widgets/ASlider.cpp
-#, c-format
-msgid "%.2fx"
-msgstr "%.2fx"
-
-#: src/toolbars/ControlToolBar.cpp
-#, c-format
-msgid "%s."
-msgstr "%s。"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
-#: src/prefs/SpectrogramSettings.cpp
-msgid "ERB"
-msgstr "ERB"
-
-#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
-#: src/prefs/SpectrogramSettings.cpp
-msgid "Bark"
-msgstr "Bark"
-
-#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
-#. developed by Steinberg GmbH
-#: src/prefs/EffectsPrefs.cpp
-msgid "V&ST"
-msgstr "V&ST"
-
-#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
-#. It is not an abbreviation for anything.  See http://vamp-plugins.org
-#: src/prefs/EffectsPrefs.cpp
-msgid "&Vamp"
-msgstr "&Vamp"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/prefs/EffectsPrefs.cpp
-msgid "N&yquist"
-msgstr "N&yquist"
-
-#. i18n-hint: abbreviates
-#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
-#: src/prefs/EffectsPrefs.cpp
-msgid "LV&2"
-msgstr "LV&2"
-
-#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
-#. (Application programming interface)
-#: src/prefs/EffectsPrefs.cpp
-msgid "&LADSPA"
-msgstr "&LADSPA"
-
-#: src/menus/PluginMenus.cpp
-msgid "..."
-msgstr "..."
-
-#: src/import/ImportPCM.cpp
-msgid "8 bit DPCM"
-msgstr "8 位 DPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "24kbs G723 ADPCM"
-msgstr "24kbs G723 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "SF (Berkeley/IRCAM/CARL)"
-msgstr "SF（Berkeley/IRCAM/CARL）"
-
-#: src/import/ImportPCM.cpp
-msgid "SDS (Midi Sample Dump Standard)"
-msgstr "SDS（Midi 采样转储标准）"
-
-#: src/import/ImportPCM.cpp
-msgid "SD2 (Sound Designer II)"
-msgstr "SD2（Sound Designer II）"
-
-#: src/import/ImportPCM.cpp
-msgid "RAW (header-less)"
-msgstr "RAW（无文件头）"
-
-#. i18n-hint: track name and R abbreviating Right channel
-#: src/export/Export.cpp
-#, c-format
-msgid "%s - R"
-msgstr "%s - 右"
-
-#. i18n-hint: track name and L abbreviating Left channel
-#: src/export/Export.cpp
-#, c-format
-msgid "%s - L"
-msgstr "%s - 左"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/effects/Effect.h
-msgid "Nyquist"
-msgstr "Nyquist"
-
-#: src/import/ImportPCM.cpp
-msgid "16 bit DPCM"
-msgstr "16 位 DPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "VOX ADPCM"
-msgstr "VOX ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "24 bit DWVW"
-msgstr "24 位 DWVW"
-
-#: src/import/ImportPCM.cpp
-msgid "16 bit DWVW"
-msgstr "16 位 DWVW"
-
-#: src/import/ImportPCM.cpp
-msgid "32kbs G721 ADPCM"
-msgstr "32kbs G721 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "GSM 6.10"
-msgstr "GSM 6.10"
-
-#: src/import/ImportPCM.cpp
-msgid "Microsoft ADPCM"
-msgstr "微软 ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "IMA ADPCM"
-msgstr "IMA ADPCM"
-
-#: src/import/ImportPCM.cpp
-msgid "A-Law"
-msgstr "A-Law"
-
-#: src/import/ImportPCM.cpp
-msgid "XI (FastTracker 2)"
-msgstr "XI（FastTracker 2）"
-
-#: src/import/ImportPCM.cpp
-msgid "WVE (Psion Series 3)"
-msgstr "WVE（Psion Series 3）"
-
-#: src/import/ImportPCM.cpp
-msgid "WAVEX (Microsoft)"
-msgstr "WAVEX（微软）"
-
-#: src/import/ImportPCM.cpp
-msgid "WAV (NIST Sphere)"
-msgstr "WAV（NIST Sphere）"
-
-#: src/import/ImportPCM.cpp
-msgid "W64 (SoundFoundry WAVE 64)"
-msgstr "W64（SoundFoundry WAVE 64）"
-
-#: src/import/ImportPCM.cpp
-msgid "VOC (Creative Labs)"
-msgstr "VOC（创新科技）"
-
-#: src/import/ImportPCM.cpp
-msgid "PVF (Portable Voice Format)"
-msgstr "PVF（便携式语音格式）"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"

--- a/locale/zh_Hant.po
+++ b/locale/zh_Hant.po
@@ -18,11 +18,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenacity 3.0.4\n"
 "Report-Msgid-Bugs-To: emabrey@tenacityaudio.org\n"
-"POT-Creation-Date: 2021-07-25 03:44-0400\n"
+"POT-Creation-Date: 2021-10-09 15:18+0200\n"
 "PO-Revision-Date: 2021-08-30 10:00+0000\n"
 "Last-Translator: XiaoPanPanKevinPan <sn00151200@gmail.com>\n"
-"Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
-"tenacity/tenacity/zh_Hant/>\n"
+"Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/tenacity/tenacity/zh_Hant/>\n"
 "Language: zh_Hant\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,74 +29,32 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.8.1-dev\n"
 
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update Audacity"
-msgstr "更新 Tenacity"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Skip"
-msgstr "略過(&S)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "&Install update"
-msgstr "安裝更新(&I)"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Changelog"
-msgstr "修改記錄"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Read more on GitHub"
-msgstr "更多資訊請閱讀 GitHub"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error checking for update"
-msgstr "檢查更新檔案時發生錯誤"
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Unable to connect to Audacity update server."
-msgstr "無法連結到 Tenacity 的更新主機."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Update data was corrupted."
-msgstr "更新檔案可能是無效或已損壞."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Error downloading update."
-msgstr "下載更新檔案的時候發生錯誤."
-
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "update dialog"
-msgid "Can't open the Audacity download link."
-msgstr "無法打開 Tenacity 下載連結."
-
-#. i18n-hint Substitution of version number for %s.
-#: libraries/lib-strings/FutureStrings.h
-#, c-format
-msgctxt "update dialog"
-msgid "Audacity %s is available!"
-msgstr "新版本 Tenacity %s 已經出來了!"
-
-#. i18n-hint comment to be moved
-#. to one of them (one is enough)
-#. i18n-hint: modifier as in "Recording preferences", not progressive verb
-#: libraries/lib-strings/FutureStrings.h
-msgctxt "preference"
-msgid "Recording"
-msgstr "錄製"
-
 #: libraries/lib-strings/Internat.cpp
 msgid "Unable to determine"
 msgstr "無法確定"
+
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s bytes"
+msgstr "%s 位元組"
+
+#. i18n-hint: Abbreviation for Kilo bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s KB"
+msgstr "%s kB"
+
+#. i18n-hint: Abbreviation for Mega bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#. i18n-hint: Abbreviation for Giga bytes
+#: libraries/lib-strings/Internat.cpp
+#, c-format
+msgid "%s GB"
+msgstr "%s GB"
 
 #: libraries/lib-strings/Languages.cpp
 msgid "Simplified"
@@ -224,7 +181,8 @@ msgid "Script"
 msgstr "腳本"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp src/effects/BassTreble.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/Benchmark.cpp
+#: src/effects/BassTreble.cpp
 msgid "Output"
 msgstr "輸出"
 
@@ -240,7 +198,12 @@ msgstr "Nyquist 腳本 (*.ny)|*.ny|Lisp 腳本 (*.lsp)|*.lsp|所有檔案|*"
 msgid "Script was not saved."
 msgstr "腳本未儲存。"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/AudacityLogger.cpp
+#: src/DBConnection.cpp src/Project.cpp src/ProjectFileIO.cpp
+#: src/ProjectHistory.cpp src/SqliteSampleBlock.cpp src/WaveClip.cpp
+#: src/WaveTrack.cpp src/export/Export.cpp src/export/ExportCL.cpp
+#: src/export/ExportMultiple.cpp src/import/RawAudioGuess.cpp
+#: src/menus/EditMenus.cpp src/prefs/KeyConfigPrefs.cpp src/widgets/Warning.cpp
 msgid "Warning"
 msgstr "警告"
 
@@ -261,7 +224,16 @@ msgid "Tango Icon Gallery (toolbar icons)"
 msgstr "Tango 圖示庫（工具列圖示）"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
-msgid "External Audacity module which provides a simple IDE for writing effects."
+msgid "Leland Lucius"
+msgstr "Leland Lucius"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+msgid "(C) 2009 by Leland Lucius"
+msgstr "(C) 2009 Leland Lucius 作品"
+
+#: modules/mod-nyq-bench/NyqBench.cpp
+#, fuzzy
+msgid "External Tenacity module which provides a simple IDE for writing effects."
 msgstr "外部的 Audacity / Tenacity 模組，提供了一個用於編寫效果器的簡單 IDE（整合式開發環境）。"
 
 #: modules/mod-nyq-bench/NyqBench.cpp
@@ -284,7 +256,8 @@ msgstr "未命名"
 msgid "Nyquist Effect Workbench - "
 msgstr "Nyquist 效果工作檯 - "
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "New"
 msgstr "新增"
 
@@ -324,7 +297,8 @@ msgstr "複製"
 msgid "Copy to clipboard"
 msgstr "複製到剪貼簿"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Cut"
 msgstr "剪下"
 
@@ -332,7 +306,8 @@ msgstr "剪下"
 msgid "Cut to clipboard"
 msgstr "剪下到剪貼簿"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp src/toolbars/EditToolBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/menus/EditMenus.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Paste"
 msgstr "貼上"
 
@@ -357,7 +332,8 @@ msgstr "全選"
 msgid "Select all text"
 msgstr "選擇所有文字"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Undo"
 msgstr "復原"
 
@@ -365,7 +341,8 @@ msgstr "復原"
 msgid "Undo last change"
 msgstr "復原最後一次變更"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp src/widgets/KeyView.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/toolbars/EditToolBar.cpp
+#: src/widgets/KeyView.cpp
 msgid "Redo"
 msgstr "重做"
 
@@ -422,7 +399,8 @@ msgid "Go to next S-expr"
 msgstr "跳至下一個 S-expr"
 
 #. i18n-hint noun
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/Contrast.cpp
+#: src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
 msgid "Start"
 msgstr "開始"
 
@@ -430,7 +408,8 @@ msgstr "開始"
 msgid "Start script"
 msgstr "開始腳本"
 
-#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
+#: modules/mod-nyq-bench/NyqBench.cpp src/effects/EffectUI.cpp
+#: src/toolbars/ControlToolBar.cpp src/widgets/ProgressDialog.cpp
 msgid "Stop"
 msgstr "停止"
 
@@ -445,7 +424,8 @@ msgid "About %s"
 msgstr "關於 %s"
 
 #. i18n-hint: In most languages OK is to be translated as OK.  It appears on a button.
-#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
+#: src/AboutDialog.cpp src/Dependencies.cpp src/SplashDialog.cpp
+#: src/effects/nyquist/Nyquist.cpp src/widgets/MultiDialog.cpp
 msgid "OK"
 msgstr "確定"
 
@@ -453,11 +433,13 @@ msgstr "確定"
 msgid "Build Information"
 msgstr "組建資訊"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/prefs/ModulePrefs.cpp
 msgid "Enabled"
 msgstr "已啟用"
 
-#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
+#: src/AboutDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/prefs/ModulePrefs.cpp
 msgid "Disabled"
 msgstr "未啟用"
 
@@ -467,8 +449,9 @@ msgid "The Build"
 msgstr "版本編號"
 
 #: src/AboutDialog.cpp
-msgid "Commit Id:"
-msgstr "提交 ID："
+#, fuzzy
+msgid "Version:"
+msgstr "版本：%s"
 
 #: src/AboutDialog.cpp
 msgid "Build type:"
@@ -478,22 +461,28 @@ msgstr "組建類型："
 msgid "Compiler:"
 msgstr "編譯器："
 
+#: src/AboutDialog.cpp
+msgid "wxWidgets:"
+msgstr ""
+
 #. i18n-hint: The directory audacity is installed into (on *nix systems)
 #: src/AboutDialog.cpp
 msgid "Installation Prefix:"
 msgstr "安裝前綴："
 
 #: src/AboutDialog.cpp
-msgid "Settings folder:"
+#, fuzzy
+msgid "Config folder:"
+msgstr "設定資料夾："
+
+#: src/AboutDialog.cpp
+#, fuzzy
+msgid "Data folder:"
 msgstr "設定資料夾："
 
 #: src/AboutDialog.cpp
 msgid "File Format Support"
 msgstr "檔案格式支援"
-
-#: src/AboutDialog.cpp
-msgid "Cross-platform GUI library"
-msgstr "跨平臺 GUI 函式庫"
 
 #: src/AboutDialog.cpp
 msgid "Audio playback and recording"
@@ -507,7 +496,6 @@ msgstr "取樣頻率轉換"
 msgid "MP3 Importing"
 msgstr "MP3 匯入"
 
-#. i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "Ogg Vorbis Import and Export"
 msgstr "Ogg Vorbis 匯入和匯出"
@@ -516,7 +504,6 @@ msgstr "Ogg Vorbis 匯入和匯出"
 msgid "ID3 tag support"
 msgstr "ID3 標記支援"
 
-#. i18n-hint: FLAC stands for Free Lossless Audio Codec, but is effectively a proper noun and so shouldn't be translated
 #: src/AboutDialog.cpp
 msgid "FLAC import and export"
 msgstr "FLAC 匯入和匯出"
@@ -534,14 +521,6 @@ msgid "FFmpeg Import/Export"
 msgstr "FFmpeg 匯入/匯出"
 
 #: src/AboutDialog.cpp
-msgid "Import via GStreamer"
-msgstr "透過 GStreamer 匯入"
-
-#: src/AboutDialog.cpp
-msgid "Features"
-msgstr "功能"
-
-#: src/AboutDialog.cpp
 msgid "Plug-in support"
 msgstr "外掛程式支援"
 
@@ -556,6 +535,10 @@ msgstr "音高和拍速變更支援"
 #: src/AboutDialog.cpp
 msgid "Extreme Pitch and Tempo Change support"
 msgstr "極端音高和拍速變更支援"
+
+#: src/AboutDialog.cpp
+msgid "Features"
+msgstr "功能"
 
 #: src/AboutDialog.cpp
 msgid "GPL License"
@@ -674,6 +657,10 @@ msgstr "%s，Audacity 圖形"
 msgid "%s (incorporating %s, %s, %s, %s and %s)"
 msgstr "%s（併入 %s、%s、%s、%s 及 %s）"
 
+#: src/AboutDialog.cpp
+msgid "<h3>"
+msgstr "<h3>"
+
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp
 msgid "Free, open source, cross-platform audio recorder and editor."
@@ -682,6 +669,10 @@ msgstr "這是款免費、開源且跨平台的錄音及編輯音訊軟體。"
 #: src/AboutDialog.cpp
 msgid "Credits"
 msgstr "版權所有"
+
+#: src/AboutDialog.cpp
+msgid "Please note that names are sorted in alphabetical order, not in order of importance."
+msgstr "請注意，此處姓名皆依字母順序排序，無關乎重要程度。"
 
 #: src/AboutDialog.cpp
 msgid "DarkTenacity Customisation"
@@ -730,6 +721,7 @@ msgstr "Audacity 網站和圖形"
 #. *  your own name(s) to the credits.
 #. *
 #. *  For example:  "English translation by Dominic Mazzoni."
+#.
 #: src/AboutDialog.cpp
 msgid "translator_credits"
 msgstr ""
@@ -759,6 +751,22 @@ msgstr "Audacity 特別鳴謝："
 msgid "%s website: "
 msgstr "%s 網站: "
 
+#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
+#: src/AboutDialog.cpp
+#, c-format
+msgid "%s %s 1999-%s %s contributors"
+msgstr "%s %s 1999-%s %s 貢獻者"
+
+#. i18n-hint The registered trademark symbol (r) is substituted at %s
+#: src/AboutDialog.cpp
+#, c-format
+msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
+msgstr "在此程式中，Audacity%s 水印僅用於描述以及呈現訊息方面。"
+
+#: src/AboutDialog.cpp
+msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
+msgstr "Tenacity 並非由 MuseCY SM Ltd. 或者 Dominic M Mazzoni 出產，也不受其認證或背書。"
+
 #: src/AdornedRulerPanel.cpp
 msgid "Timeline actions disabled during recording"
 msgstr "錄製時時間軸動作已停用"
@@ -780,6 +788,7 @@ msgstr "時間軸"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Seek"
 msgstr "點選並拖動以開始定位播放"
@@ -787,6 +796,7 @@ msgstr "點選並拖動以開始定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click or drag to begin Scrub"
 msgstr "點選並拖動以開始跟隨播放"
@@ -794,6 +804,7 @@ msgstr "點選並拖動以開始跟隨播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Click & move to Scrub. Click & drag to Seek."
 msgstr "點選並移動以跟隨播放。點選並拖動以定位播放。"
@@ -801,6 +812,7 @@ msgstr "點選並移動以跟隨播放。點選並拖動以定位播放。"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Seek"
 msgstr "移動以定位播放"
@@ -808,6 +820,7 @@ msgstr "移動以定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/AdornedRulerPanel.cpp
 msgid "Move to Scrub"
 msgstr "移動以跟隨播放"
@@ -864,7 +877,17 @@ msgstr ""
 "不能鎖定超出\n"
 "專案終點的區域。"
 
-#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp src/export/ExportMP2.cpp src/menus/TrackMenus.cpp src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp src/prefs/KeyConfigPrefs.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp src/widgets/UnwritableLocationErrorDialog.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: src/AdornedRulerPanel.cpp src/AudioIO.cpp src/FileNames.cpp
+#: src/ProjectAudioManager.cpp src/TimerRecordDialog.cpp
+#: src/effects/Contrast.cpp src/effects/Effect.cpp src/effects/Generator.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/ExportFFmpeg.cpp
+#: src/export/ExportMP2.cpp src/menus/TrackMenus.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DirectoriesPrefs.cpp
+#: src/prefs/KeyConfigPrefs.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/widgets/UnwritableLocationErrorDialog.cpp
+#: plug-ins/eq-xml-to-txt-converter.ny
 msgid "Error"
 msgstr "錯誤"
 
@@ -888,7 +911,8 @@ msgstr ""
 "這是個一次性問題，在 '安裝' 後詢問是否重設偏好設定。"
 
 #: src/AudacityApp.cpp
-msgid "Reset Audacity Preferences"
+#, fuzzy
+msgid "Reset Tenacity Preferences"
 msgstr "重設 Tenacity 偏好設定"
 
 #: src/AudacityApp.cpp
@@ -903,7 +927,8 @@ msgstr ""
 "其已從「近期檔案」清單移除。"
 
 #: src/AudacityApp.cpp
-msgid "SQLite library failed to initialize.  Audacity cannot continue."
+#, fuzzy
+msgid "SQLite library failed to initialize.  Tenacity cannot continue."
 msgstr "Tenacity 因 SQLite 函式庫初始化失敗而無法繼續執行。"
 
 #: src/AudacityApp.cpp
@@ -928,7 +953,7 @@ msgstr "開啟(&O)..."
 msgid "Open &Recent..."
 msgstr "開啟近期檔案(&R)..."
 
-#: src/AudacityApp.cpp
+#: src/AudacityApp.cpp src/menus/HelpMenus.cpp
 msgid "&About Tenacity..."
 msgstr "關於 Tenacity(&A)..."
 
@@ -941,9 +966,10 @@ msgid "&File"
 msgstr "檔案(&F)"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a safe place to store temporary files.\n"
-"Audacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
+"Tenacity could not find a safe place to store temporary files.\n"
+"Tenacity needs a place where automatic cleanup programs won't delete the temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity 找不到安全的位置來存放暫存檔案。\n"
@@ -951,20 +977,23 @@ msgstr ""
 "請在「偏好設定」輸入合適的目錄。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity could not find a place to store temporary files.\n"
+"Tenacity could not find a place to store temporary files.\n"
 "Please enter an appropriate directory in the preferences dialog."
 msgstr ""
 "Tenacity 找不到位置來存放暫存檔案。\n"
 "請在「偏好設定」對話框輸入合適的目錄。"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."
+#, fuzzy
+msgid "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."
 msgstr "即將結束 Tenacity。請再次執行 Tenacity 來使用新的暫存目錄。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Running two copies of Audacity simultaneously may cause\n"
+"Running two copies of Tenacity simultaneously may cause\n"
 "data loss or cause your system to crash.\n"
 "\n"
 msgstr ""
@@ -973,15 +1002,17 @@ msgstr ""
 "\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Audacity was not able to lock the temporary files directory.\n"
-"This folder may be in use by another copy of Audacity.\n"
+"Tenacity was not able to lock the temporary files directory.\n"
+"This folder may be in use by another copy of Tenacity.\n"
 msgstr ""
 "Tenacity 無法鎖定暫存檔案目錄。\n"
 "該資料夾可能正被另一個 Tenacity 實體所使用。\n"
 
 #: src/AudacityApp.cpp
-msgid "Do you still want to start Audacity?"
+#, fuzzy
+msgid "Do you still want to start Tenacity?"
 msgstr "仍然想要啟動 Tenacity 嗎？"
 
 #: src/AudacityApp.cpp
@@ -989,19 +1020,22 @@ msgid "Error Locking Temporary Folder"
 msgstr "暫存資料夾發生檔案鎖定錯誤"
 
 #: src/AudacityApp.cpp
-msgid "The system has detected that another copy of Audacity is running.\n"
+#, fuzzy
+msgid "The system has detected that another copy of Tenacity is running.\n"
 msgstr "系統偵測到有另一個 Tenacity 程式正在執行。\n"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"Use the New or Open commands in the currently running Audacity\n"
+"Use the New or Open commands in the currently running Tenacity\n"
 "process to open multiple projects simultaneously.\n"
 msgstr ""
 "在目前執行的 Tenacity 中使用「新增」或「開啟」指令\n"
 "可以同時開啟多個專案。\n"
 
 #: src/AudacityApp.cpp
-msgid "Audacity is already running"
+#, fuzzy
+msgid "Tenacity is already running"
 msgstr "Tenacity 已經在執行"
 
 #: src/AudacityApp.cpp
@@ -1017,7 +1051,8 @@ msgstr ""
 "需要重新開機。"
 
 #: src/AudacityApp.cpp
-msgid "Audacity Startup Failure"
+#, fuzzy
+msgid "Tenacity Startup Failure"
 msgstr "Tenacity 啟動失敗"
 
 #: src/AudacityApp.cpp
@@ -1057,8 +1092,9 @@ msgstr ""
 "需要重新開機。"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
-"The Audacity IPC server failed to initialize.\n"
+"The Tenacity IPC server failed to initialize.\n"
 "\n"
 "This is likely due to a resource shortage\n"
 "and a reboot may be required."
@@ -1090,7 +1126,8 @@ msgstr "執行自我診斷"
 
 #. i18n-hint: This displays the Audacity version
 #: src/AudacityApp.cpp
-msgid "display Audacity version"
+#, fuzzy
+msgid "display Tenacity version"
 msgstr "顯示 Tenacity 版本"
 
 #. i18n-hint: This is a list of one or more files that Audacity
@@ -1100,9 +1137,10 @@ msgid "audio or project file name"
 msgstr "音訊或專案的檔案名"
 
 #: src/AudacityApp.cpp
+#, fuzzy
 msgid ""
 "Audacity project (.aup3) files are not currently \n"
-"associated with Audacity. \n"
+"associated with Tenacity. \n"
 "\n"
 "Associate them, so they open on double-click?"
 msgstr ""
@@ -1115,16 +1153,18 @@ msgstr ""
 msgid "Audacity Project Files"
 msgstr "Audacity / Tenacity 專案檔案"
 
-#: src/AudacityException.h src/commands/MessageCommand.cpp src/widgets/AudacityMessageBox.cpp
+#: src/AudacityException.h src/commands/MessageCommand.cpp
+#: src/widgets/AudacityMessageBox.cpp
 msgid "Message"
 msgstr "訊息"
 
 #: src/AudacityFileConfig.cpp
-msgid "Audacity Configuration Error"
+#, fuzzy
+msgid "Tenacity Configuration Error"
 msgstr "Tenacity 組態設定檔有錯誤"
 
 #: src/AudacityFileConfig.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The following configuration file could not be accessed:\n"
 "\n"
@@ -1134,7 +1174,7 @@ msgid ""
 "\n"
 "You can attempt to correct the issue and then click \"Retry\" to continue.\n"
 "\n"
-"If you choose to \"Quit Audacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
+"If you choose to \"Quit Tenacity\", your project may be left in an unsaved state which will be recovered the next time you open it."
 msgstr ""
 "無法存取以下設定檔：\n"
 "\n"
@@ -1146,12 +1186,15 @@ msgstr ""
 "\n"
 "如果選擇「結束 Tenacity」，您的專案可能會處於未儲存狀態，但下次開啟後就會復原。"
 
-#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp src/widgets/MultiDialog.cpp
+#: src/AudacityFileConfig.cpp src/ShuttleGui.cpp src/commands/HelpCommand.cpp
+#: src/effects/Equalization.cpp src/export/Export.cpp src/menus/HelpMenus.cpp
+#: src/widgets/MultiDialog.cpp
 msgid "Help"
 msgstr "說明"
 
 #: src/AudacityFileConfig.cpp src/AutoRecoveryDialog.cpp
-msgid "&Quit Audacity"
+#, fuzzy
+msgid "&Quit Tenacity"
 msgstr "結束 Tenacity (&Q)"
 
 #: src/AudacityFileConfig.cpp
@@ -1159,7 +1202,8 @@ msgid "&Retry"
 msgstr "重試(&R)"
 
 #: src/AudacityLogger.cpp
-msgid "Audacity Log"
+#, fuzzy
+msgid "Tenacity Log"
 msgstr "Tenacity 日誌"
 
 #: src/AudacityLogger.cpp src/Tags.cpp
@@ -1171,7 +1215,8 @@ msgstr "儲存(&S)..."
 msgid "Cl&ear"
 msgstr "清除(&E)"
 
-#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/AudacityLogger.cpp src/ShuttleGui.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 msgid "&Close"
 msgstr "關閉(&C)"
 
@@ -1226,7 +1271,8 @@ msgid "Error Initializing Midi"
 msgstr "初始化 MIDI 時發生錯誤"
 
 #: src/AudioIO.cpp
-msgid "Audacity Audio"
+#, fuzzy
+msgid "Tenacity Audio"
 msgstr "Tenacity 音訊"
 
 #: src/AudioIO.cpp src/ProjectAudioManager.cpp
@@ -1241,37 +1287,6 @@ msgstr ""
 #: src/AudioIO.cpp
 msgid "Out of memory!"
 msgstr "記憶體不足！"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
-msgstr "輸入強度自動調整已停止。無法再最佳化。音量還是太高。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment decreased the volume to %f."
-msgstr "輸入強度自動調整已將音量降低至 %f。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
-msgstr "輸入強度自動調整已停止。無法再最佳化。音量還是太低。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment increased the volume to %.2f."
-msgstr "輸入強度自動調整已將音量提高至 %.2f。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
-msgstr "輸入強度自動調整已停止。分析的總次數已經達到極限，但仍找不到可接受的音量。音量還是太高。"
-
-#: src/AudioIO.cpp
-msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
-msgstr "輸入強度自動調整已停止。分析的總次數已經達到極限，但仍找不到可接受的音量。音量還是太低。"
-
-#: src/AudioIO.cpp
-#, c-format
-msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
-msgstr "輸入強度自動調整已停止。%.2f 似乎是可接受的音量。"
 
 #: src/AudioIOBase.cpp
 msgid "Stream is active ... unable to gather information.\n"
@@ -1370,43 +1385,6 @@ msgstr "找不到「%s」的播放裝置。\n"
 msgid "Cannot check mutual sample rates without both devices.\n"
 msgstr "沒有兩組裝置，故無法檢查共有的取樣頻率。\n"
 
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "Received %d while opening devices\n"
-msgstr "開啟裝置時，接收到 %d\n"
-
-#: src/AudioIOBase.cpp
-msgid "Unable to open Portmixer\n"
-msgstr "無法開啟連接埠混音器\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available mixers:\n"
-msgstr "可用的混音器：\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available recording sources:\n"
-msgstr "可用的錄音來源：\n"
-
-#: src/AudioIOBase.cpp
-msgid "Available playback volumes:\n"
-msgstr "可用的播放儲存器：\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is emulated\n"
-msgstr "錄音的音量是模擬的\n"
-
-#: src/AudioIOBase.cpp
-msgid "Recording volume is native\n"
-msgstr "錄音的音量是原生的\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is emulated\n"
-msgstr "播放的音量是模擬的\n"
-
-#: src/AudioIOBase.cpp
-msgid "Playback volume is native\n"
-msgstr "播放的音量是原生的\n"
-
 #. i18n-hint: Supported, meaning made available by the system
 #: src/AudioIOBase.cpp
 #, c-format
@@ -1449,8 +1427,9 @@ msgid "Automatic Crash Recovery"
 msgstr "當機自動復原"
 
 #: src/AutoRecoveryDialog.cpp
+#, fuzzy
 msgid ""
-"The following projects were not saved properly the last time Audacity was run and can be automatically recovered.\n"
+"The following projects were not saved properly the last time Tenacity was run and can be automatically recovered.\n"
 "\n"
 "After recovery, save the projects to ensure changes are written to disk."
 msgstr ""
@@ -1463,12 +1442,14 @@ msgid "Recoverable &projects"
 msgstr "可復原的專案(&P)"
 
 #. i18n-hint: (verb).  It instruct the user to select items.
-#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp src/prefs/MousePrefs.cpp
+#: src/AutoRecoveryDialog.cpp src/TrackInfo.cpp src/commands/SelectCommand.cpp
+#: src/prefs/MousePrefs.cpp
 msgid "Select"
 msgstr "選擇"
 
 #. i18n-hint: (noun).  It's the name of the project to recover.
-#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp src/TrackInfo.cpp
+#: src/AutoRecoveryDialog.cpp src/PluginRegistrationDialog.cpp
+#: src/TrackInfo.cpp
 msgid "Name"
 msgstr "名稱"
 
@@ -1554,6 +1535,11 @@ msgstr "效果"
 #: src/BatchCommands.cpp
 msgid "Menu Command (With Parameters)"
 msgstr "選單指令 (帶參數)"
+
+#: src/BatchCommands.cpp src/FileNames.cpp
+#, c-format
+msgid "(%s)"
+msgstr "(%s)"
 
 #: src/BatchCommands.cpp
 msgid "Menu Command (No Parameters)"
@@ -1699,7 +1685,8 @@ msgstr "還原(&S)"
 msgid "I&mport..."
 msgstr "匯入(&M)..."
 
-#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp src/effects/Equalization.cpp
+#: src/BatchProcessDialog.cpp src/effects/Contrast.cpp
+#: src/effects/Equalization.cpp
 msgid "E&xport..."
 msgstr "匯出(&X)..."
 
@@ -1740,7 +1727,8 @@ msgstr "上移(&U)"
 msgid "Move &Down"
 msgstr "下移(&D)"
 
-#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp src/menus/HelpMenus.cpp
+#: src/BatchProcessDialog.cpp src/effects/nyquist/Nyquist.cpp
+#: src/menus/HelpMenus.cpp
 msgid "&Save"
 msgstr "儲存(&S)"
 
@@ -1823,7 +1811,8 @@ msgid "Run"
 msgstr "執行"
 
 #. i18n-hint verb
-#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp src/widgets/HelpSystem.cpp
+#: src/Benchmark.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/widgets/HelpSystem.cpp
 msgid "Close"
 msgstr "關閉"
 
@@ -1969,10 +1958,6 @@ msgid "No revision identifier was provided"
 msgstr "未提供修訂版識別碼"
 
 #: src/BuildInfo.h
-msgid "Unknown date and time"
-msgstr "未知的日期和時間"
-
-#: src/BuildInfo.h
 #, c-format
 msgid "Debug build (debug level %d)"
 msgstr "除錯組建 (除錯等級 %d)"
@@ -2055,6 +2040,11 @@ msgid ""
 msgstr ""
 "必須先選擇一些音訊來用於此操作。\n"
 "(選擇其它類型的軌道無法用於此操作。)"
+
+#: src/DBConnection.cpp
+#, c-format
+msgid "(%d): %s"
+msgstr "(%d): %s"
 
 #: src/DBConnection.cpp
 #, c-format
@@ -2217,6 +2207,11 @@ msgid "&Copy Names to Clipboard"
 msgstr "複製名稱到剪貼簿(&C)"
 
 #: src/Dependencies.cpp
+#, c-format
+msgid "\"%s\", \"%s\", \"%s\"\n"
+msgstr "\"%s\", \"%s\", \"%s\"\n"
+
+#: src/Dependencies.cpp
 msgid "Missing"
 msgstr "遺失"
 
@@ -2225,10 +2220,11 @@ msgid "If you proceed, your project will not be saved to disk. Is this what you 
 msgstr "如果繼續，您的專案將不會儲存到磁碟上。要這樣做嗎？"
 
 #: src/Dependencies.cpp
+#, fuzzy
 msgid ""
 "Your project is self-contained; it does not depend on any external audio files. \n"
 "\n"
-"Some older Audacity projects may not be self-contained, and care \n"
+"Some older Tenacity projects may not be self-contained, and care \n"
 "is needed to keep their external dependencies in the right place.\n"
 "New projects will be self-contained and are less risky."
 msgstr ""
@@ -2242,7 +2238,10 @@ msgstr ""
 msgid "Dependency Check"
 msgstr "依存關係檢查"
 
-#: src/Dither.cpp src/commands/ScreenshotCommand.cpp src/effects/EffectManager.cpp src/effects/EffectUI.cpp src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny plug-ins/sample-data-export.ny
+#: src/Dither.cpp src/commands/ScreenshotCommand.cpp
+#: src/effects/EffectManager.cpp src/effects/EffectUI.cpp
+#: src/prefs/TracksBehaviorsPrefs.cpp plug-ins/equalabel.ny
+#: plug-ins/sample-data-export.ny
 msgid "None"
 msgstr "無"
 
@@ -2250,7 +2249,7 @@ msgstr "無"
 msgid "Rectangle"
 msgstr "矩形"
 
-#: src/Dither.cpp plug-ins/tremolo.ny
+#: src/Dither.cpp src/effects/ToneGen.cpp plug-ins/tremolo.ny
 msgid "Triangle"
 msgstr "三角形"
 
@@ -2262,14 +2261,60 @@ msgstr "定形"
 msgid "Rectangular"
 msgstr "矩形"
 
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Bartlett"
+msgstr "Bartlett"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hamming"
+msgstr "Hamming"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Hann"
+msgstr "Hann"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Blackman"
+msgstr "Blackman"
+
+#. i18n-hint two proper names
+#: src/FFT.cpp
+msgid "Blackman-Harris"
+msgstr "Blackman-Harris"
+
+#. i18n-hint a proper name
+#: src/FFT.cpp
+msgid "Welch"
+msgstr "Welch"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=2.5)"
+msgstr "高斯函數（a=2.5）"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=3.5)"
+msgstr "高斯函數（a=3.5）"
+
+#. i18n-hint a mathematical function named for C. F. Gauss
+#: src/FFT.cpp
+msgid "Gaussian(a=4.5)"
+msgstr "高斯函數（a=4.5）"
+
 #: src/FFmpeg.cpp
 msgid "FFmpeg support not compiled in"
 msgstr "編譯時未加入 FFmpeg 支援"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
 "FFmpeg was configured in Preferences and successfully loaded before, \n"
-"but this time Audacity failed to load it at startup. \n"
+"but this time Tenacity failed to load it at startup. \n"
 "\n"
 "You may want to go back to Preferences > Libraries and re-configure it."
 msgstr ""
@@ -2291,8 +2336,8 @@ msgid "Locate FFmpeg"
 msgstr "定位 FFmpeg"
 
 #: src/FFmpeg.cpp
-#, c-format
-msgid "Audacity needs the file '%s' to import and export audio via FFmpeg."
+#, fuzzy, c-format
+msgid "Tenacity needs the file '%s' to import and export audio via FFmpeg."
 msgstr "Tenacity 需要「%s」檔案，才能以 FFmpeg 匯入和匯出音訊。"
 
 #: src/FFmpeg.cpp
@@ -2305,7 +2350,8 @@ msgstr "'%s' 的位置："
 msgid "To find '%s', click here -->"
 msgstr "如要尋找 '%s'，請點選此處 -->"
 
-#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp plug-ins/nyquist-plug-in-installer.ny
+#: src/FFmpeg.cpp src/export/ExportCL.cpp src/export/ExportMP3.cpp
+#: plug-ins/nyquist-plug-in-installer.ny
 msgid "Browse..."
 msgstr "瀏覽..."
 
@@ -2331,8 +2377,9 @@ msgid "FFmpeg not found"
 msgstr "找不到 FFmpeg"
 
 #: src/FFmpeg.cpp
+#, fuzzy
 msgid ""
-"Audacity attempted to use FFmpeg to import an audio file,\n"
+"Tenacity attempted to use FFmpeg to import an audio file,\n"
 "but the libraries were not found.\n"
 "\n"
 "To use FFmpeg import, go to Edit > Preferences > Libraries\n"
@@ -2362,26 +2409,26 @@ msgid "Only libavformat.so"
 msgstr "只有 libavformat.so"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to open a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to open a file in %s."
 msgstr "Tenacity 無法開啟檔案： %s 。"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity failed to read from a file in %s."
+#, fuzzy, c-format
+msgid "Tenacity failed to read from a file in %s."
 msgstr ""
 "Tenacity 無法開啟檔案：\n"
 "  %s。"
 
 #: src/FileException.cpp
-#, c-format
-msgid "Audacity successfully wrote a file in %s but failed to rename it as %s."
+#, fuzzy, c-format
+msgid "Tenacity successfully wrote a file in %s but failed to rename it as %s."
 msgstr "Audacity 成功寫入 %s 檔案，但未能將之重新命名為 %s。"
 
 #: src/FileException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write to a file.\n"
+"Tenacity failed to write to a file.\n"
 "Perhaps %s is not writable or the disk is full.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -2419,7 +2466,9 @@ msgstr "不複製任何音訊(&N)"
 msgid "As&k"
 msgstr "詢問(&K)"
 
-#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: src/FileNames.cpp plug-ins/eq-xml-to-txt-converter.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "All files"
 msgstr "所有檔案"
 
@@ -2514,7 +2563,12 @@ msgstr "對數頻率"
 
 #. i18n-hint: abbreviates decibels
 #. i18n-hint: short form of 'decibels'.
-#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/Equalization.cpp src/effects/Loudness.cpp src/effects/Normalize.cpp src/effects/ScienFilter.cpp src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/FreqWindow.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/Equalization.cpp src/effects/Loudness.cpp
+#: src/effects/Normalize.cpp src/effects/ScienFilter.cpp
+#: src/effects/TruncSilence.cpp src/prefs/WaveformSettings.cpp
+#: src/widgets/Meter.cpp plug-ins/sample-data-export.ny
 msgid "dB"
 msgstr "分貝"
 
@@ -2525,6 +2579,15 @@ msgstr "滾動"
 #: src/FreqWindow.cpp src/prefs/MousePrefs.cpp
 msgid "Zoom"
 msgstr "縮放"
+
+#. i18n-hint: This is the abbreviation for "Hertz", or
+#. cycles per second.
+#. i18n-hint: Name of display format that shows frequency in hertz
+#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp
+#: src/effects/ScienFilter.cpp src/import/ImportRaw.cpp
+#: src/widgets/NumericTextCtrl.cpp
+msgid "Hz"
+msgstr "Hz"
 
 #: src/FreqWindow.cpp
 msgid "Scroll Horizontal"
@@ -2615,10 +2678,15 @@ msgid "%.4f sec (%d Hz) (%s) = %.3f"
 msgstr "%.4f 秒 (%d Hz) (%s) = %.3f"
 
 #: src/FreqWindow.cpp
+msgid "spectrum.txt"
+msgstr "spectrum.txt"
+
+#: src/FreqWindow.cpp
 msgid "Export Spectral Data As:"
 msgstr "將頻譜資料匯出為："
 
-#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp src/menus/FileMenus.cpp
+#: src/FreqWindow.cpp src/LabelDialog.cpp src/effects/Contrast.cpp
+#: src/menus/FileMenus.cpp
 #, c-format
 msgid "Couldn't write to file: %s"
 msgstr "無法寫入到檔案：%s"
@@ -2707,8 +2775,7 @@ msgstr "我們強烈建議您使用我們的最新穩定正式發佈版，它有
 
 #: src/HelpText.cpp
 msgid "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>"
-msgstr ""
-"您可以加入我們的[[https://tenacityaudio.org|社群]]，來幫助我們令 Tenacity 變得更好。<hr><br><br>"
+msgstr "您可以加入我們的[[https://tenacityaudio.org|社群]]，來幫助我們令 Tenacity 變得更好。<hr><br><br>"
 
 #: src/HelpText.cpp
 msgid "How to get help"
@@ -2721,9 +2788,7 @@ msgstr "以下是我們所提供的支援方式："
 #. i18n-hint: Preserve '[[help:Quick_Help|' as it's the name of a link.
 #: src/HelpText.cpp
 msgid "[[help:Quick_Help|Quick Help]] - if not installed locally, [[https://manual.audacityteam.org/quick_help.html|view online]]"
-msgstr ""
-"[[help:Quick_Help|快速說明]] - 若未安裝至本機，請參閱[[https://manual.audacityteam.org/"
-"quick_help.html|網路版本]]"
+msgstr "[[help:Quick_Help|快速說明]] - 若未安裝至本機，請參閱[[https://manual.audacityteam.org/quick_help.html|網路版本]]"
 
 #. i18n-hint: Preserve '[[help:Main_Page|' as it's the name of a link.
 #: src/HelpText.cpp
@@ -2736,23 +2801,15 @@ msgstr " [[https://forum.audacityteam.org/|論壇]] - 直接在網路上提問�
 
 #: src/HelpText.cpp
 msgid "More:</b> Visit our [[https://wiki.audacityteam.org/index.php|Wiki]] for tips, tricks, extra tutorials and effects plug-ins."
-msgstr ""
-"更多：</b>請參訪我們的 [[https://wiki.audacityteam.org/index.php|Wiki]] "
-"以獲取最新的提示、技巧、額外的教學和效果外掛程式。"
+msgstr "更多：</b>請參訪我們的 [[https://wiki.audacityteam.org/index.php|Wiki]] 以獲取最新的提示、技巧、額外的教學和效果外掛程式。"
 
 #: src/HelpText.cpp
 msgid "Audacity can import unprotected files in many other formats (such as M4A and WMA, compressed WAV files from portable recorders and audio from video files) if you download and install the optional [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign| FFmpeg library]] to your computer."
-msgstr ""
-"如果您下載並安裝額外的 [[https://manual.audacityteam.org/man/"
-"faq_opening_and_saving_files.html#foreign|FFmpeg 函式庫]]到您的電腦，Tenacity "
-"可以匯入許多其它格式 (例如：M4A、WMA、攜帶式錄音裝置壓制的 WAV 檔案和視訊檔案中的音訊) 的未受保護檔案。"
+msgstr "如果您下載並安裝額外的 [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#foreign|FFmpeg 函式庫]]到您的電腦，Tenacity 可以匯入許多其它格式 (例如：M4A、WMA、攜帶式錄音裝置壓制的 WAV 檔案和視訊檔案中的音訊) 的未受保護檔案。"
 
 #: src/HelpText.cpp
 msgid "You can also read our help on importing [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI files]] and tracks from [[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd| audio CDs]]."
-msgstr ""
-"您也可以參閱關於如何匯入 [[https://manual.audacityteam.org/man/playing_and_recording."
-"html#midi|MIDI 檔案]]和從[[https://manual.audacityteam.org/man/"
-"faq_opening_and_saving_files.html#fromcd|音訊 CD]] 匯入軌道的說明。"
+msgstr "您也可以參閱關於如何匯入 [[https://manual.audacityteam.org/man/playing_and_recording.html#midi|MIDI 檔案]]和從[[https://manual.audacityteam.org/man/faq_opening_and_saving_files.html#fromcd|音訊 CD]] 匯入軌道的說明。"
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
@@ -2760,10 +2817,7 @@ msgstr "您的電腦似乎並未安裝「help」資料夾。請[[*URL*|線上檢
 
 #: src/HelpText.cpp
 msgid "The Manual does not appear to be installed. Please [[*URL*|view the Manual online]] or [[https://manual.audacityteam.org/man/unzipping_the_manual.html| download the Manual]].<br><br>To always view the Manual online, change \"Location of Manual\" in Interface Preferences to \"From Internet\"."
-msgstr ""
-"您的電腦似乎並未安裝手冊。請[[*URL*|線上檢視內容]]或[[https://manual.audacityteam.org/man/"
-"unzipping_the_manual."
-"html|下載整份使用手冊]]。<br><br>如果您希望總是在網路上瀏覽使用手冊，請在偏好設定中將「使用手冊位置」變更為「網路」。"
+msgstr "您的電腦似乎並未安裝手冊。請[[*URL*|線上檢視內容]]或[[https://manual.audacityteam.org/man/unzipping_the_manual.html|下載整份使用手冊]]。<br><br>如果您希望總是在網路上瀏覽使用手冊，請在偏好設定中將「使用手冊位置」變更為「網路」。"
 
 #: src/HistoryWindow.cpp
 msgid "History"
@@ -2822,19 +2876,19 @@ msgid "&History..."
 msgstr "歷史記錄(&H)..."
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error in %s at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s 發生內部錯誤：位於 %s，第 %d 行。\n"
 "請前往 https://tenacityaudio.org/ 通知 Tenacity 團隊。"
 
 #: src/InconsistencyException.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Internal error at %s line %d.\n"
-"Please inform the Audacity team at https://forum.audacityteam.org/."
+"Please inform the Tenacity team at https://tenacityaudio.org/#community-buttons."
 msgstr ""
 "%s 發生內部錯誤：位於 %s，第 %d 行。\n"
 "請前往 https://tenacityaudio.org/ 通知 Tenacity 團隊。"
@@ -2853,7 +2907,9 @@ msgid "Track"
 msgstr "軌道"
 
 #. i18n-hint: (noun)
-#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
+#: src/LabelDialog.cpp src/commands/SetLabelCommand.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp plug-ins/equalabel.ny
 msgid "Label"
 msgstr "標籤"
 
@@ -2913,7 +2969,8 @@ msgstr "輸入軌道名稱"
 #. i18n-hint: (noun) it's the name of a kind of track.
 #. i18n-hint: This is for screen reader software and indicates that
 #. this is a Label track.
-#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp src/TrackPanelAx.cpp
+#: src/LabelDialog.cpp src/LabelDialog.h src/LabelTrack.cpp
+#: src/TrackPanelAx.cpp
 msgid "Label Track"
 msgstr "標籤軌道"
 
@@ -2924,11 +2981,13 @@ msgstr "無法讀入一個或更多的標籤。"
 #. i18n-hint: Title on a dialog indicating that this is the first
 #. * time Audacity has been run.
 #: src/LangChoice.cpp
-msgid "Audacity First Run"
+#, fuzzy
+msgid "Tenacity First Run"
 msgstr "Tenacity 首次執行"
 
 #: src/LangChoice.cpp
-msgid "Choose Language for Audacity to use:"
+#, fuzzy
+msgid "Choose Language for Tenacity to use:"
 msgstr "選擇 Tenacity 使用的語言："
 
 #. i18n-hint: The %s's are replaced by translated and untranslated
@@ -2938,7 +2997,8 @@ msgstr "選擇 Tenacity 使用的語言："
 msgid "The language you have chosen, %s (%s), is not the same as the system language, %s (%s)."
 msgstr "所選的語言 %s (%s) 和系統語言 %s (%s) 不相同。"
 
-#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+#: src/LangChoice.cpp src/effects/VST/VSTEffect.cpp
+#: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 msgid "Confirm"
 msgstr "確認"
 
@@ -2956,12 +3016,13 @@ msgstr ""
 "原本的檔案已另存為「%s」"
 
 #: src/Legacy.cpp
-msgid "Opening Audacity Project"
+#, fuzzy
+msgid "Opening Tenacity Project"
 msgstr "正在開啟 Audacity / Tenacity 專案"
 
 #: src/LyricsWindow.cpp
-#, c-format
-msgid "Audacity Karaoke%s"
+#, fuzzy, c-format
+msgid "Tenacity Karaoke%s"
 msgstr "Tenacity 卡拉OK%s"
 
 #: src/LyricsWindow.cpp
@@ -3012,19 +3073,23 @@ msgid "Mixing and rendering tracks"
 msgstr "混音並算繪軌道"
 
 #: src/MixerBoard.cpp
-#, c-format
-msgid "Audacity Mixer Board%s"
+#, fuzzy, c-format
+msgid "Tenacity Mixer Board%s"
 msgstr "Tenacity 混音器面板%s"
 
 #. i18n-hint: title of the Gain slider, used to adjust the volume
 #. i18n-hint: Title of the Gain slider, used to adjust the volume
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Gain"
 msgstr "增益"
 
 #. i18n-hint: title of the MIDI Velocity slider
 #. i18n-hint: Title of the Velocity slider, used to adjust the volume of note tracks
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Velocity"
 msgstr "力度"
 
@@ -3033,17 +3098,23 @@ msgid "Musical Instrument"
 msgstr "樂器"
 
 #. i18n-hint: Title of the Pan slider, used to move the sound left or right
-#: src/MixerBoard.cpp src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Pan"
 msgstr "平移"
 
 #. i18n-hint: This is on a button that will silence this track.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Mute"
 msgstr "靜音"
 
 #. i18n-hint: This is on a button that will silence all the other tracks.
-#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp src/tracks/playabletrack/ui/PlayableTrackControls.cpp
+#: src/MixerBoard.cpp src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackButtonHandles.cpp
+#: src/tracks/playabletrack/ui/PlayableTrackControls.cpp
 msgid "Solo"
 msgstr "獨奏"
 
@@ -3051,15 +3122,18 @@ msgstr "獨奏"
 msgid "Signal Level Meter"
 msgstr "訊號強度計量表"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved gain slider"
 msgstr "已移動增益滑桿"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
 msgid "Moved velocity slider"
 msgstr "已移動速率滑桿"
 
-#: src/MixerBoard.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/MixerBoard.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
 msgid "Moved pan slider"
 msgstr "已移動平移滑桿"
 
@@ -3094,9 +3168,9 @@ msgstr ""
 "不會載入該模組。"
 
 #: src/ModuleManager.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"The module \"%s\" is matched with Audacity version \"%s\".\n"
+"The module \"%s\" is matched with Tenacity version \"%s\".\n"
 "\n"
 "It will not be loaded."
 msgstr ""
@@ -3130,16 +3204,19 @@ msgstr ""
 "\n"
 "僅使用可信任來源的模組"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny plug-ins/sample-data-export.ny
 msgid "Yes"
 msgstr "是"
 
-#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny plug-ins/equalabel.ny plug-ins/limiter.ny
+#: src/ModuleManager.cpp src/TimerRecordDialog.cpp plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/limiter.ny
 msgid "No"
 msgstr "否"
 
 #: src/ModuleManager.cpp
-msgid "Audacity Module Loader"
+#, fuzzy
+msgid "Tenacity Module Loader"
 msgstr "Tenacity 模組載入器"
 
 #: src/ModuleManager.cpp
@@ -3162,6 +3239,116 @@ msgstr ""
 #: src/NoteTrack.cpp src/TrackPanelAx.cpp
 msgid "Note Track"
 msgstr "音符軌道"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C"
+msgstr "C"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯"
+msgstr "C♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D"
+msgstr "D"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯"
+msgstr "D♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E"
+msgstr "E"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F"
+msgstr "F"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯"
+msgstr "F♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G"
+msgstr "G"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯"
+msgstr "G♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A"
+msgstr "A"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯"
+msgstr "A♯"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B"
+msgstr "B"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♭"
+msgstr "D♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "E♭"
+msgstr "E♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♭"
+msgstr "G♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♭"
+msgstr "A♭"
+
+#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "B♭"
+msgstr "B♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "C♯/D♭"
+msgstr "C♯/D♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "D♯/E♭"
+msgstr "D♯/E♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "F♯/G♭"
+msgstr "F♯/G♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "G♯/A♭"
+msgstr "G♯/A♭"
+
+#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
+#: src/PitchName.cpp
+msgid "A♯/B♭"
+msgstr "A♯/B♭"
 
 #: src/PluginManager.cpp
 #, c-format
@@ -3270,7 +3457,8 @@ msgstr "全選(&S)"
 msgid "C&lear All"
 msgstr "全部清除(&L)"
 
-#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp src/prefs/RecordingPrefs.cpp
+#: src/PluginRegistrationDialog.cpp src/effects/EffectUI.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "&Enable"
 msgstr "啟用(&E)"
 
@@ -3349,9 +3537,10 @@ msgid "Mismatched Sampling Rates"
 msgstr "取樣速率不符"
 
 #: src/ProjectAudioManager.cpp src/menus/TransportMenus.cpp
+#, fuzzy
 msgid ""
 "Too few tracks are selected for recording at this sample rate.\n"
-"(Audacity requires two channels at the same sample rate for\n"
+"(Tenacity requires two channels at the same sample rate for\n"
 "each stereo track)"
 msgstr ""
 "選取的音軌過少，以致無法以此取樣速率錄製。\n"
@@ -3380,10 +3569,11 @@ msgid "Dropouts"
 msgstr "Dropout"
 
 #: src/ProjectAudioManager.cpp
+#, fuzzy
 msgid ""
 "Recorded audio was lost at the labeled locations. Possible causes:\n"
 "\n"
-"Other applications are competing with Audacity for processor time\n"
+"Other applications are competing with Tenacity for processor time\n"
 "\n"
 "You are saving directly to a slow external storage device\n"
 msgstr ""
@@ -3423,11 +3613,11 @@ msgid "Inspecting project file data"
 msgstr "正在檢查專案檔案資料"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing external audio file(s) \n"
-"('aliased files'). There is no way for Audacity \n"
+"('aliased files'). There is no way for Tenacity \n"
 "to recover these files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3470,11 +3660,11 @@ msgid "Warning - Missing Aliased File(s)"
 msgstr "警告 - 遺失別名檔案"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing alias (.auf) blockfile(s). \n"
-"Audacity can fully regenerate these files \n"
+"Tenacity can fully regenerate these files \n"
 "from the current audio in the project."
 msgstr ""
 "「%s」資料夾的專案檢查\n"
@@ -3499,12 +3689,12 @@ msgid "Warning - Missing Alias Summary File(s)"
 msgstr "警告 - 遺失別名摘要檔案"
 
 #: src/ProjectFSCK.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Project check of \"%s\" folder \n"
 "detected %lld missing audio data (.au) blockfile(s), \n"
 "probably due to a bug, system crash, or accidental \n"
-"deletion. There is no way for Audacity to recover \n"
+"deletion. There is no way for Tenacity to recover \n"
 "these missing files automatically. \n"
 "\n"
 "If you choose the first or second option below, \n"
@@ -3561,7 +3751,8 @@ msgstr "警告 - 孤立區塊檔案"
 
 #. i18n-hint: This title appears on a dialog that indicates the progress
 #. in doing something.
-#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp src/menus/TransportMenus.cpp
+#: src/ProjectFSCK.cpp src/ProjectFileIO.cpp src/UndoManager.cpp
+#: src/menus/TransportMenus.cpp
 msgid "Progress"
 msgstr "進度"
 
@@ -3586,6 +3777,11 @@ msgstr "警告：自動復原時發生問題"
 #: src/ProjectFileIO.cpp src/menus/WindowMenus.cpp
 msgid "<untitled>"
 msgstr "<未命名>"
+
+#: src/ProjectFileIO.cpp
+#, c-format
+msgid "[Project %02i] "
+msgstr "[專案 %02i] "
 
 #: src/ProjectFileIO.cpp
 msgid "Failed to open the project's database"
@@ -3655,12 +3851,14 @@ msgstr ""
 "(無法產生系統需要的暫存檔案)"
 
 #: src/ProjectFileIO.cpp
-msgid "This is not an Audacity project file"
+#, fuzzy
+msgid "This is not an Tenacity project file"
 msgstr "這不是 Audacity / Tenacity 專案檔案"
 
 #: src/ProjectFileIO.cpp
+#, fuzzy
 msgid ""
-"This project was created with a newer version of Audacity.\n"
+"This project was created with a newer version of Tenacity.\n"
 "\n"
 "You will need to upgrade to open it."
 msgstr ""
@@ -3794,9 +3992,9 @@ msgid "Error Writing to File"
 msgstr "寫入檔案時發生錯誤"
 
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity failed to write file %s.\n"
+"Tenacity failed to write file %s.\n"
 "Perhaps disk is full or not writable.\n"
 "For tips on freeing up space, click the help button."
 msgstr ""
@@ -3810,9 +4008,16 @@ msgstr "正在壓縮專案"
 
 #. i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.
 #: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] Audacity \"%s\""
+#, fuzzy, c-format
+msgid "[Project %02i] Tenacity \"%s\""
 msgstr "[專案 %02i] Tenacity \"%s\""
+
+#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp
+#: src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/prefs/PrefsPanel.cpp
+#, fuzzy
+msgid "Tenacity"
+msgstr "Tenacity"
 
 #. i18n-hint: E.g this is recovered audio that had been lost.
 #: src/ProjectFileIO.cpp
@@ -3821,10 +4026,10 @@ msgstr "(已復原)"
 
 #. i18n-hint: %s will be replaced by the version number.
 #: src/ProjectFileIO.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"This file was saved using Audacity %s.\n"
-"You are using Audacity %s. You may need to upgrade to a newer version to open this file."
+"This file was saved using Tenacity %s.\n"
+"You are using Tenacity %s. You may need to upgrade to a newer version to open this file."
 msgstr ""
 "此檔案是用 Audacity / Tenacity %s 儲存的。\n"
 "您正在使用的是 Tenacity %s。您需要升級為較新的版本，才能開啟此檔案。"
@@ -3894,8 +4099,9 @@ msgid "Backing up project"
 msgstr "正在備份專案"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot."
 msgstr ""
@@ -3904,8 +4110,9 @@ msgstr ""
 "已復原至上一個快照。"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"This project was not saved properly the last time Audacity ran.\n"
+"This project was not saved properly the last time Tenacity ran.\n"
 "\n"
 "It has been recovered to the last snapshot, but you must save it\n"
 "to preserve its contents."
@@ -3984,8 +4191,9 @@ msgid "%sSave Project \"%s\" As..."
 msgstr "%s將「%s」專案另存為..."
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
-"'Save Project' is for an Audacity project, not an audio file.\n"
+"'Save Project' is for an Tenacity project, not an audio file.\n"
 "For an audio file that will open in other apps, use 'Export'.\n"
 msgstr ""
 "「儲存專案」會將檔案存成 Tenacity 專案，而非音訊檔案。\n"
@@ -4062,11 +4270,12 @@ msgid "Error Opening Project"
 msgstr "開啟專案時發生錯誤"
 
 #: src/ProjectFileManager.cpp
+#, fuzzy
 msgid ""
 "You are trying to open an automatically created backup file.\n"
 "Doing this may result in severe data loss.\n"
 "\n"
-"Please open the actual Audacity project file instead."
+"Please open the actual Tenacity project file instead."
 msgstr ""
 "您正嘗試開啟一個自動建立的備份檔案。\n"
 "此操作可能導致嚴重的資料遺失。\n"
@@ -4175,8 +4384,8 @@ msgid "Automatic database backup failed."
 msgstr "無法自動備份資料庫。"
 
 #: src/ProjectManager.cpp
-#, c-format
-msgid "Welcome to Audacity version %s"
+#, fuzzy, c-format
+msgid "Welcome to Tenacity version %s"
 msgstr "歡迎使用 Tenacity %s 版"
 
 #. i18n-hint: The first %s numbers the project, the second %s is the project name.
@@ -4389,7 +4598,8 @@ msgstr "所有偏好設定"
 msgid "SelectionBar"
 msgstr "選取範圍列"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/SpectralSelectionBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/SpectralSelectionBar.cpp
 msgid "Spectral Selection"
 msgstr "頻譜選取範圍"
 
@@ -4397,46 +4607,55 @@ msgstr "頻譜選取範圍"
 msgid "Timer"
 msgstr "預約"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ToolsToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ToolsToolBar.cpp
 msgid "Tools"
 msgstr "工具"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ControlToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ControlToolBar.cpp
 msgid "Transport"
 msgstr "播錄"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MixerToolBar.cpp
+#: src/Screenshot.cpp
 msgid "Mixer"
 msgstr "混音器"
 
 #. i18n-hint: Noun (the meter is used for playback or record level monitoring)
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp src/widgets/Meter.cpp
 msgid "Meter"
 msgstr "計量表"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio playing.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Play Meter"
 msgstr "播放計量表"
 
 #. i18n-hint: (noun) The meter that shows the loudness of the audio being recorded.
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/MeterToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/MeterToolBar.cpp
 msgid "Record Meter"
 msgstr "錄製計量表"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/EditToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/EditToolBar.cpp
 msgid "Edit"
 msgstr "編輯"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/prefs/DevicePrefs.h src/toolbars/DeviceToolBar.cpp
 msgid "Device"
 msgstr "裝置"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/TranscriptionToolBar.cpp
 msgid "Play-at-Speed"
 msgstr "以指定速度播放"
 
-#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp src/toolbars/ScrubbingToolBar.cpp
+#: src/Screenshot.cpp src/commands/ScreenshotCommand.cpp
+#: src/toolbars/ScrubbingToolBar.cpp
 msgid "Scrub"
 msgstr "跟隨播放"
 
@@ -4451,7 +4670,10 @@ msgstr "尺標"
 #. i18n-hint: "Tracks" include audio recordings but also other collections of
 #. * data associated with a time line, such as sequences of labels, and musical
 #. * notes
-#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp src/prefs/TracksPrefs.h
+#: src/Screenshot.cpp src/commands/GetInfoCommand.cpp
+#: src/commands/GetTrackInfoCommand.cpp src/commands/ScreenshotCommand.cpp
+#: src/export/ExportMultiple.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/TracksPrefs.h
 msgid "Tracks"
 msgstr "軌道"
 
@@ -4561,7 +4783,8 @@ msgid "Activation level (dB):"
 msgstr "啟動強度 (分貝)："
 
 #: src/SplashDialog.cpp
-msgid "Welcome to Audacity!"
+#, fuzzy
+msgid "Welcome to Tenacity!"
 msgstr "歡迎使用 Tenacity！"
 
 #: src/SplashDialog.cpp
@@ -4708,9 +4931,9 @@ msgstr ""
 "有關經濟型硬碟的小提示，請點選說明按鈕。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write file:\n"
+"Tenacity could not write file:\n"
 "  %s."
 msgstr ""
 "Tenacity 無法寫入檔案：\n"
@@ -4730,9 +4953,9 @@ msgstr ""
 "  %s。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not open file:\n"
+"Tenacity could not open file:\n"
 "  %s\n"
 "for writing."
 msgstr ""
@@ -4741,9 +4964,9 @@ msgstr ""
 "來寫入。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not write images to file:\n"
+"Tenacity could not write images to file:\n"
 "  %s."
 msgstr ""
 "Tenacity 無法寫入圖像到檔案：\n"
@@ -4760,9 +4983,9 @@ msgstr ""
 "  %s。"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not find file:\n"
+"Tenacity could not find file:\n"
 "  %s.\n"
 "Theme not loaded."
 msgstr ""
@@ -4772,9 +4995,9 @@ msgstr ""
 
 #. i18n-hint: Do not translate png.  It is the name of a file format.
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not load file:\n"
+"Tenacity could not load file:\n"
 "  %s.\n"
 "Bad png format perhaps?"
 msgstr ""
@@ -4783,8 +5006,9 @@ msgstr ""
 "PNG 格式是否損壞？"
 
 #: src/Theme.cpp
+#, fuzzy
 msgid ""
-"Audacity could not read its default theme.\n"
+"Tenacity could not read its default theme.\n"
 "Please report the problem."
 msgstr ""
 "Tenacity 無法讀取附帶的預設佈景主題。\n"
@@ -4818,9 +5042,9 @@ msgstr ""
 "已經存在。是否覆寫？"
 
 #: src/Theme.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity could not save file:\n"
+"Tenacity could not save file:\n"
 "  %s"
 msgstr ""
 "Tenacity 無法儲存檔案：\n"
@@ -4859,7 +5083,11 @@ msgstr "自訂"
 #. * then the 'h' indicates the second number displayed is hours, the 'm' indicates the third
 #. * number displayed is minutes, and the 's' indicates that the fourth number displayed is
 #. * seconds.
-#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#.
+#: src/TimeDialog.h src/TimerRecordDialog.cpp src/effects/DtmfGen.cpp
+#: src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Duration"
 msgstr "持續時間"
 
@@ -4870,7 +5098,8 @@ msgid "Time Track"
 msgstr "時間軌道"
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record"
+#, fuzzy
+msgid "Tenacity Timer Record"
 msgstr "Tenacity 預約錄製"
 
 #: src/TimerRecordDialog.cpp
@@ -4943,7 +5172,8 @@ msgstr "目前專案"
 msgid "Recording start:"
 msgstr "錄製起點："
 
-#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/TimerRecordDialog.cpp src/effects/VST/VSTEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp
 msgid "Duration:"
 msgstr "持續時間："
 
@@ -4964,7 +5194,8 @@ msgid "Action after Timer Recording:"
 msgstr "預約錄製完成後動作："
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record Progress"
+#, fuzzy
+msgid "Tenacity Timer Record Progress"
 msgstr "Tenacity 預約錄製進度"
 
 #: src/TimerRecordDialog.cpp
@@ -5060,6 +5291,7 @@ msgstr "099 日 024 時 060 分 060 秒"
 #. * are translated, with the numbers left exactly as they are.
 #. * The 'h' indicates the first number displayed is hours, the 'm' indicates the second number
 #. * displayed is minutes, and the 's' indicates that the third number displayed is seconds.
+#.
 #: src/TimerRecordDialog.cpp
 msgid "Start Date and Time"
 msgstr "起始日期和時間"
@@ -5104,7 +5336,8 @@ msgstr "啟用自動匯出(&E)？"
 msgid "Export Project As:"
 msgstr "匯出專案為："
 
-#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/TimerRecordDialog.cpp src/prefs/GUIPrefs.cpp src/prefs/PlaybackPrefs.cpp
+#: src/prefs/RecordingPrefs.cpp
 msgid "Options"
 msgstr "選項"
 
@@ -5117,7 +5350,8 @@ msgid "Do nothing"
 msgstr "不動作"
 
 #: src/TimerRecordDialog.cpp
-msgid "Exit Audacity"
+#, fuzzy
+msgid "Exit Tenacity"
 msgstr "結束 Tenacity"
 
 #: src/TimerRecordDialog.cpp
@@ -5141,7 +5375,8 @@ msgid "Scheduled to stop at:"
 msgstr "計畫停止於："
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting for Start"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting for Start"
 msgstr "Tenacity 預約錄製 - 等待開始"
 
 #. i18n-hint: "in" means after a duration of time,
@@ -5167,7 +5402,8 @@ msgid "Recording Exported:"
 msgstr "錄音已匯出為："
 
 #: src/TimerRecordDialog.cpp
-msgid "Audacity Timer Record - Waiting"
+#, fuzzy
+msgid "Tenacity Timer Record - Waiting"
 msgstr "Tenacity 預約錄製 - 等待開始"
 
 #: src/TrackInfo.cpp
@@ -5364,7 +5600,11 @@ msgid "Applying %s..."
 msgstr "正在套用 %s..."
 
 #. i18n-hint: An item name followed by a value, with appropriate separating punctuation
-#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/commands/AudacityCommand.cpp src/effects/Effect.cpp
+#: src/effects/vamp/VampEffect.cpp src/menus/PluginMenus.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackSliderHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%s: %s"
 msgstr "%s：%s"
@@ -5387,13 +5627,15 @@ msgstr "%s 不是 %s 接納的參數"
 msgid "Invalid value for parameter '%s': should be %s"
 msgstr "「%s」參數有無效值：應為 %s"
 
-#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp src/widgets/KeyView.cpp
+#: src/commands/CommandManager.cpp src/prefs/MousePrefs.cpp
+#: src/widgets/KeyView.cpp
 msgid "Command"
 msgstr "指令"
 
 #. i18n-hint: %s will be the name of the effect which will be
 #. * repeated if this menu item is chosen
-#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp src/menus/PluginMenus.cpp
+#: src/commands/CommandManager.cpp src/effects/EffectUI.cpp
+#: src/menus/PluginMenus.cpp
 #, c-format
 msgid "Repeat %s"
 msgstr "重複 %s"
@@ -5520,13 +5762,24 @@ msgstr "剪輯"
 msgid "Envelopes"
 msgstr "波封"
 
-#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/GetTrackInfoCommand.cpp
+#: src/export/ExportMultiple.cpp
 msgid "Labels"
 msgstr "標籤"
 
 #: src/commands/GetInfoCommand.cpp
 msgid "Boxes"
 msgstr "匣子"
+
+#. i18n-hint JavaScript Object Notation
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "JSON"
+msgstr "JSON"
+
+#. i18n-hint name of a computer programming language
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+msgid "LISP"
+msgstr ""
 
 #: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
 msgid "Brief"
@@ -5536,7 +5789,8 @@ msgstr "簡短"
 msgid "Type:"
 msgstr "類型："
 
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
+#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMultiple.cpp
 msgid "Format:"
 msgstr "格式："
 
@@ -5563,6 +5817,10 @@ msgstr "註解"
 #: src/commands/HelpCommand.cpp src/export/ExportCL.cpp
 msgid "Command:"
 msgstr "指令："
+
+#: src/commands/HelpCommand.cpp
+msgid "_"
+msgstr "_"
 
 #: src/commands/HelpCommand.h
 msgid "Gives help on a command."
@@ -5600,12 +5858,17 @@ msgstr "匯出到檔案。"
 msgid "Builtin Commands"
 msgstr "內建指令"
 
-#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
-msgid "The Audacity Team"
+#: src/commands/LoadCommands.cpp src/effects/LoadEffects.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp
+#: src/effects/nyquist/LoadNyquist.cpp src/effects/vamp/LoadVamp.cpp
+#, fuzzy
+msgid "The Tenacity Team"
 msgstr "Tenacity 團隊"
 
 #: src/commands/LoadCommands.cpp
-msgid "Provides builtin commands to Audacity"
+#, fuzzy
+msgid "Provides builtin commands to Tenacity"
 msgstr "提供內建指令給 Tenacity"
 
 #: src/commands/LoadCommands.cpp
@@ -5668,7 +5931,10 @@ msgstr "清除日誌內容。"
 msgid "Get Preference"
 msgstr "取得偏好設定"
 
-#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp src/commands/SetTrackInfoCommand.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp src/tracks/ui/CommonTrackControls.cpp
+#: src/commands/PreferenceCommands.cpp src/commands/SetProjectCommand.cpp
+#: src/commands/SetTrackInfoCommand.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/ui/CommonTrackControls.cpp
 msgid "Name:"
 msgstr "名稱："
 
@@ -5716,7 +5982,8 @@ msgstr "全螢幕"
 msgid "Toolbars"
 msgstr "工具列"
 
-#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp src/prefs/EffectsPrefs.h
+#: src/commands/ScreenshotCommand.cpp src/prefs/EffectsPrefs.cpp
+#: src/prefs/EffectsPrefs.h
 msgid "Effects"
 msgstr "效果"
 
@@ -5856,7 +6123,8 @@ msgstr "設定"
 msgid "Add"
 msgstr "加入"
 
-#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/commands/SelectCommand.cpp src/effects/EffectUI.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
 msgid "Remove"
 msgstr "移除"
 
@@ -5941,7 +6209,8 @@ msgid "Edited Envelope"
 msgstr "已編輯的波封"
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
-#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp src/tracks/ui/EnvelopeHandle.cpp
+#: src/commands/SetEnvelopeCommand.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/EnvelopeHandle.cpp
 msgid "Envelope"
 msgstr "波封"
 
@@ -6041,7 +6310,10 @@ msgstr "平移："
 msgid "Set Track Visuals"
 msgstr "設定軌道視覺化"
 
-#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp plug-ins/sample-data-export.ny
+#: src/commands/SetTrackInfoCommand.cpp src/effects/ToneGen.cpp
+#: src/prefs/SpectrogramSettings.cpp src/prefs/TracksPrefs.cpp
+#: src/prefs/WaveformSettings.cpp src/widgets/Meter.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Linear"
 msgstr "線性"
 
@@ -6154,7 +6426,9 @@ msgid "Duck &amount:"
 msgstr "閃避總量(&A)："
 
 #. i18n-hint: Name of time display format that shows time in seconds
-#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/effects/AutoDuck.cpp src/effects/TruncSilence.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "seconds"
 msgstr "秒"
 
@@ -6178,7 +6452,8 @@ msgstr "向內漸弱長度(&O)："
 msgid "Inner &fade up length:"
 msgstr "向內漸強長度(&F)："
 
-#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp src/effects/TruncSilence.cpp
+#: src/effects/AutoDuck.cpp src/effects/Compressor.cpp
+#: src/effects/TruncSilence.cpp
 msgid "&Threshold:"
 msgstr "臨界值(&T)："
 
@@ -6316,11 +6591,13 @@ msgstr "到 (Hz)"
 msgid "t&o"
 msgstr "至(&O)"
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent C&hange:"
 msgstr "百分比變更(&H)："
 
-#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp src/effects/ChangeTempo.cpp
+#: src/effects/ChangePitch.cpp src/effects/ChangeSpeed.cpp
+#: src/effects/ChangeTempo.cpp
 msgid "Percent Change"
 msgstr "百分比變更"
 
@@ -6328,9 +6605,23 @@ msgstr "百分比變更"
 msgid "&Use high quality stretching (slow)"
 msgstr "使用高品質拉伸 (慢)(&U)"
 
+#: src/effects/ChangeSpeed.cpp
+msgid "33⅓"
+msgstr "33⅓"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "45"
+msgstr "45"
+
+#: src/effects/ChangeSpeed.cpp
+msgid "78"
+msgstr "78"
+
 #. i18n-hint: n/a is an English abbreviation meaning "not applicable".
 #. i18n-hint: Can mean "not available," "not applicable," "no answer"
-#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/ChangeSpeed.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/nyquist/Nyquist.cpp
 msgid "n/a"
 msgstr "(不適用)"
 
@@ -6358,6 +6649,7 @@ msgstr "標準黑膠唱片每分鐘轉速："
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "From rpm"
 msgstr "從 RPM"
@@ -6370,6 +6662,7 @@ msgstr "從(&F)"
 
 #. i18n-hint: changing speed of audio "from" one value "to" another
 #. "rpm" means "revolutions per minute" as on a vinyl record turntable
+#.
 #: src/effects/ChangeSpeed.cpp
 msgid "To rpm"
 msgstr "至 RPM"
@@ -6528,6 +6821,20 @@ msgstr "%.2f 秒"
 msgid "%.1f secs"
 msgstr "%.1f 秒"
 
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.0f:1"
+msgstr "%.0f:1"
+
+#. i18n-hint: Unless your language has a different convention for ratios,
+#. * like 8:1, leave as is.
+#: src/effects/Compressor.cpp
+#, c-format
+msgid "%.1f:1"
+msgstr "%.1f:1"
+
 #: src/effects/Compressor.cpp
 #, c-format
 msgid "Ratio %.0f to 1"
@@ -6643,7 +6950,8 @@ msgid "Contrast Analyzer, for measuring RMS volume differences between two selec
 msgstr "對比分析器，量測兩個音訊選取部分之間的均方根音量差異。"
 
 #. i18n-hint noun
-#: src/effects/Contrast.cpp src/effects/ToneGen.cpp src/toolbars/SelectionBar.cpp
+#: src/effects/Contrast.cpp src/effects/ToneGen.cpp
+#: src/toolbars/SelectionBar.cpp
 msgid "End"
 msgstr "結束"
 
@@ -6856,6 +7164,12 @@ msgstr "WCAG 2.0 成功準則 1.4.7：不符合"
 #: src/effects/Contrast.cpp
 msgid "Data gathered"
 msgstr "已收集資料"
+
+#. i18n-hint: day of month, month, year, hour, minute, second
+#: src/effects/Contrast.cpp
+#, c-format
+msgid "%d %s %02d %02dh %02dm %02ds"
+msgstr "%d天 %s月 %02d年 %02d小時 %02d分 %02d秒"
 
 #: src/effects/Contrast.cpp
 msgid "Contrast Analysis (WCAG 2 compliance)"
@@ -7135,7 +7449,9 @@ msgstr "雙音多頻序列(&S)："
 msgid "&Amplitude (0-1):"
 msgstr "振幅 (0 至 1)(&A)："
 
-#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp src/effects/ToneGen.cpp src/effects/TruncSilence.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/DtmfGen.cpp src/effects/Noise.cpp src/effects/Silence.cpp
+#: src/effects/ToneGen.cpp src/effects/TruncSilence.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "&Duration:"
 msgstr "持續時間(&D)："
 
@@ -7148,12 +7464,29 @@ msgid "Duty cycle:"
 msgstr "工作週期："
 
 #: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.1f %%"
+msgstr "%.1f %%"
+
+#: src/effects/DtmfGen.cpp
 msgid "Tone duration:"
 msgstr "單音持續時間："
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%.0f ms"
+msgstr "%.0f ms"
 
 #: src/effects/DtmfGen.cpp
 msgid "Silence duration:"
 msgstr "靜音持續時間："
+
+#. i18n-hint milliseconds
+#: src/effects/DtmfGen.cpp
+#, c-format
+msgid "%0.f ms"
+msgstr "%0.f ms"
 
 #: src/effects/Echo.cpp
 msgid "Echo"
@@ -7163,7 +7496,8 @@ msgstr "回音"
 msgid "Repeats the selected audio again and again"
 msgstr "不停重複選擇音訊"
 
-#: src/effects/Echo.cpp src/effects/FindClipping.cpp src/effects/Paulstretch.cpp
+#: src/effects/Echo.cpp src/effects/FindClipping.cpp
+#: src/effects/Paulstretch.cpp
 msgid "Requested value exceeds memory capacity."
 msgstr "要求值超過記憶體容量。"
 
@@ -7187,7 +7521,8 @@ msgstr "預設集"
 msgid "Export Effect Parameters"
 msgstr "匯出效果參數"
 
-#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp src/xml/XMLFileReader.cpp
+#: src/effects/Effect.cpp src/effects/VST/VSTEffect.cpp
+#: src/xml/XMLFileReader.cpp
 #, c-format
 msgid "Could not open file: \"%s\""
 msgstr "無法開啟檔案：\"%s\""
@@ -7224,6 +7559,14 @@ msgstr "正在準備預覽"
 #: src/effects/Effect.cpp
 msgid "Previewing"
 msgstr "正在預覽"
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/effects/Effect.h
+msgid "Nyquist"
+msgstr "Nyquist"
 
 #: src/effects/EffectManager.cpp
 #, c-format
@@ -7503,6 +7846,11 @@ msgstr "停止播放(&P)"
 msgid "Play"
 msgstr "播放"
 
+#. i18n-hint: Technical term for a kind of curve.
+#: src/effects/Equalization.cpp
+msgid "B-spline"
+msgstr ""
+
 #: src/effects/Equalization.cpp
 msgid "Cosine"
 msgstr "餘弦"
@@ -7546,6 +7894,10 @@ msgstr "低音減弱"
 #: src/effects/Equalization.cpp
 msgid "Low rolloff for speech"
 msgstr "適用於語音的低 Rolloff"
+
+#: src/effects/Equalization.cpp
+msgid "RIAA"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "Telephone"
@@ -7603,6 +7955,22 @@ msgstr "最小分貝"
 #: src/effects/Equalization.cpp src/effects/ScienFilter.cpp
 msgid "- dB"
 msgstr "- 分貝"
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%g kHz"
+msgstr ""
+
+#. i18n-hint k is SI abbreviation for x1,000.  Usually unchanged in translation.
+#: src/effects/Equalization.cpp
+#, c-format
+msgid "%gk"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "&EQ Type:"
@@ -7677,8 +8045,16 @@ msgid "D&efault"
 msgstr "預設值(&E)"
 
 #: src/effects/Equalization.cpp
+msgid "&SSE"
+msgstr ""
+
+#: src/effects/Equalization.cpp
 msgid "SSE &Threaded"
 msgstr "SSE 執行緒(&T)"
+
+#: src/effects/Equalization.cpp
+msgid "A&VX"
+msgstr ""
 
 #: src/effects/Equalization.cpp
 msgid "AV&X Threaded"
@@ -7923,7 +8299,8 @@ msgid "Builtin Effects"
 msgstr "內建效果"
 
 #: src/effects/LoadEffects.cpp
-msgid "Provides builtin effects to Audacity"
+#, fuzzy
+msgid "Provides builtin effects to Tenacity"
 msgstr "提供內建效果給 Tenacity"
 
 #: src/effects/LoadEffects.cpp
@@ -7968,6 +8345,14 @@ msgstr "正規化(&N)"
 #: src/effects/Loudness.cpp
 msgid "Loudness LUFS"
 msgstr "響度 LUFS"
+
+#: src/effects/Loudness.cpp
+msgid "LUFS"
+msgstr ""
+
+#: src/effects/Loudness.cpp
+msgid "RMS dB"
+msgstr ""
 
 #: src/effects/Loudness.cpp
 msgid "Normalize &stereo channels independently"
@@ -8029,8 +8414,32 @@ msgid "none, Hann (2.0.6 behavior)"
 msgstr "none, Hann (2.0.6 行為)"
 
 #: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hann, none"
+msgstr "4（預設值）"
+
+#: src/effects/NoiseReduction.cpp
 msgid "Hann, Hann (default)"
 msgstr "4（預設值）"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Blackman, Hann"
+msgstr "Blackman"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, none"
+msgstr "Hamming"
+
+#: src/effects/NoiseReduction.cpp
+#, fuzzy
+msgid "Hamming, Hann"
+msgstr "Hamming"
+
+#: src/effects/NoiseReduction.cpp
+msgid "Hamming, Reciprocal Hamming"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp src/menus/PluginMenus.cpp
 msgid "Noise Reduction"
@@ -8125,8 +8534,9 @@ msgid "Step 1"
 msgstr "第 1 步"
 
 #: src/effects/NoiseReduction.cpp src/effects/NoiseRemoval.cpp
+#, fuzzy
 msgid ""
-"Select a few seconds of just noise so Audacity knows what to filter out,\n"
+"Select a few seconds of just noise so Tenacity knows what to filter out,\n"
 "then click Get Noise Profile:"
 msgstr ""
 "選擇幾秒只有背景噪音的片段，讓 Tenacity 了解要濾除什麼內容，\n"
@@ -8178,13 +8588,63 @@ msgstr "視窗類型(&W)："
 msgid "Window si&ze:"
 msgstr "視窗大小(&Z)："
 
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#, fuzzy
+msgid "8"
+msgstr "78"
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "32"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "64"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "128"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "256"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "512"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp
+msgid "1024"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "2048 (default)"
 msgstr "2045（預設值）"
 
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "4096"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "8192"
+msgstr ""
+
+#: src/effects/NoiseReduction.cpp src/prefs/SpectrumPrefs.cpp
+msgid "16384"
+msgstr ""
+
 #: src/effects/NoiseReduction.cpp
 msgid "S&teps per window:"
 msgstr "每個視窗的音階數量(&T)："
+
+#: src/effects/NoiseReduction.cpp src/export/ExportFFmpegDialogs.cpp
+#: src/export/ExportFLAC.cpp
+msgid "2"
+msgstr ""
 
 #: src/effects/NoiseReduction.cpp
 msgid "4 (default)"
@@ -8310,6 +8770,7 @@ msgstr "使用 慢速播放 僅在極端的時間拉伸或者「停滯」效果"
 #. i18n-hint: This is how many times longer the sound will be, e.g. applying
 #. * the effect to a 1-second sample, with the default Stretch Factor of 10.0
 #. * will give an (approximately) 10 second sound
+#.
 #: src/effects/Paulstretch.cpp
 msgid "&Stretch Factor:"
 msgstr "幾倍長度(&S)："
@@ -8752,6 +9213,11 @@ msgstr "使用預設值"
 msgid "Restore Defaults"
 msgstr "設為預設值"
 
+#: src/effects/ScoreAlignDialog.cpp
+#, c-format
+msgid "%.3f"
+msgstr ""
+
 #. i18n-hint: noun
 #: src/effects/Silence.cpp
 msgctxt "generator"
@@ -8910,6 +9376,10 @@ msgstr "偵測靜音"
 msgid "Tr&uncate to:"
 msgstr "截斷至(&U)："
 
+#: src/effects/TruncSilence.cpp src/import/ImportRaw.cpp
+msgid "%"
+msgstr ""
+
 #: src/effects/TruncSilence.cpp
 msgid "C&ompress to:"
 msgstr "壓縮為(&O)："
@@ -8923,7 +9393,8 @@ msgid "VST Effects"
 msgstr "VST 效果"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Adds the ability to use VST effects in Audacity."
+#, fuzzy
+msgid "Adds the ability to use VST effects in Tenacity."
 msgstr "為 Tenacity 加入使用 VST 效果器的功能。"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -8935,7 +9406,8 @@ msgstr "正在掃描 VST 外掛程式"
 msgid "Registering %d of %d: %-64.64s"
 msgstr "註冊 %2$d / %1$d ：%3$-64.64s"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LoadLV2.cpp src/effects/vamp/LoadVamp.cpp
 msgid "Could not load the library"
 msgstr "無法載入函式庫"
 
@@ -8947,21 +9419,25 @@ msgstr "VST 效果器選項"
 msgid "Buffer Size"
 msgstr "緩衝區大小"
 
+#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
+msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
+msgstr "緩衝區大小控制每次「效果」所處理的樣本數量。較小的樣本數會讓處理過程變慢，且部分效果需要至少 8192（有些更少）個樣本才能正常工作。然而，多數的效果支持更大的樣本數，且使用比較大的數量可以明顯縮短處理時間。"
+
 #: src/effects/VST/VSTEffect.cpp
 msgid "&Buffer Size (8 to 1048576 samples):"
 msgstr "緩衝區大小 (8 到 1048576 取樣點)(&B)："
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Latency Compensation"
 msgstr "延遲補償"
 
 #: src/effects/VST/VSTEffect.cpp
 msgid "As part of their processing, some VST effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all VST effects."
-msgstr ""
-"在部分的處理模式，部分的 VST 效果必須要延遲回傳聲音給 "
-"Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 VST 效果。"
+msgstr "在部分的處理模式，部分的 VST 效果必須要延遲回傳聲音給 Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 VST 效果。"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/audiounits/AudioUnitEffect.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
 msgid "Enable &compensation"
 msgstr "啟用補償(&C)"
 
@@ -8995,7 +9471,8 @@ msgid "Standard VST program file"
 msgstr "標準 VST 程式檔"
 
 #: src/effects/VST/VSTEffect.cpp
-msgid "Audacity VST preset file"
+#, fuzzy
+msgid "Tenacity VST preset file"
 msgstr "Tenacity VST 預設集檔案"
 
 #: src/effects/VST/VSTEffect.cpp
@@ -9022,7 +9499,8 @@ msgstr "載入 VST 預設集時發生錯誤"
 msgid "Unable to load presets file."
 msgstr "無法載入預設集檔案。"
 
-#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp src/effects/lv2/LV2Effect.cpp
+#: src/effects/VST/VSTEffect.cpp src/effects/ladspa/LadspaEffect.cpp
+#: src/effects/lv2/LV2Effect.cpp
 msgid "Effect Settings"
 msgstr "效果設定"
 
@@ -9038,6 +9516,12 @@ msgstr "無法讀取預設集檔案。"
 #, c-format
 msgid "This parameter file was saved from %s. Continue?"
 msgstr "此參數檔案是從 %s 儲存的。是否繼續？"
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/effects/VST/VSTEffect.h
+msgid "VST"
+msgstr ""
 
 #: src/effects/Wahwah.cpp
 msgid "Wahwah"
@@ -9073,7 +9557,8 @@ msgid "Audio Unit Effects"
 msgstr "音訊單元（Audio Unit）效果"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "Provides Audio Unit Effects support to Audacity"
+#, fuzzy
+msgid "Provides Audio Unit Effects support to Tenacity"
 msgstr "為 Tenacity 提供音訊單元（Audio Unit）效果器支援"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
@@ -9089,10 +9574,9 @@ msgid "Audio Unit Effect Options"
 msgstr "音訊單元（Audio Unit）效果器選項"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
-msgid "As part of their processing, some Audio Unit effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
-msgstr ""
-"在部分的處理模式，部分的音訊單元（Audio Unit）效果必須要延遲回傳聲音給 "
-"Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 聲音效果單元。"
+#, fuzzy
+msgid "As part of their processing, some Audio Unit effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all Audio Unit effects."
+msgstr "在部分的處理模式，部分的音訊單元（Audio Unit）效果必須要延遲回傳聲音給 Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 聲音效果單元。"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "User Interface"
@@ -9100,9 +9584,7 @@ msgstr "介面"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select \"Full\" to use the graphical interface if supplied by the Audio Unit. Select \"Generic\" to use the system supplied generic interface. Select \"Basic\" for a basic text-only interface. Reopen the effect for this to take effect."
-msgstr ""
-"選擇「完整」，則會在音訊單元（Audio "
-"Unit）提供時使用圖形介面。選擇「通用」則使用系統提供的圖形介面。選擇「基本」則使用基本的純文字介面。重新啟動這個效果以生效。"
+msgstr "選擇「完整」，則會在音訊單元（Audio Unit）提供時使用圖形介面。選擇「通用」則使用系統提供的圖形介面。選擇「基本」則使用基本的純文字介面。重新啟動這個效果以生效。"
 
 #: src/effects/audiounits/AudioUnitEffect.cpp
 msgid "Select &interface"
@@ -9229,8 +9711,15 @@ msgstr "無法建立預設集的屬性列表"
 msgid "Failed to set class info for \"%s\" preset"
 msgstr "無法設定「%s」預設集的類別資訊"
 
+#. i18n-hint: the name of an Apple audio software protocol
+#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
+#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
+msgid "Audio Unit"
+msgstr "音訊單元（Audio Unit）"
+
 #. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
 #. (Application programming interface)
+#.
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "LADSPA Effects"
 msgstr "LADSPA 效果"
@@ -9240,7 +9729,8 @@ msgid "Provides LADSPA Effects"
 msgstr "提供 LADSPA 效果器"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "Audacity no longer uses vst-bridge"
+#, fuzzy
+msgid "Tenacity no longer uses vst-bridge"
 msgstr "Tenacity 不再使用 vst-bridge"
 
 #: src/effects/ladspa/LadspaEffect.cpp
@@ -9248,14 +9738,15 @@ msgid "LADSPA Effect Options"
 msgstr "LASDPA 效果器選項"
 
 #: src/effects/ladspa/LadspaEffect.cpp
-msgid "As part of their processing, some LADSPA effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
-msgstr ""
-"在部分的處理模式，部分的 LADSPA 效果必須要延遲回傳聲音給 "
-"Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 LADSPA 效果。"
+#, fuzzy
+msgid "As part of their processing, some LADSPA effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this option will provide that compensation, but it may not work for all LADSPA effects."
+msgstr "在部分的處理模式，部分的 LADSPA 效果必須要延遲回傳聲音給 Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 LADSPA 效果。"
 
 #. i18n-hint: An item name introducing a value, which is not part of the string but
 #. appears in a following text box window; translate with appropriate punctuation
-#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp src/effects/vamp/VampEffect.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
+#: src/effects/ladspa/LadspaEffect.cpp src/effects/nyquist/Nyquist.cpp
+#: src/effects/vamp/VampEffect.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumView.cpp
 #, c-format
 msgid "%s:"
 msgstr "%s："
@@ -9263,6 +9754,14 @@ msgstr "%s："
 #: src/effects/ladspa/LadspaEffect.cpp
 msgid "Effect Output"
 msgstr "效果輸出"
+
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/effects/ladspa/LadspaEffect.h
+#, fuzzy
+msgid "LADSPA"
+msgstr "LADSPA 效果"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 Effect Settings"
@@ -9274,10 +9773,9 @@ msgid "&Buffer Size (8 to %d) samples:"
 msgstr "緩衝區大小 (8 到 %d) 取樣點(&B)："
 
 #: src/effects/lv2/LV2Effect.cpp
-msgid "As part of their processing, some LV2 effects must delay returning audio to Audacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
-msgstr ""
-"在部分的處理模式，部分的 LV2 效果必須要延遲回傳聲音給 "
-"Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 LV2 效果。"
+#, fuzzy
+msgid "As part of their processing, some LV2 effects must delay returning audio to Tenacity. When not compensating for this delay, you will notice that small silences have been inserted into the audio. Enabling this setting will provide that compensation, but it may not work for all LV2 effects."
+msgstr "在部分的處理模式，部分的 LV2 效果必須要延遲回傳聲音給 Tenacity。如果不補償這樣的延遲，你會發現聲音當中插入少量的靜音。開啟此選項會提供這樣的補償，但無法適用於所有的 LV2 效果。"
 
 #: src/effects/lv2/LV2Effect.cpp
 msgid "LV2 effects can have a graphical interface for setting parameter values. A basic text-only method is also available.  Reopen the effect for this to take effect."
@@ -9301,12 +9799,19 @@ msgstr "%s 需要不支援的 %s 選項\n"
 msgid "Generator"
 msgstr "生成器"
 
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/effects/lv2/LV2Effect.h
+msgid "LV2"
+msgstr ""
+
 #: src/effects/lv2/LoadLV2.cpp
 msgid "LV2 Effects"
 msgstr "LV2 效果"
 
 #: src/effects/lv2/LoadLV2.cpp
-msgid "Provides LV2 Effects support to Audacity"
+#, fuzzy
+msgid "Provides LV2 Effects support to Tenacity"
 msgstr "為 Tenacity 提供 LV2 效果支援"
 
 #: src/effects/nyquist/LoadNyquist.cpp
@@ -9314,7 +9819,8 @@ msgid "Nyquist Effects"
 msgstr "Nyquist 效果"
 
 #: src/effects/nyquist/LoadNyquist.cpp
-msgid "Provides Nyquist Effects support to Audacity"
+#, fuzzy
+msgid "Provides Nyquist Effects support to Tenacity"
 msgstr "為 Tenacity 提供 Nyquist 效果支援"
 
 #: src/effects/nyquist/Nyquist.cpp
@@ -9541,7 +10047,8 @@ msgstr "選擇檔案"
 msgid "Save file as"
 msgstr "另存檔案為"
 
-#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp src/export/ExportMultiple.cpp
+#: src/effects/nyquist/Nyquist.cpp src/export/Export.cpp
+#: src/export/ExportMultiple.cpp
 msgid "untitled"
 msgstr "未命名"
 
@@ -9550,7 +10057,8 @@ msgid "Vamp Effects"
 msgstr "VAMP 效果"
 
 #: src/effects/vamp/LoadVamp.cpp
-msgid "Provides Vamp Effects support to Audacity"
+#, fuzzy
+msgid "Provides Vamp Effects support to Tenacity"
 msgstr "為 Tenacity 提供 VAMP 效果支援"
 
 #: src/effects/vamp/VampEffect.cpp
@@ -9572,6 +10080,12 @@ msgstr "外掛程式設定"
 #: src/effects/vamp/VampEffect.cpp
 msgid "Program"
 msgstr "程式"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/effects/vamp/VampEffect.h
+msgid "Vamp"
+msgstr ""
 
 #: src/export/Export.cpp
 msgid "No format specific options"
@@ -9872,7 +10386,8 @@ msgstr "正在將音訊匯出為 %s"
 msgid "Invalid sample rate"
 msgstr "無效的取樣頻率"
 
-#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp src/menus/TrackMenus.cpp
+#: src/export/ExportFFmpeg.cpp src/export/ExportMP3.cpp
+#: src/menus/TrackMenus.cpp
 msgid "Resample"
 msgstr "重新取樣"
 
@@ -9902,6 +10417,14 @@ msgstr "可以重新取樣至以下任一取樣率。"
 msgid "Sample Rates"
 msgstr "取樣頻率"
 
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#. i18n-hint: kbps is the bitrate of the MP3 file, kilobits per second
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
+#: src/export/ExportMP3.cpp
+#, c-format
+msgid "%d kbps"
+msgstr ""
+
 #: src/export/ExportFFmpegDialogs.cpp src/export/ExportMP2.cpp
 msgid "Bit Rate:"
 msgstr "位元率："
@@ -9909,6 +10432,51 @@ msgstr "位元率："
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Quality (kbps):"
 msgstr "品質 (kbps)："
+
+#. i18n-hint kbps abbreviates "thousands of bits per second"
+#: src/export/ExportFFmpegDialogs.cpp
+#, fuzzy, c-format
+msgid "%.2f kbps"
+msgstr "%.2f 秒"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "0"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "1"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "3"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "4"
+msgstr "45"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "5"
+msgstr "45"
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+msgid "6"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp src/export/ExportFLAC.cpp
+#, fuzzy
+msgid "7"
+msgstr "78"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "9"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "On"
@@ -9919,12 +10487,40 @@ msgid "Constrained"
 msgstr "強制"
 
 #: src/export/ExportFFmpegDialogs.cpp
+msgid "VOIP"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
 msgid "Audio"
 msgstr "音訊"
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Low Delay"
 msgstr "低延遲"
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "2.5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "5 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "10 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "20 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "40 ms"
+msgstr ""
+
+#: src/export/ExportFFmpegDialogs.cpp
+msgid "60 ms"
+msgstr ""
 
 #: src/export/ExportFFmpegDialogs.cpp
 msgid "Narrowband"
@@ -10525,6 +11121,42 @@ msgid "220-260 kbps (Best Quality)"
 msgstr "220-260 kbps (品質最佳)"
 
 #: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "200-250 kbps"
+msgstr "極高，220-260 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "170-210 kbps"
+msgstr "標準，170-210 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "155-195 kbps"
+msgstr "中等，145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+#, fuzzy
+msgid "145-185 kbps"
+msgstr "中等，145-185 kbps"
+
+#: src/export/ExportMP3.cpp
+msgid "110-150 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "95-135 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "80-120 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
+msgid "65-105 kbps"
+msgstr ""
+
+#: src/export/ExportMP3.cpp
 msgid "45-85 kbps (Smaller files)"
 msgstr "45-85 kbps (檔案較小)"
 
@@ -10554,7 +11186,8 @@ msgstr "最高"
 msgid "Extreme"
 msgstr "極高"
 
-#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp plug-ins/sample-data-export.ny
+#: src/export/ExportMP3.cpp src/prefs/KeyConfigPrefs.cpp
+#: plug-ins/sample-data-export.ny
 msgid "Standard"
 msgstr "標準"
 
@@ -10605,8 +11238,8 @@ msgid "Locate LAME"
 msgstr "尋找 LAME"
 
 #: src/export/ExportMP3.cpp
-#, c-format
-msgid "Audacity needs the file %s to create MP3s."
+#, fuzzy, c-format
+msgid "Tenacity needs the file %s to create MP3s."
 msgstr "Tenacity 需要 %s 檔案來建立 MP3。"
 
 #: src/export/ExportMP3.cpp
@@ -10634,10 +11267,10 @@ msgid "Where is %s?"
 msgstr "%s 在哪裡？"
 
 #: src/export/ExportMP3.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\n"
-"Please download the latest version of 'LAME for Audacity'."
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\n"
+"Please download the latest version of 'LAME for Tenacity'."
 msgstr ""
 "您正連結到 lame_enc.dll v%d.%d。這個版本與 Tenacity %d.%d.%d 並不相容。\n"
 "請下載最新版本的「LAME for Audacity」。"
@@ -10942,6 +11575,14 @@ msgstr "正在將選擇的音訊匯出為 Ogg Vorbis"
 msgid "Exporting the audio as Ogg Vorbis"
 msgstr "正在將音訊匯出為 Ogg Vorbis"
 
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "AIFF (Apple/SGI)"
+msgstr ""
+
+#: src/export/ExportPCM.cpp src/import/ImportPCM.cpp
+msgid "WAV (Microsoft)"
+msgstr ""
+
 #: src/export/ExportPCM.cpp
 msgid "Header:"
 msgstr "標頭："
@@ -10955,9 +11596,10 @@ msgid "Other uncompressed files"
 msgstr "其它非壓縮格式檔案"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
 "You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-"Audacity cannot do this, the Export was abandoned."
+"Tenacity cannot do this, the Export was abandoned."
 msgstr ""
 "嘗試匯出大於 4GB 的 WAV 或 AIFF 檔案。\n"
 "Tenacity 做不到，已中止匯出。"
@@ -10967,8 +11609,9 @@ msgid "Error Exporting"
 msgstr "匯出時發生錯誤"
 
 #: src/export/ExportPCM.cpp
+#, fuzzy
 msgid ""
-"Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+"Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
 "files bigger than 4GB."
 msgstr ""
 "匯出的 WAV 檔案已被縮減，因為 Tenacity 無法匯出大於 4GB 的 WAV\n"
@@ -11008,11 +11651,11 @@ msgid "All supported files"
 msgstr "所有支援檔案"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a MIDI file, not an audio file. \n"
-"Audacity cannot open this type of file for playing, but you can\n"
+"Tenacity cannot open this type of file for playing, but you can\n"
 "edit it by clicking File > Import > MIDI."
 msgstr ""
 "\"%s\" \n"
@@ -11021,11 +11664,11 @@ msgstr ""
 "可以透過點選「檔案」>「匯入」>「MIDI」來進行編輯。"
 
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" \n"
 "is a not an audio file. \n"
-"Audacity cannot open this type of file."
+"Tenacity cannot open this type of file."
 msgstr ""
 "「%s」\n"
 "不是音訊檔。\n"
@@ -11036,18 +11679,18 @@ msgid "Select stream(s) to import"
 msgstr "選擇要匯入的串流"
 
 #: src/import/Import.cpp
-#, c-format
-msgid "This version of Audacity was not compiled with %s support."
+#, fuzzy, c-format
+msgid "This version of Tenacity was not compiled with %s support."
 msgstr "此版本的 Tenacity 在編譯時未加入對 %s 的支援。"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an audio CD track. \n"
-"Audacity cannot open audio CDs directly. \n"
+"Tenacity cannot open audio CDs directly. \n"
 "Extract (rip) the CD tracks to an audio format that \n"
-"Audacity can import, such as WAV or AIFF."
+"Tenacity can import, such as WAV or AIFF."
 msgstr ""
 "「%s」是音訊光碟軌道。\n"
 "Tenacity 無法直接開啟音訊光碟。\n"
@@ -11056,10 +11699,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a playlist file. \n"
-"Audacity cannot open this file because it only contains links to other files. \n"
+"Tenacity cannot open this file because it only contains links to other files. \n"
 "You may be able to open it in a text editor and download the actual audio files."
 msgstr ""
 "「%s」是播放清單檔案。\n"
@@ -11068,10 +11711,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Windows Media Audio file. \n"
-"Audacity cannot open this type of file due to patent restrictions. \n"
+"Tenacity cannot open this type of file due to patent restrictions. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」是 Windows Media Audio 檔案。\n"
@@ -11080,10 +11723,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Advanced Audio Coding file.\n"
-"Without the optional FFmpeg library, Audacity cannot open this type of file.\n"
+"Without the optional FFmpeg library, Tenacity cannot open this type of file.\n"
 "Otherwise, you need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」是進階音訊編碼 (AAC) 檔案。\n"
@@ -11092,12 +11735,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an encrypted audio file. \n"
 "These typically are from an online music store. \n"
-"Audacity cannot open this type of file due to the encryption. \n"
-"Try recording the file into Audacity, or burn it to audio CD then \n"
+"Tenacity cannot open this type of file due to the encryption. \n"
+"Try recording the file into Tenacity, or burn it to audio CD then \n"
 "extract the CD track to a supported audio format such as WAV or AIFF."
 msgstr ""
 "「%s」是已加密的音訊檔案。\n"
@@ -11108,10 +11751,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a RealPlayer media file. \n"
-"Audacity cannot open this proprietary format. \n"
+"Tenacity cannot open this proprietary format. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」是 RealPlayer 媒體檔案。\n"
@@ -11120,12 +11763,12 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a notes-based file, not an audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "Try converting it to an audio file such as WAV or AIFF and \n"
-"then import it, or record it into Audacity."
+"then import it, or record it into Tenacity."
 msgstr ""
 "「%s」是基於音符的檔案，並不是音訊檔案。\n"
 "Tenacity 無法開啟此類型的檔案。\n"
@@ -11134,10 +11777,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Musepack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "If you think it might be an mp3 file, rename it to end with \".mp3\" \n"
 "and try importing it again. Otherwise you need to convert it to a supported audio \n"
 "format, such as WAV or AIFF."
@@ -11150,10 +11793,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Wavpack audio file. \n"
-"Audacity cannot open this type of file. \n"
+"Tenacity cannot open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」是 Wavpack 音訊檔案。\n"
@@ -11162,10 +11805,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a Dolby Digital audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」是 Dolby Digital 音訊檔案。\n"
@@ -11174,10 +11817,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is an Ogg Speex audio file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to convert it to a supported audio format, such as WAV or AIFF."
 msgstr ""
 "「%s」是 Ogg Speex 音訊檔案。\n"
@@ -11186,10 +11829,10 @@ msgstr ""
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\"%s\" is a video file. \n"
-"Audacity cannot currently open this type of file. \n"
+"Tenacity cannot currently open this type of file. \n"
 "You need to extract the audio to a supported format, such as WAV or AIFF."
 msgstr ""
 "「%s」是視訊檔案。\n"
@@ -11203,9 +11846,9 @@ msgstr "找不到「%s」檔案。"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity did not recognize the type of the file '%s'.\n"
+"Tenacity did not recognize the type of the file '%s'.\n"
 "\n"
 "%sFor uncompressed files, also try File > Import > Raw Data."
 msgstr ""
@@ -11228,9 +11871,9 @@ msgstr "%s，%s"
 
 #. i18n-hint: %s will be the filename
 #: src/import/Import.cpp
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Audacity recognized the type of the file '%s'.\n"
+"Tenacity recognized the type of the file '%s'.\n"
 "Importers supposedly supporting such files are:\n"
 "%s,\n"
 "but none of them understood this file format."
@@ -11260,12 +11903,13 @@ msgid "Import Project"
 msgstr "匯入專案"
 
 #: src/import/ImportAUP.cpp
+#, fuzzy
 msgid ""
 "This project was saved by Audacity version 1.0 or earlier. The format has\n"
 "changed and this version of Audacity is unable to import the project.\n"
 "\n"
 "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-"you may import it with this version of Audacity."
+"you may import it with this version of Tenacity."
 msgstr ""
 "儲存這個專案的 Audacity 版本是 1.0 或更早版本。格式已有變化，\n"
 "而這個版本的 Tenacity 無法匯入這種專案。\n"
@@ -11316,7 +11960,8 @@ msgid "Couldn't find the project data folder: \"%s\""
 msgstr "找不到專案資料資料夾：「%s」"
 
 #: src/import/ImportAUP.cpp
-msgid "MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."
+#, fuzzy
+msgid "MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."
 msgstr "在專案檔案中遇到 MIDI 音軌，但這個 Tenacity 組建未附 MIDI 支援，略過音軌。"
 
 #: src/import/ImportAUP.cpp
@@ -11330,6 +11975,10 @@ msgstr "目前已經使用中的專案已經有其時間軌，並切影響到現
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'maxsamples' attribute."
 msgstr "無效的取樣頻率 - maxsamples."
+
+#: src/import/ImportAUP.cpp
+msgid "Invalid sequence 'sampleformat' attribute."
+msgstr "無效的取樣頻率 - sampleformat."
 
 #: src/import/ImportAUP.cpp
 msgid "Invalid sequence 'numsamples' attribute."
@@ -11416,40 +12065,6 @@ msgstr "索引[%02x] 編解碼器[%s]，語言[%s]，位元率[%s]，聲道[%d]�
 #: src/import/ImportFLAC.cpp
 msgid "FLAC files"
 msgstr "FLAC 檔案"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer-compatible files"
-msgstr "GStreamer 相容檔案"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to add decoder to pipeline"
-msgstr "無法添加解碼器至管線"
-
-#: src/import/ImportGStreamer.cpp
-msgid "GStreamer Importer"
-msgstr "GStreamer 匯入器"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to set stream state to paused."
-msgstr "無法設定流狀態為暫停。"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
-msgstr "索引[%02d]，類型[%s]，聲道[%d]，速率[%d]"
-
-#: src/import/ImportGStreamer.cpp
-msgid "File doesn't contain any audio streams."
-msgstr "檔案不包含任何音軌。"
-
-#: src/import/ImportGStreamer.cpp
-msgid "Unable to import file, state change failed."
-msgstr "無法匯入檔案，狀態變更失敗。"
-
-#: src/import/ImportGStreamer.cpp
-#, c-format
-msgid "GStreamer Error: %s"
-msgstr "GStreamer 錯誤：%s"
 
 #: src/import/ImportLOF.cpp
 msgid "List of Files in basic text format"
@@ -11553,6 +12168,14 @@ msgid "WAV, AIFF, and other uncompressed types"
 msgstr "WAV、AIFF 和其它非壓縮格式類型"
 
 #: src/import/ImportPCM.cpp
+msgid "AU (Sun/NeXT)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "AVR (Audio Visual Research)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "CAF (Apple Core Audio File)"
 msgstr "CAF (Apple Core Audio 檔案)"
 
@@ -11566,8 +12189,28 @@ msgid "HTK (HMM Tool Kit)"
 msgstr "HTK (HMM 工具箱)"
 
 #: src/import/ImportPCM.cpp
+msgid "IFF (Amiga IFF/SVX8/SV16)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT4 (GNU Octave 2.0 / Matlab 4.2)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MAT5 (GNU Octave 2.1 / Matlab 5.0)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "MPC (Akai MPC 2k)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "OGG (OGG Container format)"
 msgstr "OGG (OGG 容器格式)"
+
+#: src/import/ImportPCM.cpp
+msgid "PAF (Ensoniq PARIS)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "PVF (Portable Voice Format)"
@@ -11578,12 +12221,44 @@ msgid "RAW (header-less)"
 msgstr "RAW (無標頭)"
 
 #: src/import/ImportPCM.cpp
+msgid "RF64 (RIFF 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "SD2 (Sound Designer II)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "SDS (Midi Sample Dump Standard)"
 msgstr "SDS (MIDI 取樣傾印標準)"
 
 #: src/import/ImportPCM.cpp
+msgid "SF (Berkeley/IRCAM/CARL)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "VOC (Creative Labs)"
 msgstr "VOC (創新未來)"
+
+#: src/import/ImportPCM.cpp
+msgid "W64 (SoundFoundry WAVE 64)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAV (NIST Sphere)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WAVEX (Microsoft)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "WVE (Psion Series 3)"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "XI (FastTracker 2)"
+msgstr ""
 
 #: src/import/ImportPCM.cpp
 msgid "Signed 8 bit PCM"
@@ -11614,6 +12289,34 @@ msgid "64 bit float"
 msgstr "64 位元浮點"
 
 #: src/import/ImportPCM.cpp
+msgid "U-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "A-Law"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "IMA ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "Microsoft ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "GSM 6.10"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "32kbs G721 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
+msgid "24kbs G723 ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "12 bit DWVW"
 msgstr "12 位元 DWVW"
 
@@ -11626,12 +12329,20 @@ msgid "24 bit DWVW"
 msgstr "24 位元 DWVW"
 
 #: src/import/ImportPCM.cpp
+msgid "VOX ADPCM"
+msgstr ""
+
+#: src/import/ImportPCM.cpp
 msgid "16 bit DPCM"
 msgstr "16 位元 DPCM"
 
 #: src/import/ImportPCM.cpp
 msgid "8 bit DPCM"
 msgstr "8 位元 DPCM"
+
+#: src/import/ImportPCM.cpp
+msgid "Vorbis"
+msgstr ""
 
 #: src/import/ImportPlugin.cpp src/import/ImportRaw.cpp
 #, c-format
@@ -11766,8 +12477,9 @@ msgstr "%s 右聲道"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
-#, c-format, fuzzy
+#, fuzzy, c-format
 msgid "%s %d of %d clip %s"
 msgid_plural "%s %d of %d clips %s"
 msgstr[0] "第 %s %d 個剪輯，共 %d 個 %s 剪輯"
@@ -11788,6 +12500,7 @@ msgstr "終點"
 #. last number counts all clips,
 #. and the last string is the name of the track containing the
 #. clips.
+#.
 #: src/menus/ClipMenus.cpp
 #, c-format
 msgid "%s %d and %s %d of %d clip %s"
@@ -11812,7 +12525,8 @@ msgstr "剪輯已右移"
 msgid "Time shifted clips to the left"
 msgstr "剪輯已左移"
 
-#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp src/tracks/ui/TimeShiftHandle.cpp
+#: src/menus/ClipMenus.cpp src/prefs/MousePrefs.cpp
+#: src/tracks/ui/TimeShiftHandle.cpp
 msgid "Time-Shift"
 msgstr "時間位移"
 
@@ -11950,7 +12664,8 @@ msgstr "修剪選擇的音訊軌道從 %.2f 秒到 %.2f 秒"
 msgid "Trim Audio"
 msgstr "修剪音訊"
 
-#: src/menus/EditMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/EditMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "Split"
 msgstr "分割"
 
@@ -12073,34 +12788,6 @@ msgstr "刪除鍵&2"
 #: src/menus/ExtraMenus.cpp
 msgid "Ext&ra"
 msgstr "額外(&R)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Mi&xer"
-msgstr "混音器(&X)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Ad&just Playback Volume..."
-msgstr "調整播放音量(&J)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Increase Playback Volume"
-msgstr "提高播放音量(&I)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "&Decrease Playback Volume"
-msgstr "降低播放音量(&D)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "Adj&ust Recording Volume..."
-msgstr "調整錄音音量(&U)..."
-
-#: src/menus/ExtraMenus.cpp
-msgid "I&ncrease Recording Volume"
-msgstr "提高錄音音量(&N)"
-
-#: src/menus/ExtraMenus.cpp
-msgid "D&ecrease Recording Volume"
-msgstr "降低錄音音量(&E)"
 
 #: src/menus/ExtraMenus.cpp
 msgid "De&vice"
@@ -12276,6 +12963,11 @@ msgid "&Labels..."
 msgstr "標籤(&L)..."
 
 #: src/menus/FileMenus.cpp
+#, fuzzy
+msgid "&MIDI..."
+msgstr "匯出 MI&DI..."
+
+#: src/menus/FileMenus.cpp
 msgid "&Raw Data..."
 msgstr "原始資料(&R)..."
 
@@ -12364,8 +13056,9 @@ msgid "&Getting Started"
 msgstr "入門(&G)"
 
 #: src/menus/HelpMenus.cpp
-msgid "Audacity &Manual"
-msgstr "Tenacity 使用手冊(&M)"
+#, fuzzy
+msgid "&Manual"
+msgstr "使用手冊(&M)..."
 
 #: src/menus/HelpMenus.cpp
 msgid "&Quick Help..."
@@ -12391,11 +13084,8 @@ msgstr "&MIDI 裝置資訊..."
 msgid "Show &Log..."
 msgstr "顯示日誌(&L)..."
 
-#: src/menus/HelpMenus.cpp
-msgid "&About Audacity..."
-msgstr "關於 Tenacity(&A)..."
-
-#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/menus/LabelMenus.cpp src/toolbars/TranscriptionToolBar.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Added label"
 msgstr "已加入的標籤"
 
@@ -13085,6 +13775,7 @@ msgstr "游標大幅右移(&M)"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/menus/SelectMenus.cpp src/tracks/ui/Scrubbing.cpp
 msgid "See&k"
 msgstr "定位播放(&K)"
@@ -13296,18 +13987,21 @@ msgid "Created new label track"
 msgstr "已建立新的標籤軌道"
 
 #: src/menus/TrackMenus.cpp
-msgid "This version of Audacity only allows one time track for each project window."
+#, fuzzy
+msgid "This version of Tenacity only allows one time track for each project window."
 msgstr "此版本的 Tenacity 只允許每個專案視窗擁有一條時間軌道。"
 
 #: src/menus/TrackMenus.cpp
 msgid "Created new time track"
 msgstr "已建立新的時間軌道"
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "New sample rate (Hz):"
 msgstr "新的取樣頻率 (赫茲)："
 
-#: src/menus/TrackMenus.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/menus/TrackMenus.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
 msgid "The entered value is invalid"
 msgstr "輸入的數值無效"
 
@@ -13564,7 +14258,9 @@ msgstr "正在播放"
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused;
 #. progressive verb form
-#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
+#: src/menus/TransportMenus.cpp src/prefs/DevicePrefs.cpp
+#: src/prefs/MidiIOPrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/prefs/RecordingPrefs.h src/toolbars/ControlToolBar.cpp
 msgid "Recording"
 msgstr "錄製"
 
@@ -13665,6 +14361,11 @@ msgid "&Timer Record..."
 msgstr "預約錄製(&T)..."
 
 #: src/menus/TransportMenus.cpp
+#, fuzzy
+msgid "Punch and Rol&l Record"
+msgstr "聲控啟動錄製"
+
+#: src/menus/TransportMenus.cpp
 msgid "Pla&y Region"
 msgstr "播放區域(&Y)"
 
@@ -13703,10 +14404,6 @@ msgstr "疊錄 (開啟/關閉)(&O)"
 #: src/menus/TransportMenus.cpp
 msgid "So&ftware Playthrough (on/off)"
 msgstr "軟體監播 (開啟/關閉)(&F)"
-
-#: src/menus/TransportMenus.cpp
-msgid "A&utomated Recording Level Adjustment (on/off)"
-msgstr "輸入強度自動調整 (開啟/關閉)(&U)"
 
 #: src/menus/TransportMenus.cpp
 msgid "T&ransport"
@@ -13921,7 +14618,8 @@ msgid "Preferences for Application"
 msgstr "應用程式偏好設定"
 
 #: src/prefs/ApplicationPrefs.cpp
-msgid "Update Audacity"
+#, fuzzy
+msgid "Update Tenacity"
 msgstr "更新 Tenacity"
 
 #: src/prefs/ApplicationPrefs.cpp
@@ -13967,7 +14665,8 @@ msgstr "主機(&H)："
 msgid "Using:"
 msgstr "正在使用："
 
-#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
+#: src/prefs/DevicePrefs.cpp src/prefs/MidiIOPrefs.cpp
+#: src/prefs/PlaybackPrefs.cpp src/prefs/PlaybackPrefs.h
 msgid "Playback"
 msgstr "播放"
 
@@ -13987,7 +14686,8 @@ msgstr "聲道(&N)："
 msgid "Latency"
 msgstr "遲滯"
 
-#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp src/widgets/NumericTextCtrl.cpp
+#: src/prefs/DevicePrefs.cpp src/prefs/RecordingPrefs.cpp
+#: src/widgets/NumericTextCtrl.cpp
 msgid "milliseconds"
 msgstr "毫秒"
 
@@ -14016,7 +14716,8 @@ msgid "2 (Stereo)"
 msgstr "2 (立體聲)"
 
 #. i18n-hint:  Directories, also called directories, in computer file systems
-#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h src/widgets/UnwritableLocationErrorDialog.cpp
+#: src/prefs/DirectoriesPrefs.cpp src/prefs/DirectoriesPrefs.h
+#: src/widgets/UnwritableLocationErrorDialog.cpp
 msgid "Directories"
 msgstr "目錄"
 
@@ -14124,7 +14825,8 @@ msgid "Directory %s is not writable"
 msgstr "目錄 %s 是不可寫入的"
 
 #: src/prefs/DirectoriesPrefs.cpp
-msgid "Changes to temporary directory will not take effect until Audacity is restarted"
+#, fuzzy
+msgid "Changes to temporary directory will not take effect until Tenacity is restarted"
 msgstr "變更暫存目錄在重新啟動 Tenacity 後才會生效"
 
 #: src/prefs/DirectoriesPrefs.cpp
@@ -14155,6 +14857,40 @@ msgstr "依發佈者分組"
 msgid "Grouped by Type"
 msgstr "依種類分組"
 
+#. i18n-hint: abbreviates "Linux Audio Developer's Simple Plugin API"
+#. (Application programming interface)
+#.
+#: src/prefs/EffectsPrefs.cpp
+msgid "&LADSPA"
+msgstr ""
+
+#. i18n-hint: abbreviates
+#. "Linux Audio Developer's Simple Plugin API (LADSPA) version 2"
+#: src/prefs/EffectsPrefs.cpp
+msgid "LV&2"
+msgstr ""
+
+#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
+#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
+#. In the translations of this and other strings, you may transliterate the
+#. name into another alphabet.
+#: src/prefs/EffectsPrefs.cpp
+#, fuzzy
+msgid "N&yquist"
+msgstr "Nyquist"
+
+#. i18n-hint: Vamp is the proper name of a software protocol for sound analysis.
+#. It is not an abbreviation for anything.  See http://vamp-plugins.org
+#: src/prefs/EffectsPrefs.cpp
+msgid "&Vamp"
+msgstr ""
+
+#. i18n-hint: Abbreviates Virtual Studio Technology, an audio software protocol
+#. developed by Steinberg GmbH
+#: src/prefs/EffectsPrefs.cpp
+msgid "V&ST"
+msgstr ""
+
 #: src/prefs/EffectsPrefs.cpp
 msgid "Enable Effects"
 msgstr "啟用效果模組格式"
@@ -14176,11 +14912,13 @@ msgid "Plugin Options"
 msgstr "外掛程式選項"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Check for updated plugins when Audacity starts"
+#, fuzzy
+msgid "Check for updated plugins when Tenacity starts"
 msgstr "每次 Tenacity 啟動時檢查外掛程式的更新"
 
 #: src/prefs/EffectsPrefs.cpp
-msgid "Rescan plugins next time Audacity is started"
+#, fuzzy
+msgid "Rescan plugins next time Tenacity is started"
 msgstr "下一次 Tenacity 啟動時重新掃描外掛程式"
 
 #: src/prefs/EffectsPrefs.cpp
@@ -14251,9 +14989,7 @@ msgstr "未使用的過濾器："
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "There are space characters (spaces, newlines, tabs or linefeeds) in one of the items. They are likely to break the pattern matching. Unless you know what you are doing, it is recommended to trim spaces. Do you want Audacity to trim spaces for you?"
-msgstr ""
-"在某個項目中有空白字元（空格字元、換行字元、定位字元或回車字元），這些字元可能會破壞樣式比對。除非您了解其內容，否則建議將其刪除。是否需要 "
-"Tenacity 為您刪除這些空白字元？"
+msgstr "在某個項目中有空白字元（空格字元、換行字元、定位字元或回車字元），這些字元可能會破壞樣式比對。除非您了解其內容，否則建議將其刪除。是否需要 Tenacity 為您刪除這些空白字元？"
 
 #: src/prefs/ExtImportPrefs.cpp
 msgid "Spaces detected"
@@ -14362,7 +15098,8 @@ msgid "Re&tain labels if selection snaps to a label"
 msgstr "如果選取部分貼齊標籤邊緣時保留標籤(&T)"
 
 #: src/prefs/GUIPrefs.cpp
-msgid "B&lend system and Audacity theme"
+#, fuzzy
+msgid "B&lend system and Tenacity theme"
 msgstr "混合系統和 Tenacity 主題(&L)"
 
 #. i18n-hint: RTL stands for 'Right to Left'
@@ -14540,7 +15277,8 @@ msgstr ""
 "   *   \"%s\" （因為「%s」快捷鍵已被「%s」佔用）\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
-msgid "Select an XML file containing Audacity keyboard shortcuts..."
+#, fuzzy
+msgid "Select an XML file containing Tenacity keyboard shortcuts..."
 msgstr "選擇一個含有 Tenacity 鍵盤快捷鍵的 XML 檔案..."
 
 #: src/prefs/KeyConfigPrefs.cpp
@@ -14549,8 +15287,25 @@ msgstr "匯入鍵盤快捷鍵時發生錯誤"
 
 #: src/prefs/KeyConfigPrefs.cpp
 #, c-format
+msgid ""
+"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
+"Nothing is imported."
+msgstr ""
+"這個帶有快速鍵的檔案，包含著不合規定的「快捷鍵重複」——「%s」以及「%s」。\n"
+"匯入已取消。"
+
+#: src/prefs/KeyConfigPrefs.cpp
+#, c-format
 msgid "Loaded %d keyboard shortcuts\n"
 msgstr "已載入 %d 個鍵盤快捷鍵\n"
+
+#: src/prefs/KeyConfigPrefs.cpp
+msgid ""
+"\n"
+"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
+msgstr ""
+"\n"
+"雖然下述的指令未出現在匯入檔之中，然而由於與其它新的快速鍵衝突，他們的快速鍵已被移除：\n"
 
 #: src/prefs/KeyConfigPrefs.cpp
 msgid "Loading Keyboard Shortcuts"
@@ -14655,8 +15410,9 @@ msgid "Dow&nload"
 msgstr "下載(&N)"
 
 #: src/prefs/LibraryPrefs.cpp
+#, fuzzy
 msgid ""
-"Audacity has automatically detected valid FFmpeg libraries.\n"
+"Tenacity has automatically detected valid FFmpeg libraries.\n"
 "Do you still want to locate them manually?"
 msgstr ""
 "Tenacity 已自動偵測到有效的 FFmpeg 函式庫。\n"
@@ -14715,8 +15471,9 @@ msgid "Preferences for Module"
 msgstr "模組偏好設定"
 
 #: src/prefs/ModulePrefs.cpp
+#, fuzzy
 msgid ""
-"These are experimental modules. Enable them only if you've read the Audacity Manual\n"
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\n"
 "and know what you are doing."
 msgstr ""
 "這些是實驗性模組。請在您已詳讀 Tenacity 使用手冊並了解其內容時\n"
@@ -14724,12 +15481,14 @@ msgstr ""
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Ask' means Audacity will ask if you want to load the module each time it starts."
+#, fuzzy
+msgid "  'Ask' means Tenacity will ask if you want to load the module each time it starts."
 msgstr "  「詢問」意指 Tenacity 會在每次外掛程式啟動時詢問您是否載入該外掛程式。"
 
 #. i18n-hint preserve the leading spaces
 #: src/prefs/ModulePrefs.cpp
-msgid "  'Failed' means Audacity thinks the module is broken and won't run it."
+#, fuzzy
+msgid "  'Failed' means Tenacity thinks the module is broken and won't run it."
 msgstr "  「失敗」意指 Tenacity 認為該外掛程式是損壞的，不會執行該外掛程式。"
 
 #. i18n-hint preserve the leading spaces
@@ -14738,7 +15497,8 @@ msgid "  'New' means no choice has been made yet."
 msgstr "  「新增」意指仍未做出任何選擇。"
 
 #: src/prefs/ModulePrefs.cpp
-msgid "Changes to these settings only take effect when Audacity starts up."
+#, fuzzy
+msgid "Changes to these settings only take effect when Tenacity starts up."
 msgstr "變更暫存目錄在重新啟動 Tenacity 後才會生效。"
 
 #: src/prefs/ModulePrefs.cpp
@@ -14756,6 +15516,10 @@ msgstr "找不到模組"
 #: src/prefs/ModulePrefs.h
 msgid "Module"
 msgstr "模組"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Ctrl"
+msgstr ""
 
 #: src/prefs/MousePrefs.cpp src/prefs/MousePrefs.h
 msgid "Mouse"
@@ -14797,7 +15561,10 @@ msgstr "左鍵拖動"
 msgid "Set Selection Range"
 msgstr "設定選取部分範圍"
 
-#: src/prefs/MousePrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/prefs/MousePrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Left-Click"
 msgstr "Shift-左鍵點選"
 
@@ -14884,6 +15651,15 @@ msgstr "左鍵拖動"
 #: src/prefs/MousePrefs.cpp
 msgid "Move clip up/down between tracks"
 msgstr "在軌道之間上下移動剪輯"
+
+#: src/prefs/MousePrefs.cpp
+#, fuzzy
+msgid "Alt-Left-Drag"
+msgstr "左鍵拖動"
+
+#: src/prefs/MousePrefs.cpp
+msgid "Move clips ignoring Sync-lock"
+msgstr ""
 
 #. i18n-hint: The envelope is a curve that controls the audio loudness.
 #: src/prefs/MousePrefs.cpp
@@ -15008,7 +15784,8 @@ msgid "Always scrub un&pinned"
 msgstr "忽略跟隨播放 當使用固定播放頭時 (&p)"
 
 #: src/prefs/PrefsDialog.cpp
-msgid "Audacity Preferences"
+#, fuzzy
+msgid "Tenacity Preferences"
 msgstr "Tenacity 偏好設定"
 
 #: src/prefs/PrefsDialog.cpp
@@ -15146,41 +15923,26 @@ msgid "System T&ime"
 msgstr "系統時間(&I)"
 
 #: src/prefs/RecordingPrefs.cpp
-msgid "Automated Recording Level Adjustment"
-msgstr "輸入強度自動調整"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Enable Automated Recording Level Adjustment."
-msgstr "啟用輸入強度自動調整。"
-
-#. i18n-hint: Desired maximum (peak) volume for sound
-#: src/prefs/RecordingPrefs.cpp
-msgid "Target Peak:"
-msgstr "目標峰值："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Within:"
-msgstr "在...內："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Analysis Time:"
-msgstr "分析時間："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "milliseconds (time of one analysis)"
-msgstr "毫秒 (一次分析的時間)"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Number of consecutive analysis:"
-msgstr "連續分析次數："
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "0 means endless"
-msgstr "0 表示無限"
-
-#: src/prefs/RecordingPrefs.cpp
 msgid "Punch and Roll Recording"
 msgstr "聲控啟動錄製"
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Pre-ro&ll:"
+msgstr ""
+
+#: src/prefs/RecordingPrefs.cpp
+msgid "Cross&fade:"
+msgstr "淡入淡出(&F)："
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Mel"
+msgstr ""
+
+#. i18n-hint: The name of a frequency scale in psychoacoustics, named for Heinrich Barkhausen
+#: src/prefs/SpectrogramSettings.cpp
+msgid "Bark"
+msgstr ""
 
 #. i18n-hint: The name of a frequency scale in psychoacoustics, abbreviates Equivalent Rectangular Bandwidth
 #: src/prefs/SpectrogramSettings.cpp
@@ -15320,6 +16082,10 @@ msgid "1024 - default"
 msgstr "1024 - 預設值"
 
 #: src/prefs/SpectrumPrefs.cpp
+msgid "2048"
+msgstr ""
+
+#: src/prefs/SpectrumPrefs.cpp
 msgid "32768 - most narrowband"
 msgstr "32768 - 最窄頻"
 
@@ -15417,13 +16183,14 @@ msgid "Info"
 msgstr "資訊"
 
 #: src/prefs/ThemePrefs.cpp
+#, fuzzy
 msgid ""
 "Themability is an experimental feature.\n"
 "\n"
 "To try it out, click \"Save Theme Cache\" then find and modify the images and colors in\n"
 "ImageCacheVxx.png using an image editor such as the Gimp.\n"
 "\n"
-"Click \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n"
+"Click \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n"
 "\n"
 "(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\n"
 "though the image file shows other icons too.)"
@@ -15606,7 +16373,8 @@ msgstr "取樣點"
 msgid "4 Pixels per Sample"
 msgstr "每個取樣點 4 像素"
 
-#: src/prefs/TracksPrefs.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/prefs/TracksPrefs.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Max Zoom"
 msgstr "最大縮放"
 
@@ -15728,16 +16496,24 @@ msgid "Stopped"
 msgstr "已停止"
 
 #: src/toolbars/ControlToolBar.cpp
-msgid "Pause"
-msgstr "暫停"
-
-#: src/toolbars/ControlToolBar.cpp
 msgid "Skip to Start"
 msgstr "移到起點"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Skip to End"
 msgstr "移到終點"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Pause"
+msgstr "暫停"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to Start"
+msgstr "選擇到起點"
+
+#: src/toolbars/ControlToolBar.cpp
+msgid "Select to End"
+msgstr "選擇到終點"
 
 #: src/toolbars/ControlToolBar.cpp
 msgid "Loop Play"
@@ -15750,14 +16526,6 @@ msgstr "錄製新的軌道"
 #: src/toolbars/ControlToolBar.cpp
 msgid "Append Record"
 msgstr "附加錄製"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to End"
-msgstr "選擇到終點"
-
-#: src/toolbars/ControlToolBar.cpp
-msgid "Select to Start"
-msgstr "選擇到起點"
 
 #. i18n-hint: These are strings for the status bar, and indicate whether Audacity
 #. is playing or recording or stopped, and whether it is paused.
@@ -15849,11 +16617,17 @@ msgstr "將選取部分靜音"
 msgid "Sync-Lock Tracks"
 msgstr "同步鎖定軌道"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom In"
 msgstr "放大"
 
-#: src/toolbars/EditToolBar.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/toolbars/EditToolBar.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Out"
 msgstr "縮小"
 
@@ -15920,43 +16694,6 @@ msgstr "錄製計量表工具列(&R)"
 msgid "&Playback Meter Toolbar"
 msgstr "播放計量表工具列(&P)"
 
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume"
-msgstr "錄製音量"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume"
-msgstr "播放音量"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Recording Volume: %.2f"
-msgstr "錄製音量：%.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Recording Volume (Unavailable; use system mixer.)"
-msgstr "錄製音量 (未能提供；使用系統混音器)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f (emulated)"
-msgstr "播放音量：%.2f (模擬)"
-
-#: src/toolbars/MixerToolBar.cpp
-#, c-format
-msgid "Playback Volume: %.2f"
-msgstr "播放音量：%.2f"
-
-#: src/toolbars/MixerToolBar.cpp
-msgid "Playback Volume (Unavailable; use system mixer.)"
-msgstr "播放音量 (未能提供；使用系統混音器)"
-
-#. i18n-hint: Clicking this menu item shows the toolbar
-#. with the mixer
-#: src/toolbars/MixerToolBar.cpp
-msgid "Mi&xer Toolbar"
-msgstr "混音器工具列(&X)"
-
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Seek"
 msgstr "定位播放"
@@ -15972,6 +16709,7 @@ msgstr "跟隨播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Scrubbing"
 msgstr "停止跟隨播放"
@@ -15979,6 +16717,7 @@ msgstr "停止跟隨播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Scrubbing"
 msgstr "開始跟隨播放"
@@ -15986,6 +16725,7 @@ msgstr "開始跟隨播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Stop Seeking"
 msgstr "停止定位播放"
@@ -15993,6 +16733,7 @@ msgstr "停止定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips
+#.
 #: src/toolbars/ScrubbingToolBar.cpp
 msgid "Start Seeking"
 msgstr "開始定位播放"
@@ -16047,7 +16788,9 @@ msgstr "貼齊"
 msgid "Length"
 msgstr "長度"
 
-#: src/toolbars/SelectionBar.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/toolbars/SelectionBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 msgid "Center"
 msgstr "置中"
 
@@ -16111,8 +16854,8 @@ msgstr "時間工具列(&T)"
 
 #. i18n-hint: %s will be replaced by the name of the kind of toolbar.
 #: src/toolbars/ToolBar.cpp
-#, c-format
-msgid "Audacity %s Toolbar"
+#, fuzzy, c-format
+msgid "Tenacity %s Toolbar"
 msgstr "Tenacity %s 工具列"
 
 #: src/toolbars/ToolBar.cpp
@@ -16139,7 +16882,8 @@ msgstr "時間位移工具"
 msgid "Zoom Tool"
 msgstr "縮放工具"
 
-#: src/toolbars/ToolsToolBar.cpp src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
+#: src/toolbars/ToolsToolBar.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Draw Tool"
 msgstr "繪製工具"
 
@@ -16215,11 +16959,13 @@ msgstr "拖動一個或多個標籤邊界。"
 msgid "Drag label boundary."
 msgstr "拖動標籤邊界。"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Modified Label"
 msgstr "已修改標籤"
 
-#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp src/tracks/labeltrack/ui/LabelTrackView.cpp
+#: src/tracks/labeltrack/ui/LabelGlyphHandle.cpp
+#: src/tracks/labeltrack/ui/LabelTrackView.cpp
 msgid "Label Edit"
 msgstr "標籤編輯"
 
@@ -16274,31 +17020,42 @@ msgstr "已編輯標籤"
 msgid "New label"
 msgstr "新標籤"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Up &Octave"
 msgstr "升八度音(&O)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackControls.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
 msgid "Down Octa&ve"
 msgstr "降八度音(&V)"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
 msgid "Click to vertically zoom in. Shift-click to zoom out. Drag to specify a zoom region."
 msgstr "點選以垂直放大，Shift-點選以縮小，拖動以指定一個縮放區域。"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackVZoomHandle.cpp
+#: src/tracks/timetrack/ui/TimeTrackVZoomHandle.cpp
 msgid "Right-click for menu."
 msgstr "按右鍵開啟選單。"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Zoom Reset"
 msgstr "重設縮放"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Shift-Right-Click"
 msgstr "Shift-右鍵"
 
-#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
+#: src/tracks/playabletrack/notetrack/ui/NoteTrackVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformVZoomHandle.cpp
 msgid "Left-Click/Left-Drag"
 msgstr "左鍵點選/左鍵拖動"
 
@@ -16340,7 +17097,8 @@ msgstr "合併"
 msgid "Expanded Cut Line"
 msgstr "已展開裁切線"
 
-#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp src/tracks/ui/TrackButtonHandles.cpp
+#: src/tracks/playabletrack/wavetrack/ui/CutlineHandle.cpp
+#: src/tracks/ui/TrackButtonHandles.cpp
 msgid "Expand"
 msgstr "展開"
 
@@ -16363,6 +17121,11 @@ msgstr "已移動取樣點"
 #: src/tracks/playabletrack/wavetrack/ui/SampleHandle.cpp
 msgid "Sample Edit"
 msgstr "取樣點編輯"
+
+#. i18n-hint k abbreviating kilo meaning thousands
+#: src/tracks/playabletrack/wavetrack/ui/SpectrumVRulerControls.cpp
+msgid "k"
+msgstr ""
 
 #: src/tracks/playabletrack/wavetrack/ui/SpectrumVZoomHandle.cpp
 msgid "Zoom to Fit"
@@ -16408,7 +17171,8 @@ msgstr "正在處理⋯   %i%%"
 
 #. i18n-hint: The strings name a track and a format
 #. i18n-hint: The strings name a track and a channel choice (mono, left, or right)
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
 #, c-format
 msgid "Changed '%s' to %s"
 msgstr "已將「%s」變更為 %s"
@@ -16487,7 +17251,8 @@ msgstr "頻率變更"
 msgid "Set Rate"
 msgstr "設定頻率"
 
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackControls.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackViewConstants.cpp
 msgid "&Multi-view"
 msgstr "多重檢視(&M)"
 
@@ -16580,19 +17345,22 @@ msgid "Right, %dHz"
 msgstr "右，%dHz"
 
 #. i18n-hint dB abbreviates decibels
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%+.1f dB"
 msgstr "%+.1f 分貝"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Left"
 msgstr "向左 %.0f%%"
 
 #. i18n-hint: Stereo pan setting
-#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp src/widgets/ASlider.cpp
+#: src/tracks/playabletrack/wavetrack/ui/WaveTrackSliderHandles.cpp
+#: src/widgets/ASlider.cpp
 #, c-format
 msgid "%.0f%% Right"
 msgstr "向右 %.0f%%"
@@ -16710,8 +17478,8 @@ msgstr "對數內插(&I)"
 
 #. i18n-hint Appears on hovering mouse over clip affordance
 #: src/tracks/ui/AffordanceHandle.cpp
-msgid "Click and drag to move a clip in time, or click to select"
-msgstr "點擊並拖曳以調整，雙擊以重設"
+msgid "Drag clips to reposition them. Hold Shift and drag to move all clips on the same track."
+msgstr ""
 
 #: src/tracks/ui/CommonTrackControls.cpp
 msgid "&Name..."
@@ -16762,6 +17530,7 @@ msgstr "已調整的波封。"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "&Scrub"
 msgstr "跟隨播放(&S)"
@@ -16773,6 +17542,7 @@ msgstr "定位播放"
 #. i18n-hint: These commands assist the user in finding a sound by ear. ...
 #. "Scrubbing" is variable-speed playback, ...
 #. "Seeking" is normal speed playback but with skips, ...
+#.
 #: src/tracks/ui/Scrubbing.cpp
 msgid "Scrub &Ruler"
 msgstr "跟隨播放尺標(&R)"
@@ -16968,6 +17738,12 @@ msgstr "左"
 msgid "R"
 msgstr "右"
 
+#. i18n-hint: "x" suggests a multiplicative factor
+#: src/widgets/ASlider.cpp
+#, fuzzy, c-format
+msgid "%.2fx"
+msgstr "%.2f 分貝"
+
 #: src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
@@ -17001,9 +17777,19 @@ msgstr "空白"
 msgid "Backwards"
 msgstr "後退"
 
+#. i18n-hint arrowhead meaning backward movement
+#: src/widgets/HelpSystem.cpp
+msgid "<"
+msgstr ""
+
 #: src/widgets/HelpSystem.cpp
 msgid "Forwards"
 msgstr "前進"
+
+#. i18n-hint arrowhead meaning forward movement
+#: src/widgets/HelpSystem.cpp
+msgid ">"
+msgstr ""
 
 #: src/widgets/HelpSystem.cpp
 msgid "Help on the Internet"
@@ -17216,6 +18002,7 @@ msgstr "0100 時 060 分 060 秒+># 取樣點"
 #. i18n-hint: Name of time display format that shows time in samples (at the
 #. * current project sample rate).  For example the number of a sample at 1
 #. * second into a recording at 44.1KHz would be 44,100.
+#.
 #: src/widgets/NumericTextCtrl.cpp plug-ins/sample-data-export.ny
 msgid "samples"
 msgstr "取樣點"
@@ -17377,6 +18164,27 @@ msgstr "01000,01000 影格|75"
 msgid "010,01000>0100 Hz"
 msgstr "010,01000>0100 赫茲"
 
+#: src/widgets/NumericTextCtrl.cpp
+msgid "centihertz"
+msgstr "百分之一赫茲"
+
+#. i18n-hint: Name of display format that shows frequency in kilohertz
+#: src/widgets/NumericTextCtrl.cpp
+msgid "kHz"
+msgstr "千赫茲"
+
+#. i18n-hint: Format string for displaying frequency in kilohertz. Change
+#. * the decimal point for your locale. Don't change the numbers.
+#. * The decimal separator is specified using '<' if your language uses a ',' or
+#. * to '>' if your language uses a '.'.
+#: src/widgets/NumericTextCtrl.cpp
+msgid "01000>01000 kHz|0.001"
+msgstr "01000>01000 千赫茲|0.001"
+
+#: src/widgets/NumericTextCtrl.cpp
+msgid "hertz"
+msgstr "赫茲"
+
 #. i18n-hint: Name of display format that shows log of frequency
 #. * in octaves
 #: src/widgets/NumericTextCtrl.cpp
@@ -17440,6 +18248,11 @@ msgstr "(使用脈胳選單來變更格式。)"
 #: src/widgets/NumericTextCtrl.cpp
 msgid "centiseconds"
 msgstr "厘秒"
+
+#: src/widgets/PopupMenuTable.h
+#, fuzzy, c-format
+msgid "%s (%s)"
+msgstr "(%s)"
 
 #: src/widgets/ProgressDialog.cpp
 msgid "Elapsed Time:"
@@ -17589,15 +18402,27 @@ msgstr "無法解析 XML"
 msgid "Spectral edit multi tool"
 msgstr "頻譜編輯多重工具"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 msgid "Filtering..."
 msgstr "過濾..."
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny plug-ins/beat.ny plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/limiter.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny plug-ins/tremolo.ny plug-ins/vocalrediso.ny plug-ins/vocoder.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
+msgid "Paul Licameli"
+msgstr ""
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/beat.ny plug-ins/delay.ny
+#: plug-ins/equalabel.ny plug-ins/highpass.ny plug-ins/lowpass.ny
+#: plug-ins/notch.ny plug-ins/nyquist-plug-in-installer.ny plug-ins/pluck.ny
+#: plug-ins/rhythmtrack.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/vocalrediso.ny plug-ins/vocoder.ny
 msgid "Released under terms of the GNU General Public License version 2"
 msgstr "按 GNU General Public License version 2 釋出"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny
 #, lisp-format
 msgid "~aPlease select frequencies."
 msgstr "~a請選擇頻率。"
@@ -17613,7 +18438,19 @@ msgstr ""
 "                       頻率皆為 ~a Hz)。~%~\n"
 "                       請選擇頻率範圍。"
 
-#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
+#: plug-ins/SpectralEditMulti.ny
+#, lisp-format
+msgid ""
+"~aNotch filter parameters cannot be applied.~%~\n"
+"                      Try increasing the low frequency bound~%~\n"
+"                      or reduce the filter 'Width'."
+msgstr ""
+"~aNotch 過濾器參數無法使用。~%~\n"
+"                      嘗試提高低頻率界限~%~\n"
+"                      或者縮小過濾器之 'Width'."
+
+#: plug-ins/SpectralEditMulti.ny plug-ins/SpectralEditParametricEQ.ny
+#: plug-ins/SpectralEditShelves.ny plug-ins/nyquist-plug-in-installer.ny
 #, lisp-format
 msgid "Error.~%"
 msgstr "錯誤。~%"
@@ -17674,6 +18511,25 @@ msgstr "錄音室淡出"
 #: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
 msgid "Applying Fade..."
 msgstr "正在套用淡入淡出..."
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny plug-ins/delay.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/equalabel.ny
+#: plug-ins/label-sounds.ny plug-ins/limiter.ny plug-ins/noisegate.ny
+#: plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/spectral-delete.ny plug-ins/tremolo.ny
+#, fuzzy
+msgid "Steve Daulton"
+msgstr "設為預設值(&F)"
+
+#: plug-ins/StudioFadeOut.ny plug-ins/adjustable-fade.ny
+#: plug-ins/crossfadeclips.ny plug-ins/crossfadetracks.ny
+#: plug-ins/eq-xml-to-txt-converter.ny plug-ins/label-sounds.ny
+#: plug-ins/limiter.ny plug-ins/noisegate.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny plug-ins/spectral-delete.ny
+#, fuzzy
+msgid "GNU General Public License v2.0 or later"
+msgstr "依 GNU General Public License version 2 或新版條款發布。"
 
 #: plug-ins/StudioFadeOut.ny
 #, lisp-format
@@ -17817,6 +18673,10 @@ msgstr "找尋拍子"
 #: plug-ins/beat.ny
 msgid "Finding beats..."
 msgstr "正在尋找拍子..."
+
+#: plug-ins/beat.ny
+msgid "Audacity"
+msgstr "Tenacity"
 
 #: plug-ins/beat.ny
 msgid "Threshold Percentage"
@@ -18141,13 +19001,38 @@ msgstr "高頻通過過濾器"
 msgid "Performing High-Pass Filter..."
 msgstr "正在執行高頻通過過濾器..."
 
-#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny plug-ins/rissetdrum.ny plug-ins/tremolo.ny
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/rhythmtrack.ny
+msgid "Dominic Mazzoni"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
+#: plug-ins/rissetdrum.ny plug-ins/tremolo.ny
 msgid "Frequency (Hz)"
 msgstr "頻率 (赫茲)"
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny
 msgid "Roll-off (dB per octave)"
 msgstr "滾降 (每八度/分貝)"
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "6 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "12 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "24 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "36 dB"
+msgstr ""
+
+#: plug-ins/highpass.ny plug-ins/lowpass.ny
+msgid "48 dB"
+msgstr ""
 
 #: plug-ins/highpass.ny plug-ins/lowpass.ny plug-ins/notch.ny
 msgid "Frequency must be at least 0.1 Hz."
@@ -18168,10 +19053,6 @@ msgstr ""
 #: plug-ins/label-sounds.ny
 msgid "Label Sounds"
 msgstr "標籤音效"
-
-#: plug-ins/label-sounds.ny plug-ins/noisegate.ny
-msgid "Released under terms of the GNU General Public License version 2 or later."
-msgstr "依 GNU General Public License version 2 或新版條款發布。"
 
 #: plug-ins/label-sounds.ny
 msgid "Threshold level (dB)"
@@ -18233,6 +19114,12 @@ msgstr "最長結尾靜音"
 msgid "Sound ##1"
 msgstr "聲音 ##1"
 
+#. i18n-hint: hours minutes and seconds. Do not translate "~a".
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "~ah ~am ~as"
+msgstr ""
+
 #: plug-ins/label-sounds.ny
 #, lisp-format
 msgid "Too many silences detected.~%Only the first 10000 labels added."
@@ -18248,6 +19135,11 @@ msgstr "錯誤。~%選取範圍必須小於 ~a。"
 #, lisp-format
 msgid "No sounds found.~%Try lowering the 'Threshold' or reduce 'Minimum sound duration'."
 msgstr "找不到聲音。~%請嘗試降低「臨界值」或是減少「最小聲音區間」。"
+
+#: plug-ins/label-sounds.ny
+#, lisp-format
+msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
+msgstr "聲音之間的標記區域需要~%至少兩種聲音~%。然而只偵測到一種聲音。"
 
 #: plug-ins/limiter.ny
 msgid "Limiter"
@@ -18366,6 +19258,19 @@ msgstr "衰減 (ms)"
 #, lisp-format
 msgid ""
 "Error.\n"
+"\"Gate frequencies above: ~s kHz\"\n"
+"is too high for selected track.\n"
+"Set the control below ~a kHz."
+msgstr ""
+"錯誤。\n"
+"「中心頻率必須高於： ~s kHz」\n"
+"對於所選軌道而言太高了。\n"
+"請將其改為 ~a kHz 以下之值。"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Error.\n"
 "Selection too long.\n"
 "Maximum length is ~a."
 msgstr ""
@@ -18383,6 +19288,21 @@ msgstr ""
 "錯誤。\n"
 "選擇的音訊過短。\n"
 "選擇範圍必須長於 ~a 毫秒。"
+
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid ""
+"Peak based on first ~a seconds ~a dB~%\n"
+"Suggested Threshold Setting ~a dB."
+msgstr ""
+"根據前 ~a 秒之峰值 ~a dB~%\n"
+"建議的臨界值為 ~a dB。"
+
+#. i18n-hint: hours and minutes. Do not translate "~a".
+#: plug-ins/noisegate.ny
+#, lisp-format
+msgid "~ah ~am"
+msgstr ""
 
 #: plug-ins/notch.ny
 msgid "Notch Filter"
@@ -18432,7 +19352,8 @@ msgstr "Lisp 檔案"
 msgid "HTML file"
 msgstr "HTML 檔案"
 
-#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny plug-ins/sample-data-import.ny
+#: plug-ins/nyquist-plug-in-installer.ny plug-ins/sample-data-export.ny
+#: plug-ins/sample-data-import.ny
 msgid "Text file"
 msgstr "文字檔案"
 
@@ -18509,6 +19430,10 @@ msgid "MIDI values for C notes: 36, 48, 60 [middle C], 72, 84, 96."
 msgstr "C 音的 MIDI 值：36, 48, 60 [中央 C], 72, 84, 96。"
 
 #: plug-ins/pluck.ny
+msgid "David R.Sky"
+msgstr ""
+
+#: plug-ins/pluck.ny
 msgid "Pluck MIDI pitch"
 msgstr "撥弦聲 MIDI 音高"
 
@@ -18555,6 +19480,10 @@ msgstr "每小節 1 ~ 20 拍"
 #: plug-ins/rhythmtrack.ny
 msgid "Swing amount"
 msgstr "搖擺量"
+
+#: plug-ins/rhythmtrack.ny
+msgid "+/- 1"
+msgstr ""
 
 #: plug-ins/rhythmtrack.ny
 msgid "Set 'Number of bars' to zero to enable the 'Rhythm track duration'."
@@ -18647,6 +19576,10 @@ msgstr "Risset 鼓點"
 #: plug-ins/rissetdrum.ny
 msgid "Generating Risset Drum..."
 msgstr "正在建立 Risset Drum..."
+
+#: plug-ins/rissetdrum.ny
+msgid "Steven Jones"
+msgstr ""
 
 #: plug-ins/rissetdrum.ny
 msgid "Decay (seconds)"
@@ -19054,6 +19987,10 @@ msgid "Applying Action..."
 msgstr "正在套用動作..."
 
 #: plug-ins/vocalrediso.ny
+msgid "Robert Haenggi"
+msgstr ""
+
+#: plug-ins/vocalrediso.ny
 msgid "Remove Vocals: to mono"
 msgstr "移除人聲：轉為單聲道"
 
@@ -19103,12 +20040,59 @@ msgstr "人聲最高剪點 (High Cut) (Hz)"
 
 #: plug-ins/vocalrediso.ny
 #, lisp-format
+msgid ""
+"Average x: ~a, y: ~a\n"
+"                    Covariance x y: ~a\n"
+"                    Average variance x: ~a, y: ~a\n"
+"                    Standard deviation x: ~a, y: ~a\n"
+"                    Coefficient of correlation: ~a\n"
+"                    Coefficient of determination: ~a\n"
+"                    Variation of residuals: ~a\n"
+"                    y equals ~a plus ~a times x~%"
+msgstr ""
+"平均值 x：~a, y：~a\n"
+"                    共變異數/協方差 x y：~a\n"
+"                    平均變異數 x：~a, y：~a\n"
+"                    標準差 x：~a, y：~a\n"
+"                    相關係數：~a\n"
+"                    決定係數：~a\n"
+"                    殘差之變化：~a\n"
+"                    y 等於 ~a 加 ~a 乘以 x~%"
+
+#: plug-ins/vocalrediso.ny
+#, lisp-format
 msgid "Pan position: ~a~%The left and right channels are correlated by about ~a %. This means:~%~a~%"
 msgstr "平移位置：~a~%左右聲道有 ~a % 相關。代表：~%~a~%"
 
 #: plug-ins/vocalrediso.ny
+msgid ""
+" - The two channels are identical, i.e. dual mono.\n"
+"                The center can't be removed.\n"
+"                Any remaining difference may be caused by lossy encoding."
+msgstr ""
+" - 兩個軌道完全相同，也就是「雙重單聲道」。\n"
+"                因此，中間部分難以被移除。\n"
+"                任何留下的差異有可能是有損編碼造成的。"
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
+"                Most likely, the center extraction will be poor."
+msgstr ""
+" - 兩個軌道高度相關，也就是「近乎單聲道（nearly mono）」或者是「幾乎平移（extremely panned）」。\n"
+"                提取出的中間部分可能會很糟糕。"
+
+#: plug-ins/vocalrediso.ny
 msgid " - A fairly good value, at least stereo in average and not too wide spread."
 msgstr " - 不錯，至少平均來說是立體聲，不是隔得很遠。"
+
+#: plug-ins/vocalrediso.ny
+msgid ""
+" - An ideal value for Stereo.\n"
+"                However, the center extraction depends also on the used reverb."
+msgstr ""
+" - 對立體聲來說，這是個理想值。\n"
+"                然而，中間部分的提取也會被所使用的混響影響。"
 
 #: plug-ins/vocalrediso.ny
 msgid ""
@@ -19155,6 +20139,10 @@ msgid "Processing Vocoder..."
 msgstr "正在處理 Vocoder..."
 
 #: plug-ins/vocoder.ny
+msgid "Edgar-RFT"
+msgstr ""
+
+#: plug-ins/vocoder.ny
 msgid "Distance: (1 to 120, default = 20)"
 msgstr "距離：(1 至 120，預設 = 20)"
 
@@ -19194,6 +20182,229 @@ msgstr "Radar Needles 頻率 (赫茲)"
 #, lisp-format
 msgid "Error.~%Stereo track required."
 msgstr "錯誤。~%必須是立體聲。"
+
+#~ msgctxt "update dialog"
+#~ msgid "Update Audacity"
+#~ msgstr "更新 Tenacity"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Skip"
+#~ msgstr "略過(&S)"
+
+#~ msgctxt "update dialog"
+#~ msgid "&Install update"
+#~ msgstr "安裝更新(&I)"
+
+#~ msgctxt "update dialog"
+#~ msgid "Changelog"
+#~ msgstr "修改記錄"
+
+#~ msgctxt "update dialog"
+#~ msgid "Read more on GitHub"
+#~ msgstr "更多資訊請閱讀 GitHub"
+
+#~ msgctxt "update dialog"
+#~ msgid "Error checking for update"
+#~ msgstr "檢查更新檔案時發生錯誤"
+
+#~ msgctxt "update dialog"
+#~ msgid "Unable to connect to Audacity update server."
+#~ msgstr "無法連結到 Tenacity 的更新主機."
+
+#~ msgctxt "update dialog"
+#~ msgid "Update data was corrupted."
+#~ msgstr "更新檔案可能是無效或已損壞."
+
+#~ msgctxt "update dialog"
+#~ msgid "Error downloading update."
+#~ msgstr "下載更新檔案的時候發生錯誤."
+
+#~ msgctxt "update dialog"
+#~ msgid "Can't open the Audacity download link."
+#~ msgstr "無法打開 Tenacity 下載連結."
+
+#, c-format
+#~ msgctxt "update dialog"
+#~ msgid "Audacity %s is available!"
+#~ msgstr "新版本 Tenacity %s 已經出來了!"
+
+#~ msgctxt "preference"
+#~ msgid "Recording"
+#~ msgstr "錄製"
+
+#~ msgid "Commit Id:"
+#~ msgstr "提交 ID："
+
+#~ msgid "Cross-platform GUI library"
+#~ msgstr "跨平臺 GUI 函式庫"
+
+#~ msgid "Import via GStreamer"
+#~ msgstr "透過 GStreamer 匯入"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too high."
+#~ msgstr "輸入強度自動調整已停止。無法再最佳化。音量還是太高。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment decreased the volume to %f."
+#~ msgstr "輸入強度自動調整已將音量降低至 %f。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. It was not possible to optimize it more. Still too low."
+#~ msgstr "輸入強度自動調整已停止。無法再最佳化。音量還是太低。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment increased the volume to %.2f."
+#~ msgstr "輸入強度自動調整已將音量提高至 %.2f。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too high."
+#~ msgstr "輸入強度自動調整已停止。分析的總次數已經達到極限，但仍找不到可接受的音量。音量還是太高。"
+
+#~ msgid "Automated Recording Level Adjustment stopped. The total number of analyses has been exceeded without finding an acceptable volume. Still too low."
+#~ msgstr "輸入強度自動調整已停止。分析的總次數已經達到極限，但仍找不到可接受的音量。音量還是太低。"
+
+#, c-format
+#~ msgid "Automated Recording Level Adjustment stopped. %.2f seems an acceptable volume."
+#~ msgstr "輸入強度自動調整已停止。%.2f 似乎是可接受的音量。"
+
+#, c-format
+#~ msgid "Received %d while opening devices\n"
+#~ msgstr "開啟裝置時，接收到 %d\n"
+
+#~ msgid "Unable to open Portmixer\n"
+#~ msgstr "無法開啟連接埠混音器\n"
+
+#~ msgid "Available mixers:\n"
+#~ msgstr "可用的混音器：\n"
+
+#~ msgid "Available recording sources:\n"
+#~ msgstr "可用的錄音來源：\n"
+
+#~ msgid "Available playback volumes:\n"
+#~ msgstr "可用的播放儲存器：\n"
+
+#~ msgid "Recording volume is emulated\n"
+#~ msgstr "錄音的音量是模擬的\n"
+
+#~ msgid "Recording volume is native\n"
+#~ msgstr "錄音的音量是原生的\n"
+
+#~ msgid "Playback volume is emulated\n"
+#~ msgstr "播放的音量是模擬的\n"
+
+#~ msgid "Playback volume is native\n"
+#~ msgstr "播放的音量是原生的\n"
+
+#~ msgid "Unknown date and time"
+#~ msgstr "未知的日期和時間"
+
+#~ msgid "GStreamer-compatible files"
+#~ msgstr "GStreamer 相容檔案"
+
+#~ msgid "Unable to add decoder to pipeline"
+#~ msgstr "無法添加解碼器至管線"
+
+#~ msgid "GStreamer Importer"
+#~ msgstr "GStreamer 匯入器"
+
+#~ msgid "Unable to set stream state to paused."
+#~ msgstr "無法設定流狀態為暫停。"
+
+#, c-format
+#~ msgid "Index[%02d], Type[%s], Channels[%d], Rate[%d]"
+#~ msgstr "索引[%02d]，類型[%s]，聲道[%d]，速率[%d]"
+
+#~ msgid "File doesn't contain any audio streams."
+#~ msgstr "檔案不包含任何音軌。"
+
+#~ msgid "Unable to import file, state change failed."
+#~ msgstr "無法匯入檔案，狀態變更失敗。"
+
+#, c-format
+#~ msgid "GStreamer Error: %s"
+#~ msgstr "GStreamer 錯誤：%s"
+
+#~ msgid "Mi&xer"
+#~ msgstr "混音器(&X)"
+
+#~ msgid "Ad&just Playback Volume..."
+#~ msgstr "調整播放音量(&J)..."
+
+#~ msgid "&Increase Playback Volume"
+#~ msgstr "提高播放音量(&I)"
+
+#~ msgid "&Decrease Playback Volume"
+#~ msgstr "降低播放音量(&D)"
+
+#~ msgid "Adj&ust Recording Volume..."
+#~ msgstr "調整錄音音量(&U)..."
+
+#~ msgid "I&ncrease Recording Volume"
+#~ msgstr "提高錄音音量(&N)"
+
+#~ msgid "D&ecrease Recording Volume"
+#~ msgstr "降低錄音音量(&E)"
+
+#~ msgid "Audacity &Manual"
+#~ msgstr "Tenacity 使用手冊(&M)"
+
+#~ msgid "&About Audacity..."
+#~ msgstr "關於 Tenacity(&A)..."
+
+#~ msgid "A&utomated Recording Level Adjustment (on/off)"
+#~ msgstr "輸入強度自動調整 (開啟/關閉)(&U)"
+
+#~ msgid "Automated Recording Level Adjustment"
+#~ msgstr "輸入強度自動調整"
+
+#~ msgid "Enable Automated Recording Level Adjustment."
+#~ msgstr "啟用輸入強度自動調整。"
+
+#~ msgid "Target Peak:"
+#~ msgstr "目標峰值："
+
+#~ msgid "Within:"
+#~ msgstr "在...內："
+
+#~ msgid "Analysis Time:"
+#~ msgstr "分析時間："
+
+#~ msgid "milliseconds (time of one analysis)"
+#~ msgstr "毫秒 (一次分析的時間)"
+
+#~ msgid "Number of consecutive analysis:"
+#~ msgstr "連續分析次數："
+
+#~ msgid "0 means endless"
+#~ msgstr "0 表示無限"
+
+#~ msgid "Recording Volume"
+#~ msgstr "錄製音量"
+
+#~ msgid "Playback Volume"
+#~ msgstr "播放音量"
+
+#, c-format
+#~ msgid "Recording Volume: %.2f"
+#~ msgstr "錄製音量：%.2f"
+
+#~ msgid "Recording Volume (Unavailable; use system mixer.)"
+#~ msgstr "錄製音量 (未能提供；使用系統混音器)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f (emulated)"
+#~ msgstr "播放音量：%.2f (模擬)"
+
+#, c-format
+#~ msgid "Playback Volume: %.2f"
+#~ msgstr "播放音量：%.2f"
+
+#~ msgid "Playback Volume (Unavailable; use system mixer.)"
+#~ msgstr "播放音量 (未能提供；使用系統混音器)"
+
+#~ msgid "Mi&xer Toolbar"
+#~ msgstr "混音器工具列(&X)"
+
+#~ msgid "Click and drag to move a clip in time, or click to select"
+#~ msgstr "點擊並拖曳以調整，雙擊以重設"
 
 #~ msgid "Program build date:"
 #~ msgstr "程式組建日期："
@@ -19298,461 +20509,6 @@ msgstr "錯誤。~%必須是立體聲。"
 #~ msgid "Send"
 #~ msgstr "送出 (&S)"
 
-#: src/import/ImportAUP.cpp
-msgid "Invalid sequence 'sampleformat' attribute."
-msgstr "無效的取樣頻率 - sampleformat."
-
-#: src/AboutDialog.cpp
-msgid "Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni."
-msgstr "Tenacity 並非由 MuseCY SM Ltd. 或者 Dominic M Mazzoni 出產，也不受其認證或背書。"
-
-#: plug-ins/vocalrediso.ny
-msgid ""
-" - An ideal value for Stereo.\n"
-"                However, the center extraction depends also on the used reverb."
-msgstr ""
-" - 對立體聲來說，這是個理想值。\n"
-"                然而，中間部分的提取也會被所使用的混響影響。"
-
-#: plug-ins/vocalrediso.ny
-msgid ""
-" - The two Channels are strongly related, i.e. nearly mono or extremely panned.\n"
-"                Most likely, the center extraction will be poor."
-msgstr ""
-" - 兩個軌道高度相關，也就是「近乎單聲道（nearly mono）」或者是「幾乎平移（extremely panned）」。\n"
-"                提取出的中間部分可能會很糟糕。"
-
-#: plug-ins/vocalrediso.ny
-msgid ""
-" - The two channels are identical, i.e. dual mono.\n"
-"                The center can't be removed.\n"
-"                Any remaining difference may be caused by lossy encoding."
-msgstr ""
-" - 兩個軌道完全相同，也就是「雙重單聲道」。\n"
-"                因此，中間部分難以被移除。\n"
-"                任何留下的差異有可能是有損編碼造成的。"
-
-#: plug-ins/noisegate.ny
-#, lisp-format
-msgid ""
-"Peak based on first ~a seconds ~a dB~%\n"
-"Suggested Threshold Setting ~a dB."
-msgstr ""
-"根據前 ~a 秒之峰值 ~a dB~%\n"
-"建議的臨界值為 ~a dB。"
-
-#: plug-ins/noisegate.ny
-#, lisp-format
-msgid ""
-"Error.\n"
-"\"Gate frequencies above: ~s kHz\"\n"
-"is too high for selected track.\n"
-"Set the control below ~a kHz."
-msgstr ""
-"錯誤。\n"
-"「中心頻率必須高於： ~s kHz」\n"
-"對於所選軌道而言太高了。\n"
-"請將其改為 ~a kHz 以下之值。"
-
-#: plug-ins/label-sounds.ny
-#, lisp-format
-msgid "Labelling regions between sounds requires~%at least two sounds.~%Only one sound detected."
-msgstr "聲音之間的標記區域需要~%至少兩種聲音~%。然而只偵測到一種聲音。"
-
-#: plug-ins/SpectralEditMulti.ny
-#, lisp-format
-msgid ""
-"~aNotch filter parameters cannot be applied.~%~\n"
-"                      Try increasing the low frequency bound~%~\n"
-"                      or reduce the filter 'Width'."
-msgstr ""
-"~aNotch 過濾器參數無法使用。~%~\n"
-"                      嘗試提高低頻率界限~%~\n"
-"                      或者縮小過濾器之 'Width'."
-
-#: src/widgets/NumericTextCtrl.cpp
-msgid "hertz"
-msgstr "赫茲"
-
-#. i18n-hint: Format string for displaying frequency in kilohertz. Change
-#. * the decimal point for your locale. Don't change the numbers.
-#. * The decimal separator is specified using '<' if your language uses a ',' or
-#. * to '>' if your language uses a '.'.
-#: src/widgets/NumericTextCtrl.cpp
-msgid "01000>01000 kHz|0.001"
-msgstr "01000>01000 千赫茲|0.001"
-
-#. i18n-hint: Name of display format that shows frequency in kilohertz
-#: src/widgets/NumericTextCtrl.cpp
-msgid "kHz"
-msgstr "千赫茲"
-
-#: src/widgets/NumericTextCtrl.cpp
-msgid "centihertz"
-msgstr "百分之一赫茲"
-
-#: src/prefs/RecordingPrefs.cpp
-msgid "Cross&fade:"
-msgstr "淡入淡出(&F)："
-
-#: src/prefs/KeyConfigPrefs.cpp
-msgid ""
-"\n"
-"The following commands are not mentioned in the imported file, but have their shortcuts removed because of the conflict with other new shortcuts:\n"
-msgstr ""
-"\n"
-"雖然下述的指令未出現在匯入檔之中，然而由於與其它新的快速鍵衝突，他們的快速鍵已被移除：\n"
-
-#: src/effects/VST/VSTEffect.cpp src/effects/lv2/LV2Effect.cpp
-msgid "The buffer size controls the number of samples sent to the effect on each iteration. Smaller values will cause slower processing and some effects require 8192 samples or less to work properly. However most effects can accept large buffers and using them will greatly reduce processing time."
-msgstr ""
-"緩衝區大小控制每次「效果」所處理的樣本數量。較小的樣本數會讓處理過程變慢，且部分效果需要至少 "
-"8192（有些更少）個樣本才能正常工作。然而，多數的效果支持更大的樣本數，且使用比較大的數量可以明顯縮短處理時間。"
-
-#. i18n-hint The registered trademark symbol (r) is substituted at %s
-#: src/AboutDialog.cpp
 #, c-format
-msgid "The Audacity%s trademark is used within this software for descriptive and informational purposes only."
-msgstr "在此程式中，Audacity%s 水印僅用於描述以及呈現訊息方面。"
-
-#: src/AboutDialog.cpp
-msgid "Please note that names are sorted in alphabetical order, not in order of importance."
-msgstr "請注意，此處姓名皆依字母順序排序，無關乎重要程度。"
-
-#: plug-ins/vocalrediso.ny
-#, lisp-format
-msgid ""
-"Average x: ~a, y: ~a\n"
-"                    Covariance x y: ~a\n"
-"                    Average variance x: ~a, y: ~a\n"
-"                    Standard deviation x: ~a, y: ~a\n"
-"                    Coefficient of correlation: ~a\n"
-"                    Coefficient of determination: ~a\n"
-"                    Variation of residuals: ~a\n"
-"                    y equals ~a plus ~a times x~%"
-msgstr ""
-"平均值 x：~a, y：~a\n"
-"                    共變異數/協方差 x y：~a\n"
-"                    平均變異數 x：~a, y：~a\n"
-"                    標準差 x：~a, y：~a\n"
-"                    相關係數：~a\n"
-"                    決定係數：~a\n"
-"                    殘差之變化：~a\n"
-"                    y 等於 ~a 加 ~a 乘以 x~%"
-
-#. i18n-hint: the name of an Apple audio software protocol
-#. i18n-hint: Audio Unit is the name of an Apple audio software protocol
-#: src/effects/audiounits/AudioUnitEffect.h src/prefs/EffectsPrefs.cpp
-msgid "Audio Unit"
-msgstr "音訊單元（Audio Unit）"
-
-#: src/ProjectFileIO.cpp
-#, c-format
-msgid "[Project %02i] "
-msgstr "[專案 %02i] "
-
-#: src/prefs/KeyConfigPrefs.cpp
-#, c-format
-msgid ""
-"The file with the shortcuts contains illegal shortcut duplicates for \"%s\" and \"%s\".\n"
-"Nothing is imported."
-msgstr ""
-"這個帶有快速鍵的檔案，包含著不合規定的「快捷鍵重複」——「%s」以及「%s」。\n"
-"匯入已取消。"
-
-#. i18n-hint: "Nyquist" is an embedded interpreted programming language in
-#. Audacity, named in honor of the Swedish-American Harry Nyquist (or Nyqvist).
-#. In the translations of this and other strings, you may transliterate the
-#. name into another alphabet.
-#: src/effects/Effect.h
-msgid "Nyquist"
-msgstr "Nyquist"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%0.f ms"
-msgstr "%0.f ms"
-
-#. i18n-hint milliseconds
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.0f ms"
-msgstr "%.0f ms"
-
-#: src/effects/DtmfGen.cpp
-#, c-format
-msgid "%.1f %%"
-msgstr "%.1f %%"
-
-#. i18n-hint: day of month, month, year, hour, minute, second
-#: src/effects/Contrast.cpp
-#, c-format
-msgid "%d %s %02d %02dh %02dm %02ds"
-msgstr "%d天 %s月 %02d年 %02d小時 %02d分 %02d秒"
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.1f:1"
-msgstr "%.1f:1"
-
-#. i18n-hint: Unless your language has a different convention for ratios,
-#. * like 8:1, leave as is.
-#: src/effects/Compressor.cpp
-#, c-format
-msgid "%.0f:1"
-msgstr "%.0f:1"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "78"
-msgstr "78"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "45"
-msgstr "45"
-
-#: src/effects/ChangeSpeed.cpp
-msgid "33⅓"
-msgstr "33⅓"
-
-#: src/commands/HelpCommand.cpp
-msgid "_"
-msgstr "_"
-
-#. i18n-hint JavaScript Object Notation
-#: src/commands/GetInfoCommand.cpp src/commands/HelpCommand.cpp
-msgid "JSON"
-msgstr "JSON"
-
-#: src/ProjectFileIO.cpp src/commands/AudacityCommand.cpp src/effects/Effect.cpp src/effects/nyquist/Nyquist.cpp src/prefs/PrefsPanel.cpp plug-ins/beat.ny
-msgid "Audacity"
-msgstr "Tenacity"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯/B♭"
-msgstr "A♯/B♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯/A♭"
-msgstr "G♯/A♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯/G♭"
-msgstr "F♯/G♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯/E♭"
-msgstr "D♯/E♭"
-
-#. i18n-hint: Two, alternate names of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯/D♭"
-msgstr "C♯/D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B♭"
-msgstr "B♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♭"
-msgstr "A♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♭"
-msgstr "G♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E♭"
-msgstr "E♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♭"
-msgstr "D♭"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "B"
-msgstr "B"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A♯"
-msgstr "A♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "A"
-msgstr "A"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G♯"
-msgstr "G♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "G"
-msgstr "G"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F♯"
-msgstr "F♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "F"
-msgstr "F"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "E"
-msgstr "E"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Welch"
-msgstr "Welch"
-
-#. i18n-hint: This is the abbreviation for "Hertz", or
-#. cycles per second.
-#. i18n-hint: Name of display format that shows frequency in hertz
-#: src/FreqWindow.cpp src/effects/ChangePitch.cpp src/effects/Equalization.cpp src/effects/ScienFilter.cpp src/import/ImportRaw.cpp src/widgets/NumericTextCtrl.cpp
-msgid "Hz"
-msgstr "Hz"
-
-#: src/FreqWindow.cpp
-msgid "spectrum.txt"
-msgstr "spectrum.txt"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C"
-msgstr "C"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "C♯"
-msgstr "C♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D♯"
-msgstr "D♯"
-
-#. i18n-hint: Name of a musical note in the 12-tone chromatic scale
-#: src/PitchName.cpp
-msgid "D"
-msgstr "D"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=4.5)"
-msgstr "高斯函數（a=4.5）"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=3.5)"
-msgstr "高斯函數（a=3.5）"
-
-#. i18n-hint a mathematical function named for C. F. Gauss
-#: src/FFT.cpp
-msgid "Gaussian(a=2.5)"
-msgstr "高斯函數（a=2.5）"
-
-#. i18n-hint two proper names
-#: src/FFT.cpp
-msgid "Blackman-Harris"
-msgstr "Blackman-Harris"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Blackman"
-msgstr "Blackman"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hann"
-msgstr "Hann"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Hamming"
-msgstr "Hamming"
-
-#. i18n-hint a proper name
-#: src/FFT.cpp
-msgid "Bartlett"
-msgstr "Bartlett"
-
-#: src/Dependencies.cpp
-#, c-format
-msgid "\"%s\", \"%s\", \"%s\"\n"
-msgstr "\"%s\", \"%s\", \"%s\"\n"
-
-#: src/DBConnection.cpp
-#, c-format
-msgid "(%d): %s"
-msgstr "(%d): %s"
-
-#: src/BatchCommands.cpp src/FileNames.cpp
-#, c-format
-msgid "(%s)"
-msgstr "(%s)"
-
-#: src/AudioIOBase.cpp
-#, c-format
-msgid "%d - %s\n"
-msgstr "%d - %s\n"
-
-#. i18n-hint Tenacity's name substitutes for first and fourth %s, and the second and third %s are the copyright symbol and final year of copyright
-#: src/AboutDialog.cpp
-#, c-format
-msgid "%s %s 1999-%s %s contributors"
-msgstr "%s %s 1999-%s %s 貢獻者"
-
-#: src/AboutDialog.cpp
-msgid "<h3>"
-msgstr "<h3>"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "(C) 2009 by Leland Lucius"
-msgstr "(C) 2009 Leland Lucius 作品"
-
-#: modules/mod-nyq-bench/NyqBench.cpp
-msgid "Leland Lucius"
-msgstr "Leland Lucius"
-
-#. i18n-hint: Abbreviation for Giga bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s GB"
-msgstr "%s GB"
-
-#. i18n-hint: Abbreviation for Mega bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s MB"
-msgstr "%s MB"
-
-#. i18n-hint: Abbreviation for Kilo bytes
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s KB"
-msgstr "%s kB"
-
-#: libraries/lib-strings/Internat.cpp
-#, c-format
-msgid "%s bytes"
-msgstr "%s 位元組"
+#~ msgid "%d - %s\n"
+#~ msgstr "%d - %s\n"

--- a/modules/mod-nyq-bench/NyqBench.cpp
+++ b/modules/mod-nyq-bench/NyqBench.cpp
@@ -227,7 +227,7 @@ void NyqTextCtrl::OnKeyDown(wxKeyEvent & e)
       if (e.GetKeyCode() == WXK_UP && e.GetModifiers() == 0) {
          long x;
          long y;
-   
+
          PositionToXY(GetInsertionPoint(), &x, &y);
          if (x == 0 && y > 1) {
             y--;
@@ -268,7 +268,7 @@ void NyqTextCtrl::OnUpdate(wxUpdateUIEvent & e)
 
    if (pos != mLastCaretPos) {
       int lpos = wxMax(0, pos - 1);
-   
+
       wxString text = GetRange(lpos, pos);
       if (text.Length() > 0) {
          if (text[0] == wxT('(')) {
@@ -460,7 +460,7 @@ void NyqTextCtrl::FindParens()
                   // Shamelessly stolen from xlread.c/pcomment()
                   wxChar lastch = -1;
                   int n = 1;
-              
+
                   /* look for the matching delimiter (and handle nesting) */
                   while (n > 0 && ++pos < len) {
                      wxChar ch = text[(int)pos];
@@ -853,7 +853,7 @@ void NyqBench::PopulateOrExchange(ShuttleGui & S)
                                        wxSP_LIVE_UPDATE |
                                        wxSP_3DSASH |
                                        wxSP_NOBORDER);
-      
+
       scriptp = new wxPanel(mSplitter,
                             wxID_ANY,
                             wxDefaultPosition,
@@ -905,7 +905,7 @@ void NyqBench::PopulateOrExchange(ShuttleGui & S)
                                 wxDefaultSize,
                                 wxTE_READONLY |
 #if !defined(__WXMAC__)
-// I could not get the bloody horizontal scroll bar to appear on 
+// I could not get the bloody horizontal scroll bar to appear on
 // wxMac, so we can't use wxTE_DONTWRAP as you can't easily scroll
 // left and right.
                                 wxTE_DONTWRAP |
@@ -1006,7 +1006,7 @@ void NyqBench::OnOpen(wxCommandEvent & e)
                      wxEmptyString,
                      _("Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"),
                      wxFD_OPEN | wxRESIZE_BORDER);
- 
+
    if (dlog.ShowModal() != wxID_OK) {
       return;
    }
@@ -1024,7 +1024,7 @@ void NyqBench::OnSave(wxCommandEvent & e)
    if (mScript->GetLastPosition() == 0) {
       return;
    }
- 
+
    if (mPath.GetFullPath().IsEmpty()) {
       OnSaveAs(e);
       return;
@@ -1045,14 +1045,14 @@ void NyqBench::OnSaveAs(wxCommandEvent & e)
    if (mScript->GetLastPosition() == 0) {
       return;
    }
- 
+
    wxFileDialog dlog(this,
                      _("Save Nyquist script"),
                      mPath.GetFullPath(),
                      wxEmptyString,
                      _("Nyquist scripts (*.ny)|*.ny|Lisp scripts (*.lsp)|*.lsp|All files|*"),
                      wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER);
- 
+
    if (dlog.ShowModal() != wxID_OK) {
       return;
    }
@@ -1371,7 +1371,7 @@ void NyqBench::OnAbout(wxCommandEvent & e)
    i.AddArtist(_("Tango Icon Gallery (toolbar icons)"));
    i.AddDeveloper(_("Leland Lucius"));
    i.SetCopyright(_("(C) 2009 by Leland Lucius"));
-   i.SetDescription(_("External Audacity module which provides a simple IDE for writing effects."));
+   i.SetDescription(_("External Tenacity module which provides a simple IDE for writing effects."));
    i.SetName(_("Nyquist Effect Workbench"));
 
    wxAboutBox(i);
@@ -1684,7 +1684,7 @@ void NyqBench::RecreateToolbar(bool large)
    tb->AddSeparator();
    tb->AddTool(ID_GO, _("Start"), mPics[18], _("Start script"));
    tb->AddTool(ID_STOP, _("Stop"), mPics[19], _("Stop script"));
-   
+
    tb->Realize();
 
    Layout();

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -223,7 +223,7 @@ namespace
                 "Reset Preferences?\n\nThis is a one-time question, after an 'install' where you asked to have the Preferences reset.");
             int action = AudacityMessageBox(
                 prompt,
-                XO("Reset Audacity Preferences"),
+                XO("Reset Tenacity Preferences"),
                 wxYES_NO, NULL);
             if (action == wxYES)   // reset
             {
@@ -979,7 +979,7 @@ bool AudacityApp::OnInit() {
     if (!ProjectFileIO::InitializeSQL())
         this->CallAfter([] {
         ::AudacityMessageBox(
-            XO("SQLite library failed to initialize.  Audacity cannot continue."));
+            XO("SQLite library failed to initialize.  Tenacity cannot continue."));
         QuitAudacity(true);
                         });
 
@@ -1597,10 +1597,10 @@ bool AudacityApp::InitTempDir() {
         // Failed
         if (!TempDirectory::IsTempDirectoryNameOK(tempFromPrefs)) {
             AudacityMessageBox(XO(
-                "Audacity could not find a safe place to store temporary files.\nAudacity needs a place where automatic cleanup programs won't delete the temporary files.\nPlease enter an appropriate directory in the preferences dialog."));
+                "Tenacity could not find a safe place to store temporary files.\nTenacity needs a place where automatic cleanup programs won't delete the temporary files.\nPlease enter an appropriate directory in the preferences dialog."));
         } else {
             AudacityMessageBox(XO(
-                "Audacity could not find a place to store temporary files.\nPlease enter an appropriate directory in the preferences dialog."));
+                "Tenacity could not find a place to store temporary files.\nPlease enter an appropriate directory in the preferences dialog."));
         }
 
         // Only want one page of the preferences
@@ -1610,7 +1610,7 @@ bool AudacityApp::InitTempDir() {
         dialog.ShowModal();
 
         AudacityMessageBox(XO(
-            "Audacity is now going to exit. Please launch Audacity again to use the new temporary directory."));
+            "Tenacity is now going to exit. Please launch Tenacity again to use the new temporary directory."));
         return false;
     }
 
@@ -1636,16 +1636,16 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
     mChecker.reset();
     auto checker = std::make_unique<wxSingleInstanceChecker>();
 
-    auto runningTwoCopiesStr = XO("Running two copies of Audacity simultaneously may cause\ndata loss or cause your system to crash.\n\n");
+    auto runningTwoCopiesStr = XO("Running two copies of Tenacity simultaneously may cause\ndata loss or cause your system to crash.\n\n");
 
     if (!checker->Create(name, dir)) {
         // Error initializing the wxSingleInstanceChecker.  We don't know
         // whether there is another instance running or not.
 
         auto prompt = XO(
-            "Audacity was not able to lock the temporary files directory.\nThis folder may be in use by another copy of Audacity.\n")
+            "Tenacity was not able to lock the temporary files directory.\nThis folder may be in use by another copy of Tenacity.\n")
             + runningTwoCopiesStr
-            + XO("Do you still want to start Audacity?");
+            + XO("Do you still want to start Tenacity?");
         int action = AudacityMessageBox(
             prompt,
             XO("Error Locking Temporary Folder"),
@@ -1706,12 +1706,12 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
         // There is another copy of Audacity running.  Force quit.
 
         auto prompt = XO(
-            "The system has detected that another copy of Audacity is running.\n")
+            "The system has detected that another copy of Tenacity is running.\n")
             + runningTwoCopiesStr
             + XO(
-                "Use the New or Open commands in the currently running Audacity\nprocess to open multiple projects simultaneously.\n");
+                "Use the New or Open commands in the currently running Tenacity\nprocess to open multiple projects simultaneously.\n");
         AudacityMessageBox(
-            prompt, XO("Audacity is already running"),
+            prompt, XO("Tenacity is already running"),
             wxOK | wxICON_ERROR);
 
         return false;
@@ -1782,7 +1782,7 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
                 XO("Unable to acquire semaphores.\n\n"
                 "This is likely due to a resource shortage\n"
                 "and a reboot may be required."),
-                XO("Audacity Startup Failure"),
+                XO("Tenacity Startup Failure"),
                 wxOK | wxICON_ERROR);
 
             return false;
@@ -1797,7 +1797,7 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
             XO("Unable to create semaphores.\n\n"
             "This is likely due to a resource shortage\n"
             "and a reboot may be required."),
-            XO("Audacity Startup Failure"),
+            XO("Tenacity Startup Failure"),
             wxOK | wxICON_ERROR);
 
         return false;
@@ -1818,7 +1818,7 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
                 XO("Unable to acquire lock semaphore.\n\n"
                 "This is likely due to a resource shortage\n"
                 "and a reboot may be required."),
-                XO("Audacity Startup Failure"),
+                XO("Tenacity Startup Failure"),
                 wxOK | wxICON_ERROR);
 
             return false;
@@ -1837,7 +1837,7 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
                 XO("Unable to acquire server semaphore.\n\n"
                 "This is likely due to a resource shortage\n"
                 "and a reboot may be required."),
-                XO("Audacity Startup Failure"),
+                XO("Tenacity Startup Failure"),
                 wxOK | wxICON_ERROR);
 
             return false;
@@ -1874,10 +1874,10 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
         // Bail if the server creation failed.
         if (mIPCServ == nullptr) {
             AudacityMessageBox(
-                XO("The Audacity IPC server failed to initialize.\n\n"
+                XO("The Tenacity IPC server failed to initialize.\n\n"
                 "This is likely due to a resource shortage\n"
                 "and a reboot may be required."),
-                XO("Audacity Startup Failure"),
+                XO("Tenacity Startup Failure"),
                 wxOK | wxICON_ERROR);
 
             return false;
@@ -1915,7 +1915,7 @@ bool AudacityApp::CreateSingleInstanceChecker(const wxString& dir) {
         // Audacity is already running.
         AudacityMessageBox(
             XO("An unrecoverable error has occurred during startup"),
-            XO("Audacity Startup Failure"),
+            XO("Tenacity Startup Failure"),
             wxOK | wxICON_ERROR);
 
         return false;
@@ -2019,7 +2019,7 @@ std::unique_ptr<wxCmdLineParser> AudacityApp::ParseCommandLine() {
     parser->AddSwitch(wxT("t"), wxT("test"), _("run self diagnostics"));
 
     /*i18n-hint: This displays the Audacity version */
-    parser->AddSwitch(wxT("v"), wxT("version"), _("display Audacity version"));
+    parser->AddSwitch(wxT("v"), wxT("version"), _("display Tenacity version"));
 
     /*i18n-hint: This is a list of one or more files that Audacity
      *           should open upon startup */
@@ -2257,7 +2257,7 @@ void AudacityApp::AssociateFileTypes() {
     int wantAssoc =
         AudacityMessageBox(
             XO(
-            "Audacity project (.aup3) files are not currently \nassociated with Audacity. \n\nAssociate them, so they open on double-click?"),
+            "Audacity project (.aup3) files are not currently \nassociated with Tenacity. \n\nAssociate them, so they open on double-click?"),
             XO("Audacity Project Files"),
             wxYES_NO | wxICON_QUESTION);
 

--- a/src/AudacityFileConfig.cpp
+++ b/src/AudacityFileConfig.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<AudacityFileConfig> AudacityFileConfig::Create(
 
 void AudacityFileConfig::Warn()
 {
-   wxDialogWrapper dlg(nullptr, wxID_ANY, XO("Audacity Configuration Error"));
+   wxDialogWrapper dlg(nullptr, wxID_ANY, XO("Tenacity Configuration Error"));
 
    ShuttleGui S(&dlg, eIsCreating);
 
@@ -72,7 +72,7 @@ void AudacityFileConfig::Warn()
                "the disk is full or you do not have write permissions to the file. "
                "More information can be obtained by clicking the help button below.\n\n"
                "You can attempt to correct the issue and then click \"Retry\" to continue.\n\n"
-               "If you choose to \"Quit Audacity\", your project may be left in an unsaved "
+               "If you choose to \"Quit Tenacity\", your project may be left in an unsaved "
                "state which will be recovered the next time you open it.")
             .Format(GetFilePath()),
             false,
@@ -89,7 +89,7 @@ void AudacityFileConfig::Warn()
          b->SetToolTip( XO("Help").Translation() );
          b->SetLabel(XO("Help").Translation());       // for screen readers
 
-         b = S.Id(wxID_CANCEL).AddButton(XXO("&Quit Audacity"));
+         b = S.Id(wxID_CANCEL).AddButton(XXO("&Quit Tenacity"));
          b = S.Id(wxID_OK).AddButton(XXO("&Retry"));
          dlg.SetAffirmativeId(wxID_OK);
 

--- a/src/AudacityLogger.cpp
+++ b/src/AudacityLogger.cpp
@@ -159,7 +159,7 @@ void AudacityLogger::Show(bool show)
 
    // This is the first use, so create the frame
    Destroy_ptr<wxFrame> frame
-      { safenew wxFrame(NULL, wxID_ANY, _("Audacity Log")) };
+      { safenew wxFrame(NULL, wxID_ANY, _("Tenacity Log")) };
    frame->SetName(frame->GetTitle());
    frame->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -18,8 +18,8 @@
 ********************************************************************//**
 
 \class AudioIoCallback
-\brief AudioIoCallback is a class that implements the callback required 
-by PortAudio.  The callback needs to be responsive, has no GUI, and 
+\brief AudioIoCallback is a class that implements the callback required
+by PortAudio.  The callback needs to be responsive, has no GUI, and
 copies data into and out of the sound card buffers.  It also sends data
 to the meters.
 
@@ -408,7 +408,7 @@ callbacks for these events.
 *//****************************************************************//**
 
 \class AudioIOStartStreamOptions
-\brief struct holding stream options, including a pointer to the 
+\brief struct holding stream options, including a pointer to the
 time warp info and AudioIOListener and whether the playback is looped.
 
 *//*******************************************************************/
@@ -956,7 +956,7 @@ AudioIO::AudioIO()
       wxASSERT(false);
    }
 
-   // This ASSERT because of casting in the callback 
+   // This ASSERT because of casting in the callback
    // functions where we cast a tempFloats buffer to a (short*) buffer.
    // We have to ASSERT in the GUI thread, if we are to see it properly.
    wxASSERT( sizeof( short ) <= sizeof( float ));
@@ -1133,13 +1133,13 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions &options,
    mRate = GetBestRate(numCaptureChannels > 0, numPlaybackChannels > 0, sampleRate);
 
    // July 2016 (Carsten and Uwe)
-   // BUG 193: Tell PortAudio sound card will handle 24 bit (under DirectSound) using 
+   // BUG 193: Tell PortAudio sound card will handle 24 bit (under DirectSound) using
    // userData.
    int captureFormat_saved = captureFormat;
    // Special case: Our 24-bit sample format is different from PortAudio's
    // 3-byte packed format. So just make PortAudio return float samples,
    // since we need float values anyway to apply the gain.
-   // ANSWER-ME: So we *never* actually handle 24-bit?! This causes mCapture to 
+   // ANSWER-ME: So we *never* actually handle 24-bit?! This causes mCapture to
    // be set to floatSample below.
    // JKC: YES that's right.  Internally Audacity uses float, and float has space for
    // 24 bits as well as exponent.  Actual 24 bit would require packing and
@@ -1229,7 +1229,7 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions &options,
    SetMeters();
 
    // July 2016 (Carsten and Uwe)
-   // BUG 193: Possibly tell portAudio to use 24 bit with DirectSound. 
+   // BUG 193: Possibly tell portAudio to use 24 bit with DirectSound.
    int  userData = 24;
    int* lpUserData = (captureFormat_saved == int24Sample) ? &userData : NULL;
 
@@ -1270,7 +1270,7 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions &options,
 #if (defined(__WXMAC__) || defined(__WXMSW__)) && wxCHECK_VERSION(3,1,0)
    // Don't want the system to sleep while audio I/O is active
    if (mPortStreamV19 != NULL && mLastPaError == paNoError) {
-      wxPowerResource::Acquire(wxPOWER_RESOURCE_SCREEN, _("Audacity Audio"));
+      wxPowerResource::Acquire(wxPOWER_RESOURCE_SCREEN, _("Tenacity Audio"));
    }
 #endif
 
@@ -1318,7 +1318,7 @@ void AudioIO::StartMonitoring( const AudioIOStartStreamOptions &options )
 
    // FIXME: TRAP_ERR PaErrorCode 'noted' but not reported in StartMonitoring.
    // Now start the PortAudio stream!
-   // TODO: ? Factor out and reuse error reporting code from end of 
+   // TODO: ? Factor out and reuse error reporting code from end of
    // AudioIO::StartStream?
    mLastPaError = Pa_StartStream( mPortStreamV19 );
 
@@ -1547,7 +1547,7 @@ int AudioIO::StartStream(const TransportTracks &tracks,
          mPlaybackMixers[ii]->Reposition( time );
       mPlaybackSchedule.RealTimeInit( time );
    }
-   
+
    // Now that we are done with SetTrackTime():
    mTimeQueue.mLastTime = mPlaybackSchedule.GetTrackTime();
    if (mTimeQueue.mData)
@@ -1698,7 +1698,7 @@ bool AudioIO::AllocateBuffers(
       // more frequent polling of the mouse
       playbackTime =
          lrint(options.pScrubbingOptions->delay * mRate) / mRate;
-   
+
    wxASSERT( playbackTime >= 0 );
    mPlaybackSamplesToCopy = playbackTime * mRate;
 
@@ -1846,7 +1846,7 @@ bool AudioIO::AllocateBuffers(
          }
       }
    } while(!bDone);
-   
+
    success = true;
    return true;
 }
@@ -2020,7 +2020,7 @@ void AudioIO::StopStream()
    // Re-enable system sleep
    wxPowerResource::Release(wxPOWER_RESOURCE_SCREEN);
 #endif
- 
+
    if( mAudioThreadFillBuffersLoopRunning)
    {
       // PortAudio callback can use the information that we are stopping to fade
@@ -2028,7 +2028,7 @@ void AudioIO::StopStream()
       mAudioThreadFillBuffersLoopRunning = false;
       auto latency = static_cast<long>(AudioIOLatencyDuration.Read());
       // If we can gracefully fade out in 200ms, with the faded-out play buffers making it through
-      // the sound card, then do so.  If we can't, don't wait around.  Just stop quickly and accept 
+      // the sound card, then do so.  If we can't, don't wait around.  Just stop quickly and accept
       // there will be a click.
       if( mbMicroFades  && (latency < 150 ))
          wxMilliSleep( latency + 50);
@@ -2134,7 +2134,7 @@ void AudioIO::StopStream()
 #endif
 
    auto pListener = GetListener();
-   
+
    // If there's no token, we were just monitoring, so we can
    // skip this next part...
    if (mStreamToken > 0) {
@@ -2202,7 +2202,7 @@ void AudioIO::StopStream()
             } );
          }
 
-         
+
          if (!mLostCaptureIntervals.empty())
          {
             // This scope may combine many splittings of wave tracks
@@ -2256,7 +2256,7 @@ void AudioIO::StopStream()
       e.SetInt(false);
       wxTheApp->ProcessEvent(e);
    }
-   
+
    if (mNumCaptureChannels > 0)
    {
       wxCommandEvent e(wasMonitoring ? EVT_AUDIOIO_MONITOR : EVT_AUDIOIO_CAPTURE);
@@ -2649,7 +2649,7 @@ void AudioIO::FillBuffers()
                   // wxASSERT(put == frames);
                   // but we can't assert in this thread
                   wxUnusedVar(put);
-               }               
+               }
             }
 
             available -= frames;
@@ -3103,7 +3103,7 @@ void AudioIoCallback::GetNextEvent()
    if (mNextEvent) {
       mNextEventTime = (mNextIsNoteOn ? mNextEvent->time :
                               mNextEvent->get_end_time()) + nextOffset;;
-   } 
+   }
    if (mNextEventTime > (mPlaybackSchedule.mT1 + midiLoopOffset)){ // terminate playback at mT1
       mNextEvent = &gAllNotesOff;
       mNextEventTime = mPlaybackSchedule.mT1 + midiLoopOffset - ALG_EPS;
@@ -3480,7 +3480,7 @@ bool AudioIoCallback::FillOutputBuffers(
       return false;
    if( !outputBuffer )
       return false;
-   if(numPlaybackChannels <= 0) 
+   if(numPlaybackChannels <= 0)
       return false;
 
    float *outputFloats = (float *)outputBuffer;
@@ -3514,7 +3514,7 @@ bool AudioIoCallback::FillOutputBuffers(
    // The drop and dropQuickly booleans are so named for historical reasons.
    // JKC: The original code attempted to be faster by doing nothing on silenced audio.
    // This, IMHO, is 'premature optimisation'.  Instead clearer and cleaner code would
-   // simply use a gain of 0.0 for silent audio and go on through to the stage of 
+   // simply use a gain of 0.0 for silent audio and go on through to the stage of
    // applying that 0.0 gain to the data mixed into the buffer.
    // Then (and only then) we would have if needed fast paths for:
    // - Applying a uniform gain of 0.0.
@@ -3556,13 +3556,13 @@ bool AudioIoCallback::FillOutputBuffers(
 
       if( mbMicroFades )
          dropQuickly = dropQuickly && TrackHasBeenFadedOut( *vt );
-         
+
       decltype(framesPerBuffer) len = 0;
 
       if (dropQuickly)
       {
          len = mPlaybackBuffers[t]->Discard(toGet);
-         // keep going here.  
+         // keep going here.
          // we may still need to issue a paComplete.
       }
       else
@@ -3667,7 +3667,7 @@ void AudioIoCallback::UpdateTimePosition(unsigned long framesPerBuffer)
 // Copy from PortAudio to our input buffers.
 //
 void AudioIoCallback::FillInputBuffers(
-   const void *inputBuffer, 
+   const void *inputBuffer,
    unsigned long framesPerBuffer,
    const PaStreamCallbackFlags statusFlags,
    float * tempFloats
@@ -3738,10 +3738,10 @@ void AudioIoCallback::FillInputBuffers(
       wxPrintf(wxT("lost %d samples\n"), (int)(framesPerBuffer - len));
    }
 
-   if (len <= 0) 
+   if (len <= 0)
       return;
 
-   // We have an ASSERT in the AudioIO constructor to alert us to 
+   // We have an ASSERT in the AudioIO constructor to alert us to
    // possible issues with the (short*) cast.  We'd have a problem if
    // sizeof(short) > sizeof(float) since our buffers are sized for floats.
    for(unsigned t = 0; t < numCaptureChannels; t++) {
@@ -3778,7 +3778,7 @@ void AudioIoCallback::FillInputBuffers(
       } // switch
 
       // JKC: mCaptureFormat must be for samples with sizeof(float) or
-      // fewer bytes (because tempFloats is sized for floats).  All 
+      // fewer bytes (because tempFloats is sized for floats).  All
       // formats are 2 or 4 bytes, so we are OK.
       const auto put =
          mCaptureBuffers[t]->Put(
@@ -3824,7 +3824,7 @@ void OldCodeToCalculateLatency()
 // return true, IFF we have fully handled the callback.
 // Prime the output buffer with 0's, optionally adding in the playthrough.
 void AudioIoCallback::DoPlaythrough(
-      const void *inputBuffer, 
+      const void *inputBuffer,
       void *outputBuffer,
       unsigned long framesPerBuffer,
       float *outputMeterFloats
@@ -3861,7 +3861,7 @@ void AudioIoCallback::DoPlaythrough(
 // Also computes rms
 void AudioIoCallback::SendVuInputMeterData(
    float *inputSamples,
-   unsigned long framesPerBuffer   
+   unsigned long framesPerBuffer
    )
 {
    const auto numCaptureChannels = mNumCaptureChannels;
@@ -3902,7 +3902,7 @@ void AudioIoCallback::SendVuOutputMeterData(
       return;
    if( mOutputMeter->IsMeterDisabled() )
       return;
-   if( !outputMeterFloats) 
+   if( !outputMeterFloats)
       return;
 
    // Get here if playback meter is live
@@ -3956,7 +3956,7 @@ unsigned AudioIoCallback::CountSoloingTracks(){
 // TODO: Consider making the two Track status functions into functions of
 // WaveTrack.
 
-// true IFF the track should be silent. 
+// true IFF the track should be silent.
 // The track may not yet be silent, since it may still be
 // fading out.
 bool AudioIoCallback::TrackShouldBeSilent( const WaveTrack &wt )
@@ -3987,8 +3987,8 @@ bool AudioIoCallback::AllTracksAlreadySilent()
    const bool dropAllQuickly = std::all_of(
       mPlaybackTracks.begin(), mPlaybackTracks.end(),
       [&]( const std::shared_ptr< WaveTrack > &vt )
-         { return 
-      TrackShouldBeSilent( *vt ) && 
+         { return
+      TrackShouldBeSilent( *vt ) &&
       TrackHasBeenFadedOut( *vt ); }
    );
    return dropAllQuickly;
@@ -4018,9 +4018,9 @@ int AudioIoCallback::AudioCallback(const void *inputBuffer, void *outputBuffer,
    // but it does nothing unless we have EXPERIMENTAL_MIDI_OUT
    // TODO: Possibly rename variables to make it clearer which ones are MIDI specific
    // and which ones affect all audio.
-   ComputeMidiTimings( 
-      timeInfo, 
-      framesPerBuffer 
+   ComputeMidiTimings(
+      timeInfo,
+      framesPerBuffer
    );
 #ifndef USE_MIDI_THREAD
    if (mMidiStream)
@@ -4057,10 +4057,10 @@ int AudioIoCallback::AudioCallback(const void *inputBuffer, void *outputBuffer,
 
       // This function may queue up a pause or resume.
       // TODO this is a bit dodgy as it toggles the Pause, and
-      // relies on an idle event to have handled that, so could 
+      // relies on an idle event to have handled that, so could
       // queue up multiple toggle requests and so do nothing.
       // Eventually it will sort itself out by random luck, but
-      // the net effect is a delay in starting/stopping sound activated 
+      // the net effect is a delay in starting/stopping sound activated
       // recording.
       CheckSoundActivatedRecordingLevel(
          inputSamples,
@@ -4071,7 +4071,7 @@ int AudioIoCallback::AudioCallback(const void *inputBuffer, void *outputBuffer,
    // Initialise output buffer to zero or to playthrough data.
    // Initialise output meter values.
    DoPlaythrough(
-      inputBuffer, 
+      inputBuffer,
       outputBuffer,
       framesPerBuffer,
       outputMeterFloats);
@@ -4093,7 +4093,7 @@ int AudioIoCallback::AudioCallback(const void *inputBuffer, void *outputBuffer,
 
    // To capture input into track (sound from microphone)
    FillInputBuffers(
-      inputBuffer, 
+      inputBuffer,
       framesPerBuffer,
       statusFlags,
       tempFloats);
@@ -4168,7 +4168,7 @@ void AudioIoCallback::CallbackCheckCompletion(
    done =  mPlaybackSchedule.PlayingAtSpeed()
       // some leftover length allowed in this case
       || (mPlaybackSchedule.PlayingStraight() && len == 0);
-   if(!done) 
+   if(!done)
       return;
 
 #ifdef EXPERIMENTAL_MIDI_OUT

--- a/src/AutoRecoveryDialog.cpp
+++ b/src/AutoRecoveryDialog.cpp
@@ -93,7 +93,7 @@ void AutoRecoveryDialog::Populate(ShuttleGui &S)
    S.StartVerticalLay(wxEXPAND, 1);
    {
       S.AddFixedText(
-         XO("The following projects were not saved properly the last time Audacity was run and "
+         XO("The following projects were not saved properly the last time Tenacity was run and "
             "can be automatically recovered.\n\n"
             "After recovery, save the projects to ensure changes are written to disk."),
          false,
@@ -122,7 +122,7 @@ void AutoRecoveryDialog::Populate(ShuttleGui &S)
 
       S.StartHorizontalLay(wxALIGN_CENTRE, 0);
       {
-         S.Id(ID_QUIT_AUDACITY).AddButton(XXO("&Quit Audacity"));
+         S.Id(ID_QUIT_AUDACITY).AddButton(XXO("&Quit Tenacity"));
          S.Id(ID_DISCARD_SELECTED).AddButton(XXO("&Discard Selected"));
          S.Id(ID_RECOVER_SELECTED).AddButton(XXO("&Recover Selected"), wxALIGN_CENTRE, true);
          S.Id(ID_SKIP).AddButton(XXO("&Skip"));
@@ -399,7 +399,7 @@ bool ShowAutoRecoveryDialogIfNeeded(AudacityProject *&pproj, bool *didRecoverAny
    if (dialog.HasRecoverables())
    {
       int ret = dialog.ShowModal();
-      
+
       switch (ret)
       {
       case ID_SKIP:
@@ -427,6 +427,6 @@ bool ShowAutoRecoveryDialogIfNeeded(AudacityProject *&pproj, bool *didRecoverAny
          return false;
       }
    }
-   
+
    return success;
 }

--- a/src/Dependencies.cpp
+++ b/src/Dependencies.cpp
@@ -29,7 +29,7 @@ data.
 *//*****************************************************************//**
 
 \class DependencyDialog
-\brief DependencyDialog shows dependencies of an AudacityProject on 
+\brief DependencyDialog shows dependencies of an AudacityProject on
 AliasedFile s.
 
 *//********************************************************************/
@@ -550,7 +550,7 @@ void DependencyDialog::OnCopyToClipboard( wxCommandEvent& )
       bool bOriginalExists = aliasedFile.mbOriginalExists;
       // All fields quoted, as e.g. size may contain a comma in the number.
       Files += XO( "\"%s\", \"%s\", \"%s\"\n").Format(
-         fileName.GetFullPath(), 
+         fileName.GetFullPath(),
          Internat::FormatSize( byteCount),
          bOriginalExists ? XO("OK") : XO("Missing") );
    }
@@ -611,7 +611,7 @@ bool ShowDependencyDialogIfNeeded(AudacityProject *project,
       {
          auto msg =
 XO("Your project is self-contained; it does not depend on any external audio files. \
-\n\nSome older Audacity projects may not be self-contained, and care \n\
+\n\nSome older Tenacity projects may not be self-contained, and care \n\
 is needed to keep their external dependencies in the right place.\n\
 New projects will be self-contained and are less risky.");
          AudacityMessageBox(

--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -103,7 +103,7 @@ void FFmpegStartup()
       {
          AudacityMessageBox(XO(
 "FFmpeg was configured in Preferences and successfully loaded before, \
-\nbut this time Audacity failed to load it at startup. \
+\nbut this time Tenacity failed to load it at startup. \
 \n\nYou may want to go back to Preferences > Libraries and re-configure it."),
             XO("FFmpeg startup failed"));
       }
@@ -476,7 +476,7 @@ public:
       {
          S.AddTitle(
             XO(
-"Audacity needs the file '%s' to import and export audio via FFmpeg.")
+"Tenacity needs the file '%s' to import and export audio via FFmpeg.")
                .Format( mName ) );
 
          S.SetBorder(3);
@@ -585,7 +585,7 @@ void FFmpegNotFoundDialog::PopulateOrExchange(ShuttleGui & S)
    S.StartVerticalLay(true);
    {
       S.AddFixedText(XO(
-"Audacity attempted to use FFmpeg to import an audio file,\n\
+"Tenacity attempted to use FFmpeg to import an audio file,\n\
 but the libraries were not found.\n\n\
 To use FFmpeg import, go to Edit > Preferences > Libraries\n\
 to download or locate the FFmpeg libraries."

--- a/src/FileException.cpp
+++ b/src/FileException.cpp
@@ -1,7 +1,7 @@
 /*!
   @file FileException.cpp
   @brief implements FileException
-  
+
 
   Created by Paul Licameli on 11/22/16.
 
@@ -22,16 +22,16 @@ TranslatableString FileException::ErrorMessage() const
    TranslatableString format;
    switch (cause) {
       case Cause::Open:
-         format = XO("Audacity failed to open a file in %s.");
+         format = XO("Tenacity failed to open a file in %s.");
          break;
       case Cause::Read:
-         format = XO("Audacity failed to read from a file in %s.");
+         format = XO("Tenacity failed to read from a file in %s.");
          break;
       case Cause::Write:
          return WriteFailureMessage(fileName);
       case Cause::Rename:
          format =
-XO("Audacity successfully wrote a file in %s but failed to rename it as %s.");
+XO("Tenacity successfully wrote a file in %s but failed to rename it as %s.");
       default:
          break;
    }
@@ -60,7 +60,7 @@ wxString FileException::ErrorHelpUrl() const
 TranslatableString
 FileException::WriteFailureMessage(const wxFileName &fileName)
 {
-   return XO("Audacity failed to write to a file.\n"
+   return XO("Tenacity failed to write to a file.\n"
      "Perhaps %s is not writable or the disk is full.\n"
      "For tips on freeing up space, click the help button."
    ).Format(FileNames::AbbreviatePath(fileName));

--- a/src/InconsistencyException.cpp
+++ b/src/InconsistencyException.cpp
@@ -1,7 +1,7 @@
 /*!
   @file InconsistencyException.cpp
   @brief Implements InconsistencyException
-  
+
 
   Created by Paul Licameli on 11/27/16.
 
@@ -25,11 +25,11 @@ TranslatableString InconsistencyException::ErrorMessage() const
 
 #ifdef __func__
    return
-XO("Internal error in %s at %s line %d.\nPlease inform the Audacity team at https://forum.audacityteam.org/.")
+XO("Internal error in %s at %s line %d.\nPlease inform the Tenacity team at https://tenacityaudio.org/#community-buttons.")
       .Format( func, path, line );
 #else
    return
-XO("Internal error at %s line %d.\nPlease inform the Audacity team at https://forum.audacityteam.org/.")
+XO("Internal error at %s line %d.\nPlease inform the Tenacity team at https://tenacityaudio.org/#community-buttons.")
       .Format( path, line );
 #endif
 }

--- a/src/LangChoice.cpp
+++ b/src/LangChoice.cpp
@@ -57,7 +57,7 @@ wxString ChooseLanguage(wxWindow *parent)
 
    /* i18n-hint: Title on a dialog indicating that this is the first
     * time Audacity has been run. */
-   LangChoiceDialog dlog(parent, -1, XO("Audacity First Run"));
+   LangChoiceDialog dlog(parent, -1, XO("Tenacity First Run"));
    dlog.CentreOnParent();
    dlog.ShowModal();
    returnVal = dlog.GetLang();
@@ -87,7 +87,7 @@ LangChoiceDialog::LangChoiceDialog(wxWindow * parent,
       S.StartHorizontalLay();
       {
          S.SetBorder(15);
-         mChoice = S.AddChoice(XXO("Choose Language for Audacity to use:"),
+         mChoice = S.AddChoice(XXO("Choose Language for Tenacity to use:"),
             mLangNames,
             lang);
       }

--- a/src/Legacy.cpp
+++ b/src/Legacy.cpp
@@ -304,7 +304,7 @@ bool ConvertLegacyProjectFile(const wxFileName &filename)
          XO(
 "Converted a 1.0 project file to the new format.\nThe old file has been saved as '%s'")
             .Format( xmlFile.GetBackupName() ),
-         XO("Opening Audacity Project"));
+         XO("Opening Tenacity Project"));
 
       return true;
    } );

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -33,7 +33,7 @@
    #include <Carbon/Carbon.h>
 #endif
 
-#define AudacityKaraokeTitle XO("Audacity Karaoke%s")
+#define AudacityKaraokeTitle XO("Tenacity Karaoke%s")
 
 enum {
    kID_RadioButton_BouncingBall = 10101,

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -62,7 +62,7 @@
 
 #include "commands/CommandManager.h"
 
-#define AudacityMixerBoardTitle XO("Audacity Mixer Board%s")
+#define AudacityMixerBoardTitle XO("Tenacity Mixer Board%s")
 
 // class MixerTrackSlider
 

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -11,7 +11,7 @@
 *******************************************************************//*!
 
 \file ModuleManager.cpp
-\brief Based on LoadLadspa, this code loads pluggable Audacity 
+\brief Based on LoadLadspa, this code loads pluggable Audacity
 extension modules.  It also has the code to
 invoke a function returning a replacement window,
 i.e. an alternative to the usual interface, for Audacity.
@@ -106,10 +106,10 @@ bool Module::Load(wxString &deferredErrorMessage)
    wxString moduleVersion = versionFn();
    if( moduleVersion != AUDACITY_VERSION_STRING) {
       AudacityMessageBox(
-         XO("The module \"%s\" is matched with Audacity version \"%s\".\n\nIt will not be loaded.")
+         XO("The module \"%s\" is matched with Tenacity version \"%s\".\n\nIt will not be loaded.")
             .Format(ShortName, moduleVersion),
          XO("Module Unsuitable"));
-      wxLogMessage(wxT("The module \"%s\" is matched with Audacity version \"%s\". It will not be loaded."), mName, moduleVersion);
+      wxLogMessage(wxT("The module \"%s\" is matched with Tenacity version \"%s\". It will not be loaded."), mName, moduleVersion);
       mLib->Unload();
       return false;
    }
@@ -120,7 +120,7 @@ bool Module::Load(wxString &deferredErrorMessage)
       return true;
    }
 
-   // However if we do have it and it does not work, 
+   // However if we do have it and it does not work,
    // then the module is bad.
    bool res = ((mDispatch(ModuleInitialize))!=0);
    if (res) {
@@ -291,7 +291,7 @@ void ModuleManager::TryLoadModules(
             XO("Yes"), XO("No"),
          };  // could add a button here for 'yes and remember that', and put it into the cfg file.  Needs more thought.
          int action;
-         action = ShowMultiDialog(msg, XO("Audacity Module Loader"),
+         action = ShowMultiDialog(msg, XO("Tenacity Module Loader"),
             buttons,
             "",
             XO("Try and load this module?"),
@@ -422,7 +422,7 @@ bool ModuleManager::DiscoverProviders()
    InitializeBuiltins();
 
 // The commented out code loads modules whether or not they are enabled.
-// none of our modules is a 'provider' of effects, so this code commented out. 
+// none of our modules is a 'provider' of effects, so this code commented out.
 #if 0
    FilePaths provList;
    FilePaths pathList;
@@ -468,7 +468,7 @@ void ModuleManager::InitializeBuiltins()
          ModuleInterface *pInterface = module.get();
          auto id = GetID(pInterface);
 
-         // Need to remember it 
+         // Need to remember it
          mDynModules[id] = std::move(module);
       }
       else
@@ -527,7 +527,7 @@ bool ModuleManager::IsProviderValid(const PluginID & WXUNUSED(providerID),
    // Builtin modules do not have a path
    if (path.empty())
    {
-      return true;  
+      return true;
    }
 
    wxFileName lib(path);

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -507,7 +507,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
             if (numberOfSelected > 0 && rateOfSelected != options.rate) {
                AudacityMessageBox(XO(
                   "Too few tracks are selected for recording at this sample rate.\n"
-                  "(Audacity requires two channels at the same sample rate for\n"
+                  "(Tenacity requires two channels at the same sample rate for\n"
                   "each stereo track)"),
                   XO("Too Few Compatible Tracks Selected"),
                   wxICON_ERROR | wxCENTRE);
@@ -521,7 +521,7 @@ void ProjectAudioManager::OnRecord(bool altAppearance)
             // If suitable tracks still not found, will record into NEW ones,
             // starting with t0
          }
-         
+
          // Whether we decided on NEW tracks or not:
          if (t1 <= selectedRegion.t0() && selectedRegion.t1() > selectedRegion.t0()) {
             t1 = selectedRegion.t1();   // record within the selection
@@ -904,7 +904,7 @@ void ProjectAudioManager::OnAudioIOStopRecording()
                ShowWarningDialog(&window, wxT("DropoutDetected"), XO("\
 Recorded audio was lost at the labeled locations. Possible causes:\n\
 \n\
-Other applications are competing with Audacity for processor time\n\
+Other applications are competing with Tenacity for processor time\n\
 \n\
 You are saving directly to a slow external storage device\n\
 "
@@ -1134,7 +1134,7 @@ static RegisteredMenuItemEnabler stopIfPaused{{
    }
 }};
 
-// GetSelectedProperties collects information about 
+// GetSelectedProperties collects information about
 // currently selected audio tracks
 PropertiesOfSelected
 GetPropertiesOfSelected(const AudacityProject &proj)
@@ -1144,10 +1144,10 @@ GetPropertiesOfSelected(const AudacityProject &proj)
    PropertiesOfSelected result;
    result.allSameRate = true;
 
-   const auto selectedTracks{ 
+   const auto selectedTracks{
       TrackList::Get(proj).Selected< const WaveTrack >() };
 
-   for (const auto & track : selectedTracks) 
+   for (const auto & track : selectedTracks)
    {
       if (rateOfSelection != RATE_NOT_SELECTED &&
          track->GetRate() != rateOfSelection)

--- a/src/ProjectFSCK.cpp
+++ b/src/ProjectFSCK.cpp
@@ -62,8 +62,8 @@ int ProjectFSCK(
          XO("Continue with repairs noted in log, and check for more errors. This will save the project in its current state, unless you \"Close project immediately\" on further error alerts.")
       };
       wxLog::FlushActive(); // MultiDialog has "Show Log..." button, so make sure log is current.
-      action = ShowMultiDialog(msg, 
-         XO("Warning - Problems Reading Sequence Tags"), 
+      action = ShowMultiDialog(msg,
+         XO("Warning - Problems Reading Sequence Tags"),
          buttons,"");
       if (action == 0)
          nResult = FSCKstatus_CLOSE_REQ;
@@ -101,7 +101,7 @@ int ProjectFSCK(
          auto msg =
 XO("Project check of \"%s\" folder \
 \ndetected %lld missing external audio file(s) \
-\n('aliased files'). There is no way for Audacity \
+\n('aliased files'). There is no way for Tenacity \
 \nto recover these files automatically. \
 \n\nIf you choose the first or second option below, \
 \nyou can try to find and restore the missing files \
@@ -120,8 +120,8 @@ XO("Project check of \"%s\" folder \
             XO("Replace missing audio with silence (permanent immediately)."),
          };
          wxLog::FlushActive(); // MultiDialog has "Show Log..." button, so make sure log is current.
-         action = ShowMultiDialog(msg, 
-            XO("Warning - Missing Aliased File(s)"), 
+         action = ShowMultiDialog(msg,
+            XO("Warning - Missing Aliased File(s)"),
             buttons,
             "");
       }
@@ -191,7 +191,7 @@ XO("Project check of \"%s\" folder \
          auto msg =
 XO("Project check of \"%s\" folder \
 \ndetected %lld missing alias (.auf) blockfile(s). \
-\nAudacity can fully regenerate these files \
+\nTenacity can fully regenerate these files \
 \nfrom the current audio in the project.")
             .Format(
                dm.GetProjectName(), (long long) missingAUFHash.size() );
@@ -201,8 +201,8 @@ XO("Project check of \"%s\" folder \
             XO("Close project immediately with no further changes"),
          };
          wxLog::FlushActive(); // MultiDialog has "Show Log..." button, so make sure log is current.
-         action = ShowMultiDialog(msg, 
-            XO("Warning - Missing Alias Summary File(s)"), 
+         action = ShowMultiDialog(msg,
+            XO("Warning - Missing Alias Summary File(s)"),
             buttons,
             "");
       }
@@ -262,7 +262,7 @@ XO("Project check of \"%s\" folder \
 XO("Project check of \"%s\" folder \
 \ndetected %lld missing audio data (.au) blockfile(s), \
 \nprobably due to a bug, system crash, or accidental \
-\ndeletion. There is no way for Audacity to recover \
+\ndeletion. There is no way for Tenacity to recover \
 \nthese missing files automatically. \
 \n\nIf you choose the first or second option below, \
 \nyou can try to find and restore the missing files \
@@ -277,9 +277,9 @@ XO("Project check of \"%s\" folder \
             XO("Replace missing audio with silence (permanent immediately)"),
          };
          wxLog::FlushActive(); // MultiDialog has "Show Log..." button, so make sure log is current.
-         action = ShowMultiDialog(msg, 
-            XO("Warning - Missing Audio Data Block File(s)"), 
-            buttons, 
+         action = ShowMultiDialog(msg,
+            XO("Warning - Missing Audio Data Block File(s)"),
+            buttons,
             "Warning_-_Missing_Audio_Data_Block_Files");
       }
 
@@ -352,8 +352,8 @@ other projects. \
             XO("Delete orphan files (permanent immediately)"),
          };
          wxLog::FlushActive(); // MultiDialog has "Show Log..." button, so make sure log is current.
-         action = ShowMultiDialog(msg, 
-            XO("Warning - Orphan Block File(s)"), 
+         action = ShowMultiDialog(msg,
+            XO("Warning - Orphan Block File(s)"),
             buttons,
             "Warning_-_Orphan_Block_Files"
          );

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -79,10 +79,10 @@ static const int ProjectFileVersion = PACK(3, 0, 0, 0);
 
 // Navigation:
 //
-// Bindings are marked out in the code by, e.g. 
+// Bindings are marked out in the code by, e.g.
 // BIND SQL sampleblocks
 // A search for "BIND SQL" will find all bindings.
-// A search for "SQL sampleblocks" will find all SQL related 
+// A search for "SQL sampleblocks" will find all SQL related
 // to sampleblocks.
 
 static const char *ProjectFileSchema =
@@ -103,7 +103,7 @@ static const char *ProjectFileSchema =
    // This is all opaque to SQLite.  It just sees two
    // big binary blobs.
    // There is no limit to document blob size.
-   // dict will be smallish, with an entry for each 
+   // dict will be smallish, with an entry for each
    // kind of field.
    "CREATE TABLE IF NOT EXISTS <schema>.project"
    "("
@@ -123,7 +123,7 @@ static const char *ProjectFileSchema =
    // This is all opaque to SQLite.  It just sees two
    // big binary blobs.
    // There is no limit to document blob size.
-   // dict will be smallish, with an entry for each 
+   // dict will be smallish, with an entry for each
    // kind of field.
    "CREATE TABLE IF NOT EXISTS <schema>.autosave"
    "("
@@ -137,7 +137,7 @@ static const char *ProjectFileSchema =
    // The blocks may be partially empty.
    // The quantity of valid data in the blocks is
    // provided in the project blob.
-   // 
+   //
    // sampleformat specifies the format of the samples stored.
    //
    // blockID is a 64 bit number.
@@ -247,7 +247,7 @@ TitleRestorer::TitleRestorer(
          sProjNumber.Printf(
             _("[Project %02i] "), project.GetProjectNumber() + 1 );
          RefreshAllTitles( true );
-      } 
+      }
    }
    else
       UnnamedCount = 0;
@@ -642,7 +642,7 @@ bool ProjectFileIO::CheckVersion()
    // It's a database that SQLite recognizes, but it's not one of ours
    if (wxStrtoul<char **>(result, nullptr, 10) != ProjectFileID)
    {
-      SetError(XO("This is not an Audacity project file"));
+      SetError(XO("This is not an Tenacity project file"));
       return false;
    }
 
@@ -659,11 +659,11 @@ bool ProjectFileIO::CheckVersion()
    if (version > ProjectFileVersion)
    {
       SetError(
-         XO("This project was created with a newer version of Audacity.\n\nYou will need to upgrade to open it.")
+         XO("This project was created with a newer version of Tenacity.\n\nYou will need to upgrade to open it.")
       );
       return false;
    }
-   
+
    // Project file is older than ours, ask the user if it's okay to
    // upgrade.
    if (version < ProjectFileVersion)
@@ -868,7 +868,7 @@ bool ProjectFileIO::CopyTo(const FilePath &destpath,
       }
    });
 
-   // Attach the destination database 
+   // Attach the destination database
    wxString sql;
    wxString dbName = destpath;
    // Bug 2793: Quotes in name need escaping for sqlite3.
@@ -1036,7 +1036,7 @@ bool ProjectFileIO::ShouldCompact(const std::vector<const TrackList *> &tracks)
    // Get the number of blocks and total length from the project file.
    unsigned long long total = GetTotalUsage();
    unsigned long long blockcount = 0;
-   
+
    auto cb = [&blockcount](int cols, char **vals, char **)
    {
       // Convert
@@ -1151,7 +1151,7 @@ bool ProjectFileIO::RenameOrWarn(const FilePath &src, const FilePath &dst)
       ShowError(
          &window,
          XO("Error Writing to File"),
-         XO("Audacity failed to write file %s.\n"
+         XO("Tenacity failed to write file %s.\n"
             "Perhaps disk is full or not writable.\n"
             "For tips on freeing up space, click the help button.")
             .Format(dst),
@@ -1275,7 +1275,7 @@ void ProjectFileIO::Compact(
             // PRL:  not clear what to do if the following fails, but the worst should
             // be, the project may reopen in its present state as a recovery file, not
             // at the last saved state.
-            // REVIEW: Could the autosave file be corrupt though at that point, and so 
+            // REVIEW: Could the autosave file be corrupt though at that point, and so
             // prevent recovery?
             // LLL: I believe Paul is correct since it's deleted with a single SQLite
             // transaction. The next time the file opens will just invoke recovery.
@@ -1418,7 +1418,7 @@ void ProjectFileIO::SetProjectTitle(int number)
    {
       name =
       /* i18n-hint: The %02i is the project number. This is followed by the project name in quotes as a %s.*/
-      XO("[Project %02i] Audacity \"%s\"")
+      XO("[Project %02i] Tenacity \"%s\"")
          .Format( number + 1,
                  name.empty() ? XO("<untitled>") : Verbatim((const char *)name))
          .Translation();
@@ -1426,7 +1426,7 @@ void ProjectFileIO::SetProjectTitle(int number)
    // If we are not showing numbers, then <untitled> shows as 'Audacity'.
    else if (name.empty())
    {
-      name = XO("Audacity").Translation();
+      name = XO("Tenacity").Translation();
    }
 
    if (mRecovered)
@@ -1591,13 +1591,13 @@ bool ProjectFileIO::HandleXMLTag(const wxChar *tag, const wxChar **attrs)
    if (codeVer<fileVer)
    {
       /* i18n-hint: %s will be replaced by the version number.*/
-      auto msg = XO("This file was saved using Audacity %s.\nYou are using Audacity %s. You may need to upgrade to a newer version to open this file.")
+      auto msg = XO("This file was saved using Tenacity %s.\nYou are using Tenacity %s. You may need to upgrade to a newer version to open this file.")
          .Format(audacityVersion, AUDACITY_VERSION_STRING);
 
       ShowError(
          &window,
          XO("Can't open project file"),
-         msg, 
+         msg,
          "FAQ:Errors_opening_an_Audacity_project"
          );
 
@@ -1834,7 +1834,7 @@ bool ProjectFileIO::LoadProject(const FilePath &fileName, bool ignoreAutosave)
       // Error already set
       return false;
    }
- 
+
    // If we didn't have an autosave doc, load the project doc instead
    if (buffer.GetDataLen() == 0)
    {
@@ -1878,7 +1878,7 @@ bool ProjectFileIO::LoadProject(const FilePath &fileName, bool ignoreAutosave)
       }
 
       // Check for orphans blocks...sets mRecovered if any were deleted
-      
+
       auto blockids = WaveTrackFactory::Get( mProject )
          .GetSampleBlockFactory()
             ->GetActiveBlockIDs();
@@ -1890,7 +1890,7 @@ bool ProjectFileIO::LoadProject(const FilePath &fileName, bool ignoreAutosave)
             return false;
          }
       }
-   
+
       // Remember if we used autosave or not
       if (usedAutosave)
       {
@@ -1945,7 +1945,7 @@ bool ProjectFileIO::UpdateSaved(const TrackList *tracks)
    return true;
 }
 
-// REVIEW: This function is believed to report an error to the user in all cases 
+// REVIEW: This function is believed to report an error to the user in all cases
 // of failure.  Callers are believed not to need to do so if they receive 'false'.
 // LLL: All failures checks should now be displaying an error.
 bool ProjectFileIO::SaveProject(
@@ -2125,7 +2125,7 @@ bool ProjectFileIO::SaveProject(
       // saved database below.
       CloseProject();
 
-      // And make it the active project file 
+      // And make it the active project file
       UseConnection(std::move(newConn), fileName);
    }
    else

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -152,7 +152,7 @@ auto ProjectFileManager::ReadProjectFile(
    /// Parse project file
    ///
    bool bParseSuccess = projectFileIO.LoadProject(fileName, discardAutosave);
-   
+
    bool err = false;
 
    if (bParseSuccess)
@@ -172,9 +172,9 @@ auto ProjectFileManager::ReadProjectFile(
 
          AudacityMessageBox(
             resaved
-               ? XO("This project was not saved properly the last time Audacity ran.\n\n"
+               ? XO("This project was not saved properly the last time Tenacity ran.\n\n"
                     "It has been recovered to the last snapshot.")
-               : XO("This project was not saved properly the last time Audacity ran.\n\n"
+               : XO("This project was not saved properly the last time Tenacity ran.\n\n"
                     "It has been recovered to the last snapshot, but you must save it\n"
                     "to preserve its contents."),
             XO("Project Recovered"),
@@ -436,7 +436,7 @@ bool ProjectFileManager::SaveAs(bool allowOverwrite /* = false */)
    TranslatableString title = XO("%sSave Project \"%s\" As...")
       .Format( Restorer.sProjNumber, Restorer.sProjName );
    TranslatableString message = XO("\
-'Save Project' is for an Audacity project, not an audio file.\n\
+'Save Project' is for an Tenacity project, not an audio file.\n\
 For an audio file that will open in other apps, use 'Export'.\n");
 
    if (ShowWarningDialog(&window, wxT("FirstProjectSave"), message, true) != wxID_OK) {
@@ -588,7 +588,7 @@ bool ProjectFileManager::SaveCopy(const FilePath &fileName /* = wxT("") */)
       {
          // JKC: I removed 'wxFD_OVERWRITE_PROMPT' because we are checking
          // for overwrite ourselves later, and we disallow it.
-         // Previously we disallowed overwrite because we would have had 
+         // Previously we disallowed overwrite because we would have had
          // to DELETE the many smaller files too, or prompt to move them.
          // Maybe we could allow it now that we have aup3 format?
          fName = FileNames::SelectFile(FileNames::Operation::Export,
@@ -751,7 +751,7 @@ void ProjectFileManager::CompactProjectOnClose()
          // without save.  Don't leave the document blob from the last
          // push of undo history, when that undo state may get purged
          // with deletion of some new sample blocks.
-         // REVIEW: UpdateSaved() might fail too.  Do we need to test 
+         // REVIEW: UpdateSaved() might fail too.  Do we need to test
          // for that and report it?
          projectFileIO.UpdateSaved( mLastSavedTracks.get() );
       }
@@ -777,9 +777,9 @@ bool ProjectFileManager::OpenNewProject()
       ShowExceptionDialog(
          nullptr,
          XO("Can't open new empty project"),
-         XO("Error opening a new empty project"), 
+         XO("Error opening a new empty project"),
          "FAQ:Errors_opening_a_new_empty_project",
-         true, 
+         true,
          audacity::ToWString(projectFileIO.GetLastLog()));
    }
    return bOK;
@@ -891,7 +891,7 @@ AudacityProject *ProjectFileManager::OpenFile( const ProjectChooserFn &chooser,
    {
       AudacityMessageBox(
          XO(
-"You are trying to open an automatically created backup file.\nDoing this may result in severe data loss.\n\nPlease open the actual Audacity project file instead."),
+"You are trying to open an automatically created backup file.\nDoing this may result in severe data loss.\n\nPlease open the actual Tenacity project file instead."),
          XO("Warning - Backup File Detected"),
          wxOK | wxCENTRE,
          nullptr);
@@ -1088,7 +1088,7 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
    double newRate = 0;
    wxString trackNameBase = fn.GetName();
    int i = -1;
-   
+
    // Fix the bug 2109.
    // In case the project had soloed tracks before importing,
    // all newly imported tracks are muted.
@@ -1116,7 +1116,7 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
       tracks.MakeMultiChannelTrack(*first, nChannels, true);
    }
    newTracks.clear();
-      
+
    // Now name them
 
    // Add numbers to track names only if there is more than one (mono or stereo)

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -513,7 +513,7 @@ void InitProjectWindow( ProjectWindow &window )
 #endif
 
    window.UpdateStatusWidths();
-   auto msg = XO("Welcome to Audacity version %s")
+   auto msg = XO("Welcome to Tenacity version %s")
       .Format( AUDACITY_VERSION_STRING );
    ProjectManager::Get( project ).SetStatusText( msg, mainStatusBarField );
 
@@ -528,7 +528,7 @@ AudacityProject *ProjectManager::New()
    bool bMaximized = false;
    bool bIconized = false;
    GetNextWindowPlacement(&wndRect, &bMaximized, &bIconized);
-   
+
    // Create and show a NEW project
    // Use a non-default deleter in the smart pointer!
    auto sp = std::make_shared< AudacityProject >();
@@ -550,10 +550,10 @@ AudacityProject *ProjectManager::New()
    projectFileManager.OpenNewProject();
 
    MenuManager::Get( project ).CreateMenusAndCommands( project );
-   
+
    projectHistory.InitialState();
    projectManager.RestartTimer();
-   
+
    if(bMaximized) {
       window.Maximize(true);
    }
@@ -561,7 +561,7 @@ AudacityProject *ProjectManager::New()
       // if the user close down and iconized state we could start back up and iconized state
       // window.Iconize(TRUE);
    }
-   
+
    //Initialise the Listeners
    auto gAudioIO = AudioIO::Get();
    gAudioIO->SetListener(
@@ -572,27 +572,27 @@ AudacityProject *ProjectManager::New()
    SpectralSelectionBar::Get( project ).SetListener( &projectSelectionManager );
 #endif
    TimeToolBar::Get( project ).SetListener( &projectSelectionManager );
-   
+
 #if wxUSE_DRAG_AND_DROP
    // We can import now, so become a drag target
    //   SetDropTarget(safenew AudacityDropTarget(this));
    //   mTrackPanel->SetDropTarget(safenew AudacityDropTarget(this));
-   
+
    // SetDropTarget takes ownership
    TrackPanel::Get( project ).SetDropTarget( safenew DropTarget( &project ) );
 #endif
-   
+
    //Set the NEW project as active:
    SetActiveProject(p);
-   
+
    // Okay, GetActiveProject() is ready. Now we can get its CommandManager,
    // and add the shortcut keys to the tooltips.
    ToolManager::Get( *p ).RegenerateTooltips();
-   
+
    ModuleManager::Get().Dispatch(ProjectInitialized);
-   
+
    window.Show(true);
-   
+
    return p;
 }
 
@@ -657,8 +657,8 @@ void ProjectManager::OnCloseWindow(wxCloseEvent & event)
 
    // We may not bother to prompt the user to save, if the
    // project is now empty.
-   if (!sbSkipPromptingForSave 
-      && event.CanVeto() 
+   if (!sbSkipPromptingForSave
+      && event.CanVeto()
       && (settings.EmptyCanBeDirty() || bHasTracks)) {
       if ( UndoManager::Get( project ).UnsavedChanges() ) {
          TitleRestorer Restorer( window, project );// RAII
@@ -1031,7 +1031,7 @@ void ProjectManager::OnStatusChange( wxCommandEvent &evt )
    auto field = static_cast<StatusBarField>( evt.GetInt() );
    const auto &msg = ProjectStatus::Get( project ).Get( field );
    SetStatusText( msg, field );
-   
+
    if ( field == mainStatusBarField )
       // When recording, let the NEW status message stay at least as long as
       // the timer interval (if it is not replaced again by this function),
@@ -1089,7 +1089,7 @@ int ProjectManager::GetEstimatedRecordingMinsLeftOnDisk(long lCaptureChannels) {
    double dRecTime = 0.0;
    double bytesOnDiskPerSample = SAMPLE_SIZE_DISK(oCaptureFormat);
    dRecTime = lFreeSpace.GetHi() * 4294967296.0 + lFreeSpace.GetLo();
-   dRecTime /= bytesOnDiskPerSample;   
+   dRecTime /= bytesOnDiskPerSample;
    dRecTime /= lCaptureChannels;
    dRecTime /= ProjectSettings::Get( project ).GetRate();
 

--- a/src/SplashDialog.cpp
+++ b/src/SplashDialog.cpp
@@ -71,7 +71,7 @@ void SplashDialog::DoHelpWelcome( AudacityProject &project )
 }
 
 SplashDialog::SplashDialog(wxWindow * parent)
-   :  wxDialogWrapper(parent, -1, XO("Welcome to Audacity!"),
+   :  wxDialogWrapper(parent, -1, XO("Welcome to Tenacity!"),
       wxPoint( -1, 60 ), // default x position, y position 60 pixels from top of screen.
       wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
@@ -107,9 +107,9 @@ void SplashDialog::Populate( ShuttleGui & S )
    // It also makes it easier to revert to full size if we decide to.
    const float fScale=0.5f;// smaller size.
    wxImage RescaledImage( m_pLogo->ConvertToImage() );
-   wxColour MainColour( 
-      RescaledImage.GetRed(1,1), 
-      RescaledImage.GetGreen(1,1), 
+   wxColour MainColour(
+      RescaledImage.GetRed(1,1),
+      RescaledImage.GetGreen(1,1),
       RescaledImage.GetBlue(1,1));
    this->SetBackgroundColour(MainColour);
 

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -54,7 +54,7 @@ and use it for toolbar and window layouts too.
 *//*****************************************************************//**
 
 \class auStaticText
-\brief is like wxStaticText, except it can be themed.  wxStaticText 
+\brief is like wxStaticText, except it can be themed.  wxStaticText
 can't be.
 
 *//*****************************************************************/
@@ -311,8 +311,8 @@ void ThemeBase::LoadTheme( teThemeType Theme )
    int TextColourDifference =  ColourDistance( CurrentText, DesiredText );
 
    bIsUsingSystemTextColour = ( TextColourDifference == 0 );
-   // Theming is very accepting of alternative text colours.  They just need to 
-   // have decent contrast to the background colour, if we're blending themes. 
+   // Theming is very accepting of alternative text colours.  They just need to
+   // have decent contrast to the background colour, if we're blending themes.
    if( !bIsUsingSystemTextColour ){
       int ContrastLevel        =  ColourDistance( Back, DesiredText );
       bIsUsingSystemTextColour = bRecolourOnLoad && (ContrastLevel > 250);
@@ -336,7 +336,7 @@ void ThemeBase::RecolourBitmap( int iIndex, wxColour From, wxColour To )
 }
 
 int ThemeBase::ColourDistance( wxColour & From, wxColour & To ){
-   return 
+   return
       abs( From.Red() - To.Red() )
       + abs( From.Green() - To.Green() )
       + abs( From.Blue() - To.Blue() );
@@ -415,7 +415,7 @@ wxImage ThemeBase::MaskedImage( char const ** pXpm, char const ** pMask )
 
 // Legacy function to allow use of an XPM where no theme image was defined.
 // Bit depth and mask needs review.
-// Note that XPMs don't offer translucency, so unsuitable for a round shape overlay, 
+// Note that XPMs don't offer translucency, so unsuitable for a round shape overlay,
 // for example.
 void ThemeBase::RegisterImage( int &iIndex, char const ** pXpm, const wxString & Name )
 {
@@ -657,8 +657,8 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
          mFlow.GetNextPosition( SrcImage.GetWidth(), SrcImage.GetHeight());
          ImageCache.SetRGB( mFlow.Rect(), 0xf2, 0xb0, 0x27 );
          if( (mFlow.mFlags & resFlagSkip) == 0 )
-            PasteSubImage( &ImageCache, &SrcImage, 
-               mFlow.mxPos + mFlow.mBorderWidth, 
+            PasteSubImage( &ImageCache, &SrcImage,
+               mFlow.mxPos + mFlow.mBorderWidth,
                mFlow.myPos + mFlow.mBorderWidth);
          else
             ImageCache.SetRGB( mFlow.RectInner(), 1,1,1);
@@ -739,7 +739,7 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
 #if 0
       // Deliberate policy to use the fast/cheap blocky pixel-multiplication
       // algorithm, as this introduces no artifacts on repeated scale up/down.
-      ImageCache.Rescale( 
+      ImageCache.Rescale(
          ImageCache.GetWidth()*4,
          ImageCache.GetHeight()*4,
          wxIMAGE_QUALITY_NEAREST );
@@ -747,7 +747,7 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
       if( !ImageCache.SaveFile( FileName, wxBITMAP_TYPE_PNG ))
       {
          AudacityMessageBox(
-            XO("Audacity could not write file:\n  %s.")
+            XO("Tenacity could not write file:\n  %s.")
                .Format( FileName ));
          return;
       }
@@ -767,14 +767,14 @@ void ThemeBase::CreateImageCache( bool bBinarySave )
       if( !OutStream.OpenFile( FileName ))
       {
          AudacityMessageBox(
-            XO("Audacity could not open file:\n  %s\nfor writing.")
+            XO("Tenacity could not open file:\n  %s\nfor writing.")
                .Format( FileName ));
          return;
       }
       if( !ImageCache.SaveFile(OutStream, wxBITMAP_TYPE_PNG ) )
       {
          AudacityMessageBox(
-            XO("Audacity could not write images to file:\n  %s.")
+            XO("Tenacity could not write images to file:\n  %s.")
                .Format( FileName ));
          return;
       }
@@ -934,7 +934,7 @@ bool ThemeBase::ReadImageCache( teThemeType type, bool bOkIfNotFound)
          if( bOkIfNotFound )
             return false; // did not load the images, so return false.
          AudacityMessageBox(
-            XO("Audacity could not find file:\n  %s.\nTheme not loaded.")
+            XO("Tenacity could not find file:\n  %s.\nTheme not loaded.")
                .Format( FileName ));
          return false;
       }
@@ -942,7 +942,7 @@ bool ThemeBase::ReadImageCache( teThemeType type, bool bOkIfNotFound)
       {
          AudacityMessageBox(
             /* i18n-hint: Do not translate png.  It is the name of a file format.*/
-            XO("Audacity could not load file:\n  %s.\nBad png format perhaps?")
+            XO("Tenacity could not load file:\n  %s.\nBad png format perhaps?")
                .Format( FileName ));
          return false;
       }
@@ -953,20 +953,20 @@ bool ThemeBase::ReadImageCache( teThemeType type, bool bOkIfNotFound)
       size_t ImageSize = 0;
       const unsigned char * pImage = nullptr;
       switch( type ){
-         default: 
-         case themeClassic : 
+         default:
+         case themeClassic :
             ImageSize = sizeof(ClassicImageCacheAsData);
             pImage = ClassicImageCacheAsData;
             break;
-         case themeLight : 
+         case themeLight :
             ImageSize = sizeof(LightImageCacheAsData);
             pImage = LightImageCacheAsData;
             break;
-         case themeDark : 
+         case themeDark :
             ImageSize = sizeof(DarkImageCacheAsData);
             pImage = DarkImageCacheAsData;
             break;
-         case themeHiContrast : 
+         case themeHiContrast :
             ImageSize = sizeof(HiContrastImageCacheAsData);
             pImage = HiContrastImageCacheAsData;
             break;
@@ -982,7 +982,7 @@ bool ThemeBase::ReadImageCache( teThemeType type, bool bOkIfNotFound)
          // Or some experiment is being tried with NEW formats for it.
          AudacityMessageBox(
             XO(
-"Audacity could not read its default theme.\nPlease report the problem."));
+"Tenacity could not read its default theme.\nPlease report the problem."));
          return false;
       }
       //wxLogDebug("Read %i by %i", ImageCache.GetWidth(), ImageCache.GetHeight() );
@@ -1067,7 +1067,7 @@ void ThemeBase::LoadComponents( bool bOkIfNotFound )
                AudacityMessageBox(
                   XO(
                /* i18n-hint: Do not translate png.  It is the name of a file format.*/
-"Audacity could not load file:\n  %s.\nBad png format perhaps?")
+"Tenacity could not load file:\n  %s.\nBad png format perhaps?")
                      .Format( FileName ));
                return;
             }
@@ -1158,7 +1158,7 @@ void ThemeBase::SaveComponents()
          if( !mImages[i].SaveFile( FileName, wxBITMAP_TYPE_PNG ))
          {
             AudacityMessageBox(
-               XO("Audacity could not save file:\n  %s")
+               XO("Tenacity could not save file:\n  %s")
                   .Format( FileName ));
             return;
          }
@@ -1263,7 +1263,7 @@ BEGIN_EVENT_TABLE(auStaticText, wxWindow)
     EVT_ERASE_BACKGROUND(auStaticText::OnErase)
 END_EVENT_TABLE()
 
- 
+
 auStaticText::auStaticText(wxWindow* parent, wxString textIn) :
  wxWindow(parent, wxID_ANY)
 {
@@ -1283,7 +1283,7 @@ auStaticText::auStaticText(wxWindow* parent, wxString textIn) :
    SetName(textIn);
    SetLabel(textIn);
 }
- 
+
 void auStaticText::OnPaint(wxPaintEvent & WXUNUSED(evt))
 {
    wxPaintDC dc(this);

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -152,7 +152,7 @@ END_EVENT_TABLE()
 
 TimerRecordDialog::TimerRecordDialog(
    wxWindow* parent, AudacityProject &project, bool bAlreadySaved)
-: wxDialogWrapper(parent, -1, XO("Audacity Timer Record"), wxDefaultPosition,
+: wxDialogWrapper(parent, -1, XO("Tenacity Timer Record"), wxDefaultPosition,
            wxDefaultSize, wxCAPTION)
 , mProject{ project }
 {
@@ -403,7 +403,7 @@ void TimerRecordDialog::OnOK(wxCommandEvent& WXUNUSED(event))
    // complete this Timer Recording.
    // If we dont think there is enough space then ask the user
    // if they want to continue.
-   // We don't stop the user from starting the recording 
+   // We don't stop the user from starting the recording
    // as its possible that they plan to free up some
    // space before the recording begins
    auto &projectManager = ProjectManager::Get( mProject );
@@ -519,7 +519,7 @@ int TimerRecordDialog::RunWaitDialog()
 
       TimerProgressDialog
          progress(m_TimeSpan_Duration.GetMilliseconds().GetValue(),
-                  XO("Audacity Timer Record Progress"),
+                  XO("Tenacity Timer Record Progress"),
                   columns,
                   pdlgHideCancelButton | pdlgConfirmStopCancel);
 
@@ -548,8 +548,8 @@ int TimerRecordDialog::RunWaitDialog()
 }
 
 int TimerRecordDialog::ExecutePostRecordActions(bool bWasStopped) {
-   // MY: We no longer automatically (and silently) call ->Save() when the 
-   // timer recording is completed.  We can now Save and/or Export depending 
+   // MY: We no longer automatically (and silently) call ->Save() when the
+   // timer recording is completed.  We can now Save and/or Export depending
    // on the options selected by the user.
    // Once completed, we can also close Audacity, restart the system or
    // shutdown the system.
@@ -789,7 +789,7 @@ void TimerRecordDialog::PopulateOrExchange(ShuttleGui& S)
                ID_DATEPICKER_END, // wxWindowID id,
                m_DateTime_End); // const wxDateTime& dt = wxDefaultDateTime,
             // const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
-            //                            long style = wxDP_DEFAULT | wxDP_SHOWCENTURY, 
+            //                            long style = wxDP_DEFAULT | wxDP_SHOWCENTURY,
             //                            const wxValidator& validator = wxDefaultValidator,
             //                            const wxString& name = "datectrl")
             m_pDatePickerCtrl_End->SetRange(m_DateTime_Start, wxInvalidDateTime); // No backdating.
@@ -888,7 +888,7 @@ void TimerRecordDialog::PopulateOrExchange(ShuttleGui& S)
                m_pTimerAfterCompleteChoiceCtrl = S.AddChoice(XXO("After Recording completes:"),
                      {
                         XO("Do nothing") ,
-                        XO("Exit Audacity") ,
+                        XO("Exit Tenacity") ,
                   #ifdef __WINDOWS__
                         XO("Restart system") ,
                         XO("Shutdown system") ,
@@ -972,13 +972,13 @@ void TimerRecordDialog::UpdateEnd()
 {
    //v Use remaining disk -> record time calcs from AudacityProject::OnTimer to set range?
    m_DateTime_End = m_DateTime_Start + m_TimeSpan_Duration;
-   //wxLogDebug( "Time start %s end %s", 
+   //wxLogDebug( "Time start %s end %s",
    //   m_DateTime_Start.FormatISOCombined(' '),
    //   m_DateTime_End.FormatISOCombined(' ') );
 
    // Disable the range limitation (to fix Bug 1749 and 1978)
    // Otherwise SetVallue asserts when going back in time.
-   m_pDatePickerCtrl_End->SetRange(wxInvalidDateTime, wxInvalidDateTime); 
+   m_pDatePickerCtrl_End->SetRange(wxInvalidDateTime, wxInvalidDateTime);
    m_pDatePickerCtrl_End->SetValue(m_DateTime_End);
    // Re-enable range limitation to constrain user input.
    m_pDatePickerCtrl_End->SetRange(m_DateTime_Start, wxInvalidDateTime); // No backdating.
@@ -1017,7 +1017,7 @@ ProgressResult TimerRecordDialog::WaitForStart()
    wxDateTime startWait_DateTime = wxDateTime::UNow();
    wxTimeSpan waitDuration = m_DateTime_Start - startWait_DateTime;
    TimerProgressDialog progress(waitDuration.GetMilliseconds().GetValue(),
-      XO("Audacity Timer Record - Waiting for Start"),
+      XO("Tenacity Timer Record - Waiting for Start"),
       columns,
       pdlgHideStopButton | pdlgConfirmStopCancel | pdlgHideElapsedTime,
       /* i18n-hint: "in" means after a duration of time,
@@ -1069,7 +1069,7 @@ ProgressResult TimerRecordDialog::PreActionDelay(int iActionIndex, TimerRecordCo
    wxDateTime dtActionTime = dtNow.Add(tsWait);
 
    TimerProgressDialog dlgAction(tsWait.GetMilliseconds().GetValue(),
-                          XO("Audacity Timer Record - Waiting"),
+                          XO("Tenacity Timer Record - Waiting"),
                           columns,
                           pdlgHideStopButton | pdlgHideElapsedTime,
                           sCountdownLabel);

--- a/src/commands/AudacityCommand.cpp
+++ b/src/commands/AudacityCommand.cpp
@@ -14,7 +14,7 @@
 *//****************************************************************//**
 
 \class AudacityCommandDialog
-\brief Default dialog used for commands.  Is populated using 
+\brief Default dialog used for commands.  Is populated using
 ShuttleGui.
 
 *//*******************************************************************/
@@ -82,7 +82,7 @@ AudacityCommand::~AudacityCommand()
 
 
 PluginPath AudacityCommand::GetPath(){        return BUILTIN_GENERIC_COMMAND_PREFIX + GetSymbol().Internal(); }
-VendorSymbol AudacityCommand::GetVendor(){      return XO("Audacity");}
+VendorSymbol AudacityCommand::GetVendor(){      return XO("Tenacity");}
 wxString AudacityCommand::GetVersion(){     return AUDACITY_VERSION_STRING;}
 
 
@@ -105,7 +105,7 @@ bool AudacityCommand::ShowInterface(wxWindow *parent, bool WXUNUSED(forceModal))
 
    // mUIDialog is null
    auto cleanup = valueRestorer( mUIDialog );
-   
+
    mUIDialog = CreateUI(parent, this);
    if (!mUIDialog)
       return false;
@@ -189,7 +189,7 @@ bool AudacityCommand::DoAudacityCommand(wxWindow *parent,
       return false;
    }
 
-   // Prompting will be bypassed when applying a command that has already 
+   // Prompting will be bypassed when applying a command that has already
    // been configured, e.g. repeating the last effect on a different selection.
    // Prompting may call AudacityCommand::Preview
    if (shouldPrompt && /*IsInteractive() && */!PromptUser(parent))

--- a/src/commands/LoadCommands.cpp
+++ b/src/commands/LoadCommands.cpp
@@ -94,7 +94,7 @@ ComponentInterfaceSymbol BuiltinCommandsModule::GetSymbol()
 
 VendorSymbol BuiltinCommandsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString BuiltinCommandsModule::GetVersion()
@@ -105,7 +105,7 @@ wxString BuiltinCommandsModule::GetVersion()
 
 TranslatableString BuiltinCommandsModule::GetDescription()
 {
-   return XO("Provides builtin commands to Audacity");
+   return XO("Provides builtin commands to Tenacity");
 }
 
 // ============================================================================

--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -166,7 +166,7 @@ VendorSymbol Effect::GetVendor()
       return mClient->GetVendor();
    }
 
-   return XO("Audacity");
+   return XO("Tenacity");
 }
 
 wxString Effect::GetVersion()
@@ -499,7 +499,7 @@ bool Effect::ShowInterface(wxWindow &parent,
 
    // mUIDialog is null
    auto cleanup = valueRestorer( mUIDialog );
-   
+
    if ( factory )
       mUIDialog = factory(parent, this, this);
    if (!mUIDialog)
@@ -748,7 +748,7 @@ void Effect::ImportPresets()
          if (ident != commandId) {
             // effect identifiers are a sensible length!
             // must also have some params.
-            if ((params.Length() < 2 ) || (ident.Length() < 2) || (ident.Length() > 30)) 
+            if ((params.Length() < 2 ) || (ident.Length() < 2) || (ident.Length() > 30))
             {
                Effect::MessageBox(
                   /* i18n-hint %s will be replaced by a file name */

--- a/src/effects/LoadEffects.cpp
+++ b/src/effects/LoadEffects.cpp
@@ -8,7 +8,7 @@
 
 **************************************************************************//**
 \class BuiltinEffectsModule
-\brief Internal module to auto register all built in effects.  
+\brief Internal module to auto register all built in effects.
 *****************************************************************************/
 
 
@@ -92,7 +92,7 @@ ComponentInterfaceSymbol BuiltinEffectsModule::GetSymbol()
 
 VendorSymbol BuiltinEffectsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString BuiltinEffectsModule::GetVersion()
@@ -103,7 +103,7 @@ wxString BuiltinEffectsModule::GetVersion()
 
 TranslatableString BuiltinEffectsModule::GetDescription()
 {
-   return XO("Provides builtin effects to Audacity");
+   return XO("Provides builtin effects to Tenacity");
 }
 
 // ============================================================================
@@ -208,7 +208,7 @@ std::unique_ptr<Effect> BuiltinEffectsModule::Instantiate(const PluginPath & pat
    auto iter = mEffects.find( path );
    if ( iter != mEffects.end() )
       return iter->second->factory();
- 
+
    wxASSERT( false );
    return nullptr;
 }

--- a/src/effects/NoiseReduction.cpp
+++ b/src/effects/NoiseReduction.cpp
@@ -1113,7 +1113,7 @@ bool EffectNoiseReduction::Worker::Classify(const Statistics &statistics, int ba
       // avoid being fooled by up and down excursions into
       // either the mistake of classifying noise as not noise
       // (leaving a musical noise chime), or the opposite
-      // (distorting the signal with a drop out). 
+      // (distorting the signal with a drop out).
       if (mNWindowsToExamine == 3)
          // No different from second greatest.
          goto secondGreatest;
@@ -1181,7 +1181,7 @@ void EffectNoiseReduction::Worker::ReduceNoise
          pGain += mBinLow;
          for (int jj = mBinLow; jj < mBinHigh; ++jj) {
             const bool isNoise = Classify(statistics, jj);
-            if (!isNoise) 
+            if (!isNoise)
                *pGain = 1.0;
             ++pGain;
          }
@@ -1337,7 +1337,7 @@ bool EffectNoiseReduction::Worker::ProcessOne
       ProcessSamples(statistics, outputTrack.get(), blockSize, &buffer[0]);
 
       // Update the Progress meter, let user cancel
-      bLoopSuccess = 
+      bLoopSuccess =
          !effect.TrackProgress(count,
                                ( samplePos - start ).as_double() /
                                len.as_double() );
@@ -1621,8 +1621,8 @@ void EffectNoiseReduction::Dialog::DisableControlsIfIsolating()
 #endif
    };
    static const int nToDisable = sizeof(toDisable) / sizeof(toDisable[0]);
-   
-   bool bIsolating = 
+
+   bool bIsolating =
 #ifdef ISOLATE_CHOICE
       mKeepNoise->GetValue();
 #else
@@ -1717,7 +1717,7 @@ void EffectNoiseReduction::Dialog::PopulateOrExchange(ShuttleGui & S)
    S.StartStatic(XO("Step 1"));
    {
       S.AddVariableText(XO(
-"Select a few seconds of just noise so Audacity knows what to filter out,\nthen click Get Noise Profile:"));
+"Select a few seconds of just noise so Tenacity knows what to filter out,\nthen click Get Noise Profile:"));
       //m_pButton_GetProfile =
       S.Id(ID_BUTTON_GETPROFILE).AddButton(XXO("&Get Noise Profile"));
    }

--- a/src/effects/NoiseRemoval.cpp
+++ b/src/effects/NoiseRemoval.cpp
@@ -710,7 +710,7 @@ void NoiseRemovalDialog::PopulateOrExchange(ShuttleGui & S)
    S.StartStatic(XO("Step 1"));
    {
       S.AddVariableText(XO(
-"Select a few seconds of just noise so Audacity knows what to filter out,\nthen click Get Noise Profile:"));
+"Select a few seconds of just noise so Tenacity knows what to filter out,\nthen click Get Noise Profile:"));
       m_pButton_GetProfile = S.Id(ID_BUTTON_GETPROFILE).AddButton(XXO("&Get Noise Profile"));
    }
    S.EndStatic();

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -68,7 +68,7 @@
 #include <dlfcn.h>
 #endif
 
-// TODO:  Unfortunately we have some dependencies on Audacity provided 
+// TODO:  Unfortunately we have some dependencies on Audacity provided
 //        dialogs, widgets and other stuff.  This will need to be cleaned up.
 
 #include "../../FileNames.h"
@@ -139,7 +139,7 @@ DECLARE_MODULE_ENTRY(AudacityModule)
 // ============================================================================
 //
 // Register this as a builtin module
-// 
+//
 // We also take advantage of the fact that wxModules are initialized before
 // the wxApp::OnInit() method is called.  We check to see if Audacity was
 // executed to scan a VST effect in a different process.
@@ -320,7 +320,7 @@ ComponentInterfaceSymbol VSTEffectsModule::GetSymbol()
 
 VendorSymbol VSTEffectsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString VSTEffectsModule::GetVersion()
@@ -331,7 +331,7 @@ wxString VSTEffectsModule::GetVersion()
 
 TranslatableString VSTEffectsModule::GetDescription()
 {
-   return XO("Adds the ability to use VST effects in Audacity.");
+   return XO("Adds the ability to use VST effects in Tenacity.");
 }
 
 // ============================================================================
@@ -395,7 +395,7 @@ PluginPaths VSTEffectsModule::FindPluginPaths(PluginManagerInterface & pm)
       }
    }
 
-#if defined(__WXMAC__)  
+#if defined(__WXMAC__)
 #define VSTPATH wxT("/Library/Audio/Plug-Ins/VST")
 
    // Look in ~/Library/Audio/Plug-Ins/VST and /Library/Audio/Plug-Ins/VST
@@ -1151,7 +1151,7 @@ VSTEffect::VSTEffect(const PluginPath & path, VSTEffect *master)
    mTimeInfo.flags = kVstTempoValid | kVstNanosValid;
 
    // UI
-   
+
    mGui = false;
    mContainer = NULL;
 
@@ -1850,7 +1850,7 @@ void VSTEffect::ExportPresets()
       {
         { XO("Standard VST bank file"), { wxT("fxb") }, true },
         { XO("Standard VST program file"), { wxT("fxp") }, true },
-        { XO("Audacity VST preset file"), { wxT("xml") }, true },
+        { XO("Tenacity VST preset file"), { wxT("xml") }, true },
       },
       wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
       NULL);
@@ -2081,7 +2081,7 @@ bool VSTEffect::Load()
 
       // Try to load the library
       auto lib = std::make_unique<wxDynamicLibrary>(realPath);
-      if (!lib) 
+      if (!lib)
          return false;
 
       // Bail if it wasn't successful
@@ -2107,7 +2107,7 @@ bool VSTEffect::Load()
    //
    // Spent a few days trying to figure out why some VSTs where running okay and
    // others were hit or miss.  The cause was that we export all of Audacity's
-   // symbols and some of the loaded libraries were picking up Audacity's and 
+   // symbols and some of the loaded libraries were picking up Audacity's and
    // not their own.
    //
    // So far, I've only seen this issue on Linux, but we might just be getting
@@ -2126,7 +2126,7 @@ bool VSTEffect::Load()
       (char*) dlopen((const char *)wxString(realPath).ToUTF8(),
                      RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)
    };
-   if (!lib) 
+   if (!lib)
    {
       return false;
    }
@@ -3340,7 +3340,7 @@ bool VSTEffect::LoadFXProgram(unsigned char **bptr, ssize_t & len, int index, bo
             return false;
          }
       }
-         
+
       // They look okay...time to start changing things
       if (!dryrun)
       {
@@ -3406,7 +3406,7 @@ bool VSTEffect::LoadFXProgram(unsigned char **bptr, ssize_t & len, int index, bo
       // Unknown type
       return false;
    }
-   
+
    if (!dryrun)
    {
       SetString(effSetProgramName, wxString(progName), index);

--- a/src/effects/audiounits/AudioUnitEffect.cpp
+++ b/src/effects/audiounits/AudioUnitEffect.cpp
@@ -132,7 +132,7 @@ public:
                                     kAudioUnitScope_Global,
                                     parmID,
                                     &info,
-                                    &dataSize);  
+                                    &dataSize);
       if (result != noErr)
       {
          return false;
@@ -191,7 +191,7 @@ public:
                                        kAudioUnitScope_Global,
                                        0,
                                        &clumpInfo,
-                                       &dataSize);  
+                                       &dataSize);
          if (result == noErr)
          {
             clumpName =  wxCFStringRef::AsString(clumpInfo.outName);
@@ -272,7 +272,7 @@ ComponentInterfaceSymbol AudioUnitEffectsModule::GetSymbol()
 
 VendorSymbol AudioUnitEffectsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString AudioUnitEffectsModule::GetVersion()
@@ -283,7 +283,7 @@ wxString AudioUnitEffectsModule::GetVersion()
 
 TranslatableString AudioUnitEffectsModule::GetDescription()
 {
-   return XO("Provides Audio Unit Effects support to Audacity");
+   return XO("Provides Audio Unit Effects support to Tenacity");
 }
 
 // ============================================================================
@@ -471,7 +471,7 @@ wxString AudioUnitEffectsModule::FromOSType(OSType type)
                 (type & 0x00ff0000) >> 8  |
                 (type & 0x0000ff00) << 8  |
                 (type & 0x000000ff) << 24;
-   
+
    return wxString::FromUTF8((char *)&rev, 4);
 }
 
@@ -540,7 +540,7 @@ AudioUnitEffectOptionsDialog::~AudioUnitEffectOptionsDialog()
 
 void AudioUnitEffectOptionsDialog::PopulateOrExchange(ShuttleGui & S)
 {
-   
+
    S.SetBorder(5);
    S.StartHorizontalLay(wxEXPAND, 1);
    {
@@ -550,7 +550,7 @@ void AudioUnitEffectOptionsDialog::PopulateOrExchange(ShuttleGui & S)
          {
             S.AddVariableText(XO(
 "As part of their processing, some Audio Unit effects must delay returning "
-"audio to Audacity. When not compensating for this delay, you will "
+"audio to Tenacity. When not compensating for this delay, you will "
 "notice that small silences have been inserted into the audio. "
 "Enabling this option will provide that compensation, but it may "
 "not work for all Audio Unit effects."),
@@ -698,7 +698,7 @@ void AudioUnitEffectImportDialog::PopulateOrExchange(ShuttleGui & S)
                mEffect->mName);
    fn = path;
    fn.Normalize();
-   
+
    // Get all presets in the local domain for this effect
    wxDir::GetAllFiles(fn.GetFullPath(), &presets, wxT("*.aupreset"));
 
@@ -712,7 +712,7 @@ void AudioUnitEffectImportDialog::PopulateOrExchange(ShuttleGui & S)
 
    // Get all presets in the user domain for this effect
    wxDir::GetAllFiles(fn.GetFullPath(), &presets, wxT("*.aupreset"));
-   
+
    presets.Sort();
 
    for (size_t i = 0, cnt = presets.size(); i < cnt; i++)
@@ -784,7 +784,7 @@ TranslatableString AudioUnitEffectImportDialog::Import(
 void AudioUnitEffectImportDialog::OnOk(wxCommandEvent & evt)
 {
    evt.Skip();
-   
+
    // Import all selected presets
    long sel = -1;
    while ((sel = mList->GetNextItem(sel, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED)) >= 0)
@@ -809,7 +809,7 @@ void AudioUnitEffectImportDialog::OnOk(wxCommandEvent & evt)
          return;
       }
    }
-  
+
    EndModal(wxID_OK);
 }
 
@@ -832,7 +832,7 @@ AudioUnitEffect::AudioUnitEffect(const PluginPath & path,
 
    mpControl = NULL;
    mUnit = NULL;
-   
+
    mBlockSize = 0.0;
    mInteractive = false;
    mIsGraphical = false;
@@ -977,7 +977,7 @@ bool AudioUnitEffect::SupportsAutomation()
                                  kAudioUnitScope_Global,
                                  0,
                                  array.get(),
-                                 &dataSize);  
+                                 &dataSize);
    if (result != noErr)
    {
       return false;
@@ -1007,9 +1007,9 @@ bool AudioUnitEffect::SupportsAutomation()
 bool AudioUnitEffect::SetHost(EffectHostInterface *host)
 {
    OSStatus result;
-   
+
    mHost = host;
- 
+
    mSampleRate = 44100;
    result = AudioComponentInstanceNew(mComponent, &mUnit);
    if (!mUnit)
@@ -1046,7 +1046,7 @@ bool AudioUnitEffect::SetHost(EffectHostInterface *host)
       }
 
       LoadPreset(mHost->GetCurrentSettingsGroup());
-   } 
+   }
 
    if (!mMaster)
    {
@@ -1063,7 +1063,7 @@ bool AudioUnitEffect::SetHost(EffectHostInterface *host)
       }
 
       AudioUnitEvent event;
- 
+
       event.mEventType = kAudioUnitEvent_ParameterValueChange;
       event.mArgument.mParameter.mAudioUnit = mUnit;
       event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
@@ -1095,7 +1095,7 @@ bool AudioUnitEffect::SetHost(EffectHostInterface *host)
                                        kAudioUnitScope_Global,
                                        0,
                                        array.get(),
-                                       &dataSize);  
+                                       &dataSize);
          if (result != noErr)
          {
             return false;
@@ -1131,7 +1131,7 @@ bool AudioUnitEffect::SetHost(EffectHostInterface *host)
 
       AudioUnitCocoaViewInfo cocoaViewInfo;
       dataSize = sizeof(AudioUnitCocoaViewInfo);
-   
+
       // Check for a Cocoa UI
       result = AudioUnitGetProperty(mUnit,
                                     kAudioUnitProperty_CocoaUI,
@@ -1208,7 +1208,7 @@ sampleCount AudioUnitEffect::GetLatency()
                            kAudioUnitScope_Global,
                            0,
                            &latency,
-                           &dataSize);  
+                           &dataSize);
 
       return sampleCount(latency * mSampleRate);
    }
@@ -1226,7 +1226,7 @@ size_t AudioUnitEffect::GetTailSize()
                         kAudioUnitScope_Global,
                         0,
                         &tailTime,
-                        &dataSize);  
+                        &dataSize);
 
    return tailTime * mSampleRate;
 }
@@ -1242,7 +1242,7 @@ bool AudioUnitEffect::ProcessInitialize(sampleCount WXUNUSED(totalLen), ChannelN
 
    mInputList.reinit(mAudioIns);
    mInputList[0].mNumberBuffers = mAudioIns;
-   
+
    mOutputList.reinit(mAudioOuts);
    mOutputList[0].mNumberBuffers = mAudioOuts;
 
@@ -1519,7 +1519,7 @@ bool AudioUnitEffect::GetAutomationParameters(CommandParameters & parms)
                                  kAudioUnitScope_Global,
                                  0,
                                  array.get(),
-                                 &dataSize);  
+                                 &dataSize);
    if (result != noErr)
    {
       return false;
@@ -1582,7 +1582,7 @@ bool AudioUnitEffect::SetAutomationParameters(CommandParameters & parms)
                                  kAudioUnitScope_Global,
                                  0,
                                  array.get(),
-                                 &dataSize);  
+                                 &dataSize);
    if (result != noErr)
    {
       return false;
@@ -1697,7 +1697,7 @@ RegistryPaths AudioUnitEffect::GetFactoryPresets()
          presets.push_back(wxCFStringRef::AsString(preset->presetName));
       }
    }
-                        
+
    return presets;
 }
 
@@ -1982,7 +1982,7 @@ bool AudioUnitEffect::LoadPreset(const RegistryPath & group)
       //wxLogError(wxT("Preset key \"%s\" not found in group \"%s\""), PRESET_KEY, group);
       return false;
    }
-   
+
    // Decode it
    wxMemoryBuffer buf = wxBase64Decode(parms);
    size_t bufLen = buf.GetDataLen();
@@ -2210,7 +2210,7 @@ bool AudioUnitEffect::SetRateAndChannels()
                GetSymbol().Internal().wx_str());
          return false;
       }
-   
+
       streamFormat.mChannelsPerFrame = mAudioOuts;
       result = AudioUnitSetProperty(mUnit,
                                     kAudioUnitProperty_StreamFormat,
@@ -2218,7 +2218,7 @@ bool AudioUnitEffect::SetRateAndChannels()
                                     0,
                                     &streamFormat,
                                     sizeof(AudioStreamBasicDescription));
-   
+
       if (result != noErr)
       {
          wxPrintf("%ls didn't accept stream format on output\n",
@@ -2498,7 +2498,7 @@ void AudioUnitEffect::EventListener(const AudioUnitEvent *inEvent,
    }
    else
    {
-      // We're the master, so propagate 
+      // We're the master, so propagate
       for (size_t i = 0, cnt = mSlaves.size(); i < cnt; i++)
       {
          mSlaves[i]->EventListener(inEvent, inParameterValue);
@@ -2606,7 +2606,7 @@ void AudioUnitEffect::GetChannelCounts()
       else if (ic == 1 && oc == 1)
       {
          havem2m = true;
-      }   
+      }
       else if (ic == 1 && oc == 2)
       {
          havem2s = true;

--- a/src/effects/ladspa/LadspaEffect.cpp
+++ b/src/effects/ladspa/LadspaEffect.cpp
@@ -126,7 +126,7 @@ ComponentInterfaceSymbol LadspaEffectsModule::GetSymbol()
 
 VendorSymbol LadspaEffectsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString LadspaEffectsModule::GetVersion()
@@ -237,7 +237,7 @@ PluginPaths LadspaEffectsModule::FindPluginPaths(PluginManagerInterface & pm)
    pm.FindFilesInPathList(wxT("*.dll"), pathList, files, true);
 
 #else
-   
+
    // Recursively scan for all shared objects
    pm.FindFilesInPathList(wxT("*.so"), pathList, files, true);
 
@@ -255,7 +255,7 @@ unsigned LadspaEffectsModule::DiscoverPluginsAtPath(
    // causes duplicate menu entries to appear.
    wxFileName ff(path);
    if (ff.GetName().CmpNoCase(wxT("vst-bridge")) == 0) {
-      errMsg = XO("Audacity no longer uses vst-bridge");
+      errMsg = XO("Tenacity no longer uses vst-bridge");
       return 0;
    }
 
@@ -439,7 +439,7 @@ void LadspaEffectOptionsDialog::PopulateOrExchange(ShuttleGui & S)
          {
             S.AddVariableText( XO(
 "As part of their processing, some LADSPA effects must delay returning "
-"audio to Audacity. When not compensating for this delay, you will "
+"audio to Tenacity. When not compensating for this delay, you will "
 "notice that small silences have been inserted into the audio. "
 "Enabling this option will provide that compensation, but it may "
 "not work for all LADSPA effects."),
@@ -738,7 +738,7 @@ bool LadspaEffect::SetHost(EffectHostInterface *host)
       // Collect the audio ports
       if (LADSPA_IS_PORT_AUDIO(d))
       {
-         if (LADSPA_IS_PORT_INPUT(d)) 
+         if (LADSPA_IS_PORT_INPUT(d))
          {
             mInputPorts[mAudioIns++] = p;
          }
@@ -1796,7 +1796,7 @@ void LadspaEffect::RefreshControls(bool outputOnly)
          forceint = true;
       }
 
-      if (LADSPA_IS_PORT_OUTPUT(d)) 
+      if (LADSPA_IS_PORT_OUTPUT(d))
       {
          continue;
       }

--- a/src/effects/lv2/LV2Effect.cpp
+++ b/src/effects/lv2/LV2Effect.cpp
@@ -276,7 +276,7 @@ void LV2EffectSettingsDialog::PopulateOrExchange(ShuttleGui &S)
          {
             S.AddVariableText( XO(
 "As part of their processing, some LV2 effects must delay returning "
-"audio to Audacity. When not compensating for this delay, you will "
+"audio to Tenacity. When not compensating for this delay, you will "
 "notice that small silences have been inserted into the audio. "
 "Enabling this setting will provide that compensation, but it may "
 "not work for all LV2 effects."),
@@ -396,7 +396,7 @@ LV2Effect::LV2Effect(const LilvPlugin *plug)
 
    mPositionSpeed = 1.0;
    mPositionFrame = 0.0;
-   
+
    mNativeWin = NULL;
    mNativeWinInitialSize = wxDefaultSize;
    mNativeWinLastSize = wxDefaultSize;
@@ -856,7 +856,7 @@ bool LV2Effect::SetHost(EffectHostInterface *host)
       {
          mCVPorts.push_back(std::make_shared<LV2CVPort>(port, index, isInput, symbol, name, groupName));
          std::shared_ptr<LV2CVPort> cvPort = mCVPorts.back();
-      
+
          // Collect the value and range info
          if (!std::isnan(minimumVals[i]))
          {
@@ -2002,7 +2002,7 @@ LV2Wrapper *LV2Effect::InitInstance(float sampleRate)
    {
       return NULL;
    }
-   
+
    LilvInstance *instance = wrapper->Instantiate(mPlug, sampleRate, mFeatures);
    if (!instance)
    {
@@ -2315,7 +2315,7 @@ bool LV2Effect::BuildPlain()
    wxSizer *innerSizer;
 
    wxASSERT(mParent); // To justify safenew
-   wxScrolledWindow *const w = safenew 
+   wxScrolledWindow *const w = safenew
       wxScrolledWindow(mParent,
                        wxID_ANY,
                        wxDefaultPosition,
@@ -2941,7 +2941,7 @@ LV2_URID LV2Effect::urid_map(LV2_URID_Map_Handle handle, const char *uri)
 LV2_URID LV2Effect::URID_Map(const char *uri)
 {
    LV2_URID urid;
-   
+
    urid = Lookup_URI(gURIDMap, uri, false);
    if (urid > 0)
    {
@@ -3528,4 +3528,4 @@ LV2_Worker_Status LV2Wrapper::Respond(uint32_t size, const void *data)
 }
 
 #endif
- 
+

--- a/src/effects/lv2/LoadLV2.cpp
+++ b/src/effects/lv2/LoadLV2.cpp
@@ -102,7 +102,7 @@ ComponentInterfaceSymbol LV2EffectsModule::GetSymbol()
 
 VendorSymbol LV2EffectsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString LV2EffectsModule::GetVersion()
@@ -113,7 +113,7 @@ wxString LV2EffectsModule::GetVersion()
 
 TranslatableString LV2EffectsModule::GetDescription()
 {
-   return XO("Provides LV2 Effects support to Audacity");
+   return XO("Provides LV2 Effects support to Tenacity");
 }
 
 // ============================================================================
@@ -153,7 +153,7 @@ bool LV2EffectsModule::Initialize()
    // Look in ~/Library/Audio/Plug-Ins/lv2 and /Library/Audio/Plug-Ins/lv2
    newVar += wxT(":$HOME") LV2PATH;
    newVar += wxT(":") LV2PATH;
-   
+
    newVar += wxT(":/usr/local/lib/lv2");
    newVar += wxT(":/usr/lib/lv2");
    newVar += wxT(":") + libdir.GetPath();

--- a/src/effects/nyquist/LoadNyquist.cpp
+++ b/src/effects/nyquist/LoadNyquist.cpp
@@ -105,7 +105,7 @@ ComponentInterfaceSymbol NyquistEffectsModule::GetSymbol()
 
 VendorSymbol NyquistEffectsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString NyquistEffectsModule::GetVersion()
@@ -116,7 +116,7 @@ wxString NyquistEffectsModule::GetVersion()
 
 TranslatableString NyquistEffectsModule::GetDescription()
 {
-   return XO("Provides Nyquist Effects support to Audacity");
+   return XO("Provides Nyquist Effects support to Tenacity");
 }
 
 // ============================================================================
@@ -198,7 +198,7 @@ bool NyquistEffectsModule::AutoRegisterPlugins(PluginManagerInterface & pm)
            TODO: Currently the names of Nyquist plug-ins cannot have
           context specific translations or internal names different from
           the visible English names.
-   
+
           This makes it unnecessary to pass a second argument to
           IsPluginRegistered for correction of the registry (as is needed
           in the case of built-in effects).

--- a/src/effects/nyquist/Nyquist.cpp
+++ b/src/effects/nyquist/Nyquist.cpp
@@ -221,7 +221,7 @@ VendorSymbol NyquistEffect::GetVendor()
 {
    if (mIsPrompt)
    {
-      return XO("Audacity");
+      return XO("Tenacity");
    }
 
    return mAuthor;

--- a/src/effects/vamp/LoadVamp.cpp
+++ b/src/effects/vamp/LoadVamp.cpp
@@ -76,7 +76,7 @@ ComponentInterfaceSymbol VampEffectsModule::GetSymbol()
 
 VendorSymbol VampEffectsModule::GetVendor()
 {
-   return XO("The Audacity Team");
+   return XO("The Tenacity Team");
 }
 
 wxString VampEffectsModule::GetVersion()
@@ -87,7 +87,7 @@ wxString VampEffectsModule::GetVersion()
 
 TranslatableString VampEffectsModule::GetDescription()
 {
-   return XO("Provides Vamp Effects support to Audacity");
+   return XO("Provides Vamp Effects support to Tenacity");
 }
 
 // ============================================================================

--- a/src/export/ExportMP3.cpp
+++ b/src/export/ExportMP3.cpp
@@ -609,7 +609,7 @@ public:
       S.StartVerticalLay(true);
       {
          S.AddTitle(
-            XO("Audacity needs the file %s to create MP3s.")
+            XO("Tenacity needs the file %s to create MP3s.")
                .Format( mName ) );
 
          S.SetBorder(3);
@@ -1094,7 +1094,7 @@ bool MP3Exporter::InitLibraryInternal()
 
 // The global ::lame_something symbols only exist if LAME is built in.
 // So we don't reference them unless they are.
-#ifdef MP3_EXPORT_BUILT_IN 
+#ifdef MP3_EXPORT_BUILT_IN
 
    lame_init = ::lame_init;
    get_lame_version = ::get_lame_version;
@@ -1234,7 +1234,7 @@ bool MP3Exporter::InitLibraryExternal(wxString libpath)
          beVersion(&v);
 
          mBladeVersion = XO(
-"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Audacity %d.%d.%d.\nPlease download the latest version of 'LAME for Audacity'.")
+"You are linking to lame_enc.dll v%d.%d. This version is not compatible with Tenacity %d.%d.%d.\nPlease download the latest version of 'LAME for Tenacity'.")
             .Format(
                v.byMajorVersion,
                v.byMinorVersion,
@@ -1543,7 +1543,7 @@ wxString MP3Exporter::GetLibraryPath()
    {
         return path;
    }
-    
+
    return wxT("/Library/Application Support/audacity/libs");
 }
 

--- a/src/export/ExportPCM.cpp
+++ b/src/export/ExportPCM.cpp
@@ -163,7 +163,7 @@ ExportPCMOptions::ExportPCMOptions(wxWindow *parent, int selformat)
    if (mSelFormat < FMT_OTHER)
    {
       mType = kFormats[selformat].format & SF_FORMAT_TYPEMASK;
-      GetEncodings(mType & SF_FORMAT_SUBMASK);   
+      GetEncodings(mType & SF_FORMAT_SUBMASK);
    }
    else
    {
@@ -267,7 +267,7 @@ void ExportPCMOptions::OnEncodingChoice(wxCommandEvent & evt)
    // And save it
    SaveEncoding(mType, sf_encoding_index_to_subtype(mEncodingIndexes[mEncodingFromChoice]));
 }
- 
+
 void ExportPCMOptions::GetTypes()
 {
    // Reset arrays
@@ -313,7 +313,7 @@ void ExportPCMOptions::GetTypes()
    // Refresh the current type
    mType = sf_header_index_to_type(mHeaderIndexes[mHeaderFromChoice]);
 }
- 
+
 void ExportPCMOptions::GetEncodings(int enc)
 {
    // Setup for queries
@@ -440,16 +440,16 @@ void ExportPCM::ReportTooBigError(wxWindow * pParent)
    //Temporary translation hack, to say 'WAV or AIFF' rather than 'WAV'
    auto message =
       XO("You have attempted to Export a WAV or AIFF file which would be greater than 4GB.\n"
-      "Audacity cannot do this, the Export was abandoned.");
+      "Tenacity cannot do this, the Export was abandoned.");
 
    ShowErrorDialog(pParent, XO("Error Exporting"), message,
                   wxT("Size_limits_for_WAV_and_AIFF_files"));
 
-// This alternative error dialog was to cover the possibility we could not 
+// This alternative error dialog was to cover the possibility we could not
 // compute the size in advance.
 #if 0
    ShowErrorDialog(pParent, XO("Error Exporting"),
-                  XO("Your exported WAV file has been truncated as Audacity cannot export WAV\n"
+                  XO("Your exported WAV file has been truncated as Tenacity cannot export WAV\n"
                     "files bigger than 4GB."),
                   wxT("Size_limits_for_WAV_files"));
 #endif
@@ -509,7 +509,7 @@ ProgressResult ExportPCM::Export(AudacityProject *project,
    }
 
    int fileFormat = sf_format & SF_FORMAT_TYPEMASK;
-   
+
    auto updateResult = ProgressResult::Success;
    {
       wxFile f;   // will be closed when it goes out of scope
@@ -548,7 +548,7 @@ ProgressResult ExportPCM::Export(AudacityProject *project,
 
       // If we can't export exactly the format they requested,
       // try the default format for that header type...
-      // 
+      //
       // LLL: I don't think this is valid since libsndfile checks
       // for all allowed subtypes explicitly and doesn't provide
       // for an unspecified subtype.
@@ -682,11 +682,11 @@ ProgressResult ExportPCM::Export(AudacityProject *project,
                updateResult = ProgressResult::Cancelled;
                break;
             }
-            
+
             updateResult = progress.Update(mixer->MixGetCurrentTime() - t0, t1 - t0);
          }
       }
-      
+
       // Install the WAV metata in a "LIST" chunk at the end of the file
       if (updateResult == ProgressResult::Success ||
           updateResult == ProgressResult::Stopped) {

--- a/src/import/Import.cpp
+++ b/src/import/Import.cpp
@@ -142,7 +142,7 @@ bool Importer::Initialize()
       // QT is only conditionally compiled and would get
       // placed at the end if present
    };
-   
+
    static struct MyVisitor final : Visitor {
       MyVisitor()
       {
@@ -188,7 +188,7 @@ Importer::GetFileTypes( const FileNames::FileType &extraType )
 
    if ( !extraType.extensions.empty() )
       fileTypes.push_back( extraType );
- 
+
    FileNames::FileTypes l;
    for(const auto &importPlugin : sImportPluginList())
    {
@@ -471,7 +471,7 @@ bool Importer::Import( AudacityProject &project,
    // MIDI files must be imported, not opened
    if (FileNames::IsMidi(fName)) {
       errorMessage = XO(
-"\"%s\" \nis a MIDI file, not an audio file. \nAudacity cannot open this type of file for playing, but you can\nedit it by clicking File > Import > MIDI.")
+"\"%s\" \nis a MIDI file, not an audio file. \nTenacity cannot open this type of file for playing, but you can\nedit it by clicking File > Import > MIDI.")
          .Format( fName );
       return false;
    }
@@ -480,7 +480,7 @@ bool Importer::Import( AudacityProject &project,
    // Bug #2647: Peter has a Word 2000 .doc file that is recognized and imported by FFmpeg.
    if (wxFileName(fName).GetExt() == wxT("doc")) {
       errorMessage =
-         XO("\"%s\" \nis a not an audio file. \nAudacity cannot open this type of file.")
+         XO("\"%s\" \nis a not an audio file. \nTenacity cannot open this type of file.")
          .Format( fName );
       return false;
    }
@@ -679,7 +679,7 @@ bool Importer::Import( AudacityProject &project,
    {
       if( unusableImportPlugin->SupportsExtension(extension) )
       {
-         errorMessage = XO("This version of Audacity was not compiled with %s support.")
+         errorMessage = XO("This version of Tenacity was not compiled with %s support.")
             .Format( unusableImportPlugin->GetPluginFormatDescription() );
          return false;
       }
@@ -693,7 +693,7 @@ bool Importer::Import( AudacityProject &project,
       if (extension.IsSameAs(wxT("cda"), false)) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is an audio CD track. \nAudacity cannot open audio CDs directly. \nExtract (rip) the CD tracks to an audio format that \nAudacity can import, such as WAV or AIFF.")
+"\"%s\" is an audio CD track. \nTenacity cannot open audio CDs directly. \nExtract (rip) the CD tracks to an audio format that \nTenacity can import, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -702,7 +702,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("m3u"), false))||(extension.IsSameAs(wxT("ram"), false))||(extension.IsSameAs(wxT("pls"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a playlist file. \nAudacity cannot open this file because it only contains links to other files. \nYou may be able to open it in a text editor and download the actual audio files.")
+"\"%s\" is a playlist file. \nTenacity cannot open this file because it only contains links to other files. \nYou may be able to open it in a text editor and download the actual audio files.")
             .Format( fName );
          return false;
       }
@@ -710,7 +710,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("wma"), false))||(extension.IsSameAs(wxT("asf"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a Windows Media Audio file. \nAudacity cannot open this type of file due to patent restrictions. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
+"\"%s\" is a Windows Media Audio file. \nTenacity cannot open this type of file due to patent restrictions. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -718,7 +718,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("aac"), false))||(extension.IsSameAs(wxT("m4a"), false))||(extension.IsSameAs(wxT("m4r"), false))||(extension.IsSameAs(wxT("mp4"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is an Advanced Audio Coding file.\nWithout the optional FFmpeg library, Audacity cannot open this type of file.\nOtherwise, you need to convert it to a supported audio format, such as WAV or AIFF.")
+"\"%s\" is an Advanced Audio Coding file.\nWithout the optional FFmpeg library, Tenacity cannot open this type of file.\nOtherwise, you need to convert it to a supported audio format, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -726,7 +726,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("m4p"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is an encrypted audio file. \nThese typically are from an online music store. \nAudacity cannot open this type of file due to the encryption. \nTry recording the file into Audacity, or burn it to audio CD then \nextract the CD track to a supported audio format such as WAV or AIFF.")
+"\"%s\" is an encrypted audio file. \nThese typically are from an online music store. \nTenacity cannot open this type of file due to the encryption. \nTry recording the file into Tenacity, or burn it to audio CD then \nextract the CD track to a supported audio format such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -734,7 +734,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("ra"), false))||(extension.IsSameAs(wxT("rm"), false))||(extension.IsSameAs(wxT("rpm"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a RealPlayer media file. \nAudacity cannot open this proprietary format. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
+"\"%s\" is a RealPlayer media file. \nTenacity cannot open this proprietary format. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -743,7 +743,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("kar"), false))||(extension.IsSameAs(wxT("mod"), false))||(extension.IsSameAs(wxT("rmi"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a notes-based file, not an audio file. \nAudacity cannot open this type of file. \nTry converting it to an audio file such as WAV or AIFF and \nthen import it, or record it into Audacity.")
+"\"%s\" is a notes-based file, not an audio file. \nTenacity cannot open this type of file. \nTry converting it to an audio file such as WAV or AIFF and \nthen import it, or record it into Tenacity.")
             .Format( fName );
          return false;
       }
@@ -752,7 +752,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("mp+"), false))||(extension.IsSameAs(wxT("mpc"), false))||(extension.IsSameAs(wxT("mpp"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a Musepack audio file. \nAudacity cannot open this type of file. \nIf you think it might be an mp3 file, rename it to end with \".mp3\" \nand try importing it again. Otherwise you need to convert it to a supported audio \nformat, such as WAV or AIFF.")
+"\"%s\" is a Musepack audio file. \nTenacity cannot open this type of file. \nIf you think it might be an mp3 file, rename it to end with \".mp3\" \nand try importing it again. Otherwise you need to convert it to a supported audio \nformat, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -761,7 +761,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("wv"), false))||(extension.IsSameAs(wxT("wvc"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a Wavpack audio file. \nAudacity cannot open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
+"\"%s\" is a Wavpack audio file. \nTenacity cannot open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -770,7 +770,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("ac3"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a Dolby Digital audio file. \nAudacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
+"\"%s\" is a Dolby Digital audio file. \nTenacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -779,7 +779,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("spx"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is an Ogg Speex audio file. \nAudacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
+"\"%s\" is an Ogg Speex audio file. \nTenacity cannot currently open this type of file. \nYou need to convert it to a supported audio format, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -788,7 +788,7 @@ bool Importer::Import( AudacityProject &project,
       if ((extension.IsSameAs(wxT("mpg"), false))||(extension.IsSameAs(wxT("mpeg"), false))||(extension.IsSameAs(wxT("avi"), false))||(extension.IsSameAs(wxT("wmv"), false))||(extension.IsSameAs(wxT("rv"), false))) {
          errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"\"%s\" is a video file. \nAudacity cannot currently open this type of file. \nYou need to extract the audio to a supported format, such as WAV or AIFF.")
+"\"%s\" is a video file. \nTenacity cannot currently open this type of file. \nYou need to extract the audio to a supported format, such as WAV or AIFF.")
             .Format( fName );
          return false;
       }
@@ -801,7 +801,7 @@ bool Importer::Import( AudacityProject &project,
       // we were not able to recognize the file type
       errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"Audacity did not recognize the type of the file '%s'.\n\n%sFor uncompressed files, also try File > Import > Raw Data.")
+"Tenacity did not recognize the type of the file '%s'.\n\n%sFor uncompressed files, also try File > Import > Raw Data.")
          .Format( fName,
 #if defined(USE_FFMPEG)
                   !FFmpegLibsInst()
@@ -825,7 +825,7 @@ bool Importer::Import( AudacityProject &project,
 
       errorMessage = XO(
 /* i18n-hint: %s will be the filename */
-"Audacity recognized the type of the file '%s'.\nImporters supposedly supporting such files are:\n%s,\nbut none of them understood this file format.")
+"Tenacity recognized the type of the file '%s'.\nImporters supposedly supporting such files are:\n%s,\nbut none of them understood this file format.")
          .Format( fName, pluglist );
    }
 

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -489,7 +489,7 @@ bool AUPImportFileHandle::Open()
             XO("This project was saved by Audacity version 1.0 or earlier. The format has\n"
                "changed and this version of Audacity is unable to import the project.\n\n"
                "Use a version of Audacity prior to v3.0.0 to upgrade the project and then\n"
-               "you may import it with this version of Audacity."),
+               "you may import it with this version of Tenacity."),
             XO("Import Project"),
             wxOK | wxCENTRE,
             &GetProjectFrame(mProject));
@@ -861,7 +861,7 @@ bool AUPImportFileHandle::HandleNoteTrack(XMLTagHandler *&handler)
    return true;
 #else
    AudacityMessageBox(
-      XO("MIDI tracks found in project file, but this build of Audacity does not include MIDI support, bypassing track."),
+      XO("MIDI tracks found in project file, but this build of Tenacity does not include MIDI support, bypassing track."),
       XO("Project Import"),
       wxOK | wxICON_EXCLAMATION | wxCENTRE,
       &GetProjectFrame(mProject));

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -274,7 +274,7 @@ void QuickFixDialog::OnFix(const PrefSetter &setter, wxWindowID id)
 {
    if ( setter )
       setter();
-   
+
    // Change the label after doing the fix, as the fix may take a second or two.
    auto pBtn = FindWindow(id);
    if( pBtn )
@@ -350,7 +350,7 @@ void OnShowLog( const CommandContext &context )
 void OnMenuTree(const CommandContext &context)
 {
    auto &project = context.project;
-   
+
    using namespace MenuTable;
    struct MyVisitor : ToolbarMenuVisitor
    {
@@ -476,7 +476,7 @@ BaseItemSharedPtr HelpMenu()
          Command( wxT("QuickHelp"), XXO("&Getting Started"), FN(OnQuickHelp),
             AlwaysEnabledFlag ),
          // DA: Emphasise it is the Audacity Manual (No separate DA manual).
-         Command( wxT("Manual"), XXO("Audacity &Manual"), FN(OnManual),
+         Command( wxT("Manual"), XXO("&Manual"), FN(OnManual),
             AlwaysEnabledFlag )
 
    #else
@@ -523,7 +523,7 @@ BaseItemSharedPtr HelpMenu()
       ,
 #endif
 
-         Command( wxT("About"), XXO("&About Audacity..."), FN(OnAbout),
+         Command( wxT("About"), XXO("&About Tenacity..."), FN(OnAbout),
             AlwaysEnabledFlag )
       )
    ) ) };

--- a/src/menus/TrackMenus.cpp
+++ b/src/menus/TrackMenus.cpp
@@ -68,7 +68,7 @@ void DoMixAndRender
       // But before removing, determine the first track after the removal
       auto last = *trackRange.rbegin();
       auto insertionPoint = * ++ tracks.Find( last );
-      
+
       auto selectedCount = (trackRange + &Track::IsLeader).size();
       wxString firstName;
       int firstColour = -1;
@@ -683,7 +683,7 @@ void OnNewTimeTrack(const CommandContext &context)
    if ( *tracks.Any<TimeTrack>().begin() ) {
       AudacityMessageBox(
          XO(
-"This version of Audacity only allows one time track for each project window.") );
+"This version of Tenacity only allows one time track for each project window.") );
       return;
    }
 
@@ -1293,7 +1293,7 @@ BaseItemSharedPtr TracksMenu()
 {
    // Tracks Menu (formerly Project Menu)
    using Options = CommandManager::Options;
-   
+
    static BaseItemSharedPtr menu{
    ( FinderScope{ findCommandHandler },
    Menu( wxT("Tracks"), XXO("&Tracks"),

--- a/src/menus/TransportMenus.cpp
+++ b/src/menus/TransportMenus.cpp
@@ -411,7 +411,7 @@ void OnTimerRecord(const CommandContext &context)
       if (numberOfSelected > 0 && rateOfSelected != settings.GetRate()) {
          AudacityMessageBox(XO(
             "Too few tracks are selected for recording at this sample rate.\n"
-            "(Audacity requires two channels at the same sample rate for\n"
+            "(Tenacity requires two channels at the same sample rate for\n"
             "each stereo track)"),
             XO("Too Few Compatible Tracks Selected"),
             wxICON_ERROR | wxCENTRE);
@@ -419,7 +419,7 @@ void OnTimerRecord(const CommandContext &context)
          return;
       }
    }
-   
+
    // We use this variable to display "Current Project" in the Timer Recording
    // save project field
    bool bProjectSaved = !ProjectFileIO::Get( project ).IsModified();
@@ -615,7 +615,7 @@ void OnPunchAndRoll(const CommandContext &context)
       // play recording tracks only
       std::copy(tracks.begin(), tracks.end(),
          std::back_inserter(transportTracks.playbackTracks));
-      
+
    // Unlike with the usual recording, a track may be chosen both for playback
    // and recording.
    transportTracks.captureTracks = std::move(tracks);

--- a/src/prefs/ApplicationPrefs.cpp
+++ b/src/prefs/ApplicationPrefs.cpp
@@ -67,7 +67,7 @@ void ApplicationPrefs::PopulateOrExchange(ShuttleGui & S)
    S.SetBorder(2);
    S.StartScroller();
 
-   S.StartStatic(XO("Update Audacity"));
+   S.StartStatic(XO("Update Tenacity"));
    {
       S.TieCheckBox(XO("&Check for Updates"),
           UpdatesCheckingSettings::DefaultUpdatesCheckingFlag);

--- a/src/prefs/DirectoriesPrefs.cpp
+++ b/src/prefs/DirectoriesPrefs.cpp
@@ -274,8 +274,8 @@ void DirectoriesPrefs::OnTempBrowse(wxCommandEvent &evt)
                                    DefaultTempDir());
 
    // Because we went through InitTemp() during initialisation,
-   // the old temp directory name in prefs should already be OK.  Just in case there is 
-   // some way we hadn't thought of for it to be not OK, 
+   // the old temp directory name in prefs should already be OK.  Just in case there is
+   // some way we hadn't thought of for it to be not OK,
    // we avoid prompting with it in that case and use the suggested default instead.
    if (!IsTempDirectoryNameOK(oldTemp))
    {
@@ -308,7 +308,7 @@ void DirectoriesPrefs::OnTempBrowse(wxCommandEvent &evt)
       wxString newDirName;
 #if defined(__WXMAC__)
       newDirName = wxT("SessionData");
-#elif defined(__WXMSW__) 
+#elif defined(__WXMSW__)
       // Clearing Bug 1271 residual issue.  Let's NOT have temp in the name.
       newDirName = wxT("SessionData");
 #else
@@ -442,7 +442,7 @@ bool DirectoriesPrefs::Validate()
    if (Temp != oldDir) {
       AudacityMessageBox(
          XO(
-"Changes to temporary directory will not take effect until Audacity is restarted"),
+"Changes to temporary directory will not take effect until Tenacity is restarted"),
          XO("Temp Directory Update"),
          wxOK | wxCENTRE | wxICON_INFORMATION);
    }

--- a/src/prefs/EffectsPrefs.cpp
+++ b/src/prefs/EffectsPrefs.cpp
@@ -216,10 +216,10 @@ void EffectsPrefs::PopulateOrExchange(ShuttleGui & S)
 #ifndef EXPERIMENTAL_EFFECT_MANAGEMENT
    S.StartStatic(XO("Plugin Options"));
    {
-      S.TieCheckBox(XXO("Check for updated plugins when Audacity starts"),
+      S.TieCheckBox(XXO("Check for updated plugins when Tenacity starts"),
                      {wxT("/Plugins/CheckForUpdates"),
                      true});
-      S.TieCheckBox(XXO("Rescan plugins next time Audacity is started"),
+      S.TieCheckBox(XXO("Rescan plugins next time Tenacity is started"),
                      {wxT("/Plugins/Rescan"),
                      false});
    }

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -188,7 +188,7 @@ void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
                     {wxT("/GUI/ShowExtraMenus"),
                      false});
 #ifdef EXPERIMENTAL_THEME_PREFS
-      // We do not want to make this option mainstream.  It's a 
+      // We do not want to make this option mainstream.  It's a
       // convenience for developers.
       S.TieCheckBox(XXO("Show alternative &styling (Mac vs PC)"),
                     {wxT("/GUI/ShowMac"),
@@ -200,7 +200,7 @@ void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Re&tain labels if selection snaps to a label"),
                     {wxT("/GUI/RetainLabels"),
                      false});
-      S.TieCheckBox(XXO("B&lend system and Audacity theme"),
+      S.TieCheckBox(XXO("B&lend system and Tenacity theme"),
                     {wxT("/GUI/BlendThemes"),
                      true});
 #ifndef __WXMAC__

--- a/src/prefs/KeyConfigPrefs.cpp
+++ b/src/prefs/KeyConfigPrefs.cpp
@@ -373,10 +373,10 @@ void KeyConfigPrefs::ClearAllKeys()
 }
 
 // Checks if the given vector of keys contains illegal duplicates.
-// In case it does, stores the prefixed labels of operations 
+// In case it does, stores the prefixed labels of operations
 // with illegal key duplicates in fMatching and sMatching.
-// Search for duplicates fully implemented here 
-// to avoid possible problems with legal shortcut duplicates.  
+// Search for duplicates fully implemented here
+// to avoid possible problems with legal shortcut duplicates.
 bool KeyConfigPrefs::ContainsIllegalDups(
    TranslatableString & fMatching, TranslatableString & sMatching) const
 {
@@ -411,11 +411,11 @@ bool KeyConfigPrefs::ContainsIllegalDups(
 }
 
 
-// This function tries to add the given shortcuts(keys) "toAdd" 
-// to the already existing shortcuts(keys). Shortcuts are added only if 
+// This function tries to add the given shortcuts(keys) "toAdd"
+// to the already existing shortcuts(keys). Shortcuts are added only if
 //      1. the shortcut for the operation isn't defined already
 //      2. the added shortcut doesn't create illegal shortcut duplicate
-// The names of operations for which the second condition was violated 
+// The names of operations for which the second condition was violated
 // are returned in a single error message
 TranslatableString KeyConfigPrefs::MergeWithExistingKeys(
    const std::vector<NormalizedKeyString> &toAdd)
@@ -434,7 +434,7 @@ TranslatableString KeyConfigPrefs::MergeWithExistingKeys(
 
       return -1;
    };
-   
+
    const NormalizedKeyString noKey{ EMPTY_SHORTCUT };
 
    for (size_t i{ 0 }; i < toAdd.size(); i++)
@@ -452,7 +452,7 @@ TranslatableString KeyConfigPrefs::MergeWithExistingKeys(
          else
          {
             TranslatableString name{ mManager->GetKeyFromName(mNames[sRes]).GET(), {} };
-            
+
             disabledShortcuts +=
                XO(
 "\n   *   \"%s\"  (because the shortcut \'%s\' is used by \"%s\")\n")
@@ -460,7 +460,7 @@ TranslatableString KeyConfigPrefs::MergeWithExistingKeys(
                      mManager->GetPrefixedLabelFromName(mNames[i]),
                      name,
                      mManager->GetPrefixedLabelFromName(mNames[sRes]) );
-            
+
             mManager->SetKeyFromIndex(i, noKey);
          }
       }
@@ -486,7 +486,7 @@ void KeyConfigPrefs::OnImport(wxCommandEvent & WXUNUSED(event))
    wxString file = wxT("Audacity-keys.xml");
 
    file = FileNames::SelectFile(FileNames::Operation::Open,
-      XO("Select an XML file containing Audacity keyboard shortcuts..."),
+      XO("Select an XML file containing Tenacity keyboard shortcuts..."),
       wxEmptyString,
       file,
       wxT(""),
@@ -498,7 +498,7 @@ void KeyConfigPrefs::OnImport(wxCommandEvent & WXUNUSED(event))
       return;
    }
 
-   // this RefreshKeyInfo is here to account for 
+   // this RefreshKeyInfo is here to account for
    // potential OnSet() function executions before importing
    RefreshKeyInfo();
 
@@ -548,8 +548,8 @@ void KeyConfigPrefs::OnImport(wxCommandEvent & WXUNUSED(event))
    TranslatableString disabledShortcuts{ MergeWithExistingKeys(oldKeys) };
 
    RefreshBindings(true);
-   
-   TranslatableString message{ 
+
+   TranslatableString message{
       XO("Loaded %d keyboard shortcuts\n").Format(mManager->GetNumberOfKeysRead()) };
 
    if (disabledShortcuts.Translation() != (""))
@@ -768,7 +768,7 @@ void KeyConfigPrefs::OnSet(wxCommandEvent & WXUNUSED(event))
 
    CommandID newCommand{ mView->GetName(mCommandSelected) };
    NormalizedKeyString enteredKey{ mKey->GetValue() };
-   NormalizedKeyString newComDefaultKey{ 
+   NormalizedKeyString newComDefaultKey{
       mManager->GetDefaultKeyFromName(newCommand) };
    CommandIDs oldCommands;
 
@@ -805,7 +805,7 @@ void KeyConfigPrefs::OnSet(wxCommandEvent & WXUNUSED(event))
          Verbatim(wxT("'%s - %s'")).Format(
             mManager->GetCategoryFromName(oldCommands[i]),
             mManager->GetPrefixedLabelFromName(oldCommands[i]));
-      
+
       if (wxCANCEL == AudacityMessageBox(
             XO(
 "The keyboard shortcut '%s' is already assigned to:\n\n\t%s\n\n\nClick OK to assign the shortcut to\n\n\t%s\n\ninstead. Otherwise, click Cancel.")
@@ -820,7 +820,7 @@ void KeyConfigPrefs::OnSet(wxCommandEvent & WXUNUSED(event))
       {
          return;
       }
-      
+
       for (const auto & command : oldCommands)
       {
          mView->SetKeyByName(command, {});

--- a/src/prefs/LibraryPrefs.cpp
+++ b/src/prefs/LibraryPrefs.cpp
@@ -195,7 +195,7 @@ void LibraryPrefs::OnFFmpegFindButton(wxCommandEvent & WXUNUSED(event))
    if (!locate) {
       int response = AudacityMessageBox(
          XO(
-"Audacity has automatically detected valid FFmpeg libraries.\nDo you still want to locate them manually?"),
+"Tenacity has automatically detected valid FFmpeg libraries.\nDo you still want to locate them manually?"),
          XO("Success"),
          wxCENTRE | wxYES_NO | wxNO_DEFAULT |wxICON_QUESTION);
       if (response == wxYES) {

--- a/src/prefs/ModulePrefs.cpp
+++ b/src/prefs/ModulePrefs.cpp
@@ -9,8 +9,8 @@
 *******************************************************************//**
 
 \class ModulePrefs
-\brief A PrefsPanel to enable/disable certain modules.  'Modules' are 
-dynamically linked libraries that modify Audacity.  They are plug-ins 
+\brief A PrefsPanel to enable/disable certain modules.  'Modules' are
+dynamically linked libraries that modify Audacity.  They are plug-ins
 with names like mod-script-pipe that add NEW features.
 
 *//*******************************************************************/
@@ -117,18 +117,18 @@ void ModulePrefs::PopulateOrExchange(ShuttleGui & S)
    S.StartStatic( {} );
    {
       S.AddFixedText(XO(
-"These are experimental modules. Enable them only if you've read the Audacity Manual\nand know what you are doing.") );
+"These are experimental modules. Enable them only if you've read the Tenacity Manual\nand know what you are doing.") );
       S.AddFixedText(XO(
 /* i18n-hint preserve the leading spaces */
-"  'Ask' means Audacity will ask if you want to load the module each time it starts.") );
+"  'Ask' means Tenacity will ask if you want to load the module each time it starts.") );
       S.AddFixedText(XO(
 /* i18n-hint preserve the leading spaces */
-"  'Failed' means Audacity thinks the module is broken and won't run it.") );
+"  'Failed' means Tenacity thinks the module is broken and won't run it.") );
       S.AddFixedText(XO(
 /* i18n-hint preserve the leading spaces */
 "  'New' means no choice has been made yet.") );
       S.AddFixedText(XO(
-"Changes to these settings only take effect when Audacity starts up."));
+"Changes to these settings only take effect when Tenacity starts up."));
       {
         S.StartMultiColumn( 2 );
         int i;

--- a/src/prefs/PrefsDialog.cpp
+++ b/src/prefs/PrefsDialog.cpp
@@ -81,12 +81,12 @@ namespace {
             if ( !!( id = ctrl.GetNextSibling( id ) ) )
                break;
          } while ( stack.pop_back(), !stack.empty() );
-         
+
          ++position;
       }
       return {};
    }
-   
+
    unsigned FindItemPosition( const wxTreeCtrl &ctrl, wxTreeItemId id )
    {
       // Return the 1-based count of the item's position in the pre-order
@@ -96,7 +96,7 @@ namespace {
          [=]( wxTreeItemId itemId, unsigned position ){
             return std::make_pair( itemId == id, position ); } );
    }
-   
+
    wxTreeItemId FindItem( const wxTreeCtrl &ctrl, int nn )
    {
       // The inverse of the function above
@@ -446,7 +446,7 @@ PrefsDialog::PrefsDialog(
    wxWindow * parent, AudacityProject *pProject,
    const TranslatableString &titlePrefix,
    PrefsPanel::Factories &factories)
-:  wxDialogWrapper(parent, wxID_ANY, XO("Audacity Preferences"),
+:  wxDialogWrapper(parent, wxID_ANY, XO("Tenacity Preferences"),
             wxDefaultPosition,
             wxDefaultSize,
             wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
@@ -640,7 +640,7 @@ void PrefsDialog::OnCancel(wxCommandEvent & WXUNUSED(event))
 
 PrefsPanel * PrefsDialog::GetCurrentPanel()
 {
-   if( mCategories) 
+   if( mCategories)
       return static_cast<PrefsPanel*>(mCategories->GetCurrentPage());
    else
    {

--- a/src/prefs/PrefsPanel.cpp
+++ b/src/prefs/PrefsPanel.cpp
@@ -69,7 +69,7 @@ PluginPath PrefsPanel::GetPath()
 { return BUILTIN_PREFS_PANEL_PREFIX + GetSymbol().Internal(); }
 
 VendorSymbol PrefsPanel::GetVendor()
-{  return XO("Audacity");}
+{  return XO("Tenacity");}
 
 wxString PrefsPanel::GetVersion()
 {     return AUDACITY_VERSION_STRING;}

--- a/src/prefs/ThemePrefs.cpp
+++ b/src/prefs/ThemePrefs.cpp
@@ -111,13 +111,13 @@ void ThemePrefs::PopulateOrExchange(ShuttleGui & S)
    {
       S.AddFixedText(
          XO(
-"Themability is an experimental feature.\n\nTo try it out, click \"Save Theme Cache\" then find and modify the images and colors in\nImageCacheVxx.png using an image editor such as the Gimp.\n\nClick \"Load Theme Cache\" to load the changed images and colors back into Audacity.\n\n(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\nthough the image file shows other icons too.)")
+"Themability is an experimental feature.\n\nTo try it out, click \"Save Theme Cache\" then find and modify the images and colors in\nImageCacheVxx.png using an image editor such as the Gimp.\n\nClick \"Load Theme Cache\" to load the changed images and colors back into Tenacity.\n\n(Only the Transport Toolbar and the colors on the wavetrack are currently affected, even\nthough the image file shows other icons too.)")
          );
 
 #ifdef _DEBUG
       S.AddFixedText(
          Verbatim(
-"This is a debug version of Audacity, with an extra button, 'Output Sourcery'. This will save a\nC version of the image cache that can be compiled in as a default.")
+"This is a debug version of Tenacity, with an extra button, 'Output Sourcery'. This will save a\nC version of the image cache that can be compiled in as a default.")
          );
 #endif
 

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -64,8 +64,8 @@ in which buttons can be placed.
 //
 #define RWIDTH 4
 
-/// \brief a wxWindow that provides the resizer for a toolbar on the 
-/// right hand side.  Responsible for drawing the resizer appearance, 
+/// \brief a wxWindow that provides the resizer for a toolbar on the
+/// right hand side.  Responsible for drawing the resizer appearance,
 /// resizing mouse events and constraining the resizing.
 class ToolBarResizer final : public wxWindow
 {
@@ -168,7 +168,7 @@ void ToolBarResizer::OnLeftDown( wxMouseEvent & event )
    event.Skip();
 
    // Retrieve the mouse position
-   // Bug 1896: This is at time of processing the event, rather than at time 
+   // Bug 1896: This is at time of processing the event, rather than at time
    // of generation of event.  Works around event.GetPosition() giving
    // incorrect values if position of resizer is changing.
    mResizeOffset = wxGetMousePosition()-mBar->GetRect().GetBottomRight();
@@ -220,7 +220,7 @@ void ToolBarResizer::OnMotion( wxMouseEvent & event )
    if( HasCapture() && event.Dragging() )
    {
       // Retrieve the mouse position
-      // Bug 1896: This is at time of processing the event, rather than at time 
+      // Bug 1896: This is at time of processing the event, rather than at time
       // of generation of event.  Works around event.GetPosition() giving
       // incorrect values if position of resizer is changing.
       wxPoint pos = wxGetMousePosition();
@@ -366,7 +366,7 @@ ToolBar::~ToolBar()
 TranslatableString ToolBar::GetTitle()
 {
    /* i18n-hint: %s will be replaced by the name of the kind of toolbar.*/
-   return XO("Audacity %s Toolbar").Format( GetLabel() );
+   return XO("Tenacity %s Toolbar").Format( GetLabel() );
 }
 
 //
@@ -508,7 +508,7 @@ wxSize ToolBar::GetSmartDockedSize()
    // 46 is the size where we switch from expanded to compact.
    if( sz.y < 46 )
       sz.y = tbs-1;
-   else 
+   else
       sz.y = 2 * tbs -1;
    return sz;
 }
@@ -561,7 +561,7 @@ void ToolBar::ReCreateButtons()
          ms->Add(mResizer, 0, wxEXPAND | wxALIGN_TOP | wxLEFT, 1);
          mResizer->SetToolTip(_("Click and drag to resize toolbar"));
       }
-      
+
       // Set dock after possibly creating resizer.
       // (Re)Establish dock state
       SetDocked(GetDock(), false);
@@ -584,7 +584,7 @@ void ToolBar::ReCreateButtons()
       sz2.SetWidth(GetMinToolbarWidth());
       sz2.y = tbs -1;
       SetMinSize(sz2);
-      
+
       // sz2 is now the minimum size.
       // sz3 is the size we were.
 


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Part of: #508

The first commit replaces almost every occurence of "Audacity" with "Tenacity" in all Translatable Strings. Some are left in, because it wouldn't make sense replacing them (e.g. "Audacity Project file (.aup)"). The second commit is `update_po_files.sh` executed, so the changed strings can be translated on weblate.

This change also removes a lot of trailing spaces. VS Code does that automatically. I left them in because it doesn't hurt anyone and I realized my editor was doing this way too late

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>